### PR TITLE
Maximum query depth at execution

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -24,7 +24,7 @@ class GraphQL::Query
   # The executor will send the field's name to the target object
   # and use the result.
   DEFAULT_RESOLVE = :__default_resolve
-  attr_reader :schema, :document, :context, :fragments, :operations, :debug
+  attr_reader :schema, :document, :context, :fragments, :operations, :debug, :max_depth
 
   # Prepare query `query_string` on `schema`
   # @param schema [GraphQL::Schema]
@@ -34,7 +34,8 @@ class GraphQL::Query
   # @param debug [Boolean] if true, errors are raised, if false, errors are put in the `errors` key
   # @param validate [Boolean] if true, `query_string` will be validated with {StaticValidation::Validator}
   # @param operation_name [String] if the query string contains many operations, this is the one which should be executed
-  def initialize(schema, query_string, context: nil, variables: {}, debug: false, validate: true, operation_name: nil)
+  # @param max_depth [Integer] the maximum depth the query is allowed, will raise if exceeded.
+  def initialize(schema, query_string, context: nil, variables: {}, debug: false, validate: true, operation_name: nil, max_depth: nil)
     @schema = schema
     @debug = debug
     @context = Context.new(query: self, values: context)
@@ -43,6 +44,7 @@ class GraphQL::Query
     @fragments = {}
     @operations = {}
     @provided_variables = variables
+    @max_depth = max_depth
     @document = GraphQL.parse(query_string)
     @document.definitions.each do |part|
       if part.is_a?(GraphQL::Language::Nodes::FragmentDefinition)

--- a/lib/graphql/query/serial_execution/execution_context.rb
+++ b/lib/graphql/query/serial_execution/execution_context.rb
@@ -2,11 +2,20 @@ module GraphQL
   class Query
     class SerialExecution
       class ExecutionContext
-        attr_reader :query, :strategy
+        attr_reader :query, :strategy, :max_depth
 
         def initialize(query, strategy)
           @query = query
           @strategy = strategy
+          @max_depth = query.max_depth
+        end
+
+        def depth_check(depth)
+          return unless max_depth
+
+          if depth > max_depth
+            raise GraphQL::ExecutionError, 'Max query depth was exceeded'
+          end
         end
 
         def get_type(type)

--- a/lib/graphql/query/serial_execution/selection_resolution.rb
+++ b/lib/graphql/query/serial_execution/selection_resolution.rb
@@ -2,13 +2,15 @@ module GraphQL
   class Query
     class SerialExecution
       class SelectionResolution
-        attr_reader :target, :type, :selections, :execution_context
+        attr_reader :target, :type, :selections, :execution_context, :depth
 
-        def initialize(target, type, selections, execution_context)
+        def initialize(target, type, selections, execution_context, depth: 1)
           @target = target
           @type = type
           @selections = selections
           @execution_context = execution_context
+          @depth = depth
+          execution_context.depth_check(depth)
         end
 
         def result
@@ -88,7 +90,8 @@ module GraphQL
               ast_node,
               type,
               target,
-              execution_context
+              execution_context,
+              depth: depth + 1
             ).result
           }
           chain.result


### PR DESCRIPTION
Introduces a `max_depth` argument on `GraphQL::Query`

Raises an `ExecutionError` at runtime if the maximum depth is exceeded.

Defaults to `nil`, and is not enforced in that case.

If a query like this one is executed with `max_depth: 3`:

```
      query maxDepth {
        cheese(id: 1) {
          source
          similarCheese(source: COW) {
            flavor
            similarCheese(source: COW) {
              flavor
            }
          }
        }
      }
```

it will raise a `GraphQL::ExecutionError` because it has a depth of 4

Question is: shoud it return a global error like it does right now, or should the rest of the query be returned, without the selections that are too deep ?