### PR TITLE
feat(Schema) add deprecation warning for interface type inferrence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ### Breaking changes & deprecations
 
+- In some cases, an object type is only connected to the Query (or Mutation) root by being a member of an interface.
+
+  In these cases, bugs happen, especially with Rails development mode. (And sometimes, the bugs don't appear until you deploy to a production environment!)
+
+  So, in a case like this:
+
+  ```
+  QueryType -> (exposes) -> SomeInterface -> (includes member) -> SomeObjectType
+  ```
+
+  SomeObjectType must be passed to the schema explicitly:
+
+  ```ruby
+  Schema.new(
+    # ...
+    types: [SomeObjectType]
+  )
+  ```
+
 ### New features
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,33 @@
 
   So, in a case like this:
 
-  ```
-  QueryType -> (exposes) -> SomeInterface -> (includes member) -> SomeObjectType
+  ```ruby
+  HatInterface = GraphQL::ObjectType.define do
+    # ...
+  end
+
+  FezType = GraphQL::ObjectType.define do
+    # ...
+    interfaces [HatInterface]
+  end
+
+  QueryType = GraphQL::ObjectType.define do
+    field :randomHat, HatInterface # ...
+  end
   ```
 
-  SomeObjectType must be passed to the schema explicitly:
+  `FezType` can only be discovered by `QueryType` _through_ `HatInterface`. If `fez_type.rb` hasn't been loaded by Rails, `HatInterface.possible_types` will be empty!
+
+  Now, `FezType` must be passed to the schema explicitly:
 
   ```ruby
   Schema.new(
     # ...
-    types: [SomeObjectType]
+    types: [FezType]
   )
   ```
+
+  Since the type is passed directly to the schema, it will be loaded right away!
 
 ### New features
 

--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "guard", "~> 2.12"
   s.add_development_dependency "guard-bundler", "~> 2.1"
   s.add_development_dependency "guard-minitest", "~> 2.4"
+  s.add_development_dependency "listen", "~> 3.0.0"
   s.add_development_dependency "minitest", "~> 5"
   s.add_development_dependency "minitest-focus", "~> 1.1"
   s.add_development_dependency "minitest-reporters", "~>1.0"

--- a/spec/graphql/interface_type_spec.rb
+++ b/spec/graphql/interface_type_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe GraphQL::InterfaceType do
   let(:interface) { EdibleInterface }
   it 'has possible types' do
-    assert_equal([CheeseType, MilkType], interface.possible_types)
+    assert_equal([CheeseType, MilkType, HoneyType], interface.possible_types)
   end
 
   it 'resolves types for objects' do

--- a/spec/graphql/introspection/type_type_spec.rb
+++ b/spec/graphql/introspection/type_type_spec.rb
@@ -57,7 +57,7 @@ describe GraphQL::Introspection::TypeType do
       "animalProduct" => {
         "name"=>"AnimalProduct",
         "kind"=>"INTERFACE",
-        "possibleTypes"=>[{"name"=>"Cheese"}, {"name"=>"Milk"}],
+        "possibleTypes"=>[{"name"=>"Cheese"}, {"name"=>"Milk"}, {"name"=>"Honey"}],
         "fields"=>[
           {"name"=>"source"},
         ]

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -73,6 +73,13 @@ MilkType = GraphQL::ObjectType.define do
   end
 end
 
+# No actual data; This type is an "orphan", only accessible through Interfaces
+HoneyType = GraphQL::ObjectType.define do
+  name 'Honey'
+  description "Sweet, dehydrated bee barf"
+  interfaces [EdibleInterface, AnimalProductInterface]
+end
+
 DairyType = GraphQL::ObjectType.define do
   name 'Dairy'
   description 'A farm where milk is harvested and cheese is produced'


### PR DESCRIPTION
We'll do it like graphql-js in the next version, so here's some deprecation warnings