### PR TITLE
Fixing bug with enum literals when using libgraphqlparser

### DIFF
--- a/lib/graphql/query/literal_input.rb
+++ b/lib/graphql/query/literal_input.rb
@@ -64,7 +64,7 @@ module GraphQL
 
         module EnumLiteral
           def self.coerce(value, type, variables)
-            type.coerce_input(value.name)
+            type.coerce_input(value.is_a?(String) ? value : value.name)
           end
         end
 

--- a/lib/graphql/static_validation/literal_validator.rb
+++ b/lib/graphql/static_validation/literal_validator.rb
@@ -10,6 +10,8 @@ class GraphQL::StaticValidation::LiteralValidator
       type.valid_input?(ast_value)
     elsif type.kind.enum? && ast_value.is_a?(GraphQL::Language::Nodes::Enum)
       type.valid_input?(ast_value.name)
+    elsif type.kind.enum? && ast_value.is_a?(String)
+      type.valid_input?(ast_value)
     elsif type.kind.input_object? && ast_value.is_a?(GraphQL::Language::Nodes::InputObject)
       required_input_fields_are_present(type, ast_value) &&
         present_input_field_values_are_valid(type, ast_value)


### PR DESCRIPTION
This fixes a bug when you're using the [`graphql-libgraphqlparser`](https://github.com/rmosolgo/graphql-libgraphqlparser-ruby) gem. The problem is when you have a query that contains enum literals:
```
query {
  someField(enumArg: SOME_ENUM_VALUE) {
    ...
  }
}
```
This results in an error message like this:
```
Argument 'enumArg' on Field 'someField' has an invalid value
```
The problem is that instead of getting a `GraphQL::Language::Nodes::Enum` for the argument, you just get a `String`. I think that the "correct" fix would be to modify the `graphql-libgraphqlparser` gem, but I wasn't entirely sure where the problem was, and at any rate, this little band-aid seems to resolve the problem.