### PR TITLE
Allow Automatic camelCase -> snake_case field properties option

### DIFF
--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -35,6 +35,9 @@ end
 
 # Order matters for these:
 
+require 'graphql/config'
+require 'graphql/util'
+
 require 'graphql/definition_helpers'
 require 'graphql/base_type'
 require 'graphql/object_type'

--- a/lib/graphql/config.rb
+++ b/lib/graphql/config.rb
@@ -1,0 +1,6 @@
+class GraphQL::Config
+  @try_underscored_property_names = false
+  class << self
+    attr_accessor :try_underscored_property_names
+  end
+end

--- a/lib/graphql/query/serial_execution/field_resolution.rb
+++ b/lib/graphql/query/serial_execution/field_resolution.rb
@@ -64,7 +64,14 @@ module GraphQL
 
             if value == GraphQL::Query::DEFAULT_RESOLVE
               begin
-                value = target.public_send(ast_node.name)
+                if target.respond_to?(ast_node.name) || !GraphQL::Config.try_underscored_property_names
+                  value = target.public_send(ast_node.name)
+                elsif target.respond_to?(underscored_name = GraphQL::Util.underscore_string(ast_node.name))
+                  value = target.public_send(underscored_name)
+                else
+                  # Fallback just in case #respond_to? was lying
+                  value = target.public_send(ast_node.name)
+                end
               rescue NoMethodError => err
                 raise("Couldn't resolve field '#{ast_node.name}' to #{parent_object.class} '#{parent_object}' (resulted in #{err})")
               end

--- a/lib/graphql/util.rb
+++ b/lib/graphql/util.rb
@@ -1,0 +1,10 @@
+module GraphQL::Util
+  module_function
+
+  # Based on ActiveSupport's String#underscore but less aggressive and monkey-patchy
+  def underscore_string(string)
+    string.gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
+      gsub(/([a-z\d])([A-Z])/,'\1_\2').
+      downcase
+  end
+end


### PR DESCRIPTION
Adds an option to automatically try and use an underscored version of camelcase field names, saving a bit of boilerplate property configuration.

turned on by setting `GraphQL::Config. try_underscored_property_names = true`, which then allows fields like `appearsIn` to be defined without having to manually specify the `property: :appears_in` part. Without this option set, behaviour is unchanged.

I'd like to write some tests, but from a cursory dig I couldn't find tests for any of the field resolution stuff, and I'm not familiar enough with how the codebase ties together to know where to start writing a unit test for this. Happy to take on any pointers :D 

I've swapped this code into the `vendor/bundle` directory of https://github.com/rmosolgo/graphql-ruby-demo, added an intializer to turn on the option, and deleted a bunch of config on the types definitions and it seems to work as expected.