### PR TITLE
Fix parslet transformation for unnamed operations.

### DIFF
--- a/lib/graphql/language/parser.rb
+++ b/lib/graphql/language/parser.rb
@@ -38,7 +38,7 @@ module GraphQL
       rule(:unnamed_selections) { selections.as(:unnamed_selections)}
       rule(:typed_operation_definition) {
         operation_type.as(:operation_type) >> space? >>
-        name.as(:name).maybe >> space? >>
+        name.maybe.as(:name) >> space? >>
         operation_variable_definitions.maybe.as(:optional_variables).as(:variables) >> space? >>
         directives.maybe.as(:optional_directives).as(:directives) >> space? >>
         selections.as(:selections)

--- a/spec/graphql/language/transform_spec.rb
+++ b/spec/graphql/language/transform_spec.rb
@@ -118,4 +118,9 @@ describe GraphQL::Language::Transform do
     assert_equal("someFlag", res.name)
     assert_equal([], res.arguments, 'gets [] if no args')
   end
+
+  it 'transforms unnamed operations' do
+    assert_equal(1, get_result("query { me }").parts.length)
+    assert_equal(1, get_result("mutation { touch }").parts.length)
+  end
 end


### PR DESCRIPTION
Previously the operation wouldn't be transformed if the operation name is missing

```
irb> GraphQL.parse('query { name }')
=> {:document_parts=>[{:operation_type=>"query"@0, :variables=>[], :directives=>[], :selections=>[#<GraphQL::Language::Nodes::Field:0x007fac6157a278 @name="name", @alias=nil, @arguments=[], @directives=[], @selections=[], @line=1, @col=9>]}]}
```

returning a hash from GraphQL.parse rather than a GraphQL::Language::Nodes::Document object, resulting in queries to fail with an exception like `NoMethodError - undefined method `parts' for #<Hash:0x007f5fc63dc3e0>`

I fixed this by having it capture the optional name rather than making the capture optional, since the transform needs that `:name` key to exist in the hash.