### PR TITLE
Add include method to has possible types module

### DIFF
--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -53,6 +53,10 @@ module GraphQL
       def resolve_type=(new_proc)
         @resolve_type_proc = new_proc || DEFAULT_RESOLVE_TYPE
       end
+
+      def include?(type)
+        possible_types.include?(type)
+      end
     end
 
     # Print the human-readable name of this type

--- a/readme.md
+++ b/readme.md
@@ -99,7 +99,14 @@ If you're building a backend for [Relay](http://facebook.github.io/relay/), you'
   - Add instrumentation
     - Some way to expose what queries are run, what types & fields are accessed, how long things are taking, etc
     - before-hooks for every field?
-
+  - Improve error handling
+    - Currently, the options are:
+      - `debug: false`, all errors are eaten and stringified in `response["errors"]`
+      - `debug: true`, then rescue errors yourself and build a response yourself
+    - Add an option that some fields can return errors with custom messages
+      - Like this: https://github.com/graphql/graphql-js/pull/178
+      - After a field returns an error, the executor could attach the location in the query string
+      - The result would have a `"data"` key _and_ an `"errors"` key (as in that PR and the [spec](http://facebook.github.io/graphql/#sec-Response-Format))
 
 ## Goals
 

--- a/spec/graphql/introspection/schema_type_spec.rb
+++ b/spec/graphql/introspection/schema_type_spec.rb
@@ -23,6 +23,7 @@ describe GraphQL::Introspection::SchemaType do
             {"name"=>"dairy"},
             {"name"=>"fromSource"},
             {"name"=>"favoriteEdible"},
+            {"name"=>"cow"},
             {"name"=>"searchDairy"},
             {"name"=>"error"},
             {"name"=>"maybeNull"},

--- a/spec/graphql/query/type_resolver_spec.rb
+++ b/spec/graphql/query/type_resolver_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe GraphQL::Query::TypeResolver do
+  it 'resolves correcty when child_type is UnionType' do
+    type = GraphQL::Query::TypeResolver.new(MILKS[1], DairyProductUnion, MilkType).type
+    assert_equal(MilkType, type)
+  end
+end

--- a/spec/graphql/union_type_spec.rb
+++ b/spec/graphql/union_type_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe GraphQL::UnionType do
   let(:type_1) { OpenStruct.new(kind: GraphQL::TypeKinds::OBJECT)}
   let(:type_2) { OpenStruct.new(kind: GraphQL::TypeKinds::OBJECT)}
+  let(:type_3) { OpenStruct.new(kind: GraphQL::TypeKinds::SCALAR)}
   let(:union) {
     types = [type_1, type_2]
     GraphQL::UnionType.define {
@@ -17,5 +18,13 @@ describe GraphQL::UnionType do
 
   it 'infers type from an object' do
     assert_equal(CheeseType, DairyProductUnion.resolve_type(CHEESES[1]))
+  end
+
+  it '#include? returns true if type in in possible_types' do
+    assert union.include?(type_1)
+  end
+
+  it '#include? returns false if type is not in possible_types' do
+    assert_equal(false, union.include?(type_3))
   end
 end

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -84,6 +84,20 @@ DairyProductUnion = GraphQL::UnionType.define do
   possible_types [MilkType, CheeseType]
 end
 
+CowType = GraphQL::ObjectType.define do
+  name 'Cow'
+  description 'A farm where milk is harvested and cheese is produced'
+  field :id, !types.ID
+  field :name, types.String
+  field :last_produced_dairy, DairyProductUnion
+end
+
+MaybeNullType = GraphQL::ObjectType.define do
+  name "MaybeNull"
+  description "An object whose fields return nil"
+  field :cheese, CheeseType
+end
+
 DairyProductInputType = GraphQL::InputObjectType.define {
   name "DairyProductInput"
   description "Properties for finding a dairy product"
@@ -142,6 +156,7 @@ QueryType = GraphQL::ObjectType.define do
   field :dairy, field: SingletonField.create(type: DairyType, data: DAIRY)
   field :fromSource, &SourceFieldDefn
   field :favoriteEdible, &FavoriteFieldDefn
+  field :cow, field: SingletonField.create(type: CowType, data: COW)
   field :searchDairy do
     description "Find dairy products matching a description"
     type !DairyProductUnion

--- a/spec/support/dairy_data.rb
+++ b/spec/support/dairy_data.rb
@@ -15,3 +15,9 @@ DAIRY = OpenStruct.new(
   cheese: CHEESES[1],
   milks: [MILKS[1]]
 )
+
+COW = OpenStruct.new(
+  id: 1,
+  name: 'Billy',
+  last_produced_dairy: MILKS[1]
+)


### PR DESCRIPTION
https://github.com/rmosolgo/graphql-ruby/blob/60d27b1351cc7212925c06f92ef36a75d02349eb/lib/graphql/query/type_resolver.rb#L11

This line here raises undefined method `#include?` for `UnionType` when using a union type field.

I've added an `#include?` method to the `HasPossibleTypes` module. Please correct me if this is not a bug and just me incorrectly using the type :)
