### PR TITLE
Handle the case where type coersion results in nil

### DIFF
--- a/lib/graphql/query/serial_execution/value_resolution.rb
+++ b/lib/graphql/query/serial_execution/value_resolution.rb
@@ -80,7 +80,9 @@ module GraphQL
             wrapped_type = field_type.of_type
             strategy_class = get_strategy_for_kind(wrapped_type.kind)
             inner_strategy = strategy_class.new(value, wrapped_type, target, parent_type, ast_field, execution_context)
-            inner_strategy.result
+            value = inner_strategy.result
+            raise GraphQL::InvalidNullError.new(ast_field.name, nil) if value.nil?
+            value
           end
         end
 

--- a/spec/graphql/query/executor_spec.rb
+++ b/spec/graphql/query/executor_spec.rb
@@ -168,6 +168,21 @@ describe GraphQL::Query::Executor do
       end
     end
 
+    describe 'if a non-nil value coerces to nil for a non-null field' do
+      let(:query_string) {%| query noMilk { cow { name cantBeNullButIsOnCoersion } }|}
+      it 'turns into error message and nulls the entire selection' do
+        expected = {
+          "data" => { "cow" => nil },
+          "errors" => [
+            {
+              "message" => "Cannot return null for non-nullable field cantBeNullButIsOnCoersion"
+            }
+          ]
+        }
+        assert_equal(expected, result)
+      end
+    end
+
     describe "if the schema has a rescue handler" do
       before do
         schema.rescue_from(RuntimeError) { "Error was handled!" }

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -2,6 +2,11 @@ require_relative './dairy_data'
 
 class NoSuchDairyError < StandardError; end
 
+AlwaysNilType = GraphQL::ScalarType.define do
+  name "AlwaysNilType"
+  coerce ->(value) { nil }
+end
+
 EdibleInterface = GraphQL::InterfaceType.define do
   name "Edible"
   description "Something you can eat, yum"
@@ -118,6 +123,11 @@ CowType = GraphQL::ObjectType.define do
   field :cantBeNullButRaisesExecutionError do
     type !GraphQL::STRING_TYPE
     resolve -> (t, a, c) { raise GraphQL::ExecutionError, "BOOM" }
+  end
+
+  field :cantBeNullButIsOnCoersion do
+    type !AlwaysNilType
+    resolve -> (t, a, c) { "This will be coerced to nil." }
   end
 end
 


### PR DESCRIPTION
The NonNullResolution strategy was missing handling the case where the raw value
was non-null but the inner strategy (usually scalar type coersion) would turn it
into null. This should be handled the same way as when the raw value is null.

@rmosolgo @dylanahsmith part of #139.