### PR TITLE
Use self.class::Name rather than get_class(:Name)

### DIFF
--- a/lib/graphql/query/base_execution.rb
+++ b/lib/graphql/query/base_execution.rb
@@ -18,21 +18,15 @@ module GraphQL
       end
 
       def field_resolution
-        get_class :FieldResolution
+        self.class::FieldResolution
       end
 
       def operation_resolution
-        get_class :OperationResolution
+        self.class::OperationResolution
       end
 
       def selection_resolution
-        get_class :SelectionResolution
-      end
-
-      private
-
-      def get_class(class_name)
-        self.class.const_get(class_name)
+        self.class::SelectionResolution
       end
     end
   end


### PR DESCRIPTION
This removed the get_class method, since it was always called with a constant class name.

E.g. `self.class::FieldResolution` does the same thing as `self.class.const_get(:FieldResolution)`