### PR TITLE
fix transform failure on nested lists in field arguments

### DIFF
--- a/lib/graphql/language/transform.rb
+++ b/lib/graphql/language/transform.rb
@@ -71,7 +71,7 @@ module GraphQL
       rule(alias_name: simple(:a)) { a }
       optional_sequence(:optional_field_arguments)
       rule(field_argument_name: simple(:n), field_argument_value: simple(:v)) { CREATE_NODE[:Argument, name: n.to_s, value: v, position_source: n]}
-      rule(field_argument_name: simple(:n), field_argument_value: sequence(:v)) { CREATE_NODE[:Argument, name: n.to_s, value: v, position_source: n]}
+      rule(field_argument_name: simple(:n), field_argument_value: subtree(:v)) { CREATE_NODE[:Argument, name: n.to_s, value: v, position_source: n]}
       optional_sequence(:optional_selections)
       optional_sequence(:optional_directives)
 
@@ -86,7 +86,7 @@ module GraphQL
       rule(non_null_type: simple(:t)) { CREATE_NODE[:NonNullType, of_type: t, line: t.line, col: t.col] }
 
       # Values
-      rule(array: sequence(:v)) { v }
+      rule(array: subtree(:v)) { v }
       rule(array: simple(:v)) { [] } # just `nil`
       rule(boolean: simple(:v)) { v == "true" ? true : false }
       rule(input_object: sequence(:v)) { CREATE_NODE[:InputObject, pairs: v, line: (v.first ? v.first.line : 1), col: (v.first ? v.first.col : 1)] }

--- a/spec/graphql/language/transform_spec.rb
+++ b/spec/graphql/language/transform_spec.rb
@@ -24,6 +24,7 @@ describe GraphQL::Language::Transform do
           someStuff(vars: [1,2,3])
           someOtherStuff(input: {ints: [1,2,3]})
           someEmptyStuff(emptyObj: {}, emptySpaceObj: { })
+          evenMoreStuff(arg: [[1]])
         }
       }
 


### PR DESCRIPTION
The Parslet transform fails on nested lists in field arguments, leading to line 27 of lib/graphql.rb raising:

```
raise("Parse failed! Sorry, somehow we failed to turn this string into a document. Please report this bug!")
```

I used this spec while figuring out the fix, it's a good example of the issue: https://gist.github.com/charlieschwabacher/d97d6631523aad272b84, the tests at lines 43 and 48 will fail in master.  

I didn't include it in the pull - I think the addition to transform_spec.rb should be enough to cover this, but let me know if there is anywhere you think it would make sense to add a spec similar to that gist.
