### PR TITLE
Raise when a field's type is not a valid GraphQL::BaseType object

### DIFF
--- a/lib/graphql/schema/type_reducer.rb
+++ b/lib/graphql/schema/type_reducer.rb
@@ -4,7 +4,6 @@ class GraphQL::Schema::TypeReducer
   attr_reader :type, :existing_type_hash
 
   def initialize(type, existing_type_hash)
-    type = type.nil? ? nil : type.unwrap
     validate_type(type)
     if type.respond_to?(:name) && existing_type_hash.fetch(type.name, nil).equal?(type)
       @result = existing_type_hash
@@ -58,7 +57,10 @@ class GraphQL::Schema::TypeReducer
   end
 
   def reduce_type(type, type_hash)
-    self.class.new(type, type_hash).result
+    unless type.is_a?(GraphQL::BaseType)
+      raise GraphQL::Schema::InvalidTypeError.new(type, ["Must be a GraphQL::BaseType"])
+    end
+    self.class.new(type.unwrap, type_hash).result
   end
 
   def validate_type(type)

--- a/spec/graphql/schema/type_reducer_spec.rb
+++ b/spec/graphql/schema/type_reducer_spec.rb
@@ -51,8 +51,20 @@ describe GraphQL::Schema::TypeReducer do
       end
     }
 
-    it 'raises an InvalidTypeError' do
+    let(:another_invalid_type) {
+      GraphQL::ObjectType.define do
+        name "AnotherInvalidType"
+        field :someField, String
+      end
+    }
+
+    it 'raises an InvalidTypeError when passed nil' do
       reducer = GraphQL::Schema::TypeReducer.new(invalid_type, {})
+      assert_raises(GraphQL::Schema::InvalidTypeError) { reducer.result }
+    end
+
+    it 'raises an InvalidTypeError when passed an object that isnt a GraphQL::BaseType' do
+      reducer = GraphQL::Schema::TypeReducer.new(another_invalid_type, {})
       assert_raises(GraphQL::Schema::InvalidTypeError) { reducer.result }
     end
   end


### PR DESCRIPTION
Currently when defining a field with a non-valid type, such an active record model class instead of the GraphQL type, this is raised:

`NoMethodError (undefined method unwrap for #<Class:0x007faf41021848>)`

This PR adds a check in `reduce_type` to see if the type is a subclass of `GraphQL::BaseType`. This removes the need for the nil check in initialize and will help debugging the schema when hitting that problem.

Let me know what you think!
