### PR TITLE
Middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### New features
 
+- Add `Schema#middleware` to wrap field access
+- Add `RescueMiddleware` to handle errors during field execution
+
 ### Bug fixes
 
 ## 0.9.4 (22 Sept 2015)

--- a/guides/defining_your_schema.md
+++ b/guides/defining_your_schema.md
@@ -89,3 +89,52 @@ result = MySchema.execute(query_string)
 #   ]
 # }
 ```
+
+
+## Middleware
+
+You can use _middleware_ to affect the evaluation of fields in your schema. They function like `before_action`s and `after_action`s in Rails controllers.
+
+A middleware is any object that responds to `#call(*args, next_middleware)`. Inside that method, it should either:
+
+- send `call` to the next middleware to continue the evaluation; or
+- return a value to end the evaluation early.
+
+Middlewares' `#call` is invoked with several arguments:
+
+- `parent_type` is the type whose field is being accessed
+- `parent_object` is the object being exposed by that type
+- `field_definition` is the definition for the field being accessed
+- `field_args` is the hash of arguments passed to the field
+- `query_context` is the context object passed throughout the query
+- `next_middleware` represents the execution chain. Call `#call` to continue evalution.
+
+Add a middleware to a schema by adding to the `#middleware` array.
+
+
+### Example: Authorization
+
+This middleware only continues evaluation if the `current_user` is permitted to read the target object:
+
+```ruby
+class AuthorizationMiddleware
+  def call(parent_type, parent_object, field_definition, field_args, query_context, next_middleware)
+    current_user = query_context[:current_user] # passed in when creating the query
+    if current_user && current_user.can_read?(parent_object)
+      # This user is authorized, so continue execution
+      next_middleware.call
+    else
+      # Silently halt execution
+      nil
+    end
+  end
+end
+```
+
+Then, add the middleware to your schema:
+
+```ruby
+MySchema.middleware << AuthorizationMiddleware.new
+```
+
+Now, all field access will be wrapped by that authorization routine.

--- a/guides/defining_your_schema.md
+++ b/guides/defining_your_schema.md
@@ -67,16 +67,7 @@ This field accepts an optional Boolean argument `moderated`, which it uses to fi
 
 ## Handling Errors
 
-You can rescue errors in two ways:
-
-- Set up handlers with `Schema#rescue_from`
-- Return `GraphQL::ExeceptionError`s from your fields
-
-In both cases, the message to be added to the response, along with the location of that field in the query string. Other fields can be resolved as normal.
-
-### Schema-level handlers
-
-To set up handlers, use `Schema#rescue_from`. The handler should return a string that will be inserted into the response. For example, you can set up a handler:
+You can rescue errors by defining handlers with `Schema#rescue_from`. The handler should return a string that will be inserted into the response. For example, you can set up a handler:
 
 ```ruby
 MySchema.rescue_from(ActiveRecord::RecordInvalid) { "Some data could not be saved" }
@@ -96,41 +87,5 @@ result = MySchema.execute(query_string)
 #       "locations" => [{"line" => 5, "column" => 10}]
 #      }
 #   ]
-# }
-```
-
-### Return errors from fields
-
-You can also return a `GraphQL::ExecutionError` from your field's `resolve` method. For example:
-
-```ruby
-field :errorsIfNegative, types.Int, "Returns an error if the input is less than 0" do
-  argument :number, types.Int
-  resolve -> (object, args, ctx) {
-    input = args[:number]
-    if input < 0
-      # Handle a special case by returning an error:
-      GraphQL::ExecutionError.new("'errorsIfNegative' Can't handle negative inputs")
-    else
-      input
-    end
-  }
-end
-```
-
-This will cause the `"errors"` key in the result to have that message:
-
-```ruby
-result = MySchema.execute(query_string)
-# {
-#   "data" => {
-#     # other fields may resolve successfully
-#   },
-#   "errors" => [
-#     {
-#       "message" => "'errorsIfNegative' Can't handle negative inputs",
-#       "locations" => [{"line" => 5, "column" => 10}]
-#      }
-#   ]  
 # }
 ```

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -1,5 +1,7 @@
 # A GraphQL schema which may be queried with {GraphQL::Query}.
 class GraphQL::Schema
+  extend Forwardable
+
   DIRECTIVES = [GraphQL::Directive::SkipDirective, GraphQL::Directive::IncludeDirective]
   DYNAMIC_FIELDS = ["__type", "__typename", "__schema"]
 
@@ -7,6 +9,7 @@ class GraphQL::Schema
   # Override these if you don't want the default executor:
   attr_accessor :query_execution_strategy, :mutation_execution_strategy
 
+  # @return [Array<#call>] Middlewares suitable for MiddlewareChain, applied to fields during execution
   attr_reader :middleware
 
   # @param query [GraphQL::ObjectType]  the query root for the schema
@@ -16,14 +19,16 @@ class GraphQL::Schema
     @mutation = mutation
     @directives = DIRECTIVES.reduce({}) { |m, d| m[d.name] = d; m }
     @static_validator = GraphQL::StaticValidation::Validator.new(schema: self)
-    @middleware = []
+    @rescue_middleware = GraphQL::Schema::RescueMiddleware.new
+    @middleware = [@rescue_middleware]
     # Default to the built-in execution strategy:
     self.query_execution_strategy = GraphQL::Query::SerialExecution
     self.mutation_execution_strategy = GraphQL::Query::SerialExecution
   end
 
-  # A `{ name => type }` hash of types in this schema
-  # @return [Hash]
+  def_delegators :@rescue_middleware, :rescue_from, :remove_handler
+
+  # @return [GraphQL::Schema::TypeMap] `{ name => type }` pairs of types in this schema
   def types
     @types ||= TypeReducer.find_all([query, mutation, GraphQL::Introspection::SchemaType].compact)
   end
@@ -63,7 +68,8 @@ end
 require 'graphql/schema/each_item_validator'
 require 'graphql/schema/field_validator'
 require 'graphql/schema/implementation_validator'
+require 'graphql/schema/middleware_chain'
+require 'graphql/schema/rescue_middleware'
 require 'graphql/schema/type_reducer'
 require 'graphql/schema/type_map'
 require 'graphql/schema/type_validator'
-require 'graphql/schema/middleware_chain'

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -7,6 +7,7 @@ class GraphQL::Schema
   # Override these if you don't want the default executor:
   attr_accessor :query_execution_strategy, :mutation_execution_strategy
 
+  attr_reader :middleware
 
   # @param query [GraphQL::ObjectType]  the query root for the schema
   # @param mutation [GraphQL::ObjectType, nil] the mutation root for the schema
@@ -15,6 +16,7 @@ class GraphQL::Schema
     @mutation = mutation
     @directives = DIRECTIVES.reduce({}) { |m, d| m[d.name] = d; m }
     @static_validator = GraphQL::StaticValidation::Validator.new(schema: self)
+    @middleware = []
     # Default to the built-in execution strategy:
     self.query_execution_strategy = GraphQL::Query::SerialExecution
     self.mutation_execution_strategy = GraphQL::Query::SerialExecution
@@ -64,3 +66,4 @@ require 'graphql/schema/implementation_validator'
 require 'graphql/schema/type_reducer'
 require 'graphql/schema/type_map'
 require 'graphql/schema/type_validator'
+require 'graphql/schema/middleware_chain'

--- a/lib/graphql/schema/middleware_chain.rb
+++ b/lib/graphql/schema/middleware_chain.rb
@@ -1,0 +1,27 @@
+module GraphQL
+  class Schema
+    # Given {steps} and {arguments}, call steps in order, passing `(*arguments, next_step)`.
+    #
+    # Steps should call `next_step.call` to continue the chain, or _not_ call it to stop the chain.
+    class MiddlewareChain
+      # @return [Array<#call(*args)>] Steps in this chain, will be called with arguments and `next_middleware`
+      attr_reader :steps
+
+      # @return [Array] Arguments passed to steps (followed by `next_middleware`)
+      attr_reader :arguments
+
+      def initialize(steps:, arguments:)
+        # We're gonna destroy this array, so copy it:
+        @steps = steps.dup
+        @arguments = arguments
+      end
+
+      # Run the next step in the chain, passing in arguments and handle to the next step
+      def call
+        next_step = steps.shift
+        next_middleware = self
+        next_step.call(*arguments, next_middleware)
+      end
+    end
+  end
+end

--- a/lib/graphql/schema/rescue_middleware.rb
+++ b/lib/graphql/schema/rescue_middleware.rb
@@ -1,0 +1,53 @@
+module GraphQL
+  class Schema
+    # - Store a table of errors & handlers
+    # - Rescue errors in a middleware chain, then check for a handler
+    # - If a handler is found, use it & return a {GraphQL::ExecutionError}
+    # - If no handler is found, re-raise the error
+    class RescueMiddleware
+      # @return [Hash] `{class => proc}` pairs for handling errors
+      attr_reader :rescue_table
+      def initialize
+        @rescue_table = {}
+      end
+
+      # @example Rescue from not-found by telling the user
+      #   MySchema.rescue_from(ActiveRecord::NotFound) { "An item could not be found" }
+      #
+      # @param [Class] a class of error to rescue from
+      # @yield [err] A handler to return a message for this error instance
+      # @yieldparam [Exception] an error that was rescued
+      # @yieldreturn [String] message to put in GraphQL response
+      def rescue_from(error_class, &block)
+        rescue_table[error_class] = block
+      end
+
+      # Remove the handler for `error_class`
+      # @param [Class] the error class whose handler should be removed
+      def remove_handler(error_class)
+        rescue_table.delete(error_class)
+      end
+
+      # Implement the requirement for {GraphQL::Schema::MiddlewareChain}
+      def call(*args, next_middleware)
+        begin
+          next_middleware.call
+        rescue StandardError => err
+          attempt_rescue(err)
+        end
+      end
+
+      private
+
+      def attempt_rescue(err)
+        handler = rescue_table[err.class]
+        if handler
+          message = handler.call(err)
+          GraphQL::ExecutionError.new(message)
+        else
+          raise(err)
+        end
+      end
+    end
+  end
+end

--- a/readme.md
+++ b/readme.md
@@ -97,9 +97,6 @@ If you're building a backend for [Relay](http://facebook.github.io/relay/), you'
   - Incoming enums should be exposed as `EnumValue`s, not `Nodes::Enum`s
 - Big ideas:
   - Use [graphql-parser](https://github.com/shopify/graphql-parser) (Ruby bindings for [libgraphqlparser](https://github.com/graphql/libgraphqlparser)) instead of Parslet
-  - Add instrumentation
-    - Some way to expose what queries are run, what types & fields are accessed, how long things are taking, etc
-    - before-hooks for every field?
 
 ## Goals
 

--- a/spec/graphql/query/executor_spec.rb
+++ b/spec/graphql/query/executor_spec.rb
@@ -131,5 +131,30 @@ describe GraphQL::Query::Executor do
         assert_raises(RuntimeError) { result }
       end
     end
+
+    describe "if the schema has a rescue handler" do
+      before do
+        schema.rescue_from(RuntimeError) { "Error was handled!" }
+      end
+
+      after do
+        # remove the handler from the middleware:
+        schema.remove_handler(RuntimeError)
+      end
+
+      it "adds to the errors key" do
+        expected = {
+          "data" => {"error" => nil},
+          "errors"=>[
+            {
+              "message"=>"Error was handled!",
+              "locations" => [{"line"=>1, "column"=>17}]
+            }
+          ]
+        }
+        assert_equal(expected, result)
+      end
+
+    end
   end
 end

--- a/spec/graphql/schema/middleware_chain_spec.rb
+++ b/spec/graphql/schema/middleware_chain_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe GraphQL::Schema::MiddlewareChain do
+  let(:step_1) { -> (step_values, next_step) { step_values << 1; next_step.call } }
+  let(:step_2) { -> (step_values, next_step) { step_values << 2; next_step.call } }
+  let(:step_3) { -> (step_values, next_step) { step_values << 3; :return_value } }
+  let(:steps) { [step_1, step_2, step_3] }
+  let(:step_values) { [] }
+  let(:arguments) { [step_values] }
+  let(:middleware_chain) { GraphQL::Schema::MiddlewareChain.new(steps: steps, arguments: arguments)}
+
+  describe "#call" do
+    it "runs steps in order" do
+      middleware_chain.call
+      assert_equal([1,2,3], step_values)
+    end
+
+    it "returns the value of the last middleware" do
+      assert_equal(:return_value, middleware_chain.call)
+    end
+
+    describe "when a step returns early" do
+      let(:early_return_step) { -> (step_values, next_step) { :early_return } }
+      it "doesn't continue the chain" do
+        steps.insert(2, early_return_step)
+        assert_equal(:early_return, middleware_chain.call)
+        assert_equal([1,2], step_values)
+      end
+    end
+  end
+end

--- a/spec/graphql/schema/rescue_middleware_spec.rb
+++ b/spec/graphql/schema/rescue_middleware_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+class SpecExampleError < StandardError; end
+
+describe GraphQL::Schema::RescueMiddleware do
+  let(:error_middleware) { -> (next_middleware) { raise(error_class) } }
+
+  let(:rescue_middleware) do
+    middleware = GraphQL::Schema::RescueMiddleware.new
+    middleware.rescue_from(SpecExampleError) { |err| "there was an example error: #{err.class.name}" }
+    middleware
+  end
+
+  let(:steps) { [rescue_middleware, error_middleware] }
+
+  let(:middleware_chain) { GraphQL::Schema::MiddlewareChain.new(steps: steps, arguments: [])}
+
+  describe "known errors" do
+    let(:error_class) { SpecExampleError }
+    it "handles them as execution errors" do
+      result = middleware_chain.call
+      assert_equal("there was an example error: SpecExampleError", result.message)
+      assert_equal(GraphQL::ExecutionError, result.class)
+    end
+  end
+
+  describe "unknown errors" do
+    let(:error_class) { RuntimeError }
+    it "re-raises them" do
+      assert_raises(RuntimeError) { middleware_chain.call }
+    end
+  end
+end

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -7,10 +7,10 @@ describe GraphQL::Schema do
     let(:rescue_middleware) { schema.middleware.first }
 
     it "adds handlers to the rescue middleware" do
-      assert_equal(0, rescue_middleware.rescue_table.length)
+      assert_equal(1, rescue_middleware.rescue_table.length)
       # normally, you'd use a real class, not a symbol:
       schema.rescue_from(:error_class) { "my custom message" }
-      assert_equal(1, rescue_middleware.rescue_table.length)
+      assert_equal(2, rescue_middleware.rescue_table.length)
     end
   end
 end

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe GraphQL::Schema do
+  let(:schema) { DummySchema }
+
+  describe "#rescue_from" do
+    let(:rescue_middleware) { schema.middleware.first }
+
+    it "adds handlers to the rescue middleware" do
+      assert_equal(0, rescue_middleware.rescue_table.length)
+      # normally, you'd use a real class, not a symbol:
+      schema.rescue_from(:error_class) { "my custom message" }
+      assert_equal(1, rescue_middleware.rescue_table.length)
+    end
+  end
+end

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -1,5 +1,7 @@
 require_relative './dairy_data'
 
+class NoSuchDairyError < StandardError; end
+
 EdibleInterface = GraphQL::InterfaceType.define do
   name "Edible"
   description "Something you can eat, yum"
@@ -42,7 +44,7 @@ CheeseType = GraphQL::ObjectType.define do
       # get the strings out:
       sources = a["source"].map(&:name)
       if sources.include?("YAK")
-        GraphQL::ExecutionError.new("No cheeses are made from Yak milk!")
+        raise NoSuchDairyError.new("No cheeses are made from Yak milk!")
       else
         CHEESES.values.find { |c| sources.include?(c.source) }
       end
@@ -218,3 +220,4 @@ MutationType = GraphQL::ObjectType.define do
 end
 
 DummySchema = GraphQL::Schema.new(query: QueryType, mutation: MutationType)
+DummySchema.rescue_from(NoSuchDairyError) { |err| err.message  }


### PR DESCRIPTION
- Add middleware to query execution 
  - This could also be used for metrics or permissions 
- Add RescueMiddleware for handling exceptions 

The resulting API: 

```ruby
MySchema.rescue_from(ActiveRecord::NotFound) { |err| "Some items weren't found" }
```

When a field raises that error, the field returns `nil` and the error message is put in the response