### PR TITLE
Remove deprecated params: keyword

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -13,17 +13,12 @@ class GraphQL::Query
   # @param debug [Boolean] if true, errors are raised, if false, errors are put in the `errors` key
   # @param validate [Boolean] if true, `query_string` will be validated with {StaticValidation::Validator}
   # @param operation_name [String] if the query string contains many operations, this is the one which should be executed
-  def initialize(schema, query_string, context: nil, params: nil, variables: {}, debug: true, validate: true, operation_name: nil)
+  def initialize(schema, query_string, context: nil, variables: {}, debug: true, validate: true, operation_name: nil)
     @schema = schema
     @debug = debug
     @context = Context.new(context)
 
     @variables = variables
-    if params
-      warn("[GraphQL] params option is deprecated for GraphQL::Query#new, use variables instead")
-      @variables = params
-    end
-
     @validate = validate
     @operation_name = operation_name
     @fragments = {}

--- a/readme.md
+++ b/readme.md
@@ -96,7 +96,6 @@ If you're building a backend for [Relay](http://facebook.github.io/relay/), you'
   - https://github.com/graphql/graphql-js/issues/19#issuecomment-118515077
 - Code clean-up
   - Accept native Ruby types or symbols in definitions, then convert them to GraphQL types
-  - Remove deprecated `params:` keyword
   - Raise if you try to configure an attribute which doesn't suit the type
 - Cook up some path other than "n+1s everywhere"
   - See Sangria's `project` approach ([in progress](https://github.com/rmosolgo/graphql-ruby/pull/15))


### PR DESCRIPTION
Code clean up: remove deprecated `params:` keyword in `Query#initialize`