### PR TITLE
Skip directive has precedence over include

### DIFF
--- a/lib/graphql/query/directive_chain.rb
+++ b/lib/graphql/query/directive_chain.rb
@@ -1,4 +1,3 @@
-# TODO:  `@skip` has precedence over `@include`
 # TODO: directives on fragments: http://facebook.github.io/graphql/#sec-Fragment-Directives
 class GraphQL::Query::DirectiveChain
   DIRECTIVE_ON = {
@@ -18,6 +17,11 @@ class GraphQL::Query::DirectiveChain
     directives = query.schema.directives
     on_what = DIRECTIVE_ON[ast_node.class]
     ast_directives = GET_DIRECTIVES[ast_node.class].call(ast_node, query.fragments)
+
+    if contains_skip?(ast_directives)
+      ast_directives = ast_directives.reject { |ast_directive| ast_directive.name == 'include' }
+    end
+
     applicable_directives = ast_directives
       .map { |ast_directive| [ast_directive, directives[ast_directive.name]] }
       .select { |directive_pair| directive_pair.last.on.include?(on_what) }
@@ -31,5 +35,10 @@ class GraphQL::Query::DirectiveChain
       end
       @result ||= {}
     end
+  end
+
+  private
+  def contains_skip?(directives)
+    directives.any? { |directive| directive.name == 'skip' }
   end
 end

--- a/spec/graphql/directive_spec.rb
+++ b/spec/graphql/directive_spec.rb
@@ -8,6 +8,8 @@ describe GraphQL::Directive do
         # plain fields:
         skipFlavor: flavor @skip(if: true)
         dontSkipFlavor: flavor @skip(if: false)
+        dontSkipDontIncludeFlavor: flavor @skip(if: false), @include(if: false)
+        skipAndInclude: flavor @skip(if: true), @include(if: true)
         includeFlavor: flavor @include(if: $t)
         dontIncludeFlavor: flavor @include(if: $f)
         # fields in fragments
@@ -25,6 +27,7 @@ describe GraphQL::Directive do
     it 'intercepts fields' do
       expected = { "data" =>{
         "cheese" => {
+          "dontSkipDontIncludeFlavor" => "Brie", #skip has precedence over include
           "dontSkipFlavor" => "Brie",
           "includeFlavor" => "Brie",
           "includeId" => 1,


### PR DESCRIPTION
Tried to look at other implementations and how they did this but their implementation doesn't usually this type of chain and will just return only if there's a `@skip` not taking in consideration future `directives`.

This checks if there is a `skip` directive and if so removes all `include` directives from `ast_directives`

Not sure if that's the best way to go about it. Let me know if you see a better way :dancers: 