### PR TITLE
Contextual errors when invalid types are provided for fields

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -70,10 +70,8 @@ class GraphQL::Schema
   end
 
   class InvalidTypeError < GraphQL::Error
-    def initialize(type, errors, context_message = nil)
-      message = "Type #{type.respond_to?(:name) ? type.name :  "Unnamed type"} (#{type.class.inspect}) is invalid: #{errors.join(", ")}"
-      message << " (#{context_message})" if context_message
-      super(message)
+    def initialize(type, name)
+      super("#{name} has an invalid type: must be an instance of GraphQL::BaseType, not #{type.class.inspect} (#{type.inspect})")
     end
   end
 end

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -70,8 +70,10 @@ class GraphQL::Schema
   end
 
   class InvalidTypeError < GraphQL::Error
-    def initialize(type, errors)
-      super("Type #{type.respond_to?(:name) ? type.name :  "Unnamed type" } is invalid: #{errors.join(", ")}")
+    def initialize(type, errors, context_message = nil)
+      message = "Type #{type.respond_to?(:name) ? type.name :  "Unnamed type"} (#{type.class.inspect}) is invalid: #{errors.join(", ")}"
+      message << " (#{context_message})" if context_message
+      super(message)
     end
   end
 end

--- a/lib/graphql/schema/type_reducer.rb
+++ b/lib/graphql/schema/type_reducer.rb
@@ -31,36 +31,36 @@ class GraphQL::Schema::TypeReducer
     type_hash[type.name] = type
     if type.kind.fields?
       type.all_fields.each do |field|
-        reduce_type(field.type, type_hash, "check the #{field.name} field on #{type.name}")
+        reduce_type(field.type, type_hash, "Field #{type.name}.#{field.name}")
         field.arguments.each do |name, argument|
-          reduce_type(argument.type, type_hash, "check the #{name} argument for #{field.name} field on #{type.name}")
+          reduce_type(argument.type, type_hash, "Argument #{name} on #{type.name}.#{field.name}")
         end
       end
     end
     if type.kind.object?
       type.interfaces.each do |interface|
-        reduce_type(interface, type_hash)
+        reduce_type(interface, type_hash, "Interface on #{type.name}")
       end
     end
     if type.kind.resolves?
       type.possible_types.each do |possible_type|
-        reduce_type(possible_type, type_hash)
+        reduce_type(possible_type, type_hash, "Possible type for #{type.name}")
       end
     end
     if type.kind.input_object?
       type.input_fields.each do |name, input_field|
-        reduce_type(input_field.type, type_hash, "check the #{name} input field on #{type.name}")
+        reduce_type(input_field.type, type_hash, "Input field #{type.name}.#{name}")
       end
     end
 
     type_hash
   end
 
-  def reduce_type(type, type_hash, context_message = nil)
+  def reduce_type(type, type_hash, name = nil)
     if type.is_a?(GraphQL::BaseType)
       self.class.new(type.unwrap, type_hash).result
     else
-      raise GraphQL::Schema::InvalidTypeError.new(type, ["Must be a GraphQL::BaseType"], context_message)
+      raise GraphQL::Schema::InvalidTypeError.new(type, name)
     end
   end
 

--- a/lib/graphql/schema/type_reducer.rb
+++ b/lib/graphql/schema/type_reducer.rb
@@ -31,9 +31,9 @@ class GraphQL::Schema::TypeReducer
     type_hash[type.name] = type
     if type.kind.fields?
       type.all_fields.each do |field|
-        reduce_type(field.type, type_hash)
+        reduce_type(field.type, type_hash, "check the #{field.name} field on #{type.name}")
         field.arguments.each do |name, argument|
-          reduce_type(argument.type, type_hash)
+          reduce_type(argument.type, type_hash, "check the #{name} argument for #{field.name} field on #{type.name}")
         end
       end
     end
@@ -49,18 +49,18 @@ class GraphQL::Schema::TypeReducer
     end
     if type.kind.input_object?
       type.input_fields.each do |name, input_field|
-        reduce_type(input_field.type, type_hash)
+        reduce_type(input_field.type, type_hash, "check the #{name} input field on #{type.name}")
       end
     end
 
     type_hash
   end
 
-  def reduce_type(type, type_hash)
+  def reduce_type(type, type_hash, context_message = nil)
     if type.is_a?(GraphQL::BaseType)
       self.class.new(type.unwrap, type_hash).result
     else
-      raise GraphQL::Schema::InvalidTypeError.new(type, ["Must be a GraphQL::BaseType"])
+      raise GraphQL::Schema::InvalidTypeError.new(type, ["Must be a GraphQL::BaseType"], context_message)
     end
   end
 


### PR DESCRIPTION
Provides better error messages when you have an invalid field definition. Specifically adds context to error messages when you use an invalid type:
* As the return type for a field
* As the argument type for a field argument
* As an input type on an input object

It also tells you the class of the object that you provided as a type.

**Example Use Case**
It's probably not uncommon that a GraphQL type shares a name with an Active Record model. Sometimes, it's easy to accidentally specify the model as a field type, instead of the GraphQL type that corresponds to the model:

```ruby
CreateCommentMutation = GraphQL::Relay::Mutation.define do
  name "CreateComment"
  ...
  return_field :comment, !Comment # should be CommentType, not Comment
end
```

If you make this mistake presently, you get a fairly unhelpful error message:
```
Type Unnamed type is invalid: Must be a GraphQL::BaseType
```
This PR adds more context to the error, to make debugging easier:
```
Type Unnamed type (NilClass) is invalid: Must be a GraphQL::BaseType (check the comment field on CreateCommentPayload)
```