### PR TITLE
Correctly handle `interfaces` being re-assigned

### DIFF
--- a/lib/graphql/object_type.rb
+++ b/lib/graphql/object_type.rb
@@ -31,10 +31,11 @@ class GraphQL::ObjectType < GraphQL::BaseType
 
   #   Shovel this type into each interface's `possible_types` array.
   #
-  #   (There's a bug here: if you define interfaces twice, it won't remove previous definitions.)
   #   @param new_interfaces [Array<GraphQL::Interface>] interfaces that this type implements
   def interfaces=(new_interfaces)
-    new_interfaces.each {|i| i.possible_types << self }
+    @interfaces ||= []
+    (@interfaces - new_interfaces).each { |i| i.possible_types.delete(self) }
+    (new_interfaces - @interfaces).each { |i| i.possible_types << self }
     @interfaces = new_interfaces
   end
 

--- a/spec/graphql/interface_type_spec.rb
+++ b/spec/graphql/interface_type_spec.rb
@@ -11,6 +11,24 @@ describe GraphQL::InterfaceType do
     assert_equal(MilkType, interface.resolve_type(MILKS.values.first))
   end
 
+  it 'handles when interfaces are re-assigned' do
+    iface = GraphQL::InterfaceType.define do
+    end
+    type = GraphQL::ObjectType.define do
+      interfaces [iface]
+    end
+    assert_equal([type], iface.possible_types)
+
+    type.interfaces = []
+    assert_equal([], iface.possible_types)
+
+    type.interfaces = [iface]
+    assert_equal([type], iface.possible_types)
+
+    type.interfaces = [iface]
+    assert_equal([type], iface.possible_types)
+  end
+
   describe 'query evaluation' do
     let(:result) { DummySchema.execute(query_string, context: {}, variables: {"cheeseId" => 2})}
     let(:query_string) {%|


### PR DESCRIPTION
cc @dylanahsmith 

Remove stale `possible_types` entries and add to only the ones that are new.

We ran into this due to the way we were structuring some of our code, our schema ended up with duplicate possible types.