### PR TITLE
feat(types) support circular loading for interfaces and unions

### DIFF
--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -88,5 +88,21 @@ module GraphQL
       return nil if value.nil?
       coerce_non_null_input(value)
     end
+
+    # During schema definition, types can be defined inside procs or as strings.
+    # This function converts it to a type instance
+    # @return [GraphQL::BaseType]
+    def self.resolve_related_type(type_arg)
+      case type_arg
+      when Proc
+        # lazy-eval it
+        type_arg.call
+      when String
+        # Get a constant by this name
+        Object.const_get(type_arg)
+      else
+        type_arg
+      end
+    end
   end
 end

--- a/lib/graphql/field.rb
+++ b/lib/graphql/field.rb
@@ -42,7 +42,7 @@ module GraphQL
     include GraphQL::Define::InstanceDefinable
     accepts_definitions :name, :description, :resolve, :type, :property, :deprecation_reason, argument: GraphQL::Define::AssignArgument
 
-    attr_accessor :deprecation_reason, :name, :description, :type, :property
+    attr_accessor :deprecation_reason, :name, :description, :property
     attr_reader :resolve_proc
 
     # @return [String] The name of this field on its {GraphQL::ObjectType} (or {GraphQL::InterfaceType})
@@ -71,18 +71,14 @@ module GraphQL
       @resolve_proc = resolve_proc || build_default_resolver
     end
 
+    def type=(new_return_type)
+      @clean_type = nil
+      @dirty_type = new_return_type
+    end
+
     # Get the return type for this field.
     def type
-      case @type
-      when Proc
-        # lazy-eval it
-        @type = @type.call
-      when String
-        # Get a constant by this name
-        @type = Object.const_get(@type)
-      else
-        @type
-      end
+      @clean_type ||= GraphQL::BaseType.resolve_related_type(@dirty_type)
     end
 
     # You can only set a field's name _once_ -- this to prevent

--- a/lib/graphql/union_type.rb
+++ b/lib/graphql/union_type.rb
@@ -11,7 +11,7 @@ module GraphQL
   #
   class UnionType < GraphQL::BaseType
     include GraphQL::BaseType::HasPossibleTypes
-    attr_accessor :name, :description, :possible_types
+    attr_accessor :name, :description
     accepts_definitions :possible_types, :resolve_type
 
     def kind
@@ -20,6 +20,19 @@ module GraphQL
 
     def include?(child_type_defn)
       possible_types.include?(child_type_defn)
+    end
+
+    def possible_types=(new_possible_types)
+      @clean_possible_types = nil
+      @dirty_possible_types = new_possible_types
+    end
+
+    def possible_types
+      @clean_possible_types ||= begin
+        @dirty_possible_types.map { |type| GraphQL::BaseType.resolve_related_type(type) }
+      rescue
+        @dirty_possible_types
+      end
     end
   end
 end

--- a/spec/graphql/schema/validation_spec.rb
+++ b/spec/graphql/schema/validation_spec.rb
@@ -83,7 +83,7 @@ describe GraphQL::Schema::Validation do
     let(:invalid_interfaces_object) {
       GraphQL::ObjectType.define do
         name "InvalidInterfaces"
-        interfaces({a: 1})
+        interfaces(55)
       end
     }
     let(:invalid_interface_member_object) {
@@ -101,7 +101,7 @@ describe GraphQL::Schema::Validation do
     }
 
     it "requires an Array for interfaces" do
-      assert_error_includes invalid_interfaces_object, "must be an Array of GraphQL::InterfaceType, not a Hash"
+      assert_error_includes invalid_interfaces_object, "must be an Array of GraphQL::InterfaceType, not a Fixnum"
       assert_error_includes invalid_interface_member_object, "must contain GraphQL::InterfaceType, not Symbol"
     end
 

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -27,7 +27,7 @@ end
 CheeseType = GraphQL::ObjectType.define do
   name "Cheese"
   description "Cultured dairy product"
-  interfaces [EdibleInterface, AnimalProductInterface]
+  interfaces ["EdibleInterface", -> { AnimalProductInterface }]
 
   # Can have (name, type, desc)
   field :id, !types.Int, "Unique identifier"
@@ -107,7 +107,7 @@ end
 DairyProductUnion = GraphQL::UnionType.define do
   name "DairyProduct"
   description "Kinds of food made from milk"
-  possible_types [MilkType, CheeseType]
+  possible_types ["MilkType", -> { CheeseType }]
 end
 
 CowType = GraphQL::ObjectType.define do


### PR DESCRIPTION
It's possible for ObjectTypes and Interfaces to depend on each other, or Objects and Unions, so support the same lazy-loading options as field type when defining an object's interfaces or a union's members