### PR TITLE
Remove activesupport dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.ruby-version
 doc/
 .yardoc/
 pkg/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,18 +2,11 @@ PATH
   remote: .
   specs:
     graphql (0.1.1)
-      activesupport (~> 4)
       parslet (~> 1.6)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.3)
-      i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
-      minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
-      tzinfo (~> 1.1)
     ansi (1.5.0)
     blankslate (3.1.3)
     builder (3.2.2)
@@ -43,7 +36,6 @@ GEM
       guard-compat (~> 1.2)
       minitest (>= 3.0)
     hitimes (1.2.2)
-    i18n (0.7.0)
     json (1.8.2)
     listen (2.10.0)
       celluloid (~> 0.16.0)
@@ -82,11 +74,8 @@ GEM
     simplecov-html (0.10.0)
     slop (3.6.0)
     thor (0.19.1)
-    thread_safe (0.3.5)
     timers (4.0.1)
       hitimes
-    tzinfo (1.2.2)
-      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
@@ -102,6 +91,3 @@ DEPENDENCIES
   minitest-reporters (~> 1.0)
   pry (~> 0.10)
   rake (~> 10.4)
-
-BUNDLED WITH
-   1.10.4

--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.files = Dir["{lib}/**/*", "MIT-LICENSE", "readme.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_runtime_dependency "activesupport", "~> 4"
   s.add_runtime_dependency "parslet", "~> 1.6"
 
   s.add_development_dependency "codeclimate-test-reporter", '~>0.4'

--- a/lib/graph_ql/directive.rb
+++ b/lib/graph_ql/directive.rb
@@ -34,3 +34,7 @@ class GraphQL::Directive < GraphQL::ObjectType
     @arguments
   end
 end
+
+require 'graph_ql/directives/directive_chain'
+require 'graph_ql/directives/include_directive'
+require 'graph_ql/directives/skip_directive'

--- a/lib/graph_ql/parser.rb
+++ b/lib/graph_ql/parser.rb
@@ -1,0 +1,9 @@
+require 'graph_ql/parser/nodes'
+require 'graph_ql/parser/parser'
+require 'graph_ql/parser/transform'
+require 'graph_ql/parser/visitor'
+
+module GraphQL
+  PARSER = GraphQL::Parser.new
+  TRANSFORM = GraphQL::Transform.new
+end

--- a/lib/graph_ql/query.rb
+++ b/lib/graph_ql/query.rb
@@ -1,13 +1,5 @@
 class GraphQL::Query
   DEFAULT_RESOLVE = :__default_resolve
-  extend ActiveSupport::Autoload
-  autoload(:Arguments)
-  autoload(:FieldResolutionStrategy)
-  autoload(:FragmentSpreadResolutionStrategy)
-  autoload(:InlineFragmentResolutionStrategy)
-  autoload(:OperationResolver)
-  autoload(:SelectionResolver)
-  autoload(:TypeResolver)
   attr_reader :schema, :document, :context, :fragments, :params
 
   def initialize(schema, query_string, context: nil, params: {}, debug: true, validate: true)
@@ -68,3 +60,11 @@ class GraphQL::Query
     end
   end
 end
+
+require 'graph_ql/query/arguments'
+require 'graph_ql/query/field_resolution_strategy'
+require 'graph_ql/query/fragment_spread_resolution_strategy'
+require 'graph_ql/query/inline_fragment_resolution_strategy'
+require 'graph_ql/query/operation_resolver'
+require 'graph_ql/query/selection_resolver'
+require 'graph_ql/query/type_resolver'

--- a/lib/graph_ql/schema.rb
+++ b/lib/graph_ql/schema.rb
@@ -1,11 +1,4 @@
 class GraphQL::Schema
-  extend ActiveSupport::Autoload
-  autoload(:FieldValidator)
-  autoload(:ImplementationValidator)
-  autoload(:SchemaValidator)
-  autoload(:TypeReducer)
-  autoload(:TypeValidator)
-  autoload(:UnionValidator)
   DIRECTIVES = [GraphQL::SkipDirective, GraphQL::IncludeDirective]
 
   attr_reader :query, :mutation, :directives, :static_validator
@@ -39,3 +32,10 @@ class GraphQL::Schema
     @types ||= TypeReducer.new(query, {}).result
   end
 end
+
+require 'graph_ql/schema/field_validator'
+require 'graph_ql/schema/implementation_validator'
+require 'graph_ql/schema/schema_validator'
+require 'graph_ql/schema/type_reducer'
+require 'graph_ql/schema/type_validator'
+require 'graph_ql/schema/union_validator'

--- a/lib/graph_ql/static_validation.rb
+++ b/lib/graph_ql/static_validation.rb
@@ -1,0 +1,11 @@
+module GraphQL::StaticValidation
+end
+
+require 'graph_ql/static_validation/message'
+
+require 'graph_ql/static_validation/fields_are_defined_on_type'
+require 'graph_ql/static_validation/fields_have_appropriate_selections'
+require 'graph_ql/static_validation/fields_will_merge'
+require 'graph_ql/static_validation/fragments_are_used'
+require 'graph_ql/static_validation/type_stack'
+require 'graph_ql/static_validation/validator'

--- a/lib/graph_ql/types/type_definer.rb
+++ b/lib/graph_ql/types/type_definer.rb
@@ -1,16 +1,11 @@
 require 'singleton'
 class GraphQL::TypeDefiner
   include Singleton
-  TYPES = {
-    Int:     GraphQL::INT_TYPE,
-    String:  GraphQL::STRING_TYPE,
-    Float:   GraphQL::FLOAT_TYPE,
-    Boolean: GraphQL::BOOLEAN_TYPE,
-  }
 
-  TYPES.each do |method_name, type|
-    define_method(method_name) { type }
-  end
+  def Int; GraphQL::INT_TYPE; end
+  def String; GraphQL::STRING_TYPE; end
+  def Float; GraphQL::FLOAT_TYPE; end
+  def Boolean; GraphQL::BOOLEAN_TYPE; end
 
   def [](type)
     GraphQL::ListType.new(of_type: type)

--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -1,83 +1,7 @@
-require "active_support/core_ext/object/blank"
-require "active_support/core_ext/string/inflections"
-require "active_support/dependencies/autoload"
 require "json"
 require "parslet"
 
 module GraphQL
-  extend ActiveSupport::Autoload
-  autoload(:Directive)
-  autoload(:Enum)
-  autoload(:Field)
-  autoload(:Interface)
-  autoload(:Parser)
-  autoload(:Query)
-  autoload(:Repl)
-  autoload(:Schema)
-  autoload(:TypeKinds)
-  autoload(:Union)
-  autoload(:Validator)
-  autoload(:VERSION)
-
-  autoload_under "directives" do
-    autoload(:DirectiveChain)
-    autoload(:IncludeDirective)
-    autoload(:SkipDirective)
-  end
-
-  module Introspection
-    extend ActiveSupport::Autoload
-    autoload(:ArgumentsField)
-    autoload(:DirectiveType)
-    autoload(:EnumValuesField)
-    autoload(:EnumValueType)
-    autoload(:FieldType)
-    autoload(:FieldsField)
-    autoload(:InputValueType)
-    autoload(:InputFieldsField)
-    autoload(:InterfacesField)
-    autoload(:OfTypeField)
-    autoload(:PossibleTypesField)
-    autoload(:SchemaType)
-    autoload(:TypeKindEnum)
-    autoload(:TypenameField)
-    autoload(:TypeType)
-  end
-
-  autoload_under "parser" do
-    autoload(:Nodes)
-    autoload(:Parser)
-    autoload(:Transform)
-    autoload(:Visitor)
-  end
-
-  module StaticValidation
-    extend ActiveSupport::Autoload
-    autoload(:ArgumentsObeyDefinition)
-    autoload(:FieldsAreDefinedOnType)
-    autoload(:FieldsWillMerge)
-    autoload(:FragmentsAreUsed)
-    autoload(:FieldsHaveAppropriateSelections)
-    autoload(:Message)
-    autoload(:TypeStack)
-    autoload(:Validator)
-  end
-  autoload_under "types" do
-    autoload(:AbstractType)
-    autoload(:BOOLEAN_TYPE)
-    autoload(:ScalarType)
-    autoload(:FLOAT_TYPE)
-    autoload(:InputObjectType)
-    autoload(:InputValue)
-    autoload(:INT_TYPE)
-    autoload(:ListType)
-    autoload(:NonNullType)
-    autoload(:NonNullWithBang)
-    autoload(:ObjectType)
-    autoload(:STRING_TYPE)
-    autoload(:TypeDefiner)
-  end
-
   def self.parse(string, as: nil)
     parser = as ? GraphQL::PARSER.send(as) : GraphQL::PARSER
     tree = parser.parse(string)
@@ -86,7 +10,6 @@ module GraphQL
     line, col = error.cause.source.line_and_column
     raise [line, col, string].join(", ")
   end
-
 
   module Definable
     def attr_definable(*names)
@@ -111,7 +34,58 @@ module GraphQL
     end
   end
 
-
-  PARSER = Parser.new
-  TRANSFORM = Transform.new
+  module Introspection; end
 end
+
+# Order matters for these:
+
+require 'graph_ql/types/non_null_with_bang'
+require 'graph_ql/types/object_type'
+require 'graph_ql/types/list_type'
+require 'graph_ql/types/scalar_type'
+require 'graph_ql/types/non_null_type'
+require 'graph_ql/types/input_value'
+require 'graph_ql/types/input_object_type'
+
+require 'graph_ql/types/type_definer'
+
+require 'graph_ql/enum'
+require 'graph_ql/field'
+require 'graph_ql/union'
+require 'graph_ql/type_kinds'
+require 'graph_ql/introspection/typename_field'
+
+require 'graph_ql/types/int_type'
+require 'graph_ql/types/string_type'
+require 'graph_ql/types/float_type'
+require 'graph_ql/types/boolean_type'
+
+require 'graph_ql/introspection/input_value_type'
+require 'graph_ql/introspection/enum_value_type'
+require 'graph_ql/introspection/type_kind_enum'
+
+require 'graph_ql/introspection/fields_field'
+require 'graph_ql/introspection/of_type_field'
+require 'graph_ql/introspection/input_fields_field'
+require 'graph_ql/introspection/possible_types_field'
+require 'graph_ql/introspection/enum_values_field'
+require 'graph_ql/introspection/interfaces_field'
+
+require 'graph_ql/introspection/type_type'
+require 'graph_ql/introspection/field_type'
+
+require 'graph_ql/introspection/arguments_field'
+require 'graph_ql/introspection/directive_type'
+require 'graph_ql/introspection/schema_type'
+
+require 'graph_ql/parser'
+require 'graph_ql/directive'
+require 'graph_ql/schema'
+
+# Order does not matter for these:
+
+require 'graph_ql/interface'
+require 'graph_ql/query'
+require 'graph_ql/repl'
+require 'graph_ql/static_validation'
+require 'graph_ql/version'


### PR DESCRIPTION
Make the dependency loading explicit (we're not lazy anyway since we
instantiate many types at load time). Getting the order right here is a
bit messy, but having it be explicit seems better than masking the chain
of dependencies.

r? @rmosolgo 
