### PR TITLE
Refactor: One line class/module definitions to nested style

### DIFF
--- a/lib/graphql/definition_helpers.rb
+++ b/lib/graphql/definition_helpers.rb
@@ -1,8 +1,3 @@
-module GraphQL
-  module DefinitionHelpers
-  end
-end
-
 require 'graphql/definition_helpers/non_null_with_bang'
 require 'graphql/definition_helpers/defined_by_config'
 require 'graphql/definition_helpers/string_named_hash'

--- a/lib/graphql/definition_helpers/defined_by_config.rb
+++ b/lib/graphql/definition_helpers/defined_by_config.rb
@@ -1,119 +1,123 @@
-# Provide a two-step definition process.
-#
-# 1. Use a config object to gather definitions
-# 2. Transfer definitions to an actual instance of an object
-#
-module GraphQL::DefinitionHelpers::DefinedByConfig
-  def self.included(base)
-    base.extend(ClassMethods)
-  end
+module GraphQL
+  module DefinitionHelpers
+    # Provide a two-step definition process.
+    #
+    # 1. Use a config object to gather definitions
+    # 2. Transfer definitions to an actual instance of an object
+    #
+    module DefinedByConfig
+      def self.included(base)
+        base.extend(ClassMethods)
+      end
 
-  # This object is `instance_eval`'d  when defining _any_ object in the schema.
-  # Then, the applicable properties of this object are transfered to the given instance.
-  class DefinitionConfig
-    def self.attr_definable(*names)
-      attr_accessor(*names)
-      names.each do |name|
-        ivar_name = "@#{name}".to_sym
-        define_method(name) do |new_value=nil|
-          new_value && self.instance_variable_set(ivar_name, new_value)
-          instance_variable_get(ivar_name)
+      # This object is `instance_eval`'d  when defining _any_ object in the schema.
+      # Then, the applicable properties of this object are transfered to the given instance.
+      class DefinitionConfig
+        def self.attr_definable(*names)
+          attr_accessor(*names)
+          names.each do |name|
+            ivar_name = "@#{name}".to_sym
+            define_method(name) do |new_value=nil|
+              new_value && self.instance_variable_set(ivar_name, new_value)
+              instance_variable_get(ivar_name)
+            end
+          end
+        end
+
+        attr_definable :name, :description,
+          :interfaces, # object
+          :deprecation_reason, # field
+          :type, # field / argument
+          :property, # field
+          :resolve, # field / directive
+          :resolve_type, # interface / union
+          :possible_types, # interface / union
+          :default_value, # argument
+          :on, # directive
+          :coerce, #scalar
+          :coerce_input, #scalar
+          :coerce_result #scalar
+
+        attr_reader :fields, :input_fields, :arguments, :values
+
+        def initialize
+          @interfaces = []
+          @possible_types = []
+          @on = []
+          @fields = {}
+          @arguments = {}
+          @values = []
+          @input_fields = {}
+        end
+
+        def types
+          GraphQL::DefinitionHelpers::TypeDefiner.instance
+        end
+
+        def field(name, type = nil, desc = nil, field: nil, property: nil, &block)
+          if block_given?
+            field = GraphQL::Field.define(&block)
+          else
+            field ||= GraphQL::Field.new
+          end
+          type && field.type = type
+          desc && field.description = desc
+          property && field.property = property
+          field.name ||= name.to_s
+          fields[name.to_s] = field
+        end
+
+        # For EnumType
+        def value(name, desc = nil, deprecation_reason: nil, value: name)
+          values << GraphQL::EnumType::EnumValue.new(name: name, description: desc, deprecation_reason: deprecation_reason, value: value)
+        end
+
+        # For InputObjectType
+        def input_field(name, type = nil, desc = nil, default_value: nil, &block)
+          argument = if block_given?
+                       GraphQL::Argument.define(&block)
+                     else
+                       GraphQL::Argument.new
+                     end
+          argument.name = name
+          type && argument.type = type
+          desc && argument.description = desc
+          default_value && argument.default_value = default_value
+          input_fields[name.to_s] = argument
+        end
+
+        def argument(name, type, description = nil, default_value: nil)
+          argument = GraphQL::Argument.new
+          argument.name = name.to_s
+          argument.type = type
+          argument.description = description
+          argument.default_value = default_value
+          @arguments[name.to_s] = argument
+        end
+
+        def to_instance(object, attributes)
+          attributes.each do |attr_name|
+            configured_value = self.public_send(attr_name)
+            object.public_send("#{attr_name}=", configured_value)
+          end
+          object
         end
       end
-    end
 
-    attr_definable :name, :description,
-      :interfaces, # object
-      :deprecation_reason, # field
-      :type, # field / argument
-      :property, # field
-      :resolve, # field / directive
-      :resolve_type, # interface / union
-      :possible_types, # interface / union
-      :default_value, # argument
-      :on, # directive
-      :coerce, #scalar
-      :coerce_input, #scalar
-      :coerce_result #scalar
+      module ClassMethods
+        # Pass the block to this class's `DefinitionConfig`,
+        # The return the result of {DefinitionConfig#to_instance}
+        def define(&block)
+          config = DefinitionConfig.new
+          block && config.instance_eval(&block)
+          config.to_instance(self.new, @defined_attrs)
+        end
 
-    attr_reader :fields, :input_fields, :arguments, :values
-
-    def initialize
-      @interfaces = []
-      @possible_types = []
-      @on = []
-      @fields = {}
-      @arguments = {}
-      @values = []
-      @input_fields = {}
-    end
-
-    def types
-      GraphQL::DefinitionHelpers::TypeDefiner.instance
-    end
-
-    def field(name, type = nil, desc = nil, field: nil, property: nil, &block)
-      if block_given?
-        field = GraphQL::Field.define(&block)
-      else
-        field ||= GraphQL::Field.new
+        def defined_by_config(*defined_attrs)
+          @defined_attrs ||= []
+          @defined_attrs += defined_attrs
+        end
       end
-      type && field.type = type
-      desc && field.description = desc
-      property && field.property = property
-      field.name ||= name.to_s
-      fields[name.to_s] = field
-    end
-
-    # For EnumType
-    def value(name, desc = nil, deprecation_reason: nil, value: name)
-      values << GraphQL::EnumType::EnumValue.new(name: name, description: desc, deprecation_reason: deprecation_reason, value: value)
-    end
-
-    # For InputObjectType
-    def input_field(name, type = nil, desc = nil, default_value: nil, &block)
-      argument = if block_given?
-        GraphQL::Argument.define(&block)
-      else
-        GraphQL::Argument.new
-      end
-      argument.name = name
-      type && argument.type = type
-      desc && argument.description = desc
-      default_value && argument.default_value = default_value
-      input_fields[name.to_s] = argument
-    end
-
-    def argument(name, type, description = nil, default_value: nil)
-       argument = GraphQL::Argument.new
-       argument.name = name.to_s
-       argument.type = type
-       argument.description = description
-       argument.default_value = default_value
-       @arguments[name.to_s] = argument
-     end
-
-    def to_instance(object, attributes)
-      attributes.each do |attr_name|
-        configured_value = self.public_send(attr_name)
-        object.public_send("#{attr_name}=", configured_value)
-      end
-      object
-    end
-  end
-
-  module ClassMethods
-    # Pass the block to this class's `DefinitionConfig`,
-    # The return the result of {DefinitionConfig#to_instance}
-    def define(&block)
-      config = DefinitionConfig.new
-      block && config.instance_eval(&block)
-      config.to_instance(self.new, @defined_attrs)
-    end
-
-    def defined_by_config(*defined_attrs)
-      @defined_attrs ||= []
-      @defined_attrs += defined_attrs
     end
   end
 end

--- a/lib/graphql/definition_helpers/non_null_with_bang.rb
+++ b/lib/graphql/definition_helpers/non_null_with_bang.rb
@@ -1,11 +1,15 @@
-# Wrap the object in NonNullType in response to `!`
-# @example required Int type
-#   !GraphQL::INT_TYPE
-#
-module GraphQL::DefinitionHelpers::NonNullWithBang
-  # Make the type non-null
-  # @return [GraphQL::NonNullType] a non-null type which wraps the original type
-  def !
-    to_non_null_type
+module GraphQL
+  module DefinitionHelpers
+    # Wrap the object in NonNullType in response to `!`
+    # @example required Int type
+    #   !GraphQL::INT_TYPE
+    #
+    module NonNullWithBang
+      # Make the type non-null
+      # @return [GraphQL::NonNullType] a non-null type which wraps the original type
+      def !
+        to_non_null_type
+      end
+    end
   end
 end

--- a/lib/graphql/definition_helpers/string_named_hash.rb
+++ b/lib/graphql/definition_helpers/string_named_hash.rb
@@ -1,18 +1,22 @@
-# Accepts a hash with symbol keys.
-# - convert keys to strings
-# - if the value responds to `name=`, then assign the hash key as `name`
-#
-# Used by {ObjectType#fields}, {Field#arguments} and others.
-class GraphQL::DefinitionHelpers::StringNamedHash
-  # Normalized hash for the input
-  # @return [Hash] Hash with string keys
-  attr_reader :to_h
+module GraphQL
+  module DefinitionHelpers
+    # Accepts a hash with symbol keys.
+    # - convert keys to strings
+    # - if the value responds to `name=`, then assign the hash key as `name`
+    #
+    # Used by {ObjectType#fields}, {Field#arguments} and others.
+    class StringNamedHash
+      # Normalized hash for the input
+      # @return [Hash] Hash with string keys
+      attr_reader :to_h
 
-  # @param input_hash [Hash] Hash to be normalized
-  def initialize(input_hash)
-    @to_h = input_hash
-      .reduce({}) { |memo, (key, value)| memo[key.to_s] = value; memo }
-    # Set the name of the value based on its key
-    @to_h.each {|k, v| v.respond_to?("name=") && v.name = k }
+      # @param input_hash [Hash] Hash to be normalized
+      def initialize(input_hash)
+        @to_h = input_hash
+                .reduce({}) { |memo, (key, value)| memo[key.to_s] = value; memo }
+        # Set the name of the value based on its key
+        @to_h.each {|k, v| v.respond_to?("name=") && v.name = k }
+      end
+    end
   end
 end

--- a/lib/graphql/definition_helpers/type_definer.rb
+++ b/lib/graphql/definition_helpers/type_definer.rb
@@ -1,25 +1,29 @@
-# Some conveniences for definining return & argument types.
-#
-# Passed into initialization blocks, eg {ObjectType#initialize}, {Field#initialize}
-class GraphQL::DefinitionHelpers::TypeDefiner
-  include Singleton
+module GraphQL
+  module DefinitionHelpers
+    # Some conveniences for definining return & argument types.
+    #
+    # Passed into initialization blocks, eg {ObjectType#initialize}, {Field#initialize}
+    class TypeDefiner
+      include Singleton
 
-  def Int;      GraphQL::INT_TYPE;      end
-  def String;   GraphQL::STRING_TYPE;   end
-  def Float;    GraphQL::FLOAT_TYPE;    end
-  def Boolean;  GraphQL::BOOLEAN_TYPE;  end
-  def ID;       GraphQL::ID_TYPE;       end
+      def Int;      GraphQL::INT_TYPE;      end
+      def String;   GraphQL::STRING_TYPE;   end
+      def Float;    GraphQL::FLOAT_TYPE;    end
+      def Boolean;  GraphQL::BOOLEAN_TYPE;  end
+      def ID;       GraphQL::ID_TYPE;       end
 
-  # Make a {ListType} which wraps the input type
-  #
-  # @example making a list type
-  #   list_of_strings = types[types.String]
-  #   list_of_strings.inspect
-  #   # => "[String]"
-  #
-  # @param type [Type] A type to be wrapped in a ListType
-  # @return [GraphQL::ListType] A ListType wrapping `type`
-  def [](type)
-    type.to_list_type
+      # Make a {ListType} which wraps the input type
+      #
+      # @example making a list type
+      #   list_of_strings = types[types.String]
+      #   list_of_strings.inspect
+      #   # => "[String]"
+      #
+      # @param type [Type] A type to be wrapped in a ListType
+      # @return [GraphQL::ListType] A ListType wrapping `type`
+      def [](type)
+        type.to_list_type
+      end
+    end
   end
 end


### PR DESCRIPTION
As commented here https://github.com/rmosolgo/graphql-ruby/issues/98, this PR is only a refactor to move inner class/module definitions to nested style.
It have a big diff (cause the indentation for all refactored files changed), but there are no functional changes so no specs update is required.