### PR TITLE
Add a failing spec for merging fields on interfaces.

### DIFF
--- a/lib/graphql/query/serial_execution/selection_resolution.rb
+++ b/lib/graphql/query/serial_execution/selection_resolution.rb
@@ -88,7 +88,7 @@ module GraphQL
         def merge_fields(field1, field2)
           field_type = query.schema.get_field(type, field2.name).type.unwrap
 
-          if field_type.is_a?(GraphQL::ObjectType)
+          if field_type.is_a?(GraphQL::ObjectType) || field_type.is_a?(GraphQL::InterfaceType)
             # create a new ast field node merging selections from each field.
             # Because of static validation, we can assume that name, alias,
             # arguments, and directives are exactly the same for fields 1 and 2.

--- a/lib/graphql/query/serial_execution/selection_resolution.rb
+++ b/lib/graphql/query/serial_execution/selection_resolution.rb
@@ -88,7 +88,7 @@ module GraphQL
         def merge_fields(field1, field2)
           field_type = query.schema.get_field(type, field2.name).type.unwrap
 
-          if field_type.is_a?(GraphQL::ObjectType) || field_type.is_a?(GraphQL::InterfaceType)
+          if field_type.kind.fields?
             # create a new ast field node merging selections from each field.
             # Because of static validation, we can assume that name, alias,
             # arguments, and directives are exactly the same for fields 1 and 2.

--- a/spec/graphql/interface_type_spec.rb
+++ b/spec/graphql/interface_type_spec.rb
@@ -24,6 +24,20 @@ describe GraphQL::InterfaceType do
     end
   end
 
+  describe 'mergable query evaluation' do
+    let(:result) { DummySchema.execute(query_string, context: {}, variables: {"cheeseId" => 2})}
+    let(:query_string) {%|
+      query fav {
+        favoriteEdible { fatContent }
+        favoriteEdible { origin }
+      }
+    |}
+    it 'gets fields from the type for the given object' do
+      expected = {"data"=>{"favoriteEdible"=>{"fatContent"=>0.04, "origin"=>"England"}}}
+      assert_equal(expected, result)
+    end
+  end
+
   describe '#resolve_type' do
     let(:interface) {
       GraphQL::InterfaceType.define do

--- a/spec/graphql/interface_type_spec.rb
+++ b/spec/graphql/interface_type_spec.rb
@@ -33,7 +33,7 @@ describe GraphQL::InterfaceType do
       }
     |}
     it 'gets fields from the type for the given object' do
-      expected = {"data"=>{"favoriteEdible"=>{"fatContent"=>0.04, "origin"=>"England"}}}
+      expected = {"data"=>{"favoriteEdible"=>{"fatContent"=>0.04, "origin"=>"Antiquity"}}}
       assert_equal(expected, result)
     end
   end

--- a/spec/graphql/introspection/type_type_spec.rb
+++ b/spec/graphql/introspection/type_type_spec.rb
@@ -14,6 +14,7 @@ describe GraphQL::Introspection::TypeType do
   let(:cheese_fields) {[
     {"name"=>"id",          "isDeprecated" => false, "type" => { "name" => "Non-Null", "ofType" => { "name" => "Int"}}},
     {"name"=>"flavor",      "isDeprecated" => false, "type" => { "name" => "Non-Null", "ofType" => { "name" => "String"}}},
+    {"name"=>"origin",      "isDeprecated" => false, "type" => { "name" => "Non-Null", "ofType" => { "name" => "String"}}},
     {"name"=>"source",      "isDeprecated" => false, "type" => { "name" => "Non-Null", "ofType" => { "name" => "DairyAnimal"}}},
     {"name"=>"similarCheese", "isDeprecated"=>false, "type"=>{"name"=>"Cheese", "ofType"=>nil}},
   ]}
@@ -38,6 +39,7 @@ describe GraphQL::Introspection::TypeType do
         "fields"=>[
           {"type"=>{"name"=>"Non-Null", "ofType"=>{"name"=>"ID"}}},
           {"type"=>{"name"=>"DairyAnimal", "ofType"=>nil}},
+          {"type"=>{"name"=>"Non-Null", "ofType"=>{"name"=>"String"}}},
           {"type"=>{"name"=>"Non-Null", "ofType"=>{"name"=>"Float"}}},
           {"type"=>{"name"=>"List", "ofType"=>{"name"=>"String"}}},
         ]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,8 @@ require "minitest/reporters"
 require 'pry'
 Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
 
+Minitest::Spec.make_my_diffs_pretty!
+
 # Filter out Minitest backtrace while allowing backtrace from other libraries
 # to be shown.
 Minitest.backtrace_filter = Minitest::BacktraceFilter.new

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -6,6 +6,7 @@ EdibleInterface = GraphQL::InterfaceType.define do
   name "Edible"
   description "Something you can eat, yum"
   field :fatContent, !types.Float, "Percentage which is fat", property: :bogus_property
+  field :origin, !types.String, "Place the edible comes from"
 end
 
 AnimalProductInterface = GraphQL::InterfaceType.define do
@@ -31,6 +32,7 @@ CheeseType = GraphQL::ObjectType.define do
   # Can have (name, type, desc)
   field :id, !types.Int, "Unique identifier"
   field :flavor, !types.String, "Kind of Cheese"
+  field :origin, !types.String, "Place the cheese comes from"
 
   field :source, !DairyAnimalEnum,
     "Animal which produced the milk for this cheese"
@@ -62,6 +64,7 @@ MilkType = GraphQL::ObjectType.define do
   interfaces [EdibleInterface, AnimalProductInterface]
   field :id, !types.ID
   field :source, DairyAnimalEnum, "Animal which produced this milk"
+  field :origin, !types.String, "Place the milk comes from"
   field :fatContent, !types.Float, "Percentage which is milkfat"
   field :flavors, types[types.String], "Chocolate, Strawberry, etc" do
     argument :limit, types.Int

--- a/spec/support/dairy_data.rb
+++ b/spec/support/dairy_data.rb
@@ -1,13 +1,13 @@
 Cheese = Struct.new(:id, :flavor, :origin, :fat_content, :source)
 CHEESES = {
   1 => Cheese.new(1, "Brie", "France", 0.19, 1),
-  2 => Cheese.new(2, "Gouda", "Switzerland", 0.3, 1),
-  3 => Cheese.new(3, "Manchego", "Italy", 0.065, "SHEEP")
+  2 => Cheese.new(2, "Gouda", "Netherlands", 0.3, 1),
+  3 => Cheese.new(3, "Manchego", "Spain", 0.065, "SHEEP")
 }
 
 Milk = Struct.new(:id, :fatContent, :origin, :source, :flavors)
 MILKS = {
-  1 => Milk.new(1, 0.04, "England", 1, ["Natural", "Chocolate", "Strawberry"]),
+  1 => Milk.new(1, 0.04, "Antiquity", 1, ["Natural", "Chocolate", "Strawberry"]),
 }
 
 DAIRY = OpenStruct.new(

--- a/spec/support/dairy_data.rb
+++ b/spec/support/dairy_data.rb
@@ -1,13 +1,13 @@
-Cheese = Struct.new(:id, :flavor, :fat_content, :source)
+Cheese = Struct.new(:id, :flavor, :origin, :fat_content, :source)
 CHEESES = {
-  1 => Cheese.new(1, "Brie", 0.19, 1),
-  2 => Cheese.new(2, "Gouda", 0.3, 1),
-  3 => Cheese.new(3, "Manchego", 0.065, "SHEEP")
+  1 => Cheese.new(1, "Brie", "France", 0.19, 1),
+  2 => Cheese.new(2, "Gouda", "Switzerland", 0.3, 1),
+  3 => Cheese.new(3, "Manchego", "Italy", 0.065, "SHEEP")
 }
 
-Milk = Struct.new(:id, :fatContent, :source, :flavors)
+Milk = Struct.new(:id, :fatContent, :origin, :source, :flavors)
 MILKS = {
-  1 => Milk.new(1, 0.04, 1, ["Natural", "Chocolate", "Strawberry"]),
+  1 => Milk.new(1, 0.04, "England", 1, ["Natural", "Chocolate", "Strawberry"]),
 }
 
 DAIRY = OpenStruct.new(


### PR DESCRIPTION
Demonstrates that fields on interfaces overwrite each other. Per discussion in the Ruby GraphQL Slack.