### PR TITLE
Fix delegators on GraphQL::Query::Arguments.

### DIFF
--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -8,7 +8,7 @@ module GraphQL
 
       def initialize(values)
         @values = values.inject({}) do |memo, (inner_key, inner_value)|
-          memo[inner_key] = wrap_value(inner_value)
+          memo[inner_key.to_s] = wrap_value(inner_value)
           memo
         end
       end
@@ -19,7 +19,7 @@ module GraphQL
         @values[key.to_s]
       end
 
-      def_delegators :@values_hash, :keys, :values, :each
+      def_delegators :@values, :keys, :values, :each
 
       private
 

--- a/spec/graphql/query/arguments_spec.rb
+++ b/spec/graphql/query/arguments_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+describe GraphQL::Query::Arguments do
+  let(:arguments) { GraphQL::Query::Arguments.new({ a: 1, b: 2 }) }
+
+  it 'returns keys as strings' do
+    assert_equal(['a', 'b'], arguments.keys)
+  end
+
+  it 'delegates values to values hash' do
+    assert_equal([1, 2], arguments.values)
+  end
+
+  it 'delegates each to values hash' do
+    pairs = []
+    arguments.each do |key, value|
+      pairs << [key, value]
+    end
+    assert_equal([['a', 1], ['b', 2]], pairs)
+  end
+end


### PR DESCRIPTION
## Problem

Calling `.each`, `.keys` or `.values` on an GraphQL::Query::Arguments object will result in a NoMethodError (e.g. undefined method `each' for nil:NilClass)

## Solution

def_delegators was just specifying the wrong instance variable name, so I corrected that.