### PR TITLE
refactor(InterfaceType) determine possible_types based on the schema

### DIFF
--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -50,24 +50,21 @@ module GraphQL
       # Maybe you'll need to override this in your own interfaces!
       #
       # @param object [Object] the object which needs a type to expose it
+      # @param ctx [GraphQL::Query::Context]
       # @return [GraphQL::ObjectType] the type which should expose `object`
-      def resolve_type(object)
-        instance_exec(object, &(@resolve_type_proc || DEFAULT_RESOLVE_TYPE))
+      def resolve_type(object, ctx)
+        instance_exec(object, ctx, &(@resolve_type_proc || DEFAULT_RESOLVE_TYPE))
       end
 
       # The default implementation of {#resolve_type} gets `object.class.name`
       # and finds a type with the same name
-      DEFAULT_RESOLVE_TYPE = -> (object) {
+      DEFAULT_RESOLVE_TYPE = -> (object, ctx) {
         type_name = object.class.name
-        possible_types.find {|t| t.name == type_name}
+        ctx.schema.possible_types(self).find {|t| t.name == type_name}
       }
 
       def resolve_type=(new_proc)
         @resolve_type_proc = new_proc || DEFAULT_RESOLVE_TYPE
-      end
-
-      def include?(type)
-        possible_types.include?(type)
       end
     end
 

--- a/lib/graphql/interface_type.rb
+++ b/lib/graphql/interface_type.rb
@@ -24,11 +24,6 @@ class GraphQL::InterfaceType < GraphQL::BaseType
     GraphQL::TypeKinds::INTERFACE
   end
 
-  # @return [Array<GraphQL::ObjectType>] Types which declare that they implement this interface
-  def possible_types
-    @possible_types ||= []
-  end
-
   # @return [GraphQL::Field] The defined field for `field_name`
   def get_field(field_name)
     fields[field_name]

--- a/lib/graphql/introspection/possible_types_field.rb
+++ b/lib/graphql/introspection/possible_types_field.rb
@@ -1,5 +1,11 @@
 GraphQL::Introspection::PossibleTypesField = GraphQL::Field.define do
   description "Types which compose this Union or Interface"
   type -> { types[!GraphQL::Introspection::TypeType] }
-  resolve -> (target, a, c) { target.kind.resolves? ? target.possible_types : nil }
+  resolve -> (target, args, ctx) {
+    if target.kind.resolves?
+      ctx.schema.possible_types(target)
+    else
+      nil
+    end
+  }
 end

--- a/lib/graphql/object_type.rb
+++ b/lib/graphql/object_type.rb
@@ -31,13 +31,8 @@ class GraphQL::ObjectType < GraphQL::BaseType
     @interfaces = []
   end
 
-  # Shovel this type into each interface's `possible_types` array.
-  #
   # @param new_interfaces [Array<GraphQL::Interface>] interfaces that this type implements
   def interfaces=(new_interfaces)
-    @interfaces ||= []
-    (@interfaces - new_interfaces).each { |i| i.possible_types.delete(self) }
-    (new_interfaces - @interfaces).each { |i| i.possible_types << self }
     @interfaces = new_interfaces
   end
 

--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -15,11 +15,15 @@ module GraphQL
       # @return [GraphQL::Query] The query whose context this is
       attr_reader :query
 
+      # @return [GraphQL::Schema]
+      attr_reader :schema
+
       # Make a new context which delegates key lookup to `values`
       # @param query [GraphQL::Query] the query who owns this context
       # @param values [Hash] A hash of arbitrary values which will be accessible at query-time
       def initialize(query:, values:)
         @query = query
+        @schema = query.schema
         @values = values || {}
         @errors = []
       end

--- a/lib/graphql/query/executor.rb
+++ b/lib/graphql/query/executor.rb
@@ -19,7 +19,7 @@ module GraphQL
       rescue StandardError => err
         query.context.errors << err
         query.debug && raise(err)
-        message = "Internal error" #\n#{err.backtrace.join("\n  ")}"
+        message = "Internal error" # : #{err} \n#{err.backtrace.join("\n  ")}"
         {"errors" => [{"message" => message}]}
       end
 

--- a/lib/graphql/query/serial_execution/execution_context.rb
+++ b/lib/graphql/query/serial_execution/execution_context.rb
@@ -2,15 +2,16 @@ module GraphQL
   class Query
     class SerialExecution
       class ExecutionContext
-        attr_reader :query, :strategy
+        attr_reader :query, :schema, :strategy
 
         def initialize(query, strategy)
           @query = query
+          @schema = query.schema
           @strategy = strategy
         end
 
         def get_type(type)
-          @query.schema.types[type]
+          @schema.types[type]
         end
 
         def get_fragment(name)
@@ -18,7 +19,7 @@ module GraphQL
         end
 
         def get_field(type, name)
-          @query.schema.get_field(type, name)
+          @schema.get_field(type, name)
         end
 
         def add_error(err)

--- a/lib/graphql/query/serial_execution/selection_resolution.rb
+++ b/lib/graphql/query/serial_execution/selection_resolution.rb
@@ -62,7 +62,7 @@ module GraphQL
         def fragment_type_can_apply?(ast_fragment)
           return true unless ast_fragment.type
           child_type = execution_context.get_type(ast_fragment.type)
-          resolved_type = GraphQL::Query::TypeResolver.new(target, child_type, type).type
+          resolved_type = GraphQL::Query::TypeResolver.new(target, child_type, type, execution_context.query.context).type
           !resolved_type.nil?
         end
 

--- a/lib/graphql/query/serial_execution/value_resolution.rb
+++ b/lib/graphql/query/serial_execution/value_resolution.rb
@@ -54,7 +54,7 @@ module GraphQL
 
         class HasPossibleTypeResolution < BaseResolution
           def non_null_result
-            resolved_type = field_type.resolve_type(value)
+            resolved_type = field_type.resolve_type(value, execution_context)
             strategy_class = get_strategy_for_kind(resolved_type.kind)
             inner_strategy = strategy_class.new(value, resolved_type, target, parent_type, ast_field, execution_context)
             inner_strategy.result

--- a/lib/graphql/query/type_resolver.rb
+++ b/lib/graphql/query/type_resolver.rb
@@ -3,7 +3,7 @@
 # or Return `nil` if it's a mismatch
 class GraphQL::Query::TypeResolver
   attr_reader :type
-  def initialize(target, child_type, parent_type)
+  def initialize(target, child_type, parent_type, query_ctx)
     @type = if child_type.nil?
       nil
     elsif parent_type.kind.union?
@@ -11,7 +11,7 @@ class GraphQL::Query::TypeResolver
     elsif child_type.kind.union? && child_type.include?(parent_type)
       parent_type
     elsif child_type.kind.interface?
-      child_type.resolve_type(target)
+      child_type.resolve_type(target, query_ctx)
     elsif child_type == parent_type
       parent_type
     else

--- a/lib/graphql/schema/possible_types.rb
+++ b/lib/graphql/schema/possible_types.rb
@@ -1,0 +1,34 @@
+module GraphQL
+  class Schema
+    # Find the members of a union or interface within a given schema.
+    #
+    # (Although its members never change, unions are handled this way to simplify execution code.)
+    #
+    # Internally, the calculation is cached. It's assumed that schema members _don't_ change after creating the schema!
+    #
+    # @example Get an interface's possible types
+    #   possible_types = GraphQL::Schema::PossibleTypes(MySchema)
+    #   possible_types.possible_types(MyInterface)
+    #   # => [MyObjectType, MyOtherObjectType]
+    class PossibleTypes
+      def initialize(schema)
+        @object_types = schema.types.values.select { |type| type.kind.object? }
+
+        @storage = Hash.new do |hash, key|
+          hash[key] = @object_types.select { |type| type.interfaces.include?(key) }.sort_by(&:name)
+        end
+      end
+
+      def possible_types(type_defn)
+        case type_defn
+        when GraphQL::UnionType
+          type_defn.possible_types
+        when GraphQL::InterfaceType
+          @storage[type_defn]
+        else
+          raise "#{type_defn} doesn't have possible types"
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/schema/type_reducer.rb
+++ b/lib/graphql/schema/type_reducer.rb
@@ -42,7 +42,7 @@ class GraphQL::Schema::TypeReducer
         reduce_type(interface, type_hash, "Interface on #{type.name}")
       end
     end
-    if type.kind.resolves?
+    if type.kind.union?
       type.possible_types.each do |possible_type|
         reduce_type(possible_type, type_hash, "Possible type for #{type.name}")
       end

--- a/lib/graphql/schema/type_validator.rb
+++ b/lib/graphql/schema/type_validator.rb
@@ -26,7 +26,7 @@ class GraphQL::Schema::TypeValidator
       end
     end
 
-    if type.kind.resolves?
+    if type.kind.union?
       implementation.must_respond_to(:resolve_type)
       implementation.must_respond_to(:possible_types, as: kind_name) do |possible_types|
         each_item_validator.validate(possible_types, as: "#{type_name}.possible_types", must_be: "objects") { |t| t.kind.object? }

--- a/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb
+++ b/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb
@@ -30,20 +30,20 @@ class GraphQL::StaticValidation::FragmentSpreadsArePossible
   private
 
   def validate_fragment_in_scope(parent_type, child_type, node, context)
-    intersecting_types = get_possible_types(parent_type) & get_possible_types(child_type)
+    intersecting_types = get_possible_types(parent_type, context.schema) & get_possible_types(child_type, context.schema)
     if intersecting_types.none?
       name = node.respond_to?(:name) ? " #{node.name}" : ""
       context.errors << message("Fragment#{name} on #{child_type.name} can't be spread inside #{parent_type.name}", node)
     end
   end
 
-  def get_possible_types(type)
+  def get_possible_types(type, schema)
     if type.kind.wraps?
-      get_possible_types(type.of_type)
+      get_possible_types(type.of_type, schema)
     elsif type.kind.object?
       [type]
     elsif type.kind.resolves?
-      type.possible_types
+      schema.possible_types(type)
     else
       []
     end

--- a/lib/graphql/union_type.rb
+++ b/lib/graphql/union_type.rb
@@ -16,4 +16,8 @@ class GraphQL::UnionType < GraphQL::BaseType
   def kind
     GraphQL::TypeKinds::UNION
   end
+
+  def include?(child_type_defn)
+    possible_types.include?(child_type_defn)
+  end
 end

--- a/readme.md
+++ b/readme.md
@@ -134,7 +134,6 @@ https://medium.com/@gauravtiwari/graphql-and-relay-on-rails-first-relay-powered-
 
 ## To Do
 
-- Interface's possible types should be a property of the schema, not the interface
 - Type lookup should be by type name (to support reloaded constants in Rails code)
 - Add a complexity validator (reject queries if they're too big)
 - Add docs for shared behaviors & DRY code

--- a/spec/graphql/introspection/type_type_spec.rb
+++ b/spec/graphql/introspection/type_type_spec.rb
@@ -59,7 +59,7 @@ describe GraphQL::Introspection::TypeType do
       "animalProduct" => {
         "name"=>"AnimalProduct",
         "kind"=>"INTERFACE",
-        "possibleTypes"=>[{"name"=>"Cheese"}, {"name"=>"Milk"}],
+        "possibleTypes"=>[{"name"=>"Cheese"}, {"name"=>"Honey"}, {"name"=>"Milk"}],
         "fields"=>[
           {"name"=>"source"},
         ]

--- a/spec/graphql/query/context_spec.rb
+++ b/spec/graphql/query/context_spec.rb
@@ -51,7 +51,7 @@ describe GraphQL::Query::Context do
   end
 
   describe "empty values" do
-    let(:context) { GraphQL::Query::Context.new(query: '', values: nil) }
+    let(:context) { GraphQL::Query::Context.new(query: OpenStruct.new(schema: schema), values: nil) }
 
     it 'returns nil for any key' do
       assert_equal(nil, context[:some_key])

--- a/spec/graphql/query/type_resolver_spec.rb
+++ b/spec/graphql/query/type_resolver_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe GraphQL::Query::TypeResolver do
   it 'resolves correcty when child_type is UnionType' do
-    type = GraphQL::Query::TypeResolver.new(MILKS[1], DairyProductUnion, MilkType).type
+    type = GraphQL::Query::TypeResolver.new(MILKS[1], DairyProductUnion, MilkType, nil).type
     assert_equal(MilkType, type)
   end
 end

--- a/spec/graphql/schema/type_reducer_spec.rb
+++ b/spec/graphql/schema/type_reducer_spec.rb
@@ -10,8 +10,6 @@ describe GraphQL::Schema::TypeReducer do
       "DairyAnimal" => DairyAnimalEnum,
       "Int" => GraphQL::INT_TYPE,
       "Edible" => EdibleInterface,
-      "Milk" => MilkType,
-      "ID" => GraphQL::ID_TYPE,
       "AnimalProduct" => AnimalProductInterface,
     }
     assert_equal(expected.keys, reducer.result.keys)
@@ -91,6 +89,12 @@ describe GraphQL::Schema::TypeReducer do
     it 'raises an error' do
       type_map = GraphQL::Schema::TypeReducer.find_all([])
       assert_raises(RuntimeError) { type_map["SomeType"] }
+    end
+  end
+
+  describe "when a field is only accessible through an interface" do
+    it "is found through Schema.new(types:)" do
+      assert_equal HoneyType, DummySchema.types["Honey"]
     end
   end
 end

--- a/spec/graphql/union_type_spec.rb
+++ b/spec/graphql/union_type_spec.rb
@@ -17,7 +17,7 @@ describe GraphQL::UnionType do
   end
 
   it 'infers type from an object' do
-    assert_equal(CheeseType, DairyProductUnion.resolve_type(CHEESES[1]))
+    assert_equal(CheeseType, DairyProductUnion.resolve_type(CHEESES[1], OpenStruct.new(schema: DummySchema)))
   end
 
   it '#include? returns true if type in in possible_types' do

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -83,6 +83,13 @@ MilkType = GraphQL::ObjectType.define do
   end
 end
 
+# No actual data; This type is an "orphan", only accessible through Interfaces
+HoneyType = GraphQL::ObjectType.define do
+  name 'Honey'
+  description "Sweet, dehydrated bee barf"
+  interfaces [EdibleInterface, AnimalProductInterface]
+end
+
 DairyType = GraphQL::ObjectType.define do
   name 'Dairy'
   description 'A farm where milk is harvested and cheese is produced'
@@ -273,5 +280,6 @@ DummySchema = GraphQL::Schema.new(
   mutation: MutationType,
   subscription: SubscriptionType,
   max_depth: 5,
+  types: [HoneyType],
 )
 DummySchema.rescue_from(NoSuchDairyError) { |err| err.message  }


### PR DESCRIPTION
Taking a cue from graphql/graphql-js#327

Previously, `InterfaceType#possible_types` was implemented as an array which was mutated for every object that implemented it. This caused bugs and resulted in complex gem code. 

So instead, determine possible types _within_ the schema. This will fix some nasty bugs, support Rails development better, and remove the lingering caveat when people ask "can you make multiple schemas". 

The downer is that it's a breaking change: any orphan type must be passed to `types:` (where previously it was discovered at load-time). 

Before shipping this change, I'll push a minor version with deprecation warnings.