### PR TITLE
Seperate input and result coercion for scalars.

### DIFF
--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -70,8 +70,8 @@ module GraphQL
     # Raise an error if the value becomes nil.
     # @param [Object] Incoming query value
     # @return [Object] Coerced value for query execution
-    def coerce!(input_value)
-      coerced_value = coerce(input_value)
+    def coerce_input!(input_value)
+      coerced_value = coerce_input(input_value)
 
       if coerced_value.nil?
         raise GraphQL::ExecutionError.new("Couldn't coerce #{input_value.inspect} to #{self.unwrap.name}")

--- a/lib/graphql/definition_helpers/defined_by_config.rb
+++ b/lib/graphql/definition_helpers/defined_by_config.rb
@@ -31,7 +31,9 @@ module GraphQL::DefinitionHelpers::DefinedByConfig
       :possible_types, # interface / union
       :default_value, # argument
       :on, # directive
-      :coerce #scalar
+      :coerce, #scalar
+      :coerce_input, #scalar
+      :coerce_result #scalar
 
     attr_reader :fields, :input_fields, :arguments, :values
 
@@ -41,7 +43,7 @@ module GraphQL::DefinitionHelpers::DefinedByConfig
       @on = []
       @fields = {}
       @arguments = {}
-      @values = {}
+      @values = []
       @input_fields = {}
     end
 
@@ -64,8 +66,7 @@ module GraphQL::DefinitionHelpers::DefinedByConfig
 
     # For EnumType
     def value(name, desc = nil, deprecation_reason: nil, value: name)
-      value = GraphQL::EnumType::EnumValue.new(name: name, description: description, deprecation_reason: deprecation_reason, value: value)
-      values[name] = value
+      values << GraphQL::EnumType::EnumValue.new(name: name, description: description, deprecation_reason: deprecation_reason, value: value)
     end
 
     # For InputObjectType

--- a/lib/graphql/enum_type.rb
+++ b/lib/graphql/enum_type.rb
@@ -14,8 +14,17 @@ class GraphQL::EnumType < GraphQL::BaseType
   attr_accessor :name, :description, :values
   defined_by_config :name, :description, :values
 
+  def values=(values)
+    @values_by_name = {}
+    @values_by_value = {}
+    values.each do |enum_value|
+      @values_by_name[enum_value.name] = enum_value
+      @values_by_value[enum_value.value] = enum_value
+    end
+  end
+
   def values
-    @values ||= {}
+    @values_by_name
   end
 
   # Define a value within this enum
@@ -40,8 +49,12 @@ class GraphQL::EnumType < GraphQL::BaseType
   #
   # @param value_name [String] the string representation of this enum value
   # @return [Object] the underlying value for this enum value
-  def coerce(value_name)
-    values[value_name].value
+  def coerce_input(value_name)
+    @values_by_name.fetch(value_name).value
+  end
+
+  def coerce_result(value)
+    @values_by_value.fetch(value).name
   end
 
   def to_s

--- a/lib/graphql/non_null_type.rb
+++ b/lib/graphql/non_null_type.rb
@@ -13,8 +13,12 @@ class GraphQL::NonNullType < GraphQL::BaseType
     "Non-Null"
   end
 
-  def coerce(value)
-    of_type.coerce(value)
+  def coerce_input(value)
+    of_type.coerce_input(value)
+  end
+
+  def coerce_result(value)
+    of_type.coerce_result(value)
   end
 
   def kind

--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -25,9 +25,9 @@ class GraphQL::Query::Arguments
   def reduce_value(value, arg_defn, variables)
     if value.is_a?(GraphQL::Language::Nodes::VariableIdentifier)
       raw_value = variables[value.name]
-      value = arg_defn.type.coerce!(raw_value)
+      value = arg_defn.type.coerce_input!(raw_value)
     elsif value.is_a?(GraphQL::Language::Nodes::Enum)
-      value = arg_defn.type.coerce!(value.name)
+      value = arg_defn.type.coerce_input!(value.name)
     elsif value.is_a?(GraphQL::Language::Nodes::InputObject)
       wrapped_type = arg_defn.type.unwrap
       value = self.class.new(value.pairs, wrapped_type.input_fields, variables)

--- a/lib/graphql/query/base_execution/value_resolution.rb
+++ b/lib/graphql/query/base_execution/value_resolution.rb
@@ -29,9 +29,9 @@ module GraphQL
         end
 
         class ScalarResolution < BaseResolution
-          # Apply the scalar's defined `coerce` method to the value
+          # Apply the scalar's defined `coerce_result` method to the value
           def result
-            field_type.coerce(value)
+            field_type.coerce_result(value)
           end
         end
 
@@ -60,7 +60,7 @@ module GraphQL
         class EnumResolution < BaseResolution
           # Get the string name for this enum value
           def result
-             value.to_s
+            field_type.coerce_result(value)
           end
         end
 

--- a/lib/graphql/scalar_type.rb
+++ b/lib/graphql/scalar_type.rb
@@ -1,6 +1,15 @@
 module GraphQL
   # The parent type for scalars, eg {GraphQL::STRING_TYPE}, {GraphQL::INT_TYPE}
   #
+  # @example defining a type for Time
+  #   TimeType = GraphQL::ObjectType.define do
+  #     name "Time"
+  #     description "Time since epoch in seconds"
+  #
+  #     coerce_input ->(value) { Time.at(Float(value)) }
+  #     coerce_result ->(value) { value.to_f }
+  #   end
+  #
   class ScalarType < GraphQL::BaseType
     defined_by_config :name, :coerce, :coerce_input, :coerce_result, :description
     attr_accessor :name, :description

--- a/lib/graphql/scalar_type.rb
+++ b/lib/graphql/scalar_type.rb
@@ -2,15 +2,28 @@ module GraphQL
   # The parent type for scalars, eg {GraphQL::STRING_TYPE}, {GraphQL::INT_TYPE}
   #
   class ScalarType < GraphQL::BaseType
-    defined_by_config :name, :coerce, :description
+    defined_by_config :name, :coerce, :coerce_input, :coerce_result, :description
     attr_accessor :name, :description
 
-    def coerce(value)
-      @coerce_proc.call(value)
+    def coerce=(proc)
+      self.coerce_input = proc
+      self.coerce_result = proc
     end
 
-    def coerce=(proc)
-      @coerce_proc = proc
+    def coerce_input(value)
+      @coerce_input_proc.call(value)
+    end
+
+    def coerce_input=(proc)
+      @coerce_input_proc = proc unless proc.nil?
+    end
+
+    def coerce_result(value)
+      @coerce_result_proc.call(value)
+    end
+
+    def coerce_result=(proc)
+      @coerce_result_proc = proc unless proc.nil?
     end
 
     def kind

--- a/lib/graphql/static_validation/literal_validator.rb
+++ b/lib/graphql/static_validation/literal_validator.rb
@@ -7,9 +7,9 @@ class GraphQL::StaticValidation::LiteralValidator
       item_type = type.of_type
       ast_value.all? { |val| validate(val, item_type) }
     elsif type.kind.scalar?
-      !type.coerce(ast_value).nil?
+      !type.coerce_input(ast_value).nil?
     elsif type.kind.enum? && ast_value.is_a?(GraphQL::Language::Nodes::Enum)
-      !type.coerce(ast_value.name).nil?
+      !type.coerce_input(ast_value.name).nil?
     elsif type.kind.input_object? && ast_value.is_a?(GraphQL::Language::Nodes::InputObject)
       fields = type.input_fields
       ast_value.pairs.all? do |value|

--- a/spec/graphql/enum_type_spec.rb
+++ b/spec/graphql/enum_type_spec.rb
@@ -4,7 +4,12 @@ describe GraphQL::EnumType do
   let(:enum) { DairyAnimalEnum }
 
   it 'coerces names to underlying values' do
-    assert_equal("YAK", enum.coerce("YAK"))
-    assert_equal(1, enum.coerce("COW"))
+    assert_equal("YAK", enum.coerce_input("YAK"))
+    assert_equal(1, enum.coerce_input("COW"))
+  end
+
+  it 'coerces result values to value name' do
+    assert_equal("YAK", enum.coerce_result("YAK"))
+    assert_equal("COW", enum.coerce_result(1))
   end
 end

--- a/spec/graphql/query/value_resolution_spec.rb
+++ b/spec/graphql/query/value_resolution_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe GraphQL::Query::BaseExecution::ValueResolution do
+  let(:debug) { false }
+  let(:query_root) {
+    day_of_week_enum = GraphQL::EnumType.define do
+      name "DayOfWeek"
+      value("MONDAY", value: 0)
+      value("TUESDAY", value: 1)
+      value("WEDNESDAY", value: 2)
+      value("THURSDAY", value: 3)
+      value("FRIDAY", value: 4)
+      value("SATURDAY", value: 5)
+      value("SUNDAY", value: 6)
+    end
+    GraphQL::ObjectType.define do
+      name "Query"
+      field :tomorrow, day_of_week_enum do
+        argument :today, day_of_week_enum
+        resolve ->(obj, args, ctx) { (args['today'] + 1) % 7 }
+      end
+    end
+  }
+  let(:schema) { GraphQL::Schema.new(query: query_root) }
+  let(:result) { schema.execute(
+    query_string,
+    debug: debug,
+  )}
+
+  describe "enum resolution" do
+    let(:query_string) { %|
+      {
+        tomorrow(today: FRIDAY)
+      }
+    |}
+
+    it "coerces enum input to the value and result to the name" do
+      expected = {
+        "data" => {
+          "tomorrow" => "SATURDAY"
+        }
+      }
+      assert_equal(expected, result)
+    end
+  end
+end


### PR DESCRIPTION
This is the start of a fix for issue #47, which splits input and result coercion.

The most noticeable change is that enum's now get properly coerced to their value and their value gets coerced back to the enum name in result coercion.

However, as noted in https://github.com/rmosolgo/graphql-ruby/issues/46#issuecomment-145977865, we aren't actually actually coercing most values, so the follow-up to this will add input coercion for non-scalars, so we can coerce all values in `GraphQL::Query::Arguments`.