### PR TITLE
fix(SerialExecution) non-null errors propagate to the nearest nullable field 

### DIFF
--- a/lib/graphql/query/serial_execution/operation_resolution.rb
+++ b/lib/graphql/query/serial_execution/operation_resolution.rb
@@ -18,6 +18,9 @@ module GraphQL
             selections,
             execution_context
           ).result
+        rescue GraphQL::InvalidNullError => err
+          err.parent_error? || execution_context.add_error(err)
+          nil
         end
       end
     end

--- a/lib/graphql/query/serial_execution/selection_resolution.rb
+++ b/lib/graphql/query/serial_execution/selection_resolution.rb
@@ -17,9 +17,6 @@ module GraphQL
             .reduce({}) { |result, ast_node|
               result.merge(resolve_field(ast_node))
             }
-        rescue GraphQL::InvalidNullError => err
-          err.parent_error? || execution_context.add_error(err)
-          nil
         end
 
         private

--- a/lib/graphql/query/serial_execution/value_resolution.rb
+++ b/lib/graphql/query/serial_execution/value_resolution.rb
@@ -81,11 +81,14 @@ module GraphQL
         class NonNullResolution < BaseResolution
           # Get the "wrapped" type and resolve the value according to that type
           def result
-            raise GraphQL::InvalidNullError.new(ast_field.name, value) if value.nil? || value.is_a?(GraphQL::ExecutionError)
-            wrapped_type = field_type.of_type
-            strategy_class = get_strategy_for_kind(wrapped_type.kind)
-            inner_strategy = strategy_class.new(value, wrapped_type, target, parent_type, ast_field, execution_context)
-            inner_strategy.result
+            if value.nil? || value.is_a?(GraphQL::ExecutionError)
+              raise GraphQL::InvalidNullError.new(ast_field.name, value)
+            else
+              wrapped_type = field_type.of_type
+              strategy_class = get_strategy_for_kind(wrapped_type.kind)
+              inner_strategy = strategy_class.new(value, wrapped_type, target, parent_type, ast_field, execution_context)
+              inner_strategy.result
+            end
           end
         end
 

--- a/readme.md
+++ b/readme.md
@@ -120,14 +120,13 @@ If you're building a backend for [Relay](http://facebook.github.io/relay/), you'
 
 ## To Do
 
-- __1.0 items:__
-  - Non-nulls should _propagate_ to the next non-null field (all the way up to data, if need be)
 - Subscriptions
   - Is there something to do at the graphql-ruby level to make this easier for specific implementations?
 - Accept type name as `type` argument?
   - Goal: accept `field :post, "Post"` to look up a type named `"Post"` in the schema
   - Problem: how does a field know which schema to look up the name from?
   - Problem: how can we load types in Rails without accessing the constant?
+  - Maybe support by third-party library? `type("Post!")` could implement "type_missing", keeps `graphql-ruby` very simple
 - Customizable complexity validator
   - Types / fields can define their "weight" in a query
   - Queries can be executed with a "max weight", or Schema can have a default

--- a/spec/graphql/introspection/schema_type_spec.rb
+++ b/spec/graphql/introspection/schema_type_spec.rb
@@ -21,6 +21,7 @@ describe GraphQL::Introspection::SchemaType do
             {"name"=>"cheese"},
             {"name"=>"cow"},
             {"name"=>"dairy"},
+            {"name"=>"deepNonNull"},
             {"name"=>"error"},
             {"name"=>"executionError"},
             {"name"=>"favoriteEdible"},

--- a/spec/graphql/non_null_type_spec.rb
+++ b/spec/graphql/non_null_type_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+describe GraphQL::NonNullType do
+  describe "when a non-null field returns null" do
+    it "nulls out the parent selection" do
+      query_string = %|{ cow { name cantBeNullButIs } }|
+      result = DummySchema.execute(query_string)
+      assert_equal({"cow" => nil }, result["data"])
+      assert_equal([{"message"=>"Cannot return null for non-nullable field cantBeNullButIs"}], result["errors"])
+    end
+
+    it "propagates the null up to the next nullable field" do
+      query_string = %|
+      {
+        nn1: deepNonNull {
+          nni1: nonNullInt(returning: 1)
+          nn2: deepNonNull {
+            nni2: nonNullInt(returning: 2)
+            nn3: deepNonNull {
+              nni3: nonNullInt
+            }
+          }
+        }
+      }
+      |
+      result = DummySchema.execute(query_string)
+      assert_equal(nil, result["data"])
+      assert_equal([{"message"=>"Cannot return null for non-nullable field nonNullInt"}], result["errors"])
+    end
+  end
+end

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -150,6 +150,17 @@ DairyProductInputType = GraphQL::InputObjectType.define {
   input_field :organic, types.Boolean, default_value: false
 }
 
+DeepNonNullType = GraphQL::ObjectType.define do
+  name "DeepNonNull"
+  field :nonNullInt, !types.Int do
+    argument :returning, types.Int
+    resolve -> (obj, args, ctx) { args[:returning] }
+  end
+
+  field :deepNonNull, -> { DeepNonNullType.to_non_null_type } do
+    resolve -> (obj, args, ctx) { :deepNonNull }
+  end
+end
 
 class FetchField
   def self.create(type:, data:, id_type: !GraphQL::INT_TYPE)
@@ -238,6 +249,10 @@ QueryType = GraphQL::ObjectType.define do
   # To test possibly-null fields
   field :maybeNull, MaybeNullType do
     resolve -> (t, a, c) { OpenStruct.new(cheese: nil) }
+  end
+
+  field :deepNonNull, !DeepNonNullType do
+    resolve -> (o, a, c) { :deepNonNull }
   end
 end
 


### PR DESCRIPTION
Oops, we were previously out-of-line with the spec. 

When a non-null field resolves to `nil` (which it shouldn't, this is an error), it nullifies the _whole_ selection which it is a part of. Then, if the parent field was _also_ non-null, that field nullifies its _whole_ selection, and so on, until you get to a nullable field. 

Makes sense: you never want to give `null` to a client which is expecting non-null. So ascend the query tree to make sure that doesn't happen.