### PR TITLE
Fix link in Introduction guide to Defining Your Schema guide.

### DIFF
--- a/guides/introduction.md
+++ b/guides/introduction.md
@@ -159,5 +159,5 @@ p JSON.dump(result_hash)
 
 Read more in some other guides:
 
-- [Type & Field Helpers](http://www.rubydoc.info/github/rmosolgo/graphql-ruby/file/guides/type_and_field_helpers.md)
+- [Defining Your Schema](http://www.rubydoc.info/github/rmosolgo/graphql-ruby/file/guides/defining_your_schema.md)
 - [Executing Queries](http://www.rubydoc.info/github/rmosolgo/graphql-ruby/file/guides/executing_queries.md)


### PR DESCRIPTION
## Problem

Go to the [Introduction guide](https://github.com/rmosolgo/graphql-ruby/blob/6c66f7c85dd93d7346cd308010644beb3b2e9b9c/guides/introduction.md#more-info) and click on the "Type & Field Helpers" link and it will take you to a 404 page.

## Solution

The guide being linked to was renamed to [Defining Your Schema](https://github.com/rmosolgo/graphql-ruby/blob/6c66f7c85dd93d7346cd308010644beb3b2e9b9c/guides/defining_your_schema.md), so I linked to that instead.