### PR TITLE
Make EnumType conform to input coercion

### DIFF
--- a/lib/graphql/enum_type.rb
+++ b/lib/graphql/enum_type.rb
@@ -67,6 +67,7 @@ module GraphQL
     # @param value_name [String] the string representation of this enum value
     # @return [Object] the underlying value for this enum value
     def coerce_non_null_input(value_name)
+      return nil unless @values_by_name.key?(value_name)
       @values_by_name.fetch(value_name).value
     end
 

--- a/spec/graphql/enum_type_spec.rb
+++ b/spec/graphql/enum_type_spec.rb
@@ -8,6 +8,10 @@ describe GraphQL::EnumType do
     assert_equal(1, enum.coerce_input("COW"))
   end
 
+  it "coerces invalid names to nil" do
+    assert_equal(nil, enum.coerce_input("YAKKITY"))
+  end
+
   it "coerces result values to value's value" do
     assert_equal("YAK", enum.coerce_result("YAK"))
     assert_equal("COW", enum.coerce_result(1))


### PR DESCRIPTION
It is currently required that `coerce_non_null_input` return `nil` for invalid
inputs to signal an error. `EnumType` was raising a `KeyError` instead.

@rmosolgo @dylanahsmith cc @lreeves