### PR TITLE
feat(Query): Allow an object for the root type to be specified.

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -8,7 +8,7 @@ module GraphQL
       end
     end
 
-    attr_reader :schema, :document, :context, :fragments, :operations, :debug, :max_depth
+    attr_reader :schema, :document, :context, :fragments, :operations, :debug, :root_value, :max_depth
 
     # Prepare query `query_string` on `schema`
     # @param schema [GraphQL::Schema]
@@ -18,13 +18,15 @@ module GraphQL
     # @param debug [Boolean] if true, errors are raised, if false, errors are put in the `errors` key
     # @param validate [Boolean] if true, `query_string` will be validated with {StaticValidation::Validator}
     # @param operation_name [String] if the query string contains many operations, this is the one which should be executed
-    def initialize(schema, query_string = nil, document: nil, context: nil, variables: {}, debug: false, validate: true, operation_name: nil, max_depth: nil)
+    # @param root_value [Object] the object used to resolve fields on the root type
+    def initialize(schema, query_string = nil, document: nil, context: nil, variables: {}, debug: false, validate: true, operation_name: nil, root_value: nil, max_depth: nil)
       fail ArgumentError, "a query string or document is required" unless query_string || document
 
       @schema = schema
       @debug = debug
       @max_depth = max_depth || schema.max_depth
       @context = Context.new(query: self, values: context)
+      @root_value = root_value
       @validate = validate
       @operation_name = operation_name
       @fragments = {}

--- a/lib/graphql/query/serial_execution/operation_resolution.rb
+++ b/lib/graphql/query/serial_execution/operation_resolution.rb
@@ -2,7 +2,7 @@ module GraphQL
   class Query
     class SerialExecution
       class OperationResolution
-        attr_reader :query, :target, :ast_operation_definition, :execution_context
+        attr_reader :target, :ast_operation_definition, :execution_context
 
         def initialize(ast_operation_definition, target, execution_context)
           @ast_operation_definition = ast_operation_definition
@@ -13,7 +13,7 @@ module GraphQL
         def result
           selections = ast_operation_definition.selections
           execution_context.strategy.selection_resolution.new(
-            nil,
+            execution_context.query.root_value,
             target,
             selections,
             execution_context

--- a/spec/graphql/introspection/schema_type_spec.rb
+++ b/spec/graphql/introspection/schema_type_spec.rb
@@ -27,6 +27,7 @@ describe GraphQL::Introspection::SchemaType do
             {"name"=>"fromSource"},
             {"name"=>"maybeNull"},
             {"name"=>"milk"},
+            {"name"=>"root"},
             {"name"=>"searchDairy"},
           ]
         },

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -128,6 +128,11 @@ describe GraphQL::Query do
     end
   end
 
+  it "uses root_value as the object for the root type" do
+    result = GraphQL::Query.new(schema, '{ root }', root_value: "I am root").result
+    assert_equal 'I am root', result.fetch('data').fetch('root')
+  end
+
   it "exposes fragments" do
     assert_equal(GraphQL::Language::Nodes::FragmentDefinition, query.fragments["cheeseFields"].class)
   end

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -200,6 +200,9 @@ FavoriteFieldDefn = Proc.new {
 QueryType = GraphQL::ObjectType.define do
   name "Query"
   description "Query root of the system"
+  field :root, types.String do
+    resolve ->(root_value, args, c) { root_value }
+  end
   field :cheese, field: FetchField.create(type: CheeseType, data: CHEESES)
   field :milk, field: FetchField.create(type: MilkType, data: MILKS, id_type: !types.ID)
   field :dairy, field: SingletonField.create(type: DairyType, data: DAIRY)


### PR DESCRIPTION
## Problem

There is no way to specify an object to the root query or mutation types. This is something that is supported in graphql-js with a [rootValue option](https://github.com/graphql/graphql-js/blob/v0.6.0/src/graphql.js#L32).

Having a root value can be useful since the default resolving calls methods on the object and there may be a natural root object.

## Solution

Add a `root_value` optional argument when constructing the query which the operation resolution can use for the object of the root type.