### PR TITLE
Allows for one or more possible_types in a union

### DIFF
--- a/lib/graphql/schema/validation.rb
+++ b/lib/graphql/schema/validation.rb
@@ -90,7 +90,7 @@ module GraphQL
         FIELDS_ARE_VALID = Rules.assert_named_items_are_valid("field", -> (type) { type.all_fields })
 
         HAS_ONE_OR_MORE_POSSIBLE_TYPES = -> (type) {
-          type.possible_types.length > 1 ? nil : "must have at least one possible type"
+          type.possible_types.length >= 1 ? nil : "must have at least one possible type"
         }
 
         NAME_IS_STRING = Rules.assert_property(:name, String)


### PR DESCRIPTION
This pull request modifies the validation rules to allow for one or more possible types inside of a union. As mentioned [here](https://goo.gl/Mr0jvQ), a previous version of the GraphQL specification asserted:

> A Union type must define two or more member types.

But has since been [changed](https://git.io/vouAt) to:

> A Union type must define one or more member types.

It appears that the tests and error messages are both already crafted in such a way to support this change. For example, previous to this pull request an error message would read:

```
Field Star.starrable is invalid: must have at least one possible type
```

When at least one possible type was specified. Similarly the validation test also has already been written in such a way to support this change:

```ruby
it "requires at least one possible_types" do
```