### PR TITLE
Better errors when resolve_type fails

### DIFF
--- a/lib/graphql/object_type.rb
+++ b/lib/graphql/object_type.rb
@@ -59,5 +59,26 @@ module GraphQL
         memo.merge!(iface.fields)
       end
     end
+
+
+    # Error raised when the value provided for a field can't be resolved to one of the possible types
+    # for the field.
+    class UnresolvedTypeError < GraphQL::Error
+      attr_reader :field_name, :field_type, :parent_type
+
+      def initialize(field_name, field_type, parent_type)
+        @field_name = field_name
+        @field_type = field_type
+        @parent_type = parent_type
+        super(exception_message)
+      end
+
+      private
+
+      def exception_message
+        "The value returned for field #{field_name} on #{parent_type} could not be resolved "\
+        "to one of the possible types for #{field_type}."
+      end
+    end
   end
 end

--- a/lib/graphql/query/serial_execution/value_resolution.rb
+++ b/lib/graphql/query/serial_execution/value_resolution.rb
@@ -55,6 +55,15 @@ module GraphQL
         class HasPossibleTypeResolution < BaseResolution
           def non_null_result
             resolved_type = field_type.resolve_type(value, execution_context)
+
+            if resolved_type.nil?
+              raise(
+                "The value returned for field #{ast_field.name} on #{parent_type} could not be resolved "\
+                "to one of the possible types for #{field_type}. (Did you forget to define a resolve_type proc?)\n"\
+                "Value: #{value}"
+              )
+            end
+
             strategy_class = get_strategy_for_kind(resolved_type.kind)
             inner_strategy = strategy_class.new(value, resolved_type, target, parent_type, ast_field, execution_context)
             inner_strategy.result

--- a/lib/graphql/query/serial_execution/value_resolution.rb
+++ b/lib/graphql/query/serial_execution/value_resolution.rb
@@ -56,12 +56,8 @@ module GraphQL
           def non_null_result
             resolved_type = field_type.resolve_type(value, execution_context)
 
-            if resolved_type.nil?
-              raise(
-                "The value returned for field #{ast_field.name} on #{parent_type} could not be resolved "\
-                "to one of the possible types for #{field_type}. (Did you forget to define a resolve_type proc?)\n"\
-                "Value: #{value}"
-              )
+            unless resolved_type.is_a?(GraphQL::ObjectType)
+              raise GraphQL::ObjectType::UnresolvedTypeError.new(ast_field.name, field_type, parent_type)
             end
 
             strategy_class = get_strategy_for_kind(resolved_type.kind)


### PR DESCRIPTION
Improves the error message when you have a field that returns an interface or a union, but the field's resolver returns a value that can't be resolved to one of the possible types.

Previously, it would fail with a somewhat cryptic error: 
>undefined method `kind' for nil:NilClass

I'm not sure the best way to construct a test case for this; @rmosolgo any ideas?