### PR TITLE
Add ability to modify context hash

### DIFF
--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -32,6 +32,10 @@ module GraphQL
       def [](key)
         @values[key]
       end
+
+      def []=(key, value)
+        @values[key] = value
+      end
     end
   end
 end

--- a/spec/graphql/query/context_spec.rb
+++ b/spec/graphql/query/context_spec.rb
@@ -57,4 +57,14 @@ describe GraphQL::Query::Context do
       assert_equal(nil, context[:some_key])
     end
   end
+
+  describe "assigning values" do
+    let(:context) { GraphQL::Query::Context.new(query: OpenStruct.new(schema: schema), values: nil) }
+
+    it "allows you to assign new contexts" do
+      assert_equal(nil, context[:some_key])
+      context[:some_key] = "wow!"
+      assert_equal("wow!", context[:some_key])
+    end
+  end
 end


### PR DESCRIPTION
We were noticing that `context` is not modifiable. Was this intentional? I can't think of a reason why you wouldn't want to be able to modify the context.

/cc @davidcelis