### PR TITLE
Improve the way scalar coercion happens

### DIFF
--- a/lib/graphql/boolean_type.rb
+++ b/lib/graphql/boolean_type.rb
@@ -5,5 +5,5 @@ GraphQL::BOOLEAN_TYPE = GraphQL::ScalarType.define do
   name "Boolean"
 
   coerce_input -> (value) { ALLOWED_INPUTS.include?(value) ? value : nil }
-  coerce_result -> (value) { !!value }
+  coerce_result -> (value) { value.nil? ? nil : !!value }
 end

--- a/lib/graphql/float_type.rb
+++ b/lib/graphql/float_type.rb
@@ -1,5 +1,5 @@
 GraphQL::FLOAT_TYPE = GraphQL::ScalarType.define do
   name "Float"
   coerce_input -> (value) { value.is_a?(Numeric) ? value.to_f : nil }
-  coerce_result -> (value) { value.to_f }
+  coerce_result -> (value) { value.nil? ? nil : value.to_f }
 end

--- a/lib/graphql/id_type.rb
+++ b/lib/graphql/id_type.rb
@@ -1,6 +1,6 @@
 GraphQL::ID_TYPE = GraphQL::ScalarType.define do
   name "ID"
-  coerce_result -> (value) { value.to_s }
+  coerce_result -> (value) { value.nil? ? nil : value.to_s }
   coerce_input -> (value) {
     case value
     when String, Fixnum, Bignum

--- a/lib/graphql/int_type.rb
+++ b/lib/graphql/int_type.rb
@@ -1,5 +1,5 @@
 GraphQL::INT_TYPE = GraphQL::ScalarType.define do
   name "Int"
   coerce_input -> (value) { value.is_a?(Numeric) ? value.to_i : nil }
-  coerce_result -> (value) { value.to_i }
+  coerce_result -> (value) { value.nil? ? nil : value.to_i }
 end

--- a/lib/graphql/query/serial_execution/value_resolution.rb
+++ b/lib/graphql/query/serial_execution/value_resolution.rb
@@ -33,8 +33,8 @@ module GraphQL
         end
 
         class ScalarResolution < BaseResolution
-          # Apply the scalar's defined `coerce_result` method to the value
-          def non_null_result
+          def result
+            return nil if value.is_a?(GraphQL::ExecutionError)
             field_type.coerce_result(value)
           end
         end

--- a/lib/graphql/string_type.rb
+++ b/lib/graphql/string_type.rb
@@ -1,5 +1,5 @@
 GraphQL::STRING_TYPE = GraphQL::ScalarType.define do
   name "String"
-  coerce_result -> (value) { value.to_s }
+  coerce_result -> (value) { value.nil? ? nil : value.to_s }
   coerce_input -> (value) { value.is_a?(String) ? value : nil }
 end


### PR DESCRIPTION
It is legitimate for a scalar type to want to coerce nils into non-nil values
and vice-versa, in normal (non-error) cases. This means:
- calling `coerce_result` from a method called `non_null_result` is misleading
at best, since it is legitimate for `coerce_result` to return nil
- the short-circuiting that `BaseResolution#result` does on nils is incorrect
for scalars since it doesn't give the coercion an opportunity to handle that
case

Simply override `result` instead of `non_null_result` for `ScalarResolution`.
Still short-circuit when the raw value is an `ExecutionError` but otherwise
trust the coercion proc. Update the string and id scalars to pass through nils
since otherwise they turned them into `""` which is probably undesirable.

@dylanahsmith @rmosolgo