### PR TITLE
feature: Support inline fragments without a type condition

### DIFF
--- a/lib/graphql/language/parser.rb
+++ b/lib/graphql/language/parser.rb
@@ -26,10 +26,11 @@ module GraphQL
         directives.maybe.as(:optional_directives).as(:directives)
       }
       rule(:spread) { str("...") }
+      rule(:type_condition) { str("on ") >> name.as(:optional_string_content) }
       # TODO: `on` bug, see spec
       rule(:inline_fragment) {
         spread.as(:fragment_spread_keyword) >> space? >>
-        str("on ") >> name.as(:inline_fragment_type) >> space? >>
+        type_condition.maybe.as(:inline_fragment_type) >> space? >>
         directives.maybe.as(:optional_directives).as(:directives) >> space? >>
         selections.as(:selections)
       }

--- a/lib/graphql/language/transform.rb
+++ b/lib/graphql/language/transform.rb
@@ -40,7 +40,7 @@ module GraphQL
         inline_fragment_type: simple(:n),
         directives: sequence(:d),
         selections: sequence(:s),
-      ) { CREATE_NODE[:InlineFragment, type: n.to_s, directives: d, selections: s, position_source: kw]}
+      ) { CREATE_NODE[:InlineFragment, type: n, directives: d, selections: s, position_source: kw]}
 
       # Operation Definition
       rule(

--- a/lib/graphql/query/serial_execution/selection_resolution.rb
+++ b/lib/graphql/query/serial_execution/selection_resolution.rb
@@ -64,6 +64,7 @@ module GraphQL
         end
 
         def fragment_type_can_apply?(ast_fragment)
+          return true unless ast_fragment.type
           child_type = execution_context.get_type(ast_fragment.type)
           resolved_type = GraphQL::Query::TypeResolver.new(target, child_type, type).type
           !resolved_type.nil?

--- a/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb
+++ b/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb
@@ -5,8 +5,9 @@ class GraphQL::StaticValidation::FragmentSpreadsArePossible
 
     context.visitor[GraphQL::Language::Nodes::InlineFragment] << -> (node, parent) {
       fragment_parent = context.object_types[-2]
-      fragment_child = context.object_types.last
-      validate_fragment_in_scope(fragment_parent, fragment_child, node, context)
+      if fragment_child = context.object_types.last
+        validate_fragment_in_scope(fragment_parent, fragment_child, node, context)
+      end
     }
 
     spreads_to_validate = []

--- a/lib/graphql/static_validation/rules/fragment_types_exist.rb
+++ b/lib/graphql/static_validation/rules/fragment_types_exist.rb
@@ -15,6 +15,7 @@ class GraphQL::StaticValidation::FragmentTypesExist
   private
 
   def validate_type_exists(node, context)
+    return unless node.type
     type = context.schema.types.fetch(node.type, nil)
     if type.nil?
       context.errors << message("No such type #{node.type}, so it can't be a fragment condition", node)

--- a/lib/graphql/static_validation/rules/fragments_are_on_composite_types.rb
+++ b/lib/graphql/static_validation/rules/fragments_are_on_composite_types.rb
@@ -18,6 +18,7 @@ class GraphQL::StaticValidation::FragmentsAreOnCompositeTypes
 
   def validate_type_is_composite(node, context)
     type_name = node.type
+    return unless type_name
     type_def = context.schema.types[type_name]
     if type_def.nil? || !type_def.kind.composite?
       context.errors <<  message("Invalid fragment on type #{type_name} (must be Union, Interface or Object)", node)

--- a/lib/graphql/static_validation/type_stack.rb
+++ b/lib/graphql/static_validation/type_stack.rb
@@ -52,7 +52,11 @@ class GraphQL::StaticValidation::TypeStack
 
   class FragmentWithTypeStrategy
     def push(stack, node)
-      object_type = stack.schema.types.fetch(node.type, nil)
+      object_type = if node.type
+        stack.schema.types.fetch(node.type, nil)
+      else
+        stack.object_types.last
+      end
       if !object_type.nil?
         object_type = object_type.unwrap
       end

--- a/spec/graphql/directive_spec.rb
+++ b/spec/graphql/directive_spec.rb
@@ -50,6 +50,8 @@ describe GraphQL::Directive do
         ... on Cheese @skip(if: false) { dontSkipInlineId: id }
         ... on Cheese @include(if: true) { includeInlineId: id }
         ... on Cheese @include(if: false) { dontIncludeInlineId: id }
+        ... @skip(if: true) { skipNoType: id }
+        ... @skip(if: false) { dontSkipNoType: id }
         }
       }
       fragment includeFlavorField on Cheese { includeFlavor: flavor  }
@@ -66,6 +68,7 @@ describe GraphQL::Directive do
           "includeFlavor" => "Brie",
           "dontSkipInlineId" => 1,
           "includeInlineId" => 1,
+          "dontSkipNoType" => 1,
         },
       }}
       assert_equal(expected, result)

--- a/spec/graphql/language/parser_spec.rb
+++ b/spec/graphql/language/parser_spec.rb
@@ -22,6 +22,7 @@ describe GraphQL::Language::Parser do
         name,
         ... on Species { color },
         ... family # background info, of course
+        ... @skip(if: true) { inlineFragSkip },
       }
     }
     subscription watchStuff {

--- a/spec/graphql/language/transform_spec.rb
+++ b/spec/graphql/language/transform_spec.rb
@@ -153,4 +153,9 @@ describe GraphQL::Language::Transform do
     res = get_result("{quoted: \"\\\" \\\\ \\/ \\b \\f \\n \\r \\t\"}", parse: :value_input_object)
     assert_equal("\" \\ / \b \f \n \r \t", res.arguments[0].value)
   end
+
+  it 'transforms inline fragment optional type condition' do
+    res = get_result("{ ... @skip(if: true) { skippedField }, ... on Pet { isHousebroken } }")
+    assert_equal([nil, "Pet"], res.definitions.first.selections.map(&:type))
+  end
 end


### PR DESCRIPTION
## Problem

A graphql query with an inline fragment that doesn't have a type condition would be considered an invalid query.

See the [Inline Fragments section of the graphql spec](http://facebook.github.io/graphql/#sec-Inline-Fragments) which shows that the type condition is optional and includes examples of queries with inline fragments without a type condition.

## Solution

There were several places where it was assumed that a fragment always had a type, so I had to update the parser, transformer, static validator and the selection resolution.  Basically if the type condition isn't specified, then we can skip the type check and continue using the parent type.