### PR TITLE
Implement a schema printer

### DIFF
--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -55,6 +55,7 @@ require 'graphql/introspection'
 require 'graphql/language'
 require 'graphql/directive'
 require 'graphql/schema'
+require 'graphql/schema/printer'
 
 # Order does not matter for these:
 

--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -59,25 +59,11 @@ module GraphQL
       end
     end
 
-    # Print the human-readable name of this type
+    # Print the human-readable name of this type using the query-string naming pattern
     def to_s
-      Printer.instance.print(self)
+      name
     end
 
     alias :inspect :to_s
-
-    # Print a type, using the query-style naming pattern
-    class Printer
-      include Singleton
-      def print(type)
-        if type.kind.non_null?
-          "#{print(type.of_type)}!"
-        elsif type.kind.list?
-          "[#{print(type.of_type)}]"
-        else
-          type.name
-        end
-      end
-    end
   end
 end

--- a/lib/graphql/introspection/arguments_field.rb
+++ b/lib/graphql/introspection/arguments_field.rb
@@ -1,5 +1,5 @@
 GraphQL::Introspection::ArgumentsField = GraphQL::Field.define do
   description "Arguments allowed to this object"
-  type GraphQL::ListType.new(of_type: GraphQL::Introspection::InputValueType)
+  type !GraphQL::ListType.new(of_type: !GraphQL::Introspection::InputValueType)
   resolve -> (target, a, c) { target.arguments.values }
 end

--- a/lib/graphql/introspection/field_type.rb
+++ b/lib/graphql/introspection/field_type.rb
@@ -2,7 +2,7 @@ GraphQL::Introspection::FieldType = GraphQL::ObjectType.define do
   name "__Field"
   description "Field on a GraphQL type"
   field :name, !types.String, "The name for accessing this field"
-  field :description, !types.String, "The description of this field"
+  field :description, types.String, "The description of this field"
   field :type, !GraphQL::Introspection::TypeType, "The return type of this field"
   field :isDeprecated, !types.Boolean, "Is this field deprecated?" do
       resolve -> (obj, a, c) { !!obj.deprecation_reason }

--- a/lib/graphql/introspection/input_fields_field.rb
+++ b/lib/graphql/introspection/input_fields_field.rb
@@ -1,7 +1,7 @@
 GraphQL::Introspection::InputFieldsField = GraphQL::Field.define do
   name "inputFields"
   description "fields on this input object"
-  type types[GraphQL::Introspection::InputValueType]
+  type types[!GraphQL::Introspection::InputValueType]
   resolve -> (target, a, c) {
     if target.kind.input_object?
       target.input_fields.values

--- a/lib/graphql/introspection/input_value_type.rb
+++ b/lib/graphql/introspection/input_value_type.rb
@@ -3,6 +3,6 @@ GraphQL::Introspection::InputValueType = GraphQL::ObjectType.define do
   description "An input for a field or InputObject"
   field :name, !types.String, "The key for this value"
   field :description, types.String, "What this value is used for"
-  field :type, -> { GraphQL::Introspection::TypeType }, "The expected type for this value"
+  field :type, -> { !GraphQL::Introspection::TypeType }, "The expected type for this value"
   field :defaultValue, types.String, "The value applied if no other value is provided", property: :default_value
 end

--- a/lib/graphql/introspection/interfaces_field.rb
+++ b/lib/graphql/introspection/interfaces_field.rb
@@ -1,5 +1,5 @@
 GraphQL::Introspection::InterfacesField = GraphQL::Field.define do
   description "Interfaces which this object implements"
-  type -> { !types[!GraphQL::Introspection::TypeType] }
+  type -> { types[!GraphQL::Introspection::TypeType] }
   resolve -> (target, a, c) { target.kind.object? ? target.interfaces : nil }
 end

--- a/lib/graphql/introspection/possible_types_field.rb
+++ b/lib/graphql/introspection/possible_types_field.rb
@@ -1,5 +1,5 @@
 GraphQL::Introspection::PossibleTypesField = GraphQL::Field.define do
   description "Types which compose this Union or Interface"
-  type -> { types[GraphQL::Introspection::TypeType] }
+  type -> { types[!GraphQL::Introspection::TypeType] }
   resolve -> (target, a, c) { target.kind.resolves? ? target.possible_types : nil }
 end

--- a/lib/graphql/introspection/type_type.rb
+++ b/lib/graphql/introspection/type_type.rb
@@ -2,11 +2,11 @@ GraphQL::Introspection::TypeType = GraphQL::ObjectType.define do
   name "__Type"
   description "A type in the GraphQL schema"
 
-  field :name, !types.String,  "The name of this type"
+  field :name, types.String,  "The name of this type"
   field :description, types.String, "What this type represents"
 
   field :kind do
-    type GraphQL::Introspection::TypeKindEnum
+    type !GraphQL::Introspection::TypeKindEnum
     description "The kind of this type"
     resolve -> (target, a, c) { target.kind.name }
   end

--- a/lib/graphql/list_type.rb
+++ b/lib/graphql/list_type.rb
@@ -12,4 +12,8 @@ class GraphQL::ListType < GraphQL::BaseType
   def kind
     GraphQL::TypeKinds::LIST
   end
+
+  def to_s
+    "[#{of_type.to_s}]"
+  end
 end

--- a/lib/graphql/non_null_type.rb
+++ b/lib/graphql/non_null_type.rb
@@ -20,4 +20,8 @@ class GraphQL::NonNullType < GraphQL::BaseType
   def kind
     GraphQL::TypeKinds::NON_NULL
   end
+
+  def to_s
+    "#{of_type.to_s}!"
+  end
 end

--- a/lib/graphql/schema/printer.rb
+++ b/lib/graphql/schema/printer.rb
@@ -42,90 +42,104 @@ module GraphQL
     end
 
     def print_type(type)
-      case type
-      when ScalarType
-        print_scalar(type)
-      when ObjectType
-        print_object(type)
-      when InterfaceType
-        print_interface(type)
-      when UnionType
-        print_union(type)
-      when EnumType
-        print_enum(type)
-      when InputObjectType
-        print_input_object(type)
-      else
-        raise NotImplementedError, "Unexpected type #{type.class}"
+      TypeKindPrinters::STRATEGIES.fetch(type.kind).print(type)
+    end
+
+    module TypeKindPrinters
+      module FieldPrinter
+        def print_fields(type)
+          type.fields.values.map{ |field| "  #{field.name}#{print_args(field)}: #{field.type}" }.join("\n")
+        end
+
+        def print_args(field)
+          return if field.arguments.empty?
+          "(#{field.arguments.values.map{ |arg| print_input_value(arg) }.join(", ")})"
+        end
+
+        def print_input_value(arg)
+          default_string = " = #{print_value(arg.default_value, arg.type)}" unless arg.default_value.nil?
+          "#{arg.name}: #{arg.type.to_s}#{default_string}"
+        end
+
+        def print_value(value, type)
+          case type
+          when FLOAT_TYPE
+            value.to_f.inspect
+          when INT_TYPE
+            value.to_i.inspect
+          when BOOLEAN_TYPE
+            (!!value).inspect
+          when ScalarType, ID_TYPE, STRING_TYPE
+            value.to_s.inspect
+          when EnumType
+            value.to_s
+          when InputObjectType
+            fields = value.to_h.map{ |field_name, field_value|
+              field_type = type.input_fields.fetch(field_name.to_s).type
+              "#{field_name}: #{print_value(field_value, field_type)}"
+            }.join(", ")
+            "{ #{fields} }"
+          when NonNullType
+            print_value(value, type.of_type)
+          when ListType
+            "[#{value.to_a.map{ |v| print_value(v, type.of_type) }.join(", ")}]"
+          else
+            raise NotImplementedError, "Unexpected value type #{type.inspect}"
+          end
+        end
       end
-    end
 
-    def print_scalar(type)
-      "scalar #{type.name}"
-    end
-
-    def print_object(type)
-      implementations = " implements #{type.interfaces.map(&:to_s).join(", ")}" unless type.interfaces.empty?
-      "type #{type.name}#{implementations} {\n#{print_fields(type)}\n}"
-    end
-
-    def print_interface(type)
-      "interface #{type.name} {\n#{print_fields(type)}\n}"
-    end
-
-    def print_union(type)
-      "union #{type.name} = #{type.possible_types.map(&:to_s).join(" | ")}\n}"
-    end
-
-    def print_enum(type)
-      values = type.values.values.map{ |v| "  #{v.name}" }.join("\n")
-      "enum #{type.name} {\n#{values}\n}"
-    end
-
-    def print_input_object(type)
-      fields = type.input_fields.values.map{ |field| "  #{print_input_value(field)}" }.join("\n")
-      "input #{type.name} {\n#{fields}\n}"
-    end
-
-    def print_fields(type)
-      type.fields.values.map{ |field| "  #{field.name}#{print_args(field)}: #{field.type}" }.join("\n")
-    end
-
-    def print_args(field)
-      return if field.arguments.empty?
-      "(#{field.arguments.values.map{ |arg| print_input_value(arg) }.join(", ")})"
-    end
-
-    def print_input_value(arg)
-      default_string = " = #{print_value(arg.default_value, arg.type)}" unless arg.default_value.nil?
-      "#{arg.name}: #{arg.type.to_s}#{default_string}"
-    end
-
-    def print_value(value, type)
-      case type
-      when FLOAT_TYPE
-        value.to_f.inspect
-      when INT_TYPE
-        value.to_i.inspect
-      when BOOLEAN_TYPE
-        (!!value).inspect
-      when ScalarType, ID_TYPE, STRING_TYPE
-        value.to_s.inspect
-      when EnumType
-        value.to_s
-      when InputObjectType
-        fields = value.to_h.map{ |field_name, field_value|
-          field_type = type.input_fields.fetch(field_name.to_s).type
-          "#{field_name}: #{print_value(field_value, field_type)}"
-        }.join(", ")
-        "{ #{fields} }"
-      when NonNullType
-        print_value(value, type.of_type)
-      when ListType
-        "[#{value.to_a.map{ |v| print_value(v, type.of_type) }.join(", ")}]"
-      else
-        raise NotImplementedError, "Unexpected value type #{type.inspect}"
+      class ScalarPrinter
+        def self.print(type)
+          "scalar #{type.name}"
+        end
       end
+
+      class ObjectPrinter
+        extend FieldPrinter
+        def self.print(type)
+          implementations = " implements #{type.interfaces.map(&:to_s).join(", ")}" unless type.interfaces.empty?
+          "type #{type.name}#{implementations} {\n#{print_fields(type)}\n}"
+        end
+      end
+
+      class InterfacePrinter
+        extend FieldPrinter
+        def self.print(type)
+          "interface #{type.name} {\n#{print_fields(type)}\n}"
+        end
+      end
+
+      class UnionPrinter
+        def self.print(type)
+          "union #{type.name} = #{type.possible_types.map(&:to_s).join(" | ")}\n}"
+        end
+      end
+
+      class EnumPrinter
+        def self.print(type)
+          values = type.values.values.map{ |v| "  #{v.name}" }.join("\n")
+          "enum #{type.name} {\n#{values}\n}"
+        end
+      end
+
+      class InputObjectPrinter
+        extend FieldPrinter
+        def self.print(type)
+          fields = type.input_fields.values.map{ |field| "  #{print_input_value(field)}" }.join("\n")
+          "input #{type.name} {\n#{fields}\n}"
+        end
+      end
+
+      STRATEGIES = {
+        GraphQL::TypeKinds::SCALAR =>       ScalarPrinter,
+        GraphQL::TypeKinds::OBJECT =>       ObjectPrinter,
+        GraphQL::TypeKinds::INTERFACE =>    InterfacePrinter,
+        GraphQL::TypeKinds::UNION =>        UnionPrinter,
+        GraphQL::TypeKinds::ENUM =>         EnumPrinter,
+        GraphQL::TypeKinds::INPUT_OBJECT => InputObjectPrinter,
+      }
     end
+    private_constant :TypeKindPrinters
   end
 end

--- a/lib/graphql/schema/printer.rb
+++ b/lib/graphql/schema/printer.rb
@@ -1,0 +1,131 @@
+module GraphQL
+  # Used to convert your {GraphQL::Schema} to a GraphQL schema string
+  #
+  # @example print your schema to standard output
+  #   Schema = GraphQL::Schema.new(query: QueryType)
+  #   puts GraphQL::Schema::Printer.print_schema(Schema)
+  #
+  module Schema::Printer
+    extend self
+
+    # Return a GraphQL schema string for the defined types in the schema
+    # @param schema [GraphQL::Schema]
+    def print_schema(schema)
+      print_filtered_schema(schema, method(:is_defined_type))
+    end
+
+    # Return the GraphQL schema string for the introspection type system
+    def print_introspection_schema
+      query_root = ObjectType.define do
+        name "Query"
+      end
+      schema = Schema.new(query: query_root)
+      print_filtered_schema(schema, method(:is_introspection_type))
+    end
+
+    private
+
+    def print_filtered_schema(schema, type_filter)
+      types = schema.types.values.select{ |type| type_filter.call(type) }.sort_by(&:name)
+      types.map{ |type| print_type(type) }.join("\n\n")
+    end
+
+    BUILTIN_SCALARS = Set.new(["String", "Boolean", "Int", "Float", "ID"])
+    private_constant :BUILTIN_SCALARS
+
+    def is_introspection_type(type)
+      type.name.start_with?("__")
+    end
+
+    def is_defined_type(type)
+      !is_introspection_type(type) && !BUILTIN_SCALARS.include?(type.name)
+    end
+
+    def print_type(type)
+      case type
+      when ScalarType
+        print_scalar(type)
+      when ObjectType
+        print_object(type)
+      when InterfaceType
+        print_interface(type)
+      when UnionType
+        print_union(type)
+      when EnumType
+        print_enum(type)
+      when InputObjectType
+        print_input_object(type)
+      else
+        raise NotImplementedError, "Unexpected type #{type.class}"
+      end
+    end
+
+    def print_scalar(type)
+      "scalar #{type.name}"
+    end
+
+    def print_object(type)
+      implementations = " implements #{type.interfaces.map(&:to_s).join(", ")}" unless type.interfaces.empty?
+      "type #{type.name}#{implementations} {\n#{print_fields(type)}\n}"
+    end
+
+    def print_interface(type)
+      "interface #{type.name} {\n#{print_fields(type)}\n}"
+    end
+
+    def print_union(type)
+      "union #{type.name} = #{type.possible_types.map(&:to_s).join(" | ")}\n}"
+    end
+
+    def print_enum(type)
+      values = type.values.values.map{ |v| "  #{v.name}" }.join("\n")
+      "enum #{type.name} {\n#{values}\n}"
+    end
+
+    def print_input_object(type)
+      fields = type.input_fields.values.map{ |field| "  #{print_input_value(field)}" }.join("\n")
+      "input #{type.name} {\n#{fields}\n}"
+    end
+
+    def print_fields(type)
+      type.fields.values.map{ |field| "  #{field.name}#{print_args(field)}: #{field.type}" }.join("\n")
+    end
+
+    def print_args(field)
+      return if field.arguments.empty?
+      "(#{field.arguments.values.map{ |arg| print_input_value(arg) }.join(", ")})"
+    end
+
+    def print_input_value(arg)
+      default_string = " = #{print_value(arg.default_value, arg.type)}" unless arg.default_value.nil?
+      "#{arg.name}: #{arg.type.to_s}#{default_string}"
+    end
+
+    def print_value(value, type)
+      case type
+      when FLOAT_TYPE
+        value.to_f.inspect
+      when INT_TYPE
+        value.to_i.inspect
+      when BOOLEAN_TYPE
+        (!!value).inspect
+      when ScalarType, ID_TYPE, STRING_TYPE
+        value.to_s.inspect
+      when EnumType
+        value.to_s
+      when InputObjectType
+        fields = value.to_h.map{ |field_name, field_value|
+          field_type = type.input_fields.fetch(field_name.to_s).type
+          "#{field_name}: #{print_value(field_value, field_type)}"
+        }.join(", ")
+        "{ #{fields} }"
+      when NonNullType
+        print_value(value, type.of_type)
+      when ListType
+        "[#{value.to_a.map{ |v| print_value(v, type.of_type) }.join(", ")}]"
+      else
+        raise NotImplementedError, "Unexpected value type #{type.inspect}"
+      end
+    end
+  end
+end

--- a/spec/graphql/schema/printer_spec.rb
+++ b/spec/graphql/schema/printer_spec.rb
@@ -1,0 +1,178 @@
+require 'spec_helper'
+
+describe GraphQL::Schema::Printer do
+  let(:schema) {
+    node_type = GraphQL::InterfaceType.define do
+      name "Node"
+
+      field :id, !types.ID
+    end
+
+    choice_type = GraphQL::EnumType.define do
+      name "Choice"
+
+      value "FOO"
+      value "BAR"
+    end
+
+    sub_input_type = GraphQL::InputObjectType.define do
+      name "Sub"
+      input_field :string, types.String
+    end
+
+    variant_input_type = GraphQL::InputObjectType.define do
+      name "Varied"
+      input_field :id, types.ID
+      input_field :int, types.Int
+      input_field :float, types.Float
+      input_field :bool, types.Boolean
+      input_field :enum, choice_type
+      input_field :sub, types[sub_input_type]
+    end
+
+    comment_type = GraphQL::ObjectType.define do
+      name "Comment"
+      description "A blog comment"
+      interfaces [node_type]
+
+      field :id, !types.ID
+    end
+
+    post_type = GraphQL::ObjectType.define do
+      name "Post"
+      description "A blog post"
+
+      field :id, !types.ID
+      field :title, !types.String
+      field :body, !types.String
+      field :comments, types[!comment_type]
+    end
+
+    query_root = GraphQL::ObjectType.define do
+      name "Query"
+      description "The query root of this schema"
+
+      field :post do
+        type post_type
+        argument :id, !types.ID
+        argument :varied, variant_input_type, default_value: { id: "123", int: 234, float: 2.3, enum: "FOO", sub: [{ string: "str" }] }
+        resolve -> (obj, args, ctx) { Post.find(args["id"]) }
+      end
+    end
+
+    GraphQL::Schema.new(query: query_root)
+  }
+
+  describe ".print_introspection_schema" do
+    it "returns the schema as a string for the introspection types" do
+      expected = <<SCHEMA
+type __Directive {
+  name: String!
+  description: String
+  args: [__InputValue!]!
+  onOperation: Boolean!
+  onFragment: Boolean!
+  onField: Boolean!
+}
+
+type __EnumValue {
+  name: String!
+  description: String
+  deprecationReason: String
+  isDeprecated: Boolean!
+}
+
+type __Field {
+  name: String!
+  description: String
+  type: __Type!
+  isDeprecated: Boolean!
+  args: [__InputValue!]!
+  deprecationReason: String
+}
+
+type __InputValue {
+  name: String!
+  description: String
+  type: __Type!
+  defaultValue: String
+}
+
+type __Schema {
+  types: [__Type!]!
+  directives: [__Directive!]!
+  queryType: __Type!
+  mutationType: __Type
+}
+
+type __Type {
+  name: String
+  description: String
+  kind: __TypeKind!
+  fields(includeDeprecated: Boolean = false): [__Field!]
+  ofType: __Type
+  inputFields: [__InputValue!]
+  possibleTypes: [__Type!]
+  enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
+  interfaces: [__Type!]
+}
+
+enum __TypeKind {
+  SCALAR
+  OBJECT
+  INTERFACE
+  UNION
+  ENUM
+  INPUT_OBJECT
+  LIST
+  NON_NULL
+}
+SCHEMA
+      assert_equal expected.chomp, GraphQL::Schema::Printer.print_introspection_schema
+    end
+  end
+
+  describe ".print_schema" do
+    it "returns the schema as a string for the defined types" do
+      expected = <<SCHEMA
+enum Choice {
+  FOO
+  BAR
+}
+
+type Comment implements Node {
+  id: ID!
+}
+
+interface Node {
+  id: ID!
+}
+
+type Post {
+  id: ID!
+  title: String!
+  body: String!
+  comments: [Comment!]
+}
+
+type Query {
+  post(id: ID!, varied: Varied = { id: \"123\", int: 234, float: 2.3, enum: FOO, sub: [{ string: \"str\" }] }): Post
+}
+
+input Sub {
+  string: String
+}
+
+input Varied {
+  id: ID
+  int: Int
+  float: Float
+  bool: Boolean
+  enum: Choice
+  sub: [Sub]
+}
+SCHEMA
+      assert_equal expected.chomp, GraphQL::Schema::Printer.print_schema(schema)
+    end
+  end
+end


### PR DESCRIPTION
This implements the schema printer, similar to the one in [graphl-js](https://github.com/graphql/graphql-js/blob/v0.4.4/src/utilities/schemaPrinter.js), which outputs the schema as a string in graphql format.

This can be useful for inspecting the schema, which actually turned up some differences between the inspection type system in graphql-ruby and the [graphql specification](http://facebook.github.io/graphql/#sec-Schema-Introspection), which I also fixed in this pull request.

Being able to save the schema is also useful for sharing with a client, which may be written in another language.