### PR TITLE
feat(Query): Rescue GraphQL::ExecutionError in field resolution.

### DIFF
--- a/guides/defining_your_schema.md
+++ b/guides/defining_your_schema.md
@@ -92,6 +92,7 @@ result = MySchema.execute(query_string)
 # }
 ```
 
+When explicitly raising the exception, you can raise a GraphQL::ExecutionError with a message to add to the response without specifying an error handler.
 
 ## Middleware
 

--- a/lib/graphql/query/serial_execution/field_resolution.rb
+++ b/lib/graphql/query/serial_execution/field_resolution.rb
@@ -16,7 +16,13 @@ module GraphQL
 
         def result
           result_name = ast_node.alias || ast_node.name
-          result_value = get_finished_value(get_raw_value)
+          result_value = begin
+            get_finished_value(get_raw_value)
+          rescue GraphQL::ExecutionError => err
+            err.ast_node = ast_node
+            query.context.errors << err
+            nil
+          end
           { result_name => result_value  }
         end
 
@@ -25,18 +31,13 @@ module GraphQL
         # After getting the value from the field's resolve method,
         # continue by "finishing" the value, eg. executing sub-fields or coercing values
         def get_finished_value(raw_value)
-          if raw_value.nil?
-            nil
-          elsif raw_value.is_a?(GraphQL::ExecutionError)
-            raw_value.ast_node = ast_node
-            query.context.errors << raw_value
-            nil
-          else
-            resolved_type = field.type.resolve_type(raw_value)
-            strategy_class = GraphQL::Query::BaseExecution::ValueResolution.get_strategy_for_kind(resolved_type.kind)
-            result_strategy = strategy_class.new(raw_value, resolved_type, target, parent_type, ast_node, query, execution_strategy)
-            result_strategy.result
-          end
+          raise raw_value if raw_value.instance_of?(GraphQL::ExecutionError)
+          return nil if raw_value.nil?
+
+          resolved_type = field.type.resolve_type(raw_value)
+          strategy_class = GraphQL::Query::BaseExecution::ValueResolution.get_strategy_for_kind(resolved_type.kind)
+          result_strategy = strategy_class.new(raw_value, resolved_type, target, parent_type, ast_node, query, execution_strategy)
+          result_strategy.result
         end
 
 

--- a/spec/graphql/execution_error_spec.rb
+++ b/spec/graphql/execution_error_spec.rb
@@ -18,6 +18,7 @@ describe GraphQL::ExecutionError do
         }
         flavor
       }
+      executionError
     }
 
     fragment similarCheeseFields on Cheese {
@@ -36,7 +37,8 @@ describe GraphQL::ExecutionError do
               "flavor" => "Manchego",
             },
             "flavor" => "Brie",
-            }
+            },
+            "executionError" => nil,
           },
           "errors"=>[
             {
@@ -46,6 +48,10 @@ describe GraphQL::ExecutionError do
             {
               "message"=>"No cheeses are made from Yak milk!",
               "locations"=>[{"line"=>8, "column"=>9}]
+            },
+            {
+              "message"=>"There was an execution error",
+              "locations"=>[{"line"=>16, "column"=>7}]
             },
           ]
         }

--- a/spec/graphql/introspection/schema_type_spec.rb
+++ b/spec/graphql/introspection/schema_type_spec.rb
@@ -26,6 +26,7 @@ describe GraphQL::Introspection::SchemaType do
             {"name"=>"cow"},
             {"name"=>"searchDairy"},
             {"name"=>"error"},
+            {"name"=>"executionError"},
             {"name"=>"maybeNull"},
           ]
         },

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -189,6 +189,11 @@ QueryType = GraphQL::ObjectType.define do
     resolve -> (t, a, c) { raise("This error was raised on purpose") }
   end
 
+  field :executionError do
+    type GraphQL::STRING_TYPE
+    resolve -> (t, a, c) { raise(GraphQL::ExecutionError, "There was an execution error") }
+  end
+
   # To test possibly-null fields
   field :maybeNull, MaybeNullType do
     resolve -> (t, a, c) { OpenStruct.new(cheese: nil) }


### PR DESCRIPTION
## Problem

If an GraphQL::ExecutionError object is returned from a field resolve proc, then it is reported as an error on that field.  However, it would be more natural to raise an exception of a specific class to report an error, which would require the rescue middleware.

Unfortunately, the rescue middleware currently doesn't catch all the errors during field resolution, since it misses type resolution and value coercion.

## Solution

Allow a GraphQL::ExecutionError to be intentionally raised from a resolve, coercion or type resolution proc and have that error affect only that field rather than causing the whole query to fail.