### PR TITLE
refactor(Language::Nodes) support libgraphqlparser

### DIFF
--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -16,12 +16,14 @@ module GraphQL
   end
 
   # Turn a query string into an AST
-  # @param string [String] a GraphQL query string
-  # @param as [Symbol] If you want to use this to parse some _piece_ of a document, pass the rule name (from {GraphQL::Parser})
+  # @param [String] a GraphQL query string
   # @return [GraphQL::Language::Nodes::Document]
-  def self.parse(string, as: nil)
-    parser = as ? GraphQL::PARSER.send(as) : GraphQL::PARSER
-    tree = parser.parse(string)
+  def self.parse(query_string)
+    parse_with_parslet(query_string)
+  end
+
+  def self.parse_with_parslet(string)
+    tree = GraphQL::PARSER.parse(string)
     document = GraphQL::TRANSFORM.apply(tree)
     if !document.is_a?(GraphQL::Language::Nodes::Document)
       raise("Parse failed! Sorry, somehow we failed to turn this string into a document. Please report this bug!")

--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -8,86 +8,193 @@ module GraphQL
         attr_accessor :line, :col
 
         # @param options [Hash] Must contain all attributes defined by {required_attrs}, may also include `position_source`
-        def initialize(options)
-          required_keys = self.class.required_attrs
-          allowed_keys = required_keys + [:line, :col]
-          position_source = options.delete(:position_source)
-          if !position_source.nil?
-            options[:line], options[:col] = position_source.line_and_column
+        def initialize(options={})
+          if options.key?(:position_source)
+            position_source = options.delete(:position_source)
+            @line, @col = position_source.line_and_column
+          elsif options.key?(:line)
+            @line = options.delete(:line)
+            @col = options.delete(:col)
           end
 
-          present_keys = options.keys
-          extra_keys = present_keys - allowed_keys
-          if extra_keys.any?
-            raise ArgumentError, "#{self.class.name} Extra arguments: #{extra_keys}"
-          end
-
-          missing_keys = required_keys - present_keys
-          if missing_keys.any?
-            raise ArgumentError, "#{self.class.name} Missing arguments: #{missing_keys}"
-          end
-
-          allowed_keys.each do |key|
-            if options.has_key?(key)
-              value = options[key]
-              self.send("#{key}=", value)
-            end
-          end
+          initialize_node(options)
         end
 
-        # Test all attributes, checking for any other nodes below this one
+        # This is called with node-specific options
+        def initialize_node(options={})
+          raise NotImplementedError
+        end
+
+        # @return [GraphQL::Language::Nodes::AbstractNode] all nodes in the tree below this one
         def children
-          self.class.required_attrs
-            .map { |attr| send(attr) }
+          self.class.child_attributes
+            .map { |attr_name| public_send(attr_name) }
             .flatten
-            .select { |val| val.is_a?(GraphQL::Language::Nodes::AbstractNode) }
         end
 
         class << self
-          attr_reader :required_attrs
-          # Defines attributes which are required at initialization.
-          def attr_required(*attr_names)
-            @required_attrs ||= []
-            @required_attrs += attr_names
-            attr_accessor(*attr_names)
+          def child_attributes(*attr_names)
+            @child_attributes ||= []
+            @child_attributes += attr_names
           end
+        end
 
-          # Create a new AbstractNode child which
-          # requires and exposes {attr_names}.
-          # @param attr_names [Array<Symbol>] Attributes this node class will have
-          # @param block [Block] Block passed to `Class.new`
-          # @return [Class] A new node class
-          def create(*attr_names, &block)
-            cls = Class.new(self, &block)
-            cls.attr_required(*attr_names)
-            cls
-          end
+        def position
+          [line, col]
         end
       end
 
-      Argument = AbstractNode.create(:name, :value)
-      Directive = AbstractNode.create(:name, :arguments)
-      Document = AbstractNode.create(:parts)
-      Enum = AbstractNode.create(:name)
-      Field = AbstractNode.create(:name, :alias, :arguments, :directives, :selections)
-      FragmentDefinition = AbstractNode.create(:name, :type, :directives, :selections)
-      FragmentSpread = AbstractNode.create(:name, :directives)
-      InlineFragment = AbstractNode.create(:type, :directives, :selections)
-      InputObject = AbstractNode.create(:pairs) do
+      class WrapperType < AbstractNode
+        attr_accessor :of_type
+        def initialize_node(of_type: nil)
+          @of_type = of_type
+        end
+
+        def children
+          [].freeze
+        end
+      end
+
+      class NameOnlyNode < AbstractNode
+        attr_accessor :name
+        def initialize_node(name: nil)
+          @name = name
+        end
+
+        def children
+          [].freeze
+        end
+      end
+
+
+      class Argument < AbstractNode
+        attr_accessor :name, :value
+
+        def initialize_node(name: nil, value: nil)
+          @name = name
+          @value = value
+        end
+
+        def children
+          [value].flatten.select { |v| v.is_a?(AbstractNode) }
+        end
+      end
+
+      class Directive < AbstractNode
+        attr_accessor :name, :arguments
+        child_attributes :arguments
+
+        def initialize_node(name: nil, arguments: [])
+          @name = name
+          @arguments = arguments
+        end
+      end
+
+      class Document < AbstractNode
+        attr_accessor :definitions
+        child_attributes :definitions
+
+        def initialize_node(definitions: [])
+          @definitions = definitions
+        end
+      end
+
+      class Enum < NameOnlyNode; end
+
+      class Field < AbstractNode
+        attr_accessor :name, :alias, :arguments, :directives, :selections
+        child_attributes :arguments, :directives, :selections
+
+        def initialize_node(name: nil, arguments: [], directives: [], selections: [], **kwargs)
+          @name = name
+          # oops, alias is a keyword:
+          @alias = kwargs.fetch(:alias, nil)
+          @arguments = arguments
+          @directives = directives
+          @selections = selections
+        end
+      end
+
+      class FragmentDefinition < AbstractNode
+        attr_accessor :name, :type, :directives, :selections
+        child_attributes :directives, :selections
+
+        def initialize_node(name: nil, type: nil, directives: [], selections: [])
+          @name = name
+          @type = type
+          @directives = directives
+          @selections = selections
+        end
+      end
+
+      class FragmentSpread < AbstractNode
+        attr_accessor :name, :directives
+        child_attributes :directives
+
+        def initialize_node(name: nil, directives: [])
+          @name = name
+          @directives = directives
+        end
+      end
+
+      class InlineFragment < AbstractNode
+        attr_accessor :type, :directives, :selections
+        child_attributes :directives, :selections
+
+        def initialize_node(type: nil, directives: [], selections: [])
+          @type = type
+          @directives = directives
+          @selections = selections
+        end
+      end
+
+      class InputObject < AbstractNode
+        attr_accessor :arguments
+        child_attributes :arguments
+
+        def initialize_node(arguments: [])
+          @arguments = arguments
+        end
+
         def to_h(options={})
-          pairs.inject({}) do |memo, pair|
+          arguments.inject({}) do |memo, pair|
             v = pair.value
             memo[pair.name] = v.is_a?(InputObject) ? v.to_h : v
             memo
           end
         end
       end
-      ListType = AbstractNode.create(:of_type)
-      NonNullType = AbstractNode.create(:of_type)
-      OperationDefinition = AbstractNode.create(:operation_type, :name, :variables, :directives, :selections)
-      TypeName = AbstractNode.create(:name)
-      Variable = AbstractNode.create(:name, :type, :default_value)
-      VariableIdentifier = AbstractNode.create(:name)
+
+
+
+      class ListType < WrapperType; end
+      class NonNullType < WrapperType; end
+
+      class OperationDefinition < AbstractNode
+        attr_accessor :operation_type, :name, :variables, :directives, :selections
+        child_attributes :variables, :directives, :selections
+
+        def initialize_node(operation_type: nil, name: nil, variables: [], directives: [], selections: [])
+          @operation_type = operation_type
+          @name = name
+          @variables = variables
+          @directives = directives
+          @selections = selections
+        end
+      end
+
+      class TypeName < NameOnlyNode; end
+
+      class VariableDefinition < AbstractNode
+        attr_accessor :name, :type, :default_value
+        def initialize_node(name: nil, type: nil, default_value: nil)
+          @name = name
+          @type = type
+          @default_value = default_value
+        end
+      end
+
+      class VariableIdentifier < NameOnlyNode; end
     end
   end
 end

--- a/lib/graphql/language/transform.rb
+++ b/lib/graphql/language/transform.rb
@@ -1,6 +1,5 @@
 module GraphQL
   module Language
-
     # {Transform} is a [parslet](http://kschiess.github.io/parslet/) transform for for turning the AST into objects in {GraphQL::Language::Nodes} objects.
     class Transform < Parslet::Transform
 
@@ -18,8 +17,8 @@ module GraphQL
       end
 
       # Document
-      rule(document_parts: sequence(:p)) { CREATE_NODE[:Document, parts: p, line: (p.first ? p.first.line : 1), col: (p.first ? p.first.col : 1)]}
-      rule(document_parts: simple(:p)) { CREATE_NODE[:Document, parts: [], line: 1, col: 1]}
+      rule(document_parts: sequence(:p)) { CREATE_NODE[:Document, definitions: p, line: (p.first ? p.first.line : 1), col: (p.first ? p.first.col : 1)]}
+      rule(document_parts: simple(:p)) { CREATE_NODE[:Document, definitions: [], line: 1, col: 1]}
 
       # Fragment Definition
       rule(
@@ -52,8 +51,8 @@ module GraphQL
         selections:     sequence(:s),
       ) { CREATE_NODE[:OperationDefinition, operation_type: ot.to_s, name: n.to_s, variables: v, directives: d, selections: s, position_source: ot] }
       optional_sequence(:optional_variables)
-      rule(variable_name: simple(:n), variable_type: simple(:t), variable_optional_default_value: simple(:v)) { CREATE_NODE.(:Variable, name: n.name, type: t, default_value: v, line: n.line, col: n.col)}
-      rule(variable_name: simple(:n), variable_type: simple(:t), variable_optional_default_value: sequence(:v)) { CREATE_NODE.(:Variable, name: n.name, type: t, default_value: v, line: n.line, col: n.col)}
+      rule(variable_name: simple(:n), variable_type: simple(:t), variable_optional_default_value: simple(:v)) { CREATE_NODE.(:VariableDefinition, name: n.name, type: t, default_value: v, line: n.line, col: n.col)}
+      rule(variable_name: simple(:n), variable_type: simple(:t), variable_optional_default_value: sequence(:v)) { CREATE_NODE.(:VariableDefinition, name: n.name, type: t, default_value: v, line: n.line, col: n.col)}
       rule(variable_default_value: simple(:v) ) { v }
       rule(variable_default_value: sequence(:v) ) { v }
       # Query short-hand
@@ -89,7 +88,7 @@ module GraphQL
       rule(array: subtree(:v)) { v }
       rule(array: simple(:v)) { [] } # just `nil`
       rule(boolean: simple(:v)) { v == "true" ? true : false }
-      rule(input_object: sequence(:v)) { CREATE_NODE[:InputObject, pairs: v, line: (v.first ? v.first.line : 1), col: (v.first ? v.first.col : 1)] }
+      rule(input_object: sequence(:v)) { CREATE_NODE[:InputObject, arguments: v, line: (v.first ? v.first.line : 1), col: (v.first ? v.first.col : 1)] }
       rule(input_object_name: simple(:n), input_object_value: simple(:v)) { CREATE_NODE[:Argument, name: n.to_s, value: v, position_source: n]}
       rule(input_object_name: simple(:n), input_object_value: sequence(:v)) { CREATE_NODE[:Argument, name: n.to_s, value: v, position_source: n]}
       rule(int: simple(:v)) { v.to_i }

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -44,7 +44,7 @@ class GraphQL::Query
     @operations = {}
     @provided_variables = variables
     @document = GraphQL.parse(query_string)
-    @document.parts.each do |part|
+    @document.definitions.each do |part|
       if part.is_a?(GraphQL::Language::Nodes::FragmentDefinition)
         @fragments[part.name] = part
       elsif part.is_a?(GraphQL::Language::Nodes::OperationDefinition)

--- a/lib/graphql/query/literal_input.rb
+++ b/lib/graphql/query/literal_input.rb
@@ -48,7 +48,7 @@ module GraphQL
         module InputObjectLiteral
           def self.coerce(value, type, variables)
             hash = {}
-            value.pairs.each do |arg|
+            value.arguments.each do |arg|
               field_type = type.input_fields[arg.name].type
               hash[arg.name] = LiteralInput.coerce(field_type, arg.value, variables)
             end

--- a/lib/graphql/static_validation/literal_validator.rb
+++ b/lib/graphql/static_validation/literal_validator.rb
@@ -29,14 +29,14 @@ class GraphQL::StaticValidation::LiteralValidator
       .values
       .select { |f| f.type.kind.non_null? }
       .map(&:name)
-    present_field_names = ast_node.pairs.map(&:name)
+    present_field_names = ast_node.arguments.map(&:name)
     missing_required_field_names = required_field_names - present_field_names
     missing_required_field_names.none?
   end
 
   def present_input_field_values_are_valid(type, ast_node)
     fields = type.input_fields
-    ast_node.pairs.all? do |value|
+    ast_node.arguments.all? do |value|
      field_type = fields[value.name].type
      validate(value.value, field_type)
     end

--- a/lib/graphql/static_validation/rules/variable_default_values_are_correctly_typed.rb
+++ b/lib/graphql/static_validation/rules/variable_default_values_are_correctly_typed.rb
@@ -3,7 +3,7 @@ class GraphQL::StaticValidation::VariableDefaultValuesAreCorrectlyTyped
 
   def validate(context)
     literal_validator = GraphQL::StaticValidation::LiteralValidator.new
-    context.visitor[GraphQL::Language::Nodes::Variable] << -> (node, parent) {
+    context.visitor[GraphQL::Language::Nodes::VariableDefinition] << -> (node, parent) {
       if !node.default_value.nil?
         validate_default_value(node, literal_validator, context)
       end

--- a/lib/graphql/static_validation/rules/variables_are_input_types.rb
+++ b/lib/graphql/static_validation/rules/variables_are_input_types.rb
@@ -2,7 +2,7 @@ class GraphQL::StaticValidation::VariablesAreInputTypes
   include GraphQL::StaticValidation::Message::MessageHelper
 
   def validate(context)
-    context.visitor[GraphQL::Language::Nodes::Variable] << -> (node, parent) {
+    context.visitor[GraphQL::Language::Nodes::VariableDefinition] << -> (node, parent) {
       validate_is_input_type(node, context)
     }
   end

--- a/lib/graphql/static_validation/validator.rb
+++ b/lib/graphql/static_validation/validator.rb
@@ -42,7 +42,7 @@ class GraphQL::StaticValidation::Validator
     def initialize(schema, document)
       @schema = schema
       @document = document
-      @fragments = document.parts.each_with_object({}) do |part, memo|
+      @fragments = document.definitions.each_with_object({}) do |part, memo|
         part.is_a?(GraphQL::Language::Nodes::FragmentDefinition) && memo[part.name] = part
       end
       @errors = []

--- a/spec/graphql/language/transform_spec.rb
+++ b/spec/graphql/language/transform_spec.rb
@@ -45,11 +45,11 @@ describe GraphQL::Language::Transform do
       }
     |
     res = get_result(query, debug: false)
-    assert_equal(4, res.parts.length)
+    assert_equal(4, res.definitions.length)
 
     res = get_result("{ me {id, birthdate} } # query shorthand")
-    assert_equal(1, res.parts.length)
-    assert_equal("me", res.parts.first.selections.first.name)
+    assert_equal(1, res.definitions.length)
+    assert_equal("me", res.definitions.first.selections.first.name)
   end
 
   it 'transforms operation definitions' do
@@ -117,16 +117,16 @@ describe GraphQL::Language::Transform do
     res_empty       = get_result(%q|{}|, parse: :value_input_object)
     res_empty_space = get_result(%q|{ }|, parse: :value_input_object)
 
-    assert_equal('one', res_one_pair.pairs[0].name)
-    assert_equal(1    , res_one_pair.pairs[0].value)
+    assert_equal('one', res_one_pair.arguments[0].name)
+    assert_equal(1    , res_one_pair.arguments[0].value)
 
-    assert_equal('first' , res_two_pair.pairs[0].name)
-    assert_equal('Apple' , res_two_pair.pairs[0].value)
-    assert_equal('second', res_two_pair.pairs[1].name)
-    assert_equal('Banana', res_two_pair.pairs[1].value)
+    assert_equal('first' , res_two_pair.arguments[0].name)
+    assert_equal('Apple' , res_two_pair.arguments[0].value)
+    assert_equal('second', res_two_pair.arguments[1].name)
+    assert_equal('Banana', res_two_pair.arguments[1].value)
 
-    assert_equal([], res_empty.pairs)
-    assert_equal([], res_empty_space.pairs)
+    assert_equal([], res_empty.arguments)
+    assert_equal([], res_empty_space.arguments)
   end
 
   it 'transforms directives' do
@@ -141,12 +141,12 @@ describe GraphQL::Language::Transform do
   end
 
   it 'transforms unnamed operations' do
-    assert_equal(1, get_result("query { me }").parts.length)
-    assert_equal(1, get_result("mutation { touch }").parts.length)
+    assert_equal(1, get_result("query { me }").definitions.length)
+    assert_equal(1, get_result("mutation { touch }").definitions.length)
   end
 
   it 'transforms escaped characters' do
     res = get_result("{quoted: \"\\\" \\\\ \\/ \\b \\f \\n \\r \\t\"}", parse: :value_input_object)
-    assert_equal("\" \\ / \b \f \n \r \t", res.pairs[0].value)
+    assert_equal("\" \\ / \b \f \n \r \t", res.arguments[0].value)
   end
 end

--- a/spec/graphql/query/variables_spec.rb
+++ b/spec/graphql/query/variables_spec.rb
@@ -8,7 +8,7 @@ describe GraphQL::Query::Variables do
     }
   }
   |}
-  let(:ast_variables) { GraphQL.parse(query_string).parts.first.variables }
+  let(:ast_variables) { GraphQL.parse(query_string).definitions.first.variables }
   let(:variables) { GraphQL::Query::Variables.new(
     DummySchema,
     ast_variables,

--- a/spec/graphql/static_validation/validator_spec.rb
+++ b/spec/graphql/static_validation/validator_spec.rb
@@ -14,7 +14,7 @@ class DocumentErrorValidator
 end
 
 describe GraphQL::StaticValidation::Validator do
-  let(:document)  { OpenStruct.new(name: "This is not a document", children: [], parts: []) }
+  let(:document)  { OpenStruct.new(name: "This is not a document", children: [], definitions: []) }
   let(:validator) { GraphQL::StaticValidation::Validator.new(schema: "This is not a schema", rules: [SchemaErrorValidator, DocumentErrorValidator]) }
   let(:errors) { validator.validate(document) }
   it 'uses rules' do


### PR DESCRIPTION
This will make libgraphqlparser integration easier because you can build up the AST bit-by-bit instead of giving everything to the node at `initialize`. 

- Remove the required-argument initialize (it helped during prototyping, but it's pointless now)
- Rename some AST classes and properties to present a more consistent API

__Todo__: 
- [x] Make sure this doesn't break graphql-batch 
