### PR TITLE
feat(InstanceDefinable) lazy-eval the .define block to handle circular dependencies

### DIFF
--- a/guides/introduction.md
+++ b/guides/introduction.md
@@ -125,13 +125,11 @@ We should also add a `comments` field to `PostType`:
 ```ruby
 PostType = GraphQL::ObjectType.new do |t, types, field|
   # ... existing code ...
-  field :comments, -> { !types[!CommentType] }, "Responses to this post"
+  field :comments, !types[!CommentType], "Responses to this post"
 end
 ```
 
 `types[SomeType]` means that this field returns a _list_ of `SomeType`.
-
-`PostType` and `CommentType` have a circular dependency. To deal with this, wrap one of the types in a lambda with `-> { ... }`. The lambda will be evaluated when the schema is built (and after CommentType has been defined).
 
 ## Executing a Query
 

--- a/lib/graphql/argument.rb
+++ b/lib/graphql/argument.rb
@@ -17,9 +17,14 @@ module GraphQL
   class Argument
     include GraphQL::Define::InstanceDefinable
     accepts_definitions :name, :type, :description, :default_value
-    attr_accessor :type, :description, :default_value
+    lazy_defined_attr_accessor :type, :description, :default_value
 
     # @return [String] The name of this argument on its {GraphQL::Field} or {GraphQL::InputObjectType}
-    attr_accessor :name
+    def name
+      ensure_defined
+      @name
+    end
+
+    attr_writer :name
   end
 end

--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -3,8 +3,8 @@ module GraphQL
   class BaseType
     include GraphQL::Define::NonNullWithBang
     include GraphQL::Define::InstanceDefinable
-    attr_accessor :name, :description
     accepts_definitions :name, :description
+    lazy_defined_attr_accessor :name, :description
 
     # @param other [GraphQL::BaseType] compare to this object
     # @return [Boolean] are these types equivalent? (incl. non-null, list)
@@ -53,6 +53,7 @@ module GraphQL
       # @param ctx [GraphQL::Query::Context]
       # @return [GraphQL::ObjectType] the type which should expose `object`
       def resolve_type(object, ctx)
+        ensure_defined
         instance_exec(object, ctx, &(@resolve_type_proc || DEFAULT_RESOLVE_TYPE))
       end
 

--- a/lib/graphql/directive.rb
+++ b/lib/graphql/directive.rb
@@ -3,7 +3,7 @@ module GraphQL
     include GraphQL::Define::InstanceDefinable
     accepts_definitions :locations, :name, :description, :include_proc, argument: GraphQL::Define::AssignArgument
 
-    attr_accessor :locations, :arguments, :name, :description
+    lazy_defined_attr_accessor :locations, :arguments, :name, :description, :include_proc
 
     LOCATIONS = [
       QUERY =               :QUERY,
@@ -20,11 +20,7 @@ module GraphQL
     end
 
     def include?(arguments)
-      @include_proc.call(arguments)
-    end
-
-    def include_proc=(include_proc)
-      @include_proc = include_proc
+      include_proc.call(arguments)
     end
 
     def to_s

--- a/lib/graphql/field.rb
+++ b/lib/graphql/field.rb
@@ -59,18 +59,33 @@ module GraphQL
     include GraphQL::Define::InstanceDefinable
     accepts_definitions :name, :description, :resolve, :type, :property, :deprecation_reason, :complexity, argument: GraphQL::Define::AssignArgument
 
-    attr_accessor :deprecation_reason, :name, :description, :property
+    lazy_defined_attr_accessor :deprecation_reason, :description, :property
 
     attr_reader :resolve_proc
 
     # @return [String] The name of this field on its {GraphQL::ObjectType} (or {GraphQL::InterfaceType})
-    attr_reader :name
+    def name
+      ensure_defined
+      @name
+    end
+
+    attr_writer :name
 
     # @return [Hash<String => GraphQL::Argument>] Map String argument names to their {GraphQL::Argument} implementations
-    attr_accessor :arguments
+    def arguments
+      ensure_defined
+      @arguments
+    end
+
+    attr_writer :arguments
 
     # @return [Numeric, Proc] The complexity for this field (default: 1), as a constant or a proc like `-> (query_ctx, args, child_complexity) { } # Numeric`
-    attr_accessor :complexity
+    def complexity
+      ensure_defined
+      @complexity
+    end
+
+    attr_writer :complexity
 
     def initialize
       @complexity = 1
@@ -86,7 +101,8 @@ module GraphQL
     # @param arguments [Hash] Arguments declared in the query
     # @param context [GraphQL::Query::Context]
     def resolve(object, arguments, context)
-      @resolve_proc.call(object, arguments, context)
+      ensure_defined
+      resolve_proc.call(object, arguments, context)
     end
 
     def resolve=(resolve_proc)
@@ -100,7 +116,10 @@ module GraphQL
 
     # Get the return type for this field.
     def type
-      @clean_type ||= GraphQL::BaseType.resolve_related_type(@dirty_type)
+      @clean_type ||= begin
+        ensure_defined
+        GraphQL::BaseType.resolve_related_type(@dirty_type)
+      end
     end
 
     # You can only set a field's name _once_ -- this to prevent

--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -15,7 +15,11 @@ module GraphQL
     )
 
     # @return [Hash<String => GraphQL::Argument>] Map String argument names to their {GraphQL::Argument} implementations
-    attr_accessor :arguments
+    def arguments
+      ensure_defined
+      @arguments
+    end
+    attr_writer :arguments
 
     alias :input_fields :arguments
 

--- a/lib/graphql/interface_type.rb
+++ b/lib/graphql/interface_type.rb
@@ -15,7 +15,7 @@ module GraphQL
     include GraphQL::BaseType::HasPossibleTypes
     accepts_definitions :resolve_type, field: GraphQL::Define::AssignObjectField
 
-    attr_accessor :fields
+    lazy_defined_attr_accessor :fields
 
     def initialize
       @fields = {}

--- a/lib/graphql/object_type.rb
+++ b/lib/graphql/object_type.rb
@@ -22,10 +22,9 @@ module GraphQL
   #
   class ObjectType < GraphQL::BaseType
     accepts_definitions :interfaces, field: GraphQL::Define::AssignObjectField
-    attr_accessor :name, :description
 
     # @return [Hash<String => GraphQL::Field>] Map String fieldnames to their {GraphQL::Field} implementations
-    attr_accessor :fields
+    lazy_defined_attr_accessor :fields
 
     def initialize
       @fields = {}
@@ -40,6 +39,7 @@ module GraphQL
 
     def interfaces
       @clean_interfaces ||= begin
+        ensure_defined
         @dirty_interfaces.map { |i_type| GraphQL::BaseType.resolve_related_type(i_type) }
       rescue
         @dirty_interfaces

--- a/lib/graphql/scalar_type.rb
+++ b/lib/graphql/scalar_type.rb
@@ -27,6 +27,7 @@ module GraphQL
     end
 
     def coerce_non_null_input(value)
+      ensure_defined
       @coerce_input_proc.call(value)
     end
 
@@ -37,6 +38,7 @@ module GraphQL
     end
 
     def coerce_result(value)
+      ensure_defined
       @coerce_result_proc.call(value)
     end
 

--- a/lib/graphql/union_type.rb
+++ b/lib/graphql/union_type.rb
@@ -11,7 +11,6 @@ module GraphQL
   #
   class UnionType < GraphQL::BaseType
     include GraphQL::BaseType::HasPossibleTypes
-    attr_accessor :name, :description
     accepts_definitions :possible_types, :resolve_type
 
     def kind
@@ -29,6 +28,7 @@ module GraphQL
 
     def possible_types
       @clean_possible_types ||= begin
+        ensure_defined
         @dirty_possible_types.map { |type| GraphQL::BaseType.resolve_related_type(type) }
       rescue
         @dirty_possible_types

--- a/readme.md
+++ b/readme.md
@@ -127,7 +127,6 @@ If you're building a backend for [Relay](http://facebook.github.io/relay/), you'
   - Problem: how does a field know which schema to look up the name from?
   - Problem: how can we load types in Rails without accessing the constant?
   - Maybe support by third-party library? `type("Post!")` could implement "type_missing", keeps `graphql-ruby` very simple
-- If we eval'd `define { ... }` blocks _lazily_, would that work around all circular dependency issues?
 - Type check improvements:
   - Use catch-all type/field/argument definitions instead of terminating traversal
   - Reduce ad-hoc traversals?

--- a/spec/graphql/define/instance_definable_spec.rb
+++ b/spec/graphql/define/instance_definable_spec.rb
@@ -10,12 +10,12 @@ module Garden
   end
 
   class Vegetable
-    attr_accessor :name, :start_planting_on, :end_planting_on
     include GraphQL::Define::InstanceDefinable
+    lazy_defined_attr_accessor :name, :start_planting_on, :end_planting_on
     accepts_definitions :name, plant_between: DefinePlantBetween
 
     # definition added later:
-    attr_accessor :height
+    lazy_defined_attr_accessor :height
   end
 end
 

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -27,7 +27,7 @@ end
 CheeseType = GraphQL::ObjectType.define do
   name "Cheese"
   description "Cultured dairy product"
-  interfaces ["EdibleInterface", -> { AnimalProductInterface }]
+  interfaces [EdibleInterface, AnimalProductInterface]
 
   # Can have (name, type, desc)
   field :id, !types.Int, "Unique identifier"
@@ -38,7 +38,7 @@ CheeseType = GraphQL::ObjectType.define do
     "Animal which produced the milk for this cheese"
 
   # Or can define by block:
-  field :similarCheese, -> { CheeseType }, "Cheeses like this one" do
+  field :similarCheese, CheeseType, "Cheeses like this one" do
     argument :source, !types[!DairyAnimalEnum]
     resolve -> (t, a, c) {
       # get the strings out:
@@ -51,12 +51,12 @@ CheeseType = GraphQL::ObjectType.define do
     }
   end
 
-  field :nullableCheese, -> { CheeseType }, "Cheeses like this one" do
+  field :nullableCheese, CheeseType, "Cheeses like this one" do
     argument :source, types[!DairyAnimalEnum]
     resolve -> (t, a, c) { raise("NotImplemented") }
   end
 
-  field :deeplyNullableCheese, -> { CheeseType }, "Cheeses like this one" do
+  field :deeplyNullableCheese, CheeseType, "Cheeses like this one" do
     argument :source, types[types[DairyAnimalEnum]]
     resolve -> (t, a, c) { raise("NotImplemented") }
   end
@@ -113,6 +113,7 @@ end
 DairyProductUnion = GraphQL::UnionType.define do
   name "DairyProduct"
   description "Kinds of food made from milk"
+  # Test that these forms of declaration still work:
   possible_types ["MilkType", -> { CheeseType }]
 end
 
@@ -163,7 +164,7 @@ DeepNonNullType = GraphQL::ObjectType.define do
     resolve -> (obj, args, ctx) { args[:returning] }
   end
 
-  field :deepNonNull, -> { DeepNonNullType.to_non_null_type } do
+  field :deepNonNull, DeepNonNullType.to_non_null_type do
     resolve -> (obj, args, ctx) { :deepNonNull }
   end
 end


### PR DESCRIPTION
Previously, self-referencing or mutually-dependent types required a proc to make references: 

```ruby 
PostType = GraphQL::ObjectType.define do 
  # ...
  field :similarPosts, -> { types[PostType] }
end 
```

Now, you can leave of the proc wrapper: 

```ruby 
PostType = GraphQL::ObjectType.define do 
  # ...
  field :similarPosts, types[PostType]
end 
```

The `.define { ... }` block won't be called until one of the defined values is accessed, so `PostType` will be available by then. `-> { }`-style type references are still supported in case you _really_ need to put off calculation until Schema build-time!