### PR TITLE
Field names must be strings

### DIFF
--- a/lib/graphql/field.rb
+++ b/lib/graphql/field.rb
@@ -89,6 +89,8 @@ class GraphQL::Field
   #
   # This is important because {#name} may be used by {#resolve}.
   def name=(new_name)
+    raise ArgumentError.new("GraphQL field names must be strings; cannot use #{new_name.inspect} (#{new_name.class.name}) as a field name.") unless new_name.is_a?(String)
+    
     if @name.nil?
       @name = new_name
     else


### PR DESCRIPTION
Sometimes it's easy to use a symbol for a field name, instead of a string. That causes problems inside of [`GraphQL::Introspection::FieldsField`](https://github.com/rmosolgo/graphql-ruby/blob/563c2fa275825d61f973690f4b51aeaaa931f8e2/lib/graphql/introspection/fields_field.rb#L11), because it attempts to sort the fields by name.

I think that having non-string field names might also break other things (ex, enforcing uniqueness), and it's probably usually a mistake.

One alternative would be to allow strings or symbols, but convert symbols to strings. But it seems like that is not as transparent to the developer.