### PR TITLE
Error when non-null fields resolve to nil

### DIFF
--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -68,7 +68,7 @@ require 'graphql/schema/printer'
 # Order does not matter for these:
 
 require 'graphql/execution_error'
-require 'graphql/null_non_null_error'
+require 'graphql/invalid_null_error'
 require 'graphql/query'
 require 'graphql/repl'
 require 'graphql/static_validation'

--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -68,6 +68,7 @@ require 'graphql/schema/printer'
 # Order does not matter for these:
 
 require 'graphql/execution_error'
+require 'graphql/null_non_null_error'
 require 'graphql/query'
 require 'graphql/repl'
 require 'graphql/static_validation'

--- a/lib/graphql/invalid_null_error.rb
+++ b/lib/graphql/invalid_null_error.rb
@@ -1,7 +1,7 @@
 module GraphQL
   # Raised automatically when a field's resolve function returns `nil`
   # for a non-null field.
-  class NullNonNullError < RuntimeError
+  class InvalidNullError < RuntimeError
     def initialize(field_name, value)
       @field_name = field_name
       @value = value

--- a/lib/graphql/non_null_type.rb
+++ b/lib/graphql/non_null_type.rb
@@ -21,10 +21,6 @@ class GraphQL::NonNullType < GraphQL::BaseType
     of_type.coerce_input(value)
   end
 
-  def coerce_result(value)
-    of_type.coerce_result(value)
-  end
-
   def kind
     GraphQL::TypeKinds::NON_NULL
   end

--- a/lib/graphql/null_non_null_error.rb
+++ b/lib/graphql/null_non_null_error.rb
@@ -1,0 +1,22 @@
+module GraphQL
+  # Raised automatically when a field's resolve function returns `nil`
+  # for a non-null field.
+  class NullNonNullError < RuntimeError
+    def initialize(field_name, value)
+      @field_name = field_name
+      @value = value
+    end
+
+    # @return [Hash] An entry for the response's "errors" key
+    def to_h
+      {
+        "message" => "Cannot return null for non-nullable field #{@field_name}"
+      }
+    end
+
+    # @return [Boolean] Whether the null in question was caused by another error
+    def parent_error?
+      @value.is_a?(GraphQL::ExecutionError)
+    end
+  end
+end

--- a/lib/graphql/query/serial_execution/field_resolution.rb
+++ b/lib/graphql/query/serial_execution/field_resolution.rb
@@ -16,14 +16,14 @@ module GraphQL
 
         def result
           result_name = ast_node.alias || ast_node.name
-          result_value = begin
-            get_finished_value(get_raw_value)
+          raw_value = begin
+            get_raw_value
           rescue GraphQL::ExecutionError => err
             err.ast_node = ast_node
             query.context.errors << err
-            nil
+            err
           end
-          { result_name => result_value  }
+          { result_name => get_finished_value(raw_value) }
         end
 
         private
@@ -31,8 +31,6 @@ module GraphQL
         # After getting the value from the field's resolve method,
         # continue by "finishing" the value, eg. executing sub-fields or coercing values
         def get_finished_value(raw_value)
-          raise raw_value if raw_value.instance_of?(GraphQL::ExecutionError)
-
           strategy_class = GraphQL::Query::SerialExecution::ValueResolution.get_strategy_for_kind(field.type.kind)
           result_strategy = strategy_class.new(raw_value, field.type, target, parent_type, ast_node, query, execution_strategy)
           result_strategy.result
@@ -48,7 +46,9 @@ module GraphQL
             steps: steps,
             arguments: [parent_type, target, field, arguments, query.context]
           )
-          chain.call
+          value = chain.call
+          raise value if value.instance_of?(GraphQL::ExecutionError)
+          value
         end
 
 

--- a/lib/graphql/query/serial_execution/field_resolution.rb
+++ b/lib/graphql/query/serial_execution/field_resolution.rb
@@ -32,14 +32,9 @@ module GraphQL
         # continue by "finishing" the value, eg. executing sub-fields or coercing values
         def get_finished_value(raw_value)
           raise raw_value if raw_value.instance_of?(GraphQL::ExecutionError)
-          if raw_value.nil?
-            raise GraphQL::ExecutionError, "Type mismatch resolving '#{field.name}'" if field.type.kind.non_null?
-            return nil
-          end
 
-          resolved_type = field.type.resolve_type(raw_value)
-          strategy_class = GraphQL::Query::SerialExecution::ValueResolution.get_strategy_for_kind(resolved_type.kind)
-          result_strategy = strategy_class.new(raw_value, resolved_type, target, parent_type, ast_node, query, execution_strategy)
+          strategy_class = GraphQL::Query::SerialExecution::ValueResolution.get_strategy_for_kind(field.type.kind)
+          result_strategy = strategy_class.new(raw_value, field.type, target, parent_type, ast_node, query, execution_strategy)
           result_strategy.result
         end
 

--- a/lib/graphql/query/serial_execution/field_resolution.rb
+++ b/lib/graphql/query/serial_execution/field_resolution.rb
@@ -32,7 +32,10 @@ module GraphQL
         # continue by "finishing" the value, eg. executing sub-fields or coercing values
         def get_finished_value(raw_value)
           raise raw_value if raw_value.instance_of?(GraphQL::ExecutionError)
-          return nil if raw_value.nil?
+          if raw_value.nil?
+            raise GraphQL::ExecutionError, "Type mismatch resolving '#{field.name}'" if field.type.kind.non_null?
+            return nil
+          end
 
           resolved_type = field.type.resolve_type(raw_value)
           strategy_class = GraphQL::Query::SerialExecution::ValueResolution.get_strategy_for_kind(resolved_type.kind)

--- a/lib/graphql/query/serial_execution/selection_resolution.rb
+++ b/lib/graphql/query/serial_execution/selection_resolution.rb
@@ -18,7 +18,7 @@ module GraphQL
             .reduce({}) { |result, ast_node|
               result.merge(resolve_field(ast_node))
             }
-        rescue GraphQL::NullNonNullError => err
+        rescue GraphQL::InvalidNullError => err
           query.context.errors << err unless err.parent_error?
           nil
         end

--- a/lib/graphql/query/serial_execution/selection_resolution.rb
+++ b/lib/graphql/query/serial_execution/selection_resolution.rb
@@ -18,6 +18,9 @@ module GraphQL
             .reduce({}) { |result, ast_node|
               result.merge(resolve_field(ast_node))
             }
+        rescue GraphQL::NullNonNullError => err
+          query.context.errors << err unless err.parent_error?
+          nil
         end
 
         private

--- a/lib/graphql/query/serial_execution/value_resolution.rb
+++ b/lib/graphql/query/serial_execution/value_resolution.rb
@@ -20,7 +20,7 @@ module GraphQL
           end
 
           def result
-            return nil if value.nil?
+            return nil if value.nil? || value.is_a?(GraphQL::ExecutionError)
             non_null_result
           end
 
@@ -73,7 +73,7 @@ module GraphQL
         class NonNullResolution < BaseResolution
           # Get the "wrapped" type and resolve the value according to that type
           def result
-            raise GraphQL::ExecutionError, "Type mismatch resolving '#{ast_field.name}'" if value.nil?
+            raise GraphQL::NullNonNullError.new(ast_field.name, value) if value.nil? || value.is_a?(GraphQL::ExecutionError)
             wrapped_type = field_type.of_type
             strategy_class = get_strategy_for_kind(wrapped_type.kind)
             inner_strategy = strategy_class.new(value, wrapped_type, target, parent_type, ast_field, query, execution_strategy)

--- a/lib/graphql/query/serial_execution/value_resolution.rb
+++ b/lib/graphql/query/serial_execution/value_resolution.rb
@@ -45,8 +45,8 @@ module GraphQL
           # Resolve it with the "wrapped" type of this list
           def non_null_result
             wrapped_type = field_type.of_type
+            strategy_class = get_strategy_for_kind(wrapped_type.kind)
             value.map do |item|
-              strategy_class = get_strategy_for_kind(wrapped_type.kind)
               inner_strategy = strategy_class.new(item, wrapped_type, target, parent_type, ast_field, query, execution_strategy)
               inner_strategy.result
             end

--- a/lib/graphql/query/serial_execution/value_resolution.rb
+++ b/lib/graphql/query/serial_execution/value_resolution.rb
@@ -73,7 +73,7 @@ module GraphQL
         class NonNullResolution < BaseResolution
           # Get the "wrapped" type and resolve the value according to that type
           def result
-            raise GraphQL::NullNonNullError.new(ast_field.name, value) if value.nil? || value.is_a?(GraphQL::ExecutionError)
+            raise GraphQL::InvalidNullError.new(ast_field.name, value) if value.nil? || value.is_a?(GraphQL::ExecutionError)
             wrapped_type = field_type.of_type
             strategy_class = get_strategy_for_kind(wrapped_type.kind)
             inner_strategy = strategy_class.new(value, wrapped_type, target, parent_type, ast_field, query, execution_strategy)

--- a/spec/graphql/introspection/schema_type_spec.rb
+++ b/spec/graphql/introspection/schema_type_spec.rb
@@ -27,8 +27,7 @@ describe GraphQL::Introspection::SchemaType do
             {"name"=>"searchDairy"},
             {"name"=>"error"},
             {"name"=>"executionError"},
-            {"name"=>"maybeNull"},
-            {"name"=>"cantBeNullButIs"},
+            {"name"=>"maybeNull"}
           ]
         },
         "mutationType"=> {

--- a/spec/graphql/introspection/schema_type_spec.rb
+++ b/spec/graphql/introspection/schema_type_spec.rb
@@ -28,6 +28,7 @@ describe GraphQL::Introspection::SchemaType do
             {"name"=>"error"},
             {"name"=>"executionError"},
             {"name"=>"maybeNull"},
+            {"name"=>"cantBeNullButIs"},
           ]
         },
         "mutationType"=> {

--- a/spec/graphql/query/executor_spec.rb
+++ b/spec/graphql/query/executor_spec.rb
@@ -132,6 +132,22 @@ describe GraphQL::Query::Executor do
       end
     end
 
+    describe 'if nil is given for a non-null field' do
+      let(:query_string) {%| query noMilk { cantBeNullButIs }|}
+      it 'turns into error messages' do
+        expected = {
+          "data" => { "cantBeNullButIs" => nil },
+          "errors" => [
+            {
+              "message" => "Type mismatch resolving 'cantBeNullButIs'",
+              "locations" => [ { "line" => 1, "column" => 17 } ]
+            }
+          ]
+        }
+        assert_equal(expected, result)
+      end
+    end
+
     describe "if the schema has a rescue handler" do
       before do
         schema.rescue_from(RuntimeError) { "Error was handled!" }

--- a/spec/graphql/query/executor_spec.rb
+++ b/spec/graphql/query/executor_spec.rb
@@ -133,14 +133,29 @@ describe GraphQL::Query::Executor do
     end
 
     describe 'if nil is given for a non-null field' do
-      let(:query_string) {%| query noMilk { cantBeNullButIs }|}
-      it 'turns into error messages' do
+      let(:query_string) {%| query noMilk { cow { name cantBeNullButIs } }|}
+      it 'turns into error message and nulls the entire selection' do
         expected = {
-          "data" => { "cantBeNullButIs" => nil },
+          "data" => { "cow" => nil },
           "errors" => [
             {
-              "message" => "Type mismatch resolving 'cantBeNullButIs'",
-              "locations" => [ { "line" => 1, "column" => 17 } ]
+              "message" => "Cannot return null for non-nullable field cantBeNullButIs"
+            }
+          ]
+        }
+        assert_equal(expected, result)
+      end
+    end
+
+    describe 'if an execution error is raised for a non-null field' do
+      let(:query_string) {%| query noMilk { cow { name cantBeNullButRaisesExecutionError } }|}
+      it 'uses provided error message and nulls the entire selection' do
+        expected = {
+          "data" => { "cow" => nil },
+          "errors" => [
+            {
+              "message" => "BOOM",
+              "locations" => [ { "line" => 1, "column" => 28 } ]
             }
           ]
         }

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -198,6 +198,11 @@ QueryType = GraphQL::ObjectType.define do
   field :maybeNull, MaybeNullType do
     resolve -> (t, a, c) { OpenStruct.new(cheese: nil) }
   end
+
+  field :cantBeNullButIs do
+    type !GraphQL::STRING_TYPE
+    resolve -> (t, a, c) { nil }
+  end
 end
 
 GLOBAL_VALUES = []

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -100,6 +100,16 @@ CowType = GraphQL::ObjectType.define do
   field :id, !types.ID
   field :name, types.String
   field :last_produced_dairy, DairyProductUnion
+
+  field :cantBeNullButIs do
+    type !GraphQL::STRING_TYPE
+    resolve -> (t, a, c) { nil }
+  end
+
+  field :cantBeNullButRaisesExecutionError do
+    type !GraphQL::STRING_TYPE
+    resolve -> (t, a, c) { raise GraphQL::ExecutionError, "BOOM" }
+  end
 end
 
 DairyProductInputType = GraphQL::InputObjectType.define {
@@ -197,11 +207,6 @@ QueryType = GraphQL::ObjectType.define do
   # To test possibly-null fields
   field :maybeNull, MaybeNullType do
     resolve -> (t, a, c) { OpenStruct.new(cheese: nil) }
-  end
-
-  field :cantBeNullButIs do
-    type !GraphQL::STRING_TYPE
-    resolve -> (t, a, c) { nil }
   end
 end
 


### PR DESCRIPTION
@rmosolgo @dylanahsmith I spent the last day and a bit down a rabbit-hole of nulls and type coercion. This fixes the immediate issue but raises several more interesting questions:

- We do not currently provide a way for types to specify a coercion for `nil`
  values. According to the GraphQL spec on non-null types [1], you *are*
  supposed to run coercion for `nil`s and only fail if the *coercion* produces
  `nil` (so e.g. the boolean scalar type is allowed to coerce `nil` to false if
  it wants). I took a quick try to do this but ran aground quickly.

- We do not distinguish at the scalar coercion level between nullable and
  non-null-wrapped types. It may make sense, for example, for a regular boolean
  to let `nil` stay as `nil` but to coerce `nil` to `false` when wrapped in a
  non-null; this requires knowledge in either the `coerce_result` method or the
  `ScalarResolution` strategy about whether the wrapping type is non-null.

- It is not clear to me from the GraphQL spec whether fields that raise errors
  (like the one added in this PR) should be present in the result with a null
  value or should be absent from the result entirely. Both feel odd, especially
  when the field itself is non-null. (edit: https://facebook.github.io/graphql/#sec-Nullability is clear, I just missed it the first time through).

- It is not clear to me from the GraphQL spec how nil interfaces should be
  coerced, since at least theoretically there could be multiple implementing
  object types, each with a distinct method of coercing `nil` to something
  non-null, but the executor has no way to determine which coercion to run.

[1] https://facebook.github.io/graphql/#sec-Non-Null