### PR TITLE
Field resolver context

### DIFF
--- a/lib/graphql/field.rb
+++ b/lib/graphql/field.rb
@@ -63,7 +63,7 @@ class GraphQL::Field
   # @param arguments [Hash] Arguments declared in the query
   # @param context [GraphQL::Query::Context]
   def resolve(object, arguments, context)
-    @resolve_proc.call(object, arguments, context)
+    instance_exec(object, arguments, context, &@resolve_proc)
   end
 
   def resolve=(resolve_proc)
@@ -90,7 +90,7 @@ class GraphQL::Field
   # This is important because {#name} may be used by {#resolve}.
   def name=(new_name)
     raise ArgumentError.new("GraphQL field names must be strings; cannot use #{new_name.inspect} (#{new_name.class.name}) as a field name.") unless new_name.is_a?(String)
-    
+
     if @name.nil?
       @name = new_name
     else


### PR DESCRIPTION
Before:
```ruby
GraphQL::Field.define do
  resolve -> (obj, args, context) {
    self # instance of GraphQL::Define::DefinedObjectProxy
  }
end
```

After:
```ruby
GraphQL::Field.define do
  resolve -> (obj, args, context) {
    self # instance of GraphQL::Field
  }
end
```