### PR TITLE
Automatically coerce default inputs

### DIFF
--- a/lib/graphql/query/literal_input.rb
+++ b/lib/graphql/query/literal_input.rb
@@ -21,7 +21,7 @@ module GraphQL
             arg_value = coerce(arg_defn.type, ast_arg.value, variables)
           end
           if arg_value.nil?
-            arg_value = arg_defn.default_value
+            arg_value = arg_defn.type.coerce_input(arg_defn.default_value)
           end
           values_hash[arg_name] = arg_value
         end

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -217,7 +217,9 @@ describe GraphQL::Query do
         variableDefault: searchDairy(product: $searchWithDefault) {
           ... cheeseFields
         }
-
+        convertedDefault: fromSource {
+          ... cheeseFields
+        }
       }
       fragment cheeseFields on Cheese { flavor }
     |}
@@ -242,6 +244,12 @@ describe GraphQL::Query do
     describe "when the variable has a default" do
       it "uses the variable default" do
         assert_equal("Brie", result["data"]["variableDefault"]["flavor"])
+      end
+    end
+
+    describe "when the variable has a default needing conversion" do
+      it "uses the converted variable default" do
+        assert_equal([{"flavor" => "Brie"}, {"flavor" => "Gouda"}], result["data"]["convertedDefault"])
       end
     end
   end

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -185,7 +185,7 @@ end
 SourceFieldDefn = Proc.new {
   type GraphQL::ListType.new(of_type: CheeseType)
   description "Cheese from source"
-  argument :source, !DairyAnimalEnum
+  argument :source, DairyAnimalEnum, default_value: "COW"
   resolve -> (target, arguments, context) {
     CHEESES.values.select{ |c| c.source == arguments["source"] }
   }


### PR DESCRIPTION
The schema now validates that `default_value` values are valid (they pass
through `coerce_non_null_input`) however it wasn't actually coercing them before
passing them to resolve blocks.

For the majority of types this is not a problem (e.g. 42 is a valid int and
works just fine in the context of a resolve block). However, for enums this
required that the default value be in the set of *names* but then was passing
the name unconverted into the resolve block, where the resolve block was
expecting the equivalent *value*.

The fix is to coerce default values before use, the same way we might coerce any
other input literal.

@rmosolgo @dylanahsmith cc @lreeves