### PR TITLE
More details on input validation errors

### DIFF
--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -81,6 +81,11 @@ module GraphQL
       valid_non_null_input?(value)
     end
 
+    def validate_input(value)
+      return GraphQL::Query::InputValidationResult.new if value.nil?
+      validate_non_null_input(value)
+    end
+
     def coerce_input(value)
       return nil if value.nil?
       coerce_non_null_input(value)

--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -77,8 +77,7 @@ module GraphQL
     alias :inspect :to_s
 
     def valid_input?(value)
-      return true if value.nil?
-      valid_non_null_input?(value)
+      validate_input(value).is_valid?
     end
 
     def validate_input(value)

--- a/lib/graphql/enum_type.rb
+++ b/lib/graphql/enum_type.rb
@@ -41,14 +41,10 @@ class GraphQL::EnumType < GraphQL::BaseType
     GraphQL::TypeKinds::ENUM
   end
 
-  def valid_non_null_input?(value_name)
-    @values_by_name.key?(value_name)
-  end
-
   def validate_non_null_input(value_name)
     result = GraphQL::Query::InputValidationResult.new
 
-    unless valid_non_null_input?(value_name)
+    unless @values_by_name.key?(value_name)
       result.add_problem("Expected #{JSON.dump(value_name)} to be one of: #{@values_by_name.keys.join(', ')}")
     end
 

--- a/lib/graphql/enum_type.rb
+++ b/lib/graphql/enum_type.rb
@@ -45,6 +45,16 @@ class GraphQL::EnumType < GraphQL::BaseType
     @values_by_name.key?(value_name)
   end
 
+  def validate_non_null_input(value_name)
+    result = GraphQL::Query::InputValidationResult.new
+
+    unless valid_non_null_input?(value_name)
+      result.add_problem("Expected #{JSON.dump(value_name)} to be one of: #{@values_by_name.keys.join(', ')}")
+    end
+
+    result
+  end
+
   # Get the underlying value for this enum value
   #
   # @example get episode value from Enum

--- a/lib/graphql/float_type.rb
+++ b/lib/graphql/float_type.rb
@@ -1,6 +1,6 @@
 GraphQL::FLOAT_TYPE = GraphQL::ScalarType.define do
   name "Float"
   coerce -> (value) do
-    value.respond_to?(:to_f) ? value.to_f : nil
+    value.is_a?(Numeric) ? value.to_f : nil
   end
 end

--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -20,22 +20,8 @@ class GraphQL::InputObjectType < GraphQL::BaseType
     GraphQL::TypeKinds::INPUT_OBJECT
   end
 
-  # assert that all present fields are defined
-  # _and_ all defined fields have valid values
-  def valid_non_null_input?(input)
-    input.all? { |name, value| input_fields[name] } &&
-      input_fields.all? { |name, field| field.type.valid_input?(input[name]) }
-  end
-
   def validate_non_null_input(input)
-    # Inputs are only required to provide an `all?` method and a `[]` method. That's not enough
-    # to get detailed errors, so if that's all we got, we can only provide generalized error.
-    # (see spec/support/mimimum_input_object.rb)
-    unless input.is_a?(Enumerable)
-      result = GraphQL::Query::InputValidationResult.new
-      result.add_problem("Invalid input was provided") unless valid_non_null_input?(input)
-      return result
-    end
+    fail ArgumentError.new("input must be enumerable") unless input.is_a?(Enumerable)
 
     result = GraphQL::Query::InputValidationResult.new
 

--- a/lib/graphql/list_type.rb
+++ b/lib/graphql/list_type.rb
@@ -17,10 +17,6 @@ class GraphQL::ListType < GraphQL::BaseType
     "[#{of_type.to_s}]"
   end
 
-  def valid_non_null_input?(value)
-    ensure_array(value).all?{ |item| of_type.valid_input?(item) }
-  end
-
   def validate_non_null_input(value)
     result = GraphQL::Query::InputValidationResult.new
 
@@ -28,7 +24,7 @@ class GraphQL::ListType < GraphQL::BaseType
       item_result = of_type.validate_input(item)
       result.merge_result!(index, item_result) unless item_result.is_valid?
     end
-    
+
     result
   end
 

--- a/lib/graphql/list_type.rb
+++ b/lib/graphql/list_type.rb
@@ -21,6 +21,18 @@ class GraphQL::ListType < GraphQL::BaseType
     ensure_array(value).all?{ |item| of_type.valid_input?(item) }
   end
 
+  def validate_non_null_input(value)
+    result = GraphQL::Query::InputValidationResult.new
+
+    ensure_array(value).each_with_index do |item, index|
+      item_result = of_type.validate_input(item)
+      result.merge_result!(index, item_result) unless item_result.is_valid?
+    end
+    
+    result
+  end
+
+
   def coerce_non_null_input(value)
     ensure_array(value).map{ |item| of_type.coerce_input(item) }
   end

--- a/lib/graphql/non_null_type.rb
+++ b/lib/graphql/non_null_type.rb
@@ -17,6 +17,16 @@ class GraphQL::NonNullType < GraphQL::BaseType
     !value.nil? && of_type.valid_input?(value)
   end
 
+  def validate_input(value)
+    if value.nil?
+      result = GraphQL::Query::InputValidationResult.new
+      result.add_problem("Expected value to not be null")
+      result
+    else
+      of_type.validate_input(value)
+    end
+  end
+
   def coerce_input(value)
     of_type.coerce_input(value)
   end

--- a/lib/graphql/non_null_type.rb
+++ b/lib/graphql/non_null_type.rb
@@ -14,7 +14,7 @@ class GraphQL::NonNullType < GraphQL::BaseType
   end
 
   def valid_input?(value)
-    !value.nil? && of_type.valid_input?(value)
+    validate_input(value).is_valid?
   end
 
   def validate_input(value)

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -6,46 +6,6 @@ class GraphQL::Query
     end
   end
 
-  class InputValidationResult
-    attr_accessor :problems
-
-    def initialize
-      @problems = []
-    end
-
-    def is_valid?
-      @problems.empty?
-    end
-
-    def add_problem(explanation, path = nil)
-      @problems.push({ 'path' => path || [], 'explanation' => explanation })
-    end
-
-    def merge_result!(path, inner_result)
-      inner_result.problems.each do |p|
-        item_path = [path, *p['path']]
-        add_problem(p['explanation'], item_path)
-      end
-    end
-  end
-
-  class VariableValidationError < GraphQL::ExecutionError
-    attr_accessor :value, :validation_result
-
-    def initialize(variable_ast, type, value, validation_result)
-      @value = value
-      @validation_result = validation_result
-
-      msg = "Variable #{variable_ast.name} of type #{type} was provided invalid value"
-      super(msg)
-      self.ast_node = variable_ast
-    end
-
-    def to_h
-      super.merge({ 'value' => value, 'problems' => validation_result.problems })
-    end
-  end
-
   # If a resolve function returns `GraphQL::Query::DEFAULT_RESOLVE`,
   # The executor will send the field's name to the target object
   # and use the result.
@@ -137,3 +97,5 @@ require 'graphql/query/literal_input'
 require 'graphql/query/serial_execution'
 require 'graphql/query/type_resolver'
 require 'graphql/query/variables'
+require 'graphql/query/input_validation_result'
+require 'graphql/query/variable_validation_error'

--- a/lib/graphql/query/input_validation_result.rb
+++ b/lib/graphql/query/input_validation_result.rb
@@ -12,7 +12,7 @@ class GraphQL::Query
     end
 
     def merge_result!(path, inner_result)
-      return if inner_result.problems.nil?
+      return if inner_result.is_valid?
 
       inner_result.problems.each do |p|
         item_path = [path, *p['path']]

--- a/lib/graphql/query/input_validation_result.rb
+++ b/lib/graphql/query/input_validation_result.rb
@@ -1,0 +1,23 @@
+class GraphQL::Query
+  class InputValidationResult
+    attr_accessor :problems
+
+    def is_valid?
+      @problems.nil?
+    end
+
+    def add_problem(explanation, path = nil)
+      @problems ||= []
+      @problems.push({ 'path' => path || [], 'explanation' => explanation })
+    end
+
+    def merge_result!(path, inner_result)
+      return if inner_result.problems.nil?
+
+      inner_result.problems.each do |p|
+        item_path = [path, *p['path']]
+        add_problem(p['explanation'], item_path)
+      end
+    end
+  end
+end

--- a/lib/graphql/query/variable_validation_error.rb
+++ b/lib/graphql/query/variable_validation_error.rb
@@ -1,0 +1,18 @@
+class GraphQL::Query
+  class VariableValidationError < GraphQL::ExecutionError
+    attr_accessor :value, :validation_result
+
+    def initialize(variable_ast, type, value, validation_result)
+      @value = value
+      @validation_result = validation_result
+
+      msg = "Variable #{variable_ast.name} of type #{type} was provided invalid value"
+      super(msg)
+      self.ast_node = variable_ast
+    end
+
+    def to_h
+      super.merge({ 'value' => value, 'problems' => validation_result.problems })
+    end
+  end
+end

--- a/lib/graphql/query/variables.rb
+++ b/lib/graphql/query/variables.rb
@@ -28,11 +28,8 @@ module GraphQL
         provided_value = @provided_variables[variable_name]
 
         unless variable_type.valid_input?(provided_value)
-          if provided_value.nil?
-            raise GraphQL::Query::VariableMissingError.new(ast_variable, variable_type)
-          else
-            raise GraphQL::Query::VariableValidationError.new(ast_variable, variable_type, "was provided invalid value #{JSON.dump(provided_value)}")
-          end
+          result = variable_type.validate_input(provided_value)
+          raise GraphQL::Query::VariableValidationError.new(ast_variable, variable_type, provided_value, result)
         end
         if provided_value.nil?
           GraphQL::Query::LiteralInput.coerce(variable_type, default_value, {})

--- a/lib/graphql/query/variables.rb
+++ b/lib/graphql/query/variables.rb
@@ -27,9 +27,9 @@ module GraphQL
         default_value = ast_variable.default_value
         provided_value = @provided_variables[variable_name]
 
-        unless variable_type.valid_input?(provided_value)
-          result = variable_type.validate_input(provided_value)
-          raise GraphQL::Query::VariableValidationError.new(ast_variable, variable_type, provided_value, result)
+        validation_result = variable_type.validate_input(provided_value)
+        unless validation_result.is_valid?
+          raise GraphQL::Query::VariableValidationError.new(ast_variable, variable_type, provided_value, validation_result)
         end
         if provided_value.nil?
           GraphQL::Query::LiteralInput.coerce(variable_type, default_value, {})

--- a/lib/graphql/scalar_type.rb
+++ b/lib/graphql/scalar_type.rb
@@ -19,14 +19,10 @@ module GraphQL
       self.coerce_result = proc
     end
 
-    def valid_non_null_input?(value)
-      !coerce_non_null_input(value).nil?
-    end
-
     def validate_non_null_input(value)
       result = Query::InputValidationResult.new
 
-      unless valid_non_null_input?(value)
+      unless !coerce_non_null_input(value).nil?
         result.add_problem("Could not coerce value #{JSON.dump(value)} to #{name}")
       end
 

--- a/lib/graphql/scalar_type.rb
+++ b/lib/graphql/scalar_type.rb
@@ -23,6 +23,16 @@ module GraphQL
       !coerce_non_null_input(value).nil?
     end
 
+    def validate_non_null_input(value)
+      result = Query::InputValidationResult.new
+
+      unless valid_non_null_input?(value)
+        result.add_problem("Could not coerce value #{JSON.dump(value)} to #{name}")
+      end
+
+      result
+    end
+
     def coerce_non_null_input(value)
       @coerce_input_proc.call(value)
     end

--- a/lib/graphql/scalar_type.rb
+++ b/lib/graphql/scalar_type.rb
@@ -21,11 +21,7 @@ module GraphQL
 
     def validate_non_null_input(value)
       result = Query::InputValidationResult.new
-
-      unless !coerce_non_null_input(value).nil?
-        result.add_problem("Could not coerce value #{JSON.dump(value)} to #{name}")
-      end
-
+      result.add_problem("Could not coerce value #{JSON.dump(value)} to #{name}") if coerce_non_null_input(value).nil?
       result
     end
 

--- a/spec/graphql/enum_type_spec.rb
+++ b/spec/graphql/enum_type_spec.rb
@@ -16,4 +16,12 @@ describe GraphQL::EnumType do
   it 'has value description' do
     assert_equal("Animal with horns", enum.values['GOAT'].description)
   end
+
+  describe 'validate_input with bad input' do
+    let(:result) { DairyAnimalEnum.validate_input('bad enum') }
+
+    it 'returns an invalid result' do
+      assert(!result.is_valid?)
+    end
+  end
 end

--- a/spec/graphql/input_object_type_spec.rb
+++ b/spec/graphql/input_object_type_spec.rb
@@ -13,7 +13,7 @@ describe GraphQL::InputObjectType do
   describe "input validation" do
     it "Accepts anything that yields key-value pairs to #all?" do
       values_obj = MinimumInputObject.new
-      assert DairyProductInputType.valid_non_null_input?(values_obj)
+      assert DairyProductInputType.valid_input?(values_obj)
     end
 
     describe 'validate_input with non-enumerable input' do

--- a/spec/graphql/list_type_spec.rb
+++ b/spec/graphql/list_type_spec.rb
@@ -6,4 +6,27 @@ describe GraphQL::ListType do
   it 'coerces elements in the list' do
     assert_equal([1.0, 2.0, 3.0].inspect, float_list.coerce_input([1, 2, 3]).inspect)
   end
+
+  describe 'validate_input with bad input' do
+    let(:bad_num) { 'bad_num' }
+    let(:result) { float_list.validate_input([bad_num, 2.0, 3.0]) }
+
+    it 'returns an invalid result' do
+      assert(!result.is_valid?)
+    end
+
+    it 'has one problem' do
+      assert_equal(result.problems.length, 1)
+    end
+
+    it 'has path [0]' do
+      assert_equal(result.problems[0]['path'], [0])
+    end
+
+    it 'has the correct explanation' do
+      expected = GraphQL::FLOAT_TYPE.validate_input(bad_num).problems[0]['explanation']
+      actual = result.problems[0]['explanation']
+      assert_equal(actual, expected)
+    end
+  end
 end

--- a/spec/graphql/query/executor_spec.rb
+++ b/spec/graphql/query/executor_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe GraphQL::Query::Executor do
-  let(:debug) { false }
+  let(:debug) { true }
   let(:operation_name) { nil }
   let(:schema) { DummySchema }
   let(:variables) { {"cheeseId" => 2} }
@@ -221,6 +221,26 @@ describe GraphQL::Query::Executor do
       end
     end
 
+    describe "for required input objects" do
+      let(:variables) { { } }
+      let(:query_string) {%| mutation M($input: ReplaceValuesInput!) { replaceValues(input: $input) } |}
+      it "returns a variable validation error" do
+        expected = {
+          "errors"=>[
+            {
+              "message" => "Variable input of type ReplaceValuesInput! was provided invalid value",
+              "locations" => [{ "line" => 1, "column" => 14 }],
+              "value" => nil,
+              "problems" => [
+                { "path" => [], "explanation" => "Expected value to not be null" }
+              ]
+            }
+          ]
+        }
+        assert_equal(expected, result)
+      end
+    end
+
     describe "for required input object fields" do
       let(:variables) { {"input" => {} } }
       let(:query_string) {%| mutation M($input: ReplaceValuesInput!) { replaceValues(input: $input) } |}
@@ -228,8 +248,12 @@ describe GraphQL::Query::Executor do
         expected = {
           "errors"=>[
             {
-              "message" => "Variable input of type ReplaceValuesInput! was provided invalid value {}",
-              "locations" => [{"line"=>1, "column"=>14}]
+              "message" => "Variable input of type ReplaceValuesInput! was provided invalid value",
+              "locations" => [{ "line" => 1, "column" => 14 }],
+              "value" => {},
+              "problems" => [
+                { "path" => ["values"], "explanation" => "Expected value to not be null" }
+              ]
             }
           ]
         }
@@ -244,8 +268,13 @@ describe GraphQL::Query::Executor do
         expected = {
           "errors"=>[
             {
-              "message" => "Variable input of type [DairyProductInput] was provided invalid value [{\"foo\":\"bar\"}]",
-              "locations" => [{"line"=>1, "column"=>11}]
+              "message" => "Variable input of type [DairyProductInput] was provided invalid value",
+              "locations" => [{ "line" => 1, "column" => 11 }],
+              "value" => [{ "foo" => "bar" }],
+              "problems" => [
+                { "path" => [0, "foo"], "explanation" => "Field is not defined on DairyProductInput" },
+                { "path" => [0, "source"], "explanation" => "Expected value to not be null" }
+              ]
             }
           ]
         }

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -244,7 +244,17 @@ describe GraphQL::Query do
       let(:query_variables) { {"cheeseId" => "2"} }
 
       it "raises an error" do
-        assert_equal(result["errors"][0]["message"], %{Variable cheeseId of type Int! was provided invalid value "2"})
+        expected = {
+          "errors" => [
+            {
+              "message" => "Variable cheeseId of type Int! was provided invalid value",
+              "locations"=>[{ "line" => 2, "column" => 24 }],
+              "value" => "2",
+              "problems" => [{ "path" => [], "explanation" => 'Could not coerce value "2" to Int' }]
+            }
+          ]
+        }
+        assert_equal(expected, result)
       end
     end
 
@@ -252,8 +262,17 @@ describe GraphQL::Query do
       let(:query_variables) { {} }
 
       it "raises an error" do
-        expected = "Variable cheeseId of type Int! can't be null"
-        assert_equal(result["errors"][0]["message"], expected)
+        expected = {
+          "errors" => [
+            {
+              "message" => "Variable cheeseId of type Int! was provided invalid value",
+              "locations" => [{"line" => 2, "column" => 24}],
+              "value" => nil,
+              "problems" => [{ "path" => [], "explanation" => "Expected value to not be null" }]
+            }
+          ]
+        }
+        assert_equal(expected, result)
       end
     end
 

--- a/spec/graphql/scalar_type_spec.rb
+++ b/spec/graphql/scalar_type_spec.rb
@@ -21,4 +21,32 @@ describe GraphQL::ScalarType do
   it 'coerces result value for serialization' do
     assert_equal(bignum.to_s, scalar.coerce_result(bignum))
   end
+
+  describe 'validate_input with good input' do
+    let(:result) { GraphQL::INT_TYPE.validate_input(150) }
+
+    it 'returns a valid result' do
+      assert(result.is_valid?)
+    end
+  end
+
+  describe 'validate_input with bad input' do
+    let(:result) { GraphQL::INT_TYPE.validate_input('bad num') }
+
+    it 'returns an invalid result for bad input' do
+      assert(!result.is_valid?)
+    end
+
+    it 'has one problem' do
+      assert_equal(result.problems.length, 1)
+    end
+
+    it 'has the correct explanation' do
+      assert(result.problems[0]['explanation'].include?('Could not coerce value'))
+    end
+
+    it 'has an empty path' do
+      assert(result.problems[0]['path'].empty?)
+    end
+  end
 end

--- a/spec/support/minimum_input_object.rb
+++ b/spec/support/minimum_input_object.rb
@@ -11,3 +11,16 @@ class MinimumInputObject
     pair[1]
   end
 end
+
+class MinimumInvalidInputObject
+  KEY_VALUE_PAIRS = [["source", "KOALA"], ["fatContent", 0.4]]
+
+  def all?
+    KEY_VALUE_PAIRS.all? { |pair| yield(pair) }
+  end
+
+  def [](key)
+    pair = KEY_VALUE_PAIRS.find { |k, v| k == key }
+    pair[1]
+  end
+end

--- a/spec/support/minimum_input_object.rb
+++ b/spec/support/minimum_input_object.rb
@@ -1,9 +1,11 @@
 # This is the minimum required interface for an input object
 class MinimumInputObject
+  include Enumerable
+
   KEY_VALUE_PAIRS = [["source", "COW"], ["fatContent", 0.4]]
 
-  def all?
-    KEY_VALUE_PAIRS.all? { |pair| yield(pair) }
+  def each(&block)
+    KEY_VALUE_PAIRS.each(&block)
   end
 
   def [](key)
@@ -13,10 +15,12 @@ class MinimumInputObject
 end
 
 class MinimumInvalidInputObject
+  include Enumerable
+
   KEY_VALUE_PAIRS = [["source", "KOALA"], ["fatContent", 0.4]]
 
-  def all?
-    KEY_VALUE_PAIRS.all? { |pair| yield(pair) }
+  def each(&block)
+    KEY_VALUE_PAIRS.each(&block)
   end
 
   def [](key)


### PR DESCRIPTION
This PR adds more details to the error messages that you get when you provide invalid input variables to a GraphQL query.

Currently, you get error messages like this:
```js
errors: [
  {
    message: "Variable input of type [DairyProductInput] was provided invalid value [{\"foo\":\"bar\"}]",
    locations: [{line: 1, column: 11}]
  }
]
```
The message doesn't include much information about _what_ is wrong with the value. So the goal here is to provide more information, so that you can debug faster:
```js
errors: [
  {
    message: "Variable input of type [DairyProductInput] was provided invalid value",
    locations: [{ line: 1, column: 11 }],
    value: [{ foo: "bar" }],
    problems: [
      { path: [0, "foo"], explanation: "Field is not defined on DairyProductInput" },
      { path: [0, "source"], explanation: "Expected value to not be null" }
    ]
  }
]
```

Any feedback is appreciated!