### PR TITLE
fix(context) handle empty @values

### DIFF
--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -20,7 +20,7 @@ module GraphQL
       # @param values [Hash] A hash of arbitrary values which will be accessible at query-time
       def initialize(query:, values:)
         @query = query
-        @values = values
+        @values = values || {}
         @errors = []
       end
 

--- a/spec/graphql/query/context_spec.rb
+++ b/spec/graphql/query/context_spec.rb
@@ -49,4 +49,12 @@ describe GraphQL::Query::Context do
       assert_equal(expected, result)
     end
   end
+
+  describe "empty values" do
+    let(:context) { GraphQL::Query::Context.new(query: '', values: nil) }
+
+    it 'returns nil for any key' do
+      assert_equal(nil, context[:some_key])
+    end
+  end
 end


### PR DESCRIPTION
Thoughts about defaulting `@values = {}` in `Query::Context`?  I ran into an issue where my query would check if `context[:some_key]` exists, but it would raise an error because `@values = nil` if no context is passed into the query.

Thanks!