### PR TITLE
refactor(Query) deprecate debug, provide CatchallMiddleware

### DIFF
--- a/guides/defining_your_schema.md
+++ b/guides/defining_your_schema.md
@@ -202,10 +202,13 @@ Additionally, you can define error handling and custom middleware as described b
 
 ## Handling Errors
 
-You can rescue errors by defining handlers with `Schema#rescue_from`. The handler should return a string that will be inserted into the response. For example, you can set up a handler:
+You can rescue errors by defining handlers with `Schema#rescue_from`. The handler receives the error instance and it should return a string. The returned string will be added to the `"errors"` key.
+
+For example, you can set up a handler:
 
 ```ruby
-MySchema.rescue_from(ActiveRecord::RecordInvalid) { "Some data could not be saved" }
+# The error instance is yielded to the block:
+MySchema.rescue_from(ActiveRecord::RecordInvalid) { |error| "Some data could not be saved" }
 ```
 
 Then, when a query is executed, that error is rescued and its message is added to the response:

--- a/guides/executing_queries.md
+++ b/guides/executing_queries.md
@@ -52,14 +52,6 @@ result = MySchema.execute(query_string, operation_name: "getPersonInfo")
 
 If you don't, you'll get an error.
 
-## Debug
-
-By default, `graphql-ruby` rescues any error during execution and puts it in the response's `"errors"` key. You can disable this with `debug: true`, which will cause any error to be raised.
-
-```ruby
-result = MySchema.execute(query_string, debug: true)
-```
-
 ## Validation
 
 By default, `graphql-ruby` performs validation on incoming query strings. If you want to disable this, pass `validate: false`. No guarantees it won't blow up :)

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -15,15 +15,21 @@ module GraphQL
     # @param query_string [String]
     # @param context [#[]] an arbitrary hash of values which you can access in {GraphQL::Field#resolve}
     # @param variables [Hash] values for `$variables` in the query
-    # @param debug [Boolean] if true, errors are raised, if false, errors are put in the `errors` key
+    # @param debug [Boolean] DEPRECATED if true, errors are raised, if false, errors are put in the `errors` key
     # @param validate [Boolean] if true, `query_string` will be validated with {StaticValidation::Validator}
     # @param operation_name [String] if the query string contains many operations, this is the one which should be executed
     # @param root_value [Object] the object used to resolve fields on the root type
-    def initialize(schema, query_string = nil, document: nil, context: nil, variables: {}, debug: false, validate: true, operation_name: nil, root_value: nil, max_depth: nil)
+    def initialize(schema, query_string = nil, document: nil, context: nil, variables: {}, debug: nil, validate: true, operation_name: nil, root_value: nil, max_depth: nil)
       fail ArgumentError, "a query string or document is required" unless query_string || document
 
       @schema = schema
-      @debug = debug
+      if debug == false
+        warn("Muffling errors with `debug: false` is deprecated and will be removed. For a similar behavior, use `MySchema.middleware << GraphQL::Schema::CatchallMiddleware`.")
+      elsif debug == true
+        warn("`debug:` will be removed from a future GraphQL version (and raising errors will be the default behavior, like `debug: true`)")
+      end
+      @debug = debug || false
+
       @max_depth = max_depth || schema.max_depth
       @context = Context.new(query: self, values: context)
       @root_value = root_value

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -1,3 +1,4 @@
+require "graphql/schema/catchall_middleware"
 require "graphql/schema/invalid_type_error"
 require "graphql/schema/middleware_chain"
 require "graphql/schema/rescue_middleware"

--- a/lib/graphql/schema/catchall_middleware.rb
+++ b/lib/graphql/schema/catchall_middleware.rb
@@ -1,0 +1,34 @@
+module GraphQL
+  class Schema
+    # In early GraphQL versions, errors would be "automatically"
+    # rescued and replaced with `"Internal error"`. That behavior
+    # was undesirable but this middleware is offered for people who
+    # want to preserve it.
+    #
+    # It has a couple of differences from the previous behavior:
+    #
+    # - Other parts of the query _will_ be run (previously,
+    #   execution would stop when the error was raised and the result
+    #   would have no `"data"` key at all)
+    # - The entry in {Query::Context#errors} is a {GraphQL::ExecutionError}, _not_
+    #   the originally-raised error.
+    # - The entry in the `"errors"` key includes the location of the field
+    #   which raised the errors.
+    #
+    # @example Use CatchallMiddleware with your schema
+    #     # All errors will be suppressed and replaced with "Internal error" messages
+    #     MySchema.middleware << GraphQL::Schema::CatchallMiddleware
+    #
+    module CatchallMiddleware
+      MESSAGE = "Internal error"
+
+      # Rescue any error and replace it with a {GraphQL::ExecutionError}
+      # whose message is {MESSAGE}
+      def self.call(parent_type, parent_object, field_definition, field_args, query_context, next_middleware)
+        next_middleware.call
+      rescue StandardError => err
+        GraphQL::ExecutionError.new(MESSAGE)
+      end
+    end
+  end
+end

--- a/spec/graphql/schema/catchall_middleware_spec.rb
+++ b/spec/graphql/schema/catchall_middleware_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+describe GraphQL::Schema::CatchallMiddleware do
+  let(:result) { DummySchema.execute(query_string) }
+  let(:query_string) {%| query noMilk { error }|}
+
+  before do
+    DummySchema.middleware << GraphQL::Schema::CatchallMiddleware
+  end
+
+  after do
+    DummySchema.middleware.delete(GraphQL::Schema::CatchallMiddleware)
+  end
+
+  describe "rescuing errors" do
+    let(:errors) { query.context.errors }
+
+    it "turns into error messages" do
+      expected = {
+        "data" => { "error" => nil },
+        "errors"=> [
+          {
+            "message"=>"Internal error",
+            "locations"=>[{"line"=>1, "column"=>17}],
+          },
+        ]
+      }
+      assert_equal(expected, result)
+    end
+  end
+
+end


### PR DESCRIPTION
Issue some warnings before removing `debug:` in #161 