### PR TITLE
fix(Scalar) coerce inputs according to spec

### DIFF
--- a/lib/graphql/boolean_type.rb
+++ b/lib/graphql/boolean_type.rb
@@ -1,4 +1,9 @@
 GraphQL::BOOLEAN_TYPE = GraphQL::ScalarType.define do
+  # Everything else is nil
+  ALLOWED_INPUTS = [true, false]
+
   name "Boolean"
-  coerce -> (value) { !!value }
+
+  coerce_input -> (value) { ALLOWED_INPUTS.include?(value) ? value : nil }
+  coerce_result -> (value) { !!value }
 end

--- a/lib/graphql/float_type.rb
+++ b/lib/graphql/float_type.rb
@@ -1,6 +1,5 @@
 GraphQL::FLOAT_TYPE = GraphQL::ScalarType.define do
   name "Float"
-  coerce -> (value) do
-    value.is_a?(Numeric) ? value.to_f : nil
-  end
+  coerce_input -> (value) { value.is_a?(Numeric) ? value.to_f : nil }
+  coerce_result -> (value) { value.to_f }
 end

--- a/lib/graphql/id_type.rb
+++ b/lib/graphql/id_type.rb
@@ -1,4 +1,12 @@
 GraphQL::ID_TYPE = GraphQL::ScalarType.define do
   name "ID"
-  coerce -> (value) { value.to_s }
+  coerce_result -> (value) { value.to_s }
+  coerce_input -> (value) {
+    case value
+    when String, Fixnum, Bignum
+      value.to_s
+    else
+      nil
+    end
+  }
 end

--- a/lib/graphql/int_type.rb
+++ b/lib/graphql/int_type.rb
@@ -1,4 +1,5 @@
 GraphQL::INT_TYPE = GraphQL::ScalarType.define do
   name "Int"
-  coerce -> (value) { value.is_a?(Numeric) ? value.to_i : nil }
+  coerce_input -> (value) { value.is_a?(Numeric) ? value.to_i : nil }
+  coerce_result -> (value) { value.to_i }
 end

--- a/lib/graphql/scalar_type.rb
+++ b/lib/graphql/scalar_type.rb
@@ -21,7 +21,9 @@ module GraphQL
 
     def validate_non_null_input(value)
       result = Query::InputValidationResult.new
-      result.add_problem("Could not coerce value #{JSON.dump(value)} to #{name}") if coerce_non_null_input(value).nil?
+      if coerce_non_null_input(value).nil?
+        result.add_problem("Could not coerce value #{JSON.dump(value)} to #{name}")
+      end
       result
     end
 

--- a/lib/graphql/string_type.rb
+++ b/lib/graphql/string_type.rb
@@ -1,4 +1,5 @@
 GraphQL::STRING_TYPE = GraphQL::ScalarType.define do
   name "String"
-  coerce -> (value) { value.to_s }
+  coerce_result -> (value) { value.to_s }
+  coerce_input -> (value) { value.is_a?(String) ? value : nil }
 end

--- a/spec/graphql/boolean_type_spec.rb
+++ b/spec/graphql/boolean_type_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+describe GraphQL::BOOLEAN_TYPE do
+  describe "coerce_input" do
+    def coerce_input(input)
+      GraphQL::BOOLEAN_TYPE.coerce_input(input)
+    end
+
+    it "accepts true and false" do
+      assert_equal true, coerce_input(true)
+      assert_equal false, coerce_input(false)
+    end
+
+    it "rejects other types" do
+      assert_equal nil, coerce_input("true")
+      assert_equal nil, coerce_input(5.5)
+      assert_equal nil, coerce_input(nil)
+    end
+  end
+end

--- a/spec/graphql/float_type_spec.rb
+++ b/spec/graphql/float_type_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+describe GraphQL::FLOAT_TYPE do
+  describe "coerce_input" do
+    it "accepts ints and floats" do
+      assert_equal 1.0, GraphQL::FLOAT_TYPE.coerce_input(1)
+      assert_equal 6.1, GraphQL::FLOAT_TYPE.coerce_input(6.1)
+    end
+
+    it "rejects other types" do
+      assert_equal nil, GraphQL::FLOAT_TYPE.coerce_input("55")
+      assert_equal nil, GraphQL::FLOAT_TYPE.coerce_input(true)
+    end
+  end
+end

--- a/spec/graphql/id_type_spec.rb
+++ b/spec/graphql/id_type_spec.rb
@@ -20,4 +20,13 @@ describe GraphQL::ID_TYPE do
       assert_equal(expected, result)
     end
   end
+
+  describe 'coercion for other types' do
+    let(:query_string) { %|query getMilk { cow: milk(id: 1.0) { id } }| }
+
+    it "doesn't allow other types" do
+      assert_equal nil, result["data"]
+      assert_equal 1, result["errors"].length
+    end
+  end
 end

--- a/spec/graphql/int_type_spec.rb
+++ b/spec/graphql/int_type_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+describe GraphQL::INT_TYPE do
+  describe "coerce_input" do
+    it "accepts ints and floats" do
+      assert_equal 1, GraphQL::INT_TYPE.coerce_input(1)
+      assert_equal 6, GraphQL::INT_TYPE.coerce_input(6.1)
+    end
+
+    it "rejects other types" do
+      assert_equal nil, GraphQL::INT_TYPE.coerce_input("55")
+      assert_equal nil, GraphQL::INT_TYPE.coerce_input(true)
+    end
+  end
+end

--- a/spec/graphql/static_validation/rules/variable_default_values_are_correctly_typed_spec.rb
+++ b/spec/graphql/static_validation/rules/variable_default_values_are_correctly_typed_spec.rb
@@ -4,7 +4,7 @@ describe GraphQL::StaticValidation::VariableDefaultValuesAreCorrectlyTyped do
   let(:query_string) {%|
     query getCheese(
       $id:        Int = 1,
-      $bool:      Boolean = 3.4e24, # can be coerced
+      $int:       Int = 3.4e24, # can be coerced
       $str:       String!,
       $badFloat:  Float = true,
       $badInt:    Int = "abc",

--- a/spec/graphql/string_type_spec.rb
+++ b/spec/graphql/string_type_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+describe GraphQL::STRING_TYPE do
+  describe "coerce_input" do
+    it "accepts strings" do
+      assert_equal "str", GraphQL::STRING_TYPE.coerce_input("str")
+    end
+
+    it "doesn't accept other types" do
+      assert_equal nil, GraphQL::STRING_TYPE.coerce_input(100)
+      assert_equal nil, GraphQL::STRING_TYPE.coerce_input(true)
+      assert_equal nil, GraphQL::STRING_TYPE.coerce_input(0.999)
+    end
+  end
+end


### PR DESCRIPTION
Oops, the built-in scalars weren't properly implementing input coercion. They should be more picky about what they accept! ([Spec](http://facebook.github.io/graphql/#sec-Scalars))

This will be a breaking change, but users who depend on the previous behavior can redefine it: 

```ruby 
# Previous coerce behavior for scalars:
GraphQL::BOOLEAN_TYPE.coerce = -> (value) { !!value }
GraphQL::ID_TYPE.coerce = -> (value) { value.to_s }
GraphQL::STRING_TYPE.coerce = ->  (value) { value.to_s }
# INT_TYPE and FLOAT_TYPE were unchanged 
```

PS. looking at the error messages, it looks like there's still a win to be made by getting the new validation messages into `StaticValidation`


cc @theorygeek 