### PR TITLE
Pass `field_name` to `connection_class` resolver

### DIFF
--- a/lib/graphql/relay/base_connection.rb
+++ b/lib/graphql/relay/base_connection.rb
@@ -60,10 +60,11 @@ module GraphQL
       # @param Query arguments
       # @param max_page_size [Int] The maximum number of results to return
       # @param parent [Object] The object which this collection belongs to
-      def initialize(nodes, arguments, max_page_size: nil, parent: nil)
+      def initialize(nodes, arguments, max_page_size: nil, field_name: field_name, parent: nil)
         @nodes = nodes
         @arguments = arguments
         @max_page_size = max_page_size
+        @field_name = field_name
         @parent = parent
       end
 

--- a/lib/graphql/relay/base_connection.rb
+++ b/lib/graphql/relay/base_connection.rb
@@ -60,7 +60,7 @@ module GraphQL
       # @param Query arguments
       # @param max_page_size [Int] The maximum number of results to return
       # @param parent [Object] The object which this collection belongs to
-      def initialize(nodes, arguments, max_page_size: nil, field_name: field_name, parent: nil)
+      def initialize(nodes, arguments, field_name: field_name, max_page_size: nil, parent: nil)
         @nodes = nodes
         @arguments = arguments
         @max_page_size = max_page_size

--- a/lib/graphql/relay/base_connection.rb
+++ b/lib/graphql/relay/base_connection.rb
@@ -58,9 +58,10 @@ module GraphQL
       # Make a connection, wrapping `nodes`
       # @param [Object] The collection of nodes
       # @param Query arguments
+      # @param field [Object] The underlying field
       # @param max_page_size [Int] The maximum number of results to return
       # @param parent [Object] The object which this collection belongs to
-      def initialize(nodes, arguments, field: field, max_page_size: nil, parent: nil)
+      def initialize(nodes, arguments, field:, max_page_size: nil, parent: nil)
         @nodes = nodes
         @arguments = arguments
         @max_page_size = max_page_size

--- a/lib/graphql/relay/base_connection.rb
+++ b/lib/graphql/relay/base_connection.rb
@@ -53,7 +53,7 @@ module GraphQL
         deprecate(:connection_for_items, :connection_for_nodes, 2016, 9)
       end
 
-      attr_reader :nodes, :arguments, :max_page_size, :parent
+      attr_reader :nodes, :arguments, :max_page_size, :parent, :field
 
       # Make a connection, wrapping `nodes`
       # @param [Object] The collection of nodes

--- a/lib/graphql/relay/base_connection.rb
+++ b/lib/graphql/relay/base_connection.rb
@@ -60,11 +60,11 @@ module GraphQL
       # @param Query arguments
       # @param max_page_size [Int] The maximum number of results to return
       # @param parent [Object] The object which this collection belongs to
-      def initialize(nodes, arguments, field_name: field_name, max_page_size: nil, parent: nil)
+      def initialize(nodes, arguments, field: field, max_page_size: nil, parent: nil)
         @nodes = nodes
         @arguments = arguments
         @max_page_size = max_page_size
-        @field_name = field_name
+        @field = field
         @parent = parent
       end
 

--- a/lib/graphql/relay/connection_field.rb
+++ b/lib/graphql/relay/connection_field.rb
@@ -33,7 +33,7 @@ module GraphQL
       def self.create(underlying_field, max_page_size: nil)
         underlying_field.arguments = DEFAULT_ARGUMENTS.merge(underlying_field.arguments)
         original_resolve = underlying_field.resolve_proc
-        underlying_field.resolve = GraphQL::Relay::ConnectionResolve.new(underlying_field.name, original_resolve, max_page_size: max_page_size)
+        underlying_field.resolve = GraphQL::Relay::ConnectionResolve.new(underlying_field, original_resolve, max_page_size: max_page_size)
         underlying_field
       end
     end

--- a/lib/graphql/relay/connection_resolve.rb
+++ b/lib/graphql/relay/connection_resolve.rb
@@ -1,8 +1,8 @@
 module GraphQL
   module Relay
     class ConnectionResolve
-      def initialize(field_name, underlying_resolve, max_page_size: nil)
-        @field_name = field_name
+      def initialize(field, underlying_resolve, max_page_size: nil)
+        @field = field
         @underlying_resolve = underlying_resolve
         @max_page_size = max_page_size
       end
@@ -10,7 +10,7 @@ module GraphQL
       def call(obj, args, ctx)
         nodes = @underlying_resolve.call(obj, args, ctx)
         connection_class = GraphQL::Relay::BaseConnection.connection_for_nodes(nodes)
-        connection_class.new(nodes, args, field_name: @field_name, max_page_size: @max_page_size, parent: obj)
+        connection_class.new(nodes, args, field: @field, max_page_size: @max_page_size, parent: obj)
       end
     end
   end

--- a/lib/graphql/relay/connection_resolve.rb
+++ b/lib/graphql/relay/connection_resolve.rb
@@ -10,7 +10,7 @@ module GraphQL
       def call(obj, args, ctx)
         nodes = @underlying_resolve.call(obj, args, ctx)
         connection_class = GraphQL::Relay::BaseConnection.connection_for_nodes(nodes)
-        connection_class.new(nodes, args, max_page_size: @max_page_size, field_name: @field_name, parent: obj)
+        connection_class.new(nodes, args, field_name: @field_name, max_page_size: @max_page_size, parent: obj)
       end
     end
   end

--- a/lib/graphql/relay/connection_resolve.rb
+++ b/lib/graphql/relay/connection_resolve.rb
@@ -10,7 +10,7 @@ module GraphQL
       def call(obj, args, ctx)
         nodes = @underlying_resolve.call(obj, args, ctx)
         connection_class = GraphQL::Relay::BaseConnection.connection_for_nodes(nodes)
-        connection_class.new(nodes, args, max_page_size: @max_page_size, parent: obj)
+        connection_class.new(nodes, args, max_page_size: @max_page_size, field_name: @field_name, parent: obj)
       end
     end
   end

--- a/spec/graphql/relay/connection_type_spec.rb
+++ b/spec/graphql/relay/connection_type_spec.rb
@@ -8,6 +8,7 @@ describe GraphQL::Relay::ConnectionType do
           rebels {
             basesWithCustomEdge {
               totalCountTimes100
+              fieldName
               edges {
                 upcasedName
                 upcasedParentName
@@ -26,6 +27,7 @@ describe GraphQL::Relay::ConnectionType do
         result = query(query_string)
         bases = result["data"]["rebels"]["basesWithCustomEdge"]
         assert_equal 300, bases["totalCountTimes100"]
+        assert_equal 'basesWithCustomEdge', bases["fieldName"]
         assert_equal ["YAVIN", "ECHO BASE", "SECRET HIDEOUT"] , bases["edges"].map { |e| e["upcasedName"] }
         assert_equal ["Yavin", "Echo Base", "Secret Hideout"] , bases["edges"].map { |e| e["node"]["name"] }
         assert_equal ["CustomBaseEdge"] , bases["edges"].map { |e| e["edgeClassName"] }.uniq

--- a/spec/support/star_wars_schema.rb
+++ b/spec/support/star_wars_schema.rb
@@ -77,6 +77,8 @@ CustomEdgeBaseConnectionType = BaseType.define_connection(edge_class: CustomBase
     type types.Int
     resolve -> (obj, args, ctx) { obj.nodes.count * 100 }
   end
+
+  field :fieldName, types.String, resolve: -> (obj, args, ctx) { obj.field.name }
 end
 
 Faction = GraphQL::ObjectType.define do


### PR DESCRIPTION
Kind of kicking myself for not doing this earlier. I need the `field_name` for some error message handling, so let's pass it in as a kwarg to the resolver. 