### PR TITLE
Fix parsing and transforming of string escapes.

### DIFF
--- a/lib/graphql/language/parser.rb
+++ b/lib/graphql/language/parser.rb
@@ -99,7 +99,7 @@ module GraphQL
       rule(:value_int) { (value_sign? >> match('\d').repeat(1)).as(:int) }
       rule(:value_string) { str('"') >> value_string_char.repeat.maybe.as(:optional_string_content).as(:string) >> str('"')}
       rule(:value_string_char) { value_string_escaped_char | value_string_escaped_unicode | value_string_source_char}
-      rule(:value_string_escaped_char) { str("\\") >> match('["\/bfnrt]') }
+      rule(:value_string_escaped_char) { str("\\") >> match('["\\\\/bfnrt]') }
       rule(:value_string_escaped_unicode) { str("\\") >> match('u[\dA-Fa-f]{4}')}
       rule(:value_string_source_char) { (str('"') | str("\\") | value_string_line_terminator).absent? >> any }
       rule(:value_string_line_terminator) {

--- a/lib/graphql/language/transform.rb
+++ b/lib/graphql/language/transform.rb
@@ -95,13 +95,14 @@ module GraphQL
       rule(int: simple(:v)) { v.to_i }
       rule(float: simple(:v)) { v.to_f }
 
-      ESCAPES = /\\(["\\\/bfnrt])/
+      ESCAPES = /\\["\\\/bfnrt]/
+      ESCAPES_REPLACE = { '\\"' => '"', "\\\\" => "\\", "\\/" => '/', "\\b" => "\b", "\\f" => "\f", "\\n" => "\n", "\\r" => "\r", "\\t" => "\t" }
       UTF_8 = /\\u[\da-f]{4}/i
       UTF_8_REPLACE = -> (m) { [m[-4..-1].to_i(16)].pack('U') }
 
       rule(string: simple(:v)) {
         string = v.to_s
-        string.gsub!(ESCAPES, '\1')
+        string.gsub!(ESCAPES, ESCAPES_REPLACE)
         string.gsub!(UTF_8, &UTF_8_REPLACE)
         string
       }

--- a/spec/graphql/language/transform_spec.rb
+++ b/spec/graphql/language/transform_spec.rb
@@ -144,4 +144,9 @@ describe GraphQL::Language::Transform do
     assert_equal(1, get_result("query { me }").parts.length)
     assert_equal(1, get_result("mutation { touch }").parts.length)
   end
+
+  it 'transforms escaped characters' do
+    res = get_result("{quoted: \"\\\" \\\\ \\/ \\b \\f \\n \\r \\t\"}", parse: :value_input_object)
+    assert_equal("\" \\ / \b \f \n \r \t", res.pairs[0].value)
+  end
 end


### PR DESCRIPTION
cc @eapache

## Problem

We noticed that newline characters in graphql strings were getting replaced with the character `n`, e.g.

```ruby
require 'graphql'

QueryRoot = GraphQL::ObjectType.define do
  name "Query"

  field :hello, types.String do
    argument :name, types.String
    resolve -> (obj, args, ctx) {
      puts args[:name].inspect
    }
  end
end

Schema = GraphQL::Schema.new(query: QueryRoot)
Schema.execute("{ hello(name: \"new\\nline\") }")
```

outputs `"newnline"` rather than `"new\nline"`

## Solution

The transform on the escaped string was being done with a regex which matched the escaped sequence `\n` but then just replaced it with it with the second character `n` rather than unescaping it.  I instead used a hash as a second argument to `gsub!` to replace `\n` with a newline, along with handling the other control character escapes properly.

During testing I also came across backslash not even getting matched by the parser, since `match('["\/bfnrt]')`was interpreting the backslash as a regexp escape for the following character `/`.  Instead, I needed to double escape the `\`, once because single quoted strings treat `\\` as an escape for `\`, and again to escape it for the regular expression.