### PR TITLE
Middleware Argument Override

### DIFF
--- a/lib/graphql/schema/middleware_chain.rb
+++ b/lib/graphql/schema/middleware_chain.rb
@@ -17,7 +17,8 @@ module GraphQL
       end
 
       # Run the next step in the chain, passing in arguments and handle to the next step
-      def call
+      def call(next_arguments = @arguments)
+        @arguments = next_arguments
         next_step = steps.shift
         next_middleware = self
         next_step.call(*arguments, next_middleware)

--- a/spec/graphql/schema/middleware_chain_spec.rb
+++ b/spec/graphql/schema/middleware_chain_spec.rb
@@ -27,5 +27,16 @@ describe GraphQL::Schema::MiddlewareChain do
         assert_equal([1,2], step_values)
       end
     end
+
+    describe "when a step provides alternate arguments" do
+      it "passes the new arguments to the next step" do
+        step_1 = -> (test_arg, next_step) { assert_equal(test_arg, 'HELLO'); next_step.call(['WORLD']) }
+        step_2 = -> (test_arg, next_step) { assert_equal(test_arg, 'WORLD'); test_arg }
+
+        chain = GraphQL::Schema::MiddlewareChain.new(steps: [step_1, step_2], arguments: ['HELLO'])
+        result = chain.call
+        assert_equal(result, 'WORLD')
+      end
+    end
   end
 end


### PR DESCRIPTION
Allows middleware to change the arguments that will be passed to the next middleware.

**Use Case**
Currently, middleware can be used if you want to stop execution and return a value early. For example, this is helpful for authorizing field access and returning an error.

However, sometimes you may simply want to _modify_ the value that is passed to the next middleware. In my case, I have a hash that tells me how fields on my GraphQL schema map to attributes on my models. Sometimes, I need to traverse across an association to produce the value.

This change allows me to load the associations in middleware, and then provide the associated model to the field's resolver, before the attribute access happens.