### PR TITLE
Support #to_proc-style field definitions

### DIFF
--- a/lib/graphql/define/assign_object_field.rb
+++ b/lib/graphql/define/assign_object_field.rb
@@ -2,7 +2,7 @@ module GraphQL
   module Define
     # Turn field configs into a {GraphQL::Field} and attach it to a {GraphQL::ObjectType} or {GraphQL::InterfaceType}
     module AssignObjectField
-      def self.call(fields_type, name, type = nil, desc = nil, field: nil, deprecation_reason: nil, property: nil, &block)
+      def self.call(fields_type, name = nil, type = nil, desc = nil, field: nil, deprecation_reason: nil, property: nil, &block)
         if block_given?
           field = GraphQL::Field.define(&block)
         else
@@ -13,7 +13,7 @@ module GraphQL
         property && field.property = property
         deprecation_reason && field.deprecation_reason = deprecation_reason
         field.name ||= name.to_s
-        fields_type.fields[name.to_s] = field
+        fields_type.fields[field.name.to_s] = field
       end
     end
   end

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -170,15 +170,23 @@ class FetchField
 end
 
 class SingletonField
-  def self.create(type:, data:)
-    desc = "Find the only #{type.name}"
-    return_type = type
-    GraphQL::Field.define do
-      type(return_type)
-      description(desc)
+  def initialize(name, type:, data:)
+    @name = name
+    @type = type
+    @data = data
+  end
 
-      resolve -> (t, a, c) {data}
-    end
+
+  def to_proc
+    return_type = @type
+    field_name = @name
+    return_value = @data
+    -> (types) {
+      name(field_name.to_s)
+      type(return_type)
+      description("Find the only #{return_type.name}")
+      resolve -> (t, a, c) { return_value }
+    }
   end
 end
 
@@ -205,10 +213,10 @@ QueryType = GraphQL::ObjectType.define do
   end
   field :cheese, field: FetchField.create(type: CheeseType, data: CHEESES)
   field :milk, field: FetchField.create(type: MilkType, data: MILKS, id_type: !types.ID)
-  field :dairy, field: SingletonField.create(type: DairyType, data: DAIRY)
+  field &SingletonField.new(:dairy, type: DairyType, data: DAIRY)
   field :fromSource, &SourceFieldDefn
   field :favoriteEdible, &FavoriteFieldDefn
-  field :cow, field: SingletonField.create(type: CowType, data: COW)
+  field &SingletonField.new(:cow, type: CowType, data: COW)
   field :searchDairy do
     description "Find dairy products matching a description"
     type !DairyProductUnion


### PR DESCRIPTION
One shortcoming of the current API is defining _whole_ fields programmatically. It's easy to parameterize `resolve` functions, but name, return type and arguments must be specified separately. 

This approach _allows_ you to do that -- to define the whole field in one place, but it's not a very good API ... who thought `to_proc` would be the way to define a field? 

So, this PR is mostly a "thought experiment", trying to find a good way to parameterize _whole_ field definitions