### PR TITLE
ExecutionContext object to wrap query and strategy during execution

### DIFF
--- a/lib/graphql/query/serial_execution.rb
+++ b/lib/graphql/query/serial_execution.rb
@@ -10,8 +10,11 @@ module GraphQL
       # @param query_obj [GraphQL::Query] the query object for this execution
       # @return [Hash] a spec-compliant GraphQL result, as a hash
       def execute(ast_operation, root_type, query_obj)
-        resolver = operation_resolution.new(ast_operation, root_type, query_obj, self)
-        resolver.result
+        operation_resolution.new(
+          ast_operation,
+          root_type,
+          ExecutionContext.new(query_obj, self)
+        ).result
       end
 
       def field_resolution
@@ -29,6 +32,7 @@ module GraphQL
   end
 end
 
+require 'graphql/query/serial_execution/execution_context'
 require 'graphql/query/serial_execution/value_resolution'
 require 'graphql/query/serial_execution/field_resolution'
 require 'graphql/query/serial_execution/operation_resolution'

--- a/lib/graphql/query/serial_execution/execution_context.rb
+++ b/lib/graphql/query/serial_execution/execution_context.rb
@@ -1,0 +1,30 @@
+module GraphQL
+  class Query
+    class SerialExecution
+      class ExecutionContext
+        attr_reader :query, :strategy
+
+        def initialize(query, strategy)
+          @query = query
+          @strategy = strategy
+        end
+
+        def get_type(type)
+          @query.schema.types[type]
+        end
+
+        def get_fragment(name)
+          @query.fragments[name]
+        end
+
+        def get_field(type, name)
+          @query.schema.get_field(type, name)
+        end
+
+        def add_error(err)
+          @query.context.errors << err
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/query/serial_execution/operation_resolution.rb
+++ b/lib/graphql/query/serial_execution/operation_resolution.rb
@@ -2,19 +2,22 @@ module GraphQL
   class Query
     class SerialExecution
       class OperationResolution
-        attr_reader :query, :target, :ast_operation_definition, :execution_strategy
+        attr_reader :query, :target, :ast_operation_definition, :execution_context
 
-        def initialize(ast_operation_definition, target, query, execution_strategy)
+        def initialize(ast_operation_definition, target, execution_context)
           @ast_operation_definition = ast_operation_definition
-          @query = query
           @target = target
-          @execution_strategy = execution_strategy
+          @execution_context = execution_context
         end
 
         def result
           selections = ast_operation_definition.selections
-          resolver = execution_strategy.selection_resolution.new(nil, target, selections, query, execution_strategy)
-          resolver.result
+          execution_context.strategy.selection_resolution.new(
+            nil,
+            target,
+            selections,
+            execution_context
+          ).result
         end
       end
     end

--- a/spec/graphql/query/serial_execution/execution_context_spec.rb
+++ b/spec/graphql/query/serial_execution/execution_context_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe GraphQL::Query::SerialExecution::ExecutionContext do
+  let(:query_string) { %|
+    query getFlavor($cheeseId: Int!) {
+      brie: cheese(id: 1)   { ...cheeseFields, taste: flavor }
+    }
+    fragment cheeseFields on Cheese { flavor }
+  |}
+  let(:debug) { false }
+  let(:operation_name) { nil }
+  let(:query_variables) { {"cheeseId" => 2} }
+  let(:schema) { DummySchema }
+  let(:query) { GraphQL::Query.new(
+    schema,
+    query_string,
+    variables: query_variables,
+    debug: debug,
+    operation_name: operation_name,
+  )}
+  let(:execution_context) {
+    GraphQL::Query::SerialExecution::ExecutionContext.new(query, nil)
+  }
+
+  describe "add_error" do
+    let(:err) { StandardError.new("test") }
+    let(:expected) { [err] }
+
+    it "adds an error on the query context" do
+      execution_context.add_error(err)
+      assert_equal(expected, query.context.errors)
+    end
+  end
+
+  describe "get_type" do
+    it "returns the respective type from the schema" do
+      type = execution_context.get_type('Dairy')
+      assert_equal(DairyType, type)
+    end
+  end
+
+  describe "get_field" do
+    it "returns the respective field from the schema" do
+      field = execution_context.get_field(DairyType, 'cheese')
+      assert_equal('cheese', field.name)
+    end
+  end
+
+  describe "get_fragment" do
+    it "returns a fragment on the query by name" do
+      fragment = execution_context.get_fragment('cheeseFields')
+      assert_equal('cheeseFields', fragment.name)
+    end
+  end
+end


### PR DESCRIPTION
As we add more and more features to the Executor, our `initialize` adds more and more arguments.

This PR introduces am `ExecutionContext` object that currently wraps `query` and `execution_strategy` as well as providing method to access or modify these fields.

This object wraps values that are carried all the way from the base execution up to the value resolution, and will be helpful to add any other values related to an entire query (from start to end)

I've added tests for it, but it might not be necessary as other parts are already tested.

Let me know what you think.