### PR TITLE
fix: Avoid exception from input object literal with an undefined field.

### DIFF
--- a/lib/graphql/static_validation/literal_validator.rb
+++ b/lib/graphql/static_validation/literal_validator.rb
@@ -37,8 +37,8 @@ class GraphQL::StaticValidation::LiteralValidator
   def present_input_field_values_are_valid(type, ast_node)
     fields = type.input_fields
     ast_node.arguments.all? do |value|
-     field_type = fields[value.name].type
-     validate(value.value, field_type)
+      field = fields[value.name]
+      field ? validate(value.value, field.type) : true
     end
   end
 

--- a/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb
+++ b/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb
@@ -3,6 +3,7 @@ class GraphQL::StaticValidation::ArgumentLiteralsAreCompatible < GraphQL::Static
     return if node.value.is_a?(GraphQL::Language::Nodes::VariableIdentifier)
     validator = GraphQL::StaticValidation::LiteralValidator.new
     arg_defn = defn.arguments[node.name]
+    return unless arg_defn
     valid = validator.validate(node.value, arg_defn.type)
     if !valid
       kind_of_node = node_type(parent)

--- a/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
+++ b/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
@@ -9,6 +9,7 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
       badSource: searchDairy(product: [{source: 1.1}]) { source }
       missingSource: searchDairy(product: [{fatContent: 1.1}]) { source }
       listCoerce: cheese(id: 1) { similarCheese(source: YAK) }
+      missingInputField: searchDairy(product: [{source: YAK, wacky: 1}])
     }
 
     fragment cheeseFields on Cheese {
@@ -54,7 +55,7 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
 
     fragment_error = {
       "message"=>"Argument 'source' on Field 'similarCheese' has an invalid value",
-      "locations"=>[{"line"=>12, "column"=>7}]
+      "locations"=>[{"line"=>13, "column"=>7}]
     }
     assert_includes(errors, fragment_error)
   end


### PR DESCRIPTION
## Problem

We were getting an exception when specifying a field on an input object literal that wasn't in the input object type.  This can be reproduced with the following script:

```ruby
require 'graphql'

TestInputType = GraphQL::InputObjectType.define do
  name "TestInput"
  input_field :foo, types.String
end

QueryType = GraphQL::ObjectType.define do
  name "Query"

  field :test, types.Boolean do
    argument :input, TestInputType
    resolve -> (obj, args, ctx) { 42 }
  end
end

Schema = GraphQL::Schema.new(query: QueryType)

query = '{ test(input: { bar: "value" }) }'
puts Schema.execute(query)
```

which gives the exception

```
/Users/dylansmith/src/graphql-ruby/lib/graphql/static_validation/literal_validator.rb:40:in `block in present_input_field_values_are_valid': undefined method `type' for nil:NilClass (NoMethodError)
	from /Users/dylansmith/src/graphql-ruby/lib/graphql/static_validation/literal_validator.rb:39:in `each'
	from /Users/dylansmith/src/graphql-ruby/lib/graphql/static_validation/literal_validator.rb:39:in `all?'
	from /Users/dylansmith/src/graphql-ruby/lib/graphql/static_validation/literal_validator.rb:39:in `present_input_field_values_are_valid'
	from /Users/dylansmith/src/graphql-ruby/lib/graphql/static_validation/literal_validator.rb:15:in `validate'
	from /Users/dylansmith/src/graphql-ruby/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb:6:in `validate_node'
	from /Users/dylansmith/src/graphql-ruby/lib/graphql/static_validation/arguments_validator.rb:25:in `block in validate'
```

This is tested in graphql-ruby for GraphQL::StaticValidation::ArgumentsAreDefined, which catches this invalid query, but the exception was happening in GraphQL::StaticValidation::ArgumentLiteralsAreCompatible which assumed the input fields were present for the specified input type.

## Solution

If the input field isn't present in GraphQL::StaticValidation::ArgumentLiteralsAreCompatible, then I just considered the input valid so that GraphQL::StaticValidation::ArgumentsAreDefined can consider it invalid.

## Deeper Problem

It looks like this may be a symptom of a deeper problem, since LiteralValidator deeply validates a node rather than letting the visitor deeply validate the node.  As a result, ArgumentLiteralsAreCompatible ends up validating the inner input objects before ArgumentsAreDefined, which is why that validation doesn't prevent the exception.

This redundant validation of input objects can be seen in a test which asserts two errors are in the response for one underlying error in an input object literal (https://github.com/rmosolgo/graphql-ruby/blob/v0.10.9/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb#L37-L47)

On the other hand, removing the deep validation from LiteralValidator breaks the variable default value validation, since the visitor doesn't visit any children of the variable definition.