### PR TITLE
Mutable context

### DIFF
--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -32,6 +32,10 @@ module GraphQL
       def [](key)
         @values[key]
       end
+
+      def []=(key, value)
+        @values[key] = value
+      end
     end
   end
 end

--- a/spec/graphql/query/context_spec.rb
+++ b/spec/graphql/query/context_spec.rb
@@ -57,4 +57,14 @@ describe GraphQL::Query::Context do
       assert_equal(nil, context[:some_key])
     end
   end
+
+  describe "assigning values" do
+    let(:context) { GraphQL::Query::Context.new(query: OpenStruct.new(schema: schema), values: nil) }
+
+    it "allows you to assign new contexts" do
+      assert_equal(nil, context[:some_key])
+      context[:some_key] = "wow!"
+      assert_equal("wow!", context[:some_key])
+    end
+  end
 end


### PR DESCRIPTION
Thanks @gjtorikian for these commits from #153 ... sorry, I wasn't ready to admit my need for them then :P 

I want to write to context from a middleware, in a way the the individual query doesn't have to "worry" about. This runs the risk of key conflicts ... so be it! 

