### PR TITLE
refactor: Move code to add the error to the context in field resolution.

### DIFF
--- a/lib/graphql/query/serial_execution/field_resolution.rb
+++ b/lib/graphql/query/serial_execution/field_resolution.rb
@@ -19,8 +19,6 @@ module GraphQL
           raw_value = begin
             get_raw_value
           rescue GraphQL::ExecutionError => err
-            err.ast_node = ast_node
-            query.context.errors << err
             err
           end
           { result_name => get_finished_value(raw_value) }
@@ -31,6 +29,11 @@ module GraphQL
         # After getting the value from the field's resolve method,
         # continue by "finishing" the value, eg. executing sub-fields or coercing values
         def get_finished_value(raw_value)
+          if raw_value.is_a?(GraphQL::ExecutionError)
+            raw_value.ast_node = ast_node
+            query.context.errors << raw_value
+          end
+
           strategy_class = GraphQL::Query::SerialExecution::ValueResolution.get_strategy_for_kind(field.type.kind)
           result_strategy = strategy_class.new(raw_value, field.type, target, parent_type, ast_node, query, execution_strategy)
           result_strategy.result


### PR DESCRIPTION
@rmosolgo & @eapache for review

This refactoring will allow graphql-batch to remove the adding of the error to the context in its override of get_finished_value (https://github.com/Shopify/graphql-batch/blob/7467505e80d2fd21333f5ca028f689692f6a5393/lib/graphql/batch/execution_strategy.rb#L54-L56) and replace those lines with `super(error)`

The adding of the error to the context was actually done in get_finished_value in the latest release (https://github.com/rmosolgo/graphql-ruby/blob/v0.10.9/lib/graphql/query/serial_execution/field_resolution.rb#L30) so this just reverts it back to working that way, while still catching execution errors raised from get_raw_value