### PR TITLE
Allow me to programatically set enum strings

### DIFF
--- a/lib/graphql/enum_type.rb
+++ b/lib/graphql/enum_type.rb
@@ -83,7 +83,8 @@ module GraphQL
     #
     # Created with {EnumType#value}
     class EnumValue
-      attr_reader :name, :description, :deprecation_reason, :value
+      attr_reader :name, :value
+      attr_accessor :description, :deprecation_reason
       def initialize(name:, description:, deprecation_reason:, value:)
         @name = name
         @description = description

--- a/lib/graphql/enum_type.rb
+++ b/lib/graphql/enum_type.rb
@@ -83,8 +83,7 @@ module GraphQL
     #
     # Created with {EnumType#value}
     class EnumValue
-      attr_reader :name, :value
-      attr_accessor :description, :deprecation_reason
+      attr_accessor :name, :description, :deprecation_reason, :value
       def initialize(name:, description:, deprecation_reason:, value:)
         @name = name
         @description = description


### PR DESCRIPTION
We're opting to keep our descriptions out of code, in YAML files. I noticed that `description=` yields a `NoMethodError`.

This PR allows one to programmatically set a description for enum values.

