### PR TITLE
Track validation results

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -16,7 +16,7 @@ module GraphQL
     DIRECTIVES = [GraphQL::Directive::SkipDirective, GraphQL::Directive::IncludeDirective]
     DYNAMIC_FIELDS = ["__type", "__typename", "__schema"]
 
-    attr_reader :query, :mutation, :subscription, :directives, :static_validator
+    attr_reader :query, :mutation, :subscription, :directives, :static_validator, :validation_results
     attr_accessor :max_depth
     # Override these if you don't want the default executor:
     attr_accessor :query_execution_strategy,
@@ -41,6 +41,7 @@ module GraphQL
       @static_validator = GraphQL::StaticValidation::Validator.new(schema: self)
       @rescue_middleware = GraphQL::Schema::RescueMiddleware.new
       @middleware = [@rescue_middleware]
+      @validation_results = {}
       # Default to the built-in execution strategy:
       self.query_execution_strategy = GraphQL::Query::SerialExecution
       self.mutation_execution_strategy = GraphQL::Query::SerialExecution

--- a/lib/graphql/static_validation/rules/document_does_not_exceed_max_depth.rb
+++ b/lib/graphql/static_validation/rules/document_does_not_exceed_max_depth.rb
@@ -62,6 +62,7 @@ module GraphQL
       def assert_under_max_depth(context, max_allowed_depth, depths, fragments)
         context.operations.each do |op_name, operation|
           op_depth = get_total_depth(op_name, depths, fragments)
+          context.results[:depth_reached] = op_depth
           if op_depth > max_allowed_depth
             op_name ||= "operation"
             context.errors << message("#{op_name} has depth of #{op_depth}, which exceeds max depth of #{max_allowed_depth}", operation)

--- a/lib/graphql/static_validation/validation_context.rb
+++ b/lib/graphql/static_validation/validation_context.rb
@@ -11,7 +11,7 @@ module GraphQL
     # It also provides limited access to the {TypeStack} instance,
     # which tracks state as you climb in and out of different fields.
     class ValidationContext
-      attr_reader :query, :schema, :document, :errors, :visitor, :fragments, :operations
+      attr_reader :query, :schema, :document, :errors, :visitor, :fragments, :operations, :results
       def initialize(query)
         @query = query
         @schema = query.schema
@@ -29,6 +29,7 @@ module GraphQL
         end
 
         @errors = []
+        @results = {}
         @visitor = GraphQL::Language::Visitor.new
         @type_stack = GraphQL::StaticValidation::TypeStack.new(schema, visitor)
       end

--- a/lib/graphql/static_validation/validator.rb
+++ b/lib/graphql/static_validation/validator.rb
@@ -26,6 +26,7 @@ module GraphQL
           rules.new.validate(context)
         end
         context.visitor.visit(query.document)
+        @schema.validation_results.merge!(context.results)
         context.errors.map(&:to_h)
       end
     end


### PR DESCRIPTION
Internally, we have no idea (really!) what a healthy `max_depth` value ought to be for our schema. We'd like to track and graph the query depths which people are using.

This PR proposes adding a new hash to a schema called `validation_results`. Any validation rules can push key/value pairs to `context.results`. After the validations are done, users can call `schema.validation_results` to inspect that arbitrary data.

In this case, I've added a new key called `depth_reached`. After a query has finished, we can inspect `depth_reached` and log it. We'll use real-world results to determine if our `max_allowed_depth` is too low or too high.

Thoughts on this much appreciated. 

/cc @kdaigle 