### PR TITLE
Avoid providing internal server error messages to clients.

### DIFF
--- a/lib/graphql/execution_error.rb
+++ b/lib/graphql/execution_error.rb
@@ -11,9 +11,7 @@ module GraphQL
       hash = {
         "message" => message,
       }
-      if ast_node.nil?
-        hash["locations"] = []
-      else
+      if ast_node
         hash["locations"] = [
           {
             "line" => ast_node.line,

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -1,5 +1,5 @@
 class GraphQL::Query
-  class OperationNameMissingError < GraphQL::Error
+  class OperationNameMissingError < GraphQL::ExecutionError
     def initialize(names)
       msg = "You must provide an operation name from: #{names.join(", ")}"
       super(msg)

--- a/lib/graphql/query/executor.rb
+++ b/lib/graphql/query/executor.rb
@@ -14,12 +14,12 @@ module GraphQL
       def result
         execute
       rescue GraphQL::ExecutionError => err
+        query.context.errors << err
         {"errors" => [err.to_h]}
-      rescue GraphQL::Query::OperationNameMissingError => err
-        {"errors" => [{"message" => err.message}]}
       rescue StandardError => err
+        query.context.errors << err
         query.debug && raise(err)
-        message = "Something went wrong during query execution: #{err}" #\n#{err.backtrace.join("\n  ")}"
+        message = "Internal error" #\n#{err.backtrace.join("\n  ")}"
         {"errors" => [{"message" => message}]}
       end
 

--- a/spec/graphql/query/executor_spec.rb
+++ b/spec/graphql/query/executor_spec.rb
@@ -5,12 +5,14 @@ describe GraphQL::Query::Executor do
   let(:operation_name) { nil }
   let(:schema) { DummySchema }
   let(:variables) { {"cheeseId" => 2} }
-  let(:result) { schema.execute(
+  let(:query) { GraphQL::Query.new(
+    schema,
     query_string,
     variables: variables,
     debug: debug,
     operation_name: operation_name,
   )}
+  let(:result) { query.result }
 
   describe "multiple operations" do
     let(:query_string) { %|
@@ -117,11 +119,14 @@ describe GraphQL::Query::Executor do
     let(:query_string) {%| query noMilk { error }|}
     describe 'if debug: false' do
       let(:debug) { false }
+      let(:errors) { query.context.errors }
       it 'turns into error messages' do
         expected = {"errors"=>[
-          {"message"=>"Something went wrong during query execution: This error was raised on purpose"}
+          {"message"=>"Internal error"}
         ]}
         assert_equal(expected, result)
+        assert_equal([RuntimeError], errors.map(&:class))
+        assert_equal("This error was raised on purpose", errors.first.message)
       end
     end
 


### PR DESCRIPTION
## Problem

This gem would send standard errors to clients, which could include sensitive information.  For example, when using the mysql2 gem, the error message could include the database query.

Ironically, we have been using the `debug: true` option to both hide the internal error messages and get access to the full error information for logging and for error reporting.  I would like to get rid of that hack.

## Solution

Use `"Internal error"` as the error message for standard errors.  ExecutionError should be used to report client errors.

Also, add the error to `query.context.errors` for logging and error reporting.

I also used an ExecutionError for OperationNameMissingError since I didn't want it to be treated as an internal error.  I also changed ExecutionError.to_h to omit the locations key so OperationNameMissingError continues to get rendered properly, and because there doesn't seem to be any reason to include the locations key when there is no location information for the error.