### PR TITLE
Revamp error handling

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -8,28 +8,20 @@ module GraphQL
       end
     end
 
-    attr_reader :schema, :document, :context, :fragments, :operations, :debug, :root_value, :max_depth
+    attr_reader :schema, :document, :context, :fragments, :operations, :root_value, :max_depth
 
     # Prepare query `query_string` on `schema`
     # @param schema [GraphQL::Schema]
     # @param query_string [String]
     # @param context [#[]] an arbitrary hash of values which you can access in {GraphQL::Field#resolve}
     # @param variables [Hash] values for `$variables` in the query
-    # @param debug [Boolean] DEPRECATED if true, errors are raised, if false, errors are put in the `errors` key
     # @param validate [Boolean] if true, `query_string` will be validated with {StaticValidation::Validator}
     # @param operation_name [String] if the query string contains many operations, this is the one which should be executed
     # @param root_value [Object] the object used to resolve fields on the root type
-    def initialize(schema, query_string = nil, document: nil, context: nil, variables: {}, debug: nil, validate: true, operation_name: nil, root_value: nil, max_depth: nil)
+    def initialize(schema, query_string = nil, document: nil, context: nil, variables: {}, validate: true, operation_name: nil, root_value: nil, max_depth: nil)
       fail ArgumentError, "a query string or document is required" unless query_string || document
 
       @schema = schema
-      if debug == false
-        warn("Muffling errors with `debug: false` is deprecated and will be removed. For a similar behavior, use `MySchema.middleware << GraphQL::Schema::CatchallMiddleware`.")
-      elsif debug == true
-        warn("`debug:` will be removed from a future GraphQL version (and raising errors will be the default behavior, like `debug: true`)")
-      end
-      @debug = debug || false
-
       @max_depth = max_depth || schema.max_depth
       @context = Context.new(query: self, values: context)
       @root_value = root_value

--- a/lib/graphql/query/executor.rb
+++ b/lib/graphql/query/executor.rb
@@ -8,8 +8,8 @@ module GraphQL
         @query = query
       end
 
-      # Evalute {operation_name} on {query}. Handle errors by putting them in the "errors" key.
-      # (Or, if `query.debug`, by re-raising them.)
+      # Evalute {operation_name} on {query}.
+      # Handle {GraphQL::ExecutionError}s by putting them in the "errors" key.
       # @return [Hash] A GraphQL response, with either a "data" key or an "errors" key
       def result
         execute

--- a/lib/graphql/query/executor.rb
+++ b/lib/graphql/query/executor.rb
@@ -16,11 +16,6 @@ module GraphQL
       rescue GraphQL::ExecutionError => err
         query.context.errors << err
         {"errors" => [err.to_h]}
-      rescue StandardError => err
-        query.context.errors << err
-        query.debug && raise(err)
-        message = "Internal error" # : #{err} \n#{err.backtrace.join("\n  ")}"
-        {"errors" => [{"message" => message}]}
       end
 
       private

--- a/readme.md
+++ b/readme.md
@@ -121,7 +121,6 @@ If you're building a backend for [Relay](http://facebook.github.io/relay/), you'
 
 - __1.0 items:__
   - Support type name for field types
-  - Revisit error handling & `debug:` option
 - Add a complexity validator (reject queries if they're too big)
 - Add docs for shared behaviors & DRY code
 - __Subscriptions__

--- a/spec/graphql/query/executor_spec.rb
+++ b/spec/graphql/query/executor_spec.rb
@@ -1,7 +1,6 @@
 require "spec_helper"
 
 describe GraphQL::Query::Executor do
-  let(:debug) { true }
   let(:operation_name) { nil }
   let(:schema) { DummySchema }
   let(:variables) { {"cheeseId" => 2} }
@@ -9,7 +8,6 @@ describe GraphQL::Query::Executor do
     schema,
     query_string,
     variables: variables,
-    debug: debug,
     operation_name: operation_name,
   )}
   let(:result) { query.result }

--- a/spec/graphql/query/executor_spec.rb
+++ b/spec/graphql/query/executor_spec.rb
@@ -118,25 +118,8 @@ describe GraphQL::Query::Executor do
   describe "runtime errors" do
     let(:query_string) {%| query noMilk { error }|}
 
-    describe "if debug: false" do
-      let(:debug) { false }
-      let(:errors) { query.context.errors }
-
-      it "turns into error messages" do
-        expected = {"errors"=>[
-          {"message"=>"Internal error"}
-        ]}
-        assert_equal(expected, result)
-        assert_equal([RuntimeError], errors.map(&:class))
-        assert_equal("This error was raised on purpose", errors.first.message)
-      end
-    end
-
-    describe "if debug: true" do
-      let(:debug) { true }
-      it "raises error" do
-        assert_raises(RuntimeError) { result }
-      end
+    it "raises error" do
+      assert_raises(RuntimeError) { result }
     end
 
     describe "if nil is given for a non-null field" do

--- a/spec/graphql/query/serial_execution/execution_context_spec.rb
+++ b/spec/graphql/query/serial_execution/execution_context_spec.rb
@@ -7,7 +7,6 @@ describe GraphQL::Query::SerialExecution::ExecutionContext do
     }
     fragment cheeseFields on Cheese { flavor }
   |}
-  let(:debug) { false }
   let(:operation_name) { nil }
   let(:query_variables) { {"cheeseId" => 2} }
   let(:schema) { DummySchema }
@@ -15,7 +14,6 @@ describe GraphQL::Query::SerialExecution::ExecutionContext do
     schema,
     query_string,
     variables: query_variables,
-    debug: debug,
     operation_name: operation_name,
   )}
   let(:execution_context) {

--- a/spec/graphql/query/serial_execution/value_resolution_spec.rb
+++ b/spec/graphql/query/serial_execution/value_resolution_spec.rb
@@ -1,7 +1,6 @@
 require "spec_helper"
 
 describe GraphQL::Query::SerialExecution::ValueResolution do
-  let(:debug) { false }
   let(:query_root) {
     day_of_week_enum = GraphQL::EnumType.define do
       name "DayOfWeek"
@@ -34,7 +33,6 @@ describe GraphQL::Query::SerialExecution::ValueResolution do
   let(:schema) { GraphQL::Schema.new(query: query_root) }
   let(:result) { schema.execute(
     query_string,
-    debug: debug,
   )}
 
   describe "enum resolution" do
@@ -55,7 +53,6 @@ describe GraphQL::Query::SerialExecution::ValueResolution do
   end
 
   describe "interface type resolution" do
-    let(:debug) { true }
     let(:query_string) { %|
       {
         misbehavedInterface { someField }

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -28,7 +28,6 @@ describe GraphQL::Query do
        ... on Milk   { source }
     }
   |}
-  let(:debug) { false }
   let(:operation_name) { nil }
   let(:max_depth) { nil }
   let(:query_variables) { {"cheeseId" => 2} }
@@ -39,7 +38,6 @@ describe GraphQL::Query do
     schema,
     query_string,
     variables: query_variables,
-    debug: debug,
     operation_name: operation_name,
     max_depth: max_depth,
   )}
@@ -51,7 +49,6 @@ describe GraphQL::Query do
         GraphQL::Query.new(
           schema,
           variables: query_variables,
-          debug: debug,
           operation_name: operation_name,
           max_depth: max_depth,
         )
@@ -64,7 +61,6 @@ describe GraphQL::Query do
       schema,
       document: document,
       variables: query_variables,
-      debug: debug,
       operation_name: operation_name,
       max_depth: max_depth,
     )}


### PR DESCRIPTION
- Improve documentation for `rescue_from` 
- Stop gobbling errors by default, remove `debug:` option
- Add `CatchallMiddleware` as a migration path 


Early on, I grabbed the gobble-all-errors behavior from graphql-js. It's really a poor fit, you know something is _off_ when you deploy with `debug: true`! 

Now, error handling is all opt-in, otherwise any error raised during execution will propagate back to the application. 

### Todo

- [x] before merging, push a patch version with a deprecation for the debug option