### PR TITLE
feat(StaticValidation) don't accept queries which exceed Schema#max_depth

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -6,6 +6,7 @@ class GraphQL::Schema
   DYNAMIC_FIELDS = ["__type", "__typename", "__schema"]
 
   attr_reader :query, :mutation, :subscription, :directives, :static_validator
+  attr_accessor :max_depth
   # Override these if you don't want the default executor:
   attr_accessor :query_execution_strategy,
     :mutation_execution_strategy,
@@ -17,10 +18,11 @@ class GraphQL::Schema
   # @param query [GraphQL::ObjectType]  the query root for the schema
   # @param mutation [GraphQL::ObjectType] the mutation root for the schema
   # @param subscription [GraphQL::ObjectType] the subscription root for the schema
-  def initialize(query:, mutation: nil, subscription: nil)
+  def initialize(query:, mutation: nil, subscription: nil, max_depth: nil)
     @query    = query
     @mutation = mutation
     @subscription = subscription
+    @max_depth = max_depth
     @directives = DIRECTIVES.reduce({}) { |m, d| m[d.name] = d; m }
     @static_validator = GraphQL::StaticValidation::Validator.new(schema: self)
     @rescue_middleware = GraphQL::Schema::RescueMiddleware.new

--- a/lib/graphql/static_validation/all_rules.rb
+++ b/lib/graphql/static_validation/all_rules.rb
@@ -20,4 +20,5 @@ GraphQL::StaticValidation::ALL_RULES = [
   GraphQL::StaticValidation::VariableDefaultValuesAreCorrectlyTyped,
   GraphQL::StaticValidation::VariablesAreUsedAndDefined,
   GraphQL::StaticValidation::VariableUsagesAreAllowed,
+  GraphQL::StaticValidation::DoesNotExceedMaxDepth,
 ]

--- a/lib/graphql/static_validation/rules/does_not_exceed_max_depth.rb
+++ b/lib/graphql/static_validation/rules/does_not_exceed_max_depth.rb
@@ -1,0 +1,32 @@
+module GraphQL
+  module StaticValidation
+    class DoesNotExceedMaxDepth
+      include GraphQL::StaticValidation::Message::MessageHelper
+
+      def validate(context)
+        max_allowed_depth = context.schema.max_depth
+        return if max_allowed_depth.nil?
+
+        visitor = context.visitor
+
+        current_depth = 0
+        already_exceeded_max_depth = false
+
+        visitor[GraphQL::Language::Nodes::Field] << -> (node, parent) {
+          if node.selections.any? && !already_exceeded_max_depth
+            current_depth += 1
+          elsif current_depth > max_allowed_depth
+            already_exceeded_max_depth = true
+            context.errors << message("Exceeds maximum query depth of #{max_allowed_depth}", node)
+          end
+        }
+
+        visitor[GraphQL::Language::Nodes::Field].leave << -> (node, parent) {
+          if node.selections.any? && current_depth > 0
+            current_depth -= 1
+          end
+        }
+      end
+    end
+  end
+end

--- a/spec/graphql/static_validation/rules/does_not_exceed_max_depth_spec.rb
+++ b/spec/graphql/static_validation/rules/does_not_exceed_max_depth_spec.rb
@@ -1,0 +1,61 @@
+require "spec_helper"
+
+describe GraphQL::StaticValidation::DoesNotExceedMaxDepth do
+  let(:rule) { GraphQL::StaticValidation::DoesNotExceedMaxDepth }
+  let(:validator) { GraphQL::StaticValidation::Validator.new(schema: DummySchema, rules: [rule]) }
+  let(:errors) { validator.validate(GraphQL.parse(query_string)) }
+
+  let(:query_string) { "
+    {
+      cheese(id: 1) {
+        similarCheese(source: SHEEP) {
+          similarCheese(source: SHEEP) {
+            similarCheese(source: SHEEP) {
+              similarCheese(source: SHEEP) {
+                similarCheese(source: SHEEP) {
+                  id
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  "}
+
+  describe "when the query is deeper than max depth" do
+    it "adds an error message for a too-deep query" do
+      assert_equal 1, errors.length
+    end
+  end
+
+  describe "When the query is not deeper than max_depth" do
+    before do
+      @prev_max_depth = DummySchema.max_depth
+      DummySchema.max_depth = 100
+    end
+
+    after do
+      DummySchema.max_depth = @prev_max_depth
+    end
+
+    it "doesn't add an error" do
+      assert_equal 0, errors.length
+    end
+  end
+
+  describe "when the max depth isn't set" do
+    before do
+      @prev_max_depth = DummySchema.max_depth
+      DummySchema.max_depth = nil
+    end
+
+    after do
+      DummySchema.max_depth = @prev_max_depth
+    end
+
+    it "doesn't add an error message" do
+      assert_equal 0, errors.length
+    end
+  end
+end

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -250,5 +250,6 @@ DummySchema = GraphQL::Schema.new(
   query: QueryType,
   mutation: MutationType,
   subscription: SubscriptionType,
+  max_depth: 5,
 )
 DummySchema.rescue_from(NoSuchDairyError) { |err| err.message  }


### PR DESCRIPTION
This is a simple "security" feature, [inspired by Sangria](http://sangria-graphql.org/learn/#limiting-query-depth)