### PR TITLE
Better raise for parse errors

### DIFF
--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -3,6 +3,16 @@ require "parslet"
 require "singleton"
 
 module GraphQL
+  class ParseError < StandardError
+    attr_accessor :line, :col, :query
+    def initialize(message, line, col, query)
+      super(message)
+      @line = line
+      @col = col
+      @query = query
+    end
+  end
+
   # Turn a query string into an AST
   # @param string [String] a GraphQL query string
   # @param as [Symbol] If you want to use this to parse some _piece_ of a document, pass the rule name (from {GraphQL::Parser})
@@ -12,8 +22,8 @@ module GraphQL
     tree = parser.parse(string)
     GraphQL::TRANSFORM.apply(tree)
   rescue Parslet::ParseFailed => error
-    line, col = error.cause.source.line_and_column
-    raise [error.message, line, col, string].join(", ")
+    line, col = error.cause.source.line_and_column(error.cause.pos)
+    raise GraphQL::ParseError.new(error.message, line, col, string)
   end
 end
 

--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -4,7 +4,7 @@ require "singleton"
 
 module GraphQL
   class ParseError < StandardError
-    attr_accessor :line, :col, :query
+    attr_reader :line, :col, :query
     def initialize(message, line, col, query)
       super(message)
       @line = line

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -82,6 +82,22 @@ describe GraphQL::Query do
     assert_equal(GraphQL::Language::Nodes::FragmentDefinition, query.fragments['cheeseFields'].class)
   end
 
+  it 'correctly identifies parse error location' do
+    # "Correct" is a bit of an overstatement. All Parslet errors get surfaced
+    # at the beginning of the query they were in, since Parslet sees the query
+    # as invalid. It would be great to have more granularity here.
+    e = assert_raises(GraphQL::ParseError) do
+      GraphQL.parse("
+        query getCoupons {
+          allCoupons: {data{id}}
+        }
+      ")
+    end
+    assert_equal('Extra input after last repetition at line 2 char 9.', e.message)
+    assert_equal(2, e.line)
+    assert_equal(9, e.col)
+  end
+
   describe "merging fragments with different keys" do
     let(:query_string) { %|
       query getCheeseFieldsThroughDairy {


### PR DESCRIPTION
1. Passing `error.cause.pos` into `line_and_column is necessary to avoid getting 1,1. It still doesn't help a ton, since the error is almost always the first character of your query (i.e. it only skips whitespace), but at least now it matches the pos in the error message.
1. Wrap the response in a `GraphQL::ParseError` so that it's easier to catch/handle.