### PR TITLE
Handle the default resolving in GraphQL::Field.

### DIFF
--- a/lib/graphql/field.rb
+++ b/lib/graphql/field.rb
@@ -97,7 +97,11 @@ class GraphQL::Field
       if property
         obj.public_send(property)
       else
-        GraphQL::Query::DEFAULT_RESOLVE
+        begin
+          obj.public_send(name)
+        rescue NoMethodError => err
+          raise("Couldn't resolve field '#{name}' to #{obj.class} '#{obj}' (resulted in #{err})")
+        end
       end
     end
   end

--- a/lib/graphql/query/serial_execution/field_resolution.rb
+++ b/lib/graphql/query/serial_execution/field_resolution.rb
@@ -69,15 +69,6 @@ module GraphQL
             context.ast_node = ast_node
             value = field_definition.resolve(parent_object, field_args, context)
             context.ast_node = nil
-
-            if value == GraphQL::Query::DEFAULT_RESOLVE
-              begin
-                value = target.public_send(ast_node.name)
-              rescue NoMethodError => err
-                raise("Couldn't resolve field '#{ast_node.name}' to #{parent_object.class} '#{parent_object}' (resulted in #{err})")
-              end
-            end
-
             value
           }
         end

--- a/spec/graphql/field_spec.rb
+++ b/spec/graphql/field_spec.rb
@@ -21,6 +21,7 @@ describe GraphQL::Field do
   describe '.property ' do
     let(:field) do
       GraphQL::Field.define do
+        name 'field_name'
         # satisfies 'can define by config' below
         property :internal_prop
       end
@@ -37,7 +38,7 @@ describe GraphQL::Field do
 
     describe 'default resolver' do
       def acts_like_default_resolver(field, old_prop, new_prop)
-        object = OpenStruct.new(old_prop => 'old value', new_prop => 'new value')
+        object = OpenStruct.new(old_prop => 'old value', new_prop => 'new value', field.name.to_sym => 'unset value')
 
         old_result = field.resolve(object, nil, nil)
         field.property = new_prop
@@ -47,7 +48,7 @@ describe GraphQL::Field do
 
         assert_equal(old_result, 'old value')
         assert_equal(new_result, 'new value')
-        assert_equal(unset_result, GraphQL::Query::DEFAULT_RESOLVE)
+        assert_equal(unset_result, 'unset value')
       end
 
       it 'responds to changes in property' do


### PR DESCRIPTION
@rmosolgo is there any reason why the default resolve proc doesn't just resolve the value?

## Problem

We are using a custom field that allows preload to be specified independently from the actually resolve proc, so we can call methods on a model and test that it doesn't result in N+1 queries.  We are doing this by enumerating fields and using the Field#resolve_proc directly after calling a preload proc.  However, we are overriding build_default_resolver to avoid having to detect and handle when the resolve proc returns GraphQL::Query::DEFAULT_RESOLVE.

## Solution

Call `obj.public_send(name)` in Field#build_default_resolver rather than returning `GraphQL::Query::DEFAULT_RESOLVE`