### PR TITLE
Deep freeze nodes

### DIFF
--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -48,7 +48,7 @@ module GraphQL
         end
 
         def freeze
-          children.each(&:freeze)
+          self.class.child_attributes.each { |attr_name| public_send(attr_name).each(&:freeze).freeze }
           super
         end
       end

--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -46,6 +46,11 @@ module GraphQL
         def to_query_string
           Generation.generate(self)
         end
+
+        def freeze
+          children.each(&:freeze)
+          super
+        end
       end
 
       class WrapperType < AbstractNode

--- a/spec/graphql/language/parser_spec.rb
+++ b/spec/graphql/language/parser_spec.rb
@@ -31,6 +31,16 @@ describe GraphQL::Language::Parser do
       assert document
     end
 
+    it "freeze deep freezes child nodes" do
+      refute document.frozen?
+      refute document.definitions.first.frozen?
+
+      document.freeze
+
+      assert document.frozen?
+      assert document.definitions.first.frozen?
+    end
+
     describe "visited nodes" do
       let(:query) { document.definitions.first }
       let(:fragment_def) { document.definitions.last }

--- a/spec/graphql/language/parser_spec.rb
+++ b/spec/graphql/language/parser_spec.rb
@@ -38,6 +38,7 @@ describe GraphQL::Language::Parser do
       document.freeze
 
       assert document.frozen?
+      assert document.definitions.frozen?
       assert document.definitions.first.frozen?
     end
 


### PR DESCRIPTION
`Node#freeze` freezes children as well so the entire parse tree may be treated as immutable.

An alternative API maybe to add a separate `Node#deep_freeze` if we still wanted to support shallow freezes.