### PR TITLE
Fixing bug with list nullability checks

### DIFF
--- a/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb
+++ b/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb
@@ -78,6 +78,9 @@ class GraphQL::StaticValidation::VariableUsagesAreAllowed
     if arg_type.kind.non_null? && !var_type.kind.non_null?
       false
     elsif arg_type.kind.wraps? && var_type.kind.wraps?
+      # If var_type is a non-null wrapper for a type, and arg_type is nullable, peel off the wrapper
+      # That way, a var_type of `[DairyAnimal]!` works with an arg_type of `[DairyAnimal]`
+      var_type = var_type.of_type if var_type.kind.non_null? && !arg_type.kind.non_null?
       non_null_levels_match(arg_type.of_type, var_type.of_type)
     else
       true

--- a/spec/graphql/introspection/type_type_spec.rb
+++ b/spec/graphql/introspection/type_type_spec.rb
@@ -12,8 +12,10 @@ describe GraphQL::Introspection::TypeType do
   |}
   let(:result) { DummySchema.execute(query_string, context: {}, variables: {"cheeseId" => 2}) }
   let(:cheese_fields) {[
+    {"name"=>"deeplyNullableCheese", "isDeprecated"=>false, "type"=>{"name"=>"Cheese", "ofType"=>nil}},
     {"name"=>"flavor",      "isDeprecated" => false, "type" => { "name" => "Non-Null", "ofType" => { "name" => "String"}}},
     {"name"=>"id",          "isDeprecated" => false, "type" => { "name" => "Non-Null", "ofType" => { "name" => "Int"}}},
+    {"name"=>"nullableCheese", "isDeprecated"=>false, "type"=>{"name"=>"Cheese", "ofType"=>nil}},
     {"name"=>"origin",      "isDeprecated" => false, "type" => { "name" => "Non-Null", "ofType" => { "name" => "String"}}},
     {"name"=>"similarCheese", "isDeprecated"=>false, "type"=>{"name"=>"Cheese", "ofType"=>nil}},
     {"name"=>"source",      "isDeprecated" => false, "type" => { "name" => "Non-Null", "ofType" => { "name" => "DairyAnimal"}}},
@@ -75,7 +77,7 @@ describe GraphQL::Introspection::TypeType do
     |}
     let(:deprecated_fields) { {"name"=>"fatContent", "isDeprecated"=>true, "type"=>{"name"=>"Non-Null", "ofType"=>{"name"=>"Float"}}} }
     it 'can expose deprecated fields' do
-      new_cheese_fields = [deprecated_fields] + cheese_fields
+      new_cheese_fields = ([deprecated_fields] + cheese_fields).sort_by { |f| f['name'] }
       expected = { "data" => {
         "cheeseType" => {
           "name"=> "Cheese",

--- a/spec/graphql/static_validation/rules/variable_usages_are_allowed_spec.rb
+++ b/spec/graphql/static_validation/rules/variable_usages_are_allowed_spec.rb
@@ -20,6 +20,8 @@ describe GraphQL::StaticValidation::VariableUsagesAreAllowed do
         similarCheese(source: $goodAnimals)
         other: similarCheese(source: $badAnimals)
         tooDeep: similarCheese(source: $deepAnimals)
+        nullableCheese(source: $goodAnimals)
+        deeplyNullableCheese(source: $deepAnimals)
       }
 
       milk(id: 1) {

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -51,6 +51,16 @@ CheeseType = GraphQL::ObjectType.define do
     }
   end
 
+  field :nullableCheese, -> { CheeseType }, "Cheeses like this one" do
+    argument :source, types[!DairyAnimalEnum]
+    resolve -> (t, a, c) { raise("NotImplemented") }
+  end
+
+  field :deeplyNullableCheese, -> { CheeseType }, "Cheeses like this one" do
+    argument :source, types[types[DairyAnimalEnum]]
+    resolve -> (t, a, c) { raise("NotImplemented") }
+  end
+
   field :fatContent, property: :fat_content do
     type(!GraphQL::FLOAT_TYPE)
     description("Percentage which is milkfat")


### PR DESCRIPTION
This fixes a bug where a variable of type `[DairyAnimal!]!` was considered invalid for an argument of type `[DairAnimal!]`.

According to the [GraphQL Spec §5.7.6](https://facebook.github.io/graphql/#sec-All-Variable-Usages-are-Allowed):
> If any list level of _variableType_ is not non‐null, and the corresponding level in _argument_ is non‐null, the types are not compatible.

This seems to suggest that the types _are_ compatible if any list level of _variableType_ is non-null, and the corresponding level in _argument_ is not non-null. (You have to read that sentence twice for it to make sense :P)

So I've added a test to ensure that:
* a variable of type `[DairyAnimal!]!` is compatible with an argument of type `[DairyAnimal!]`
* a variable of type `[[DairyAnimal!]!]!` is compatible with an argument of type `[[DairyAnimal]]`

Oddly enough, the second scenario was already working, but I think only accidentally. I think it's because the [`.wraps?` check inside of `non_null_levels_match`](https://github.com/rmosolgo/graphql-ruby/blob/master/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb#L80) is true for both `Non-Null` and `List`, so you'd get a weird, recursive, off-by-one situation. I'm not sure if that would've actually caused any observable bugs, but at any rate, I think this fixes them also.