### PR TITLE
Implement loading schema from JSON introspection query dump

### DIFF
--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -58,6 +58,7 @@ require "graphql/introspection"
 require "graphql/language"
 require "graphql/analysis"
 require "graphql/schema"
+require "graphql/schema/loader"
 require "graphql/schema/printer"
 
 # Order does not matter for these:

--- a/lib/graphql/interface_type.rb
+++ b/lib/graphql/interface_type.rb
@@ -23,7 +23,7 @@ module GraphQL
   #
   class InterfaceType < GraphQL::BaseType
     include GraphQL::BaseType::HasPossibleTypes
-    accepts_definitions :resolve_type, field: GraphQL::Define::AssignObjectField
+    accepts_definitions :resolve_type, :fields, field: GraphQL::Define::AssignObjectField
 
     lazy_defined_attr_accessor :fields
 

--- a/lib/graphql/schema/loader.rb
+++ b/lib/graphql/schema/loader.rb
@@ -1,0 +1,124 @@
+module GraphQL
+  class Schema
+    module Loader
+      extend self
+
+      def load(obj)
+        schema = obj.fetch("data").fetch("__schema")
+
+        types = {}
+        type_resolver = -> (type) { -> { resolve_type(types, type) } }
+
+        schema.fetch("types").each do |type|
+          next if type.fetch("name").start_with?("__")
+          type_object = define_type(type, type_resolver)
+          types[type_object.name] = type_object
+        end
+
+        query = types.fetch(schema.fetch("queryType").fetch("name"))
+
+        Schema.new(query: query, types: types.values)
+      end
+
+      private
+
+      def resolve_type(types, type)
+        case kind = type.fetch("kind")
+        when "ENUM", "INTERFACE", "INPUT_OBJECT", "OBJECT", "SCALAR", "UNION"
+          types.fetch(type.fetch("name"))
+        when "LIST"
+          ListType.new(of_type: resolve_type(types, type.fetch("ofType")))
+        when "NON_NULL"
+          NonNullType.new(of_type: resolve_type(types, type.fetch("ofType")))
+        else
+          fail NotImplementedError, "#{kind} not implemented"
+        end
+      end
+
+      def define_type(type, type_resolver)
+        case type.fetch("kind")
+        when "ENUM"
+          EnumType.define(
+            name: type["name"],
+            description: type["description"],
+            values: type["enumValues"].map { |enum|
+              EnumType::EnumValue.new(
+                name: enum["name"],
+                description: enum["description"],
+                deprecation_reason: enum["deprecationReason"],
+                value: enum["value"]
+              )
+            })
+        when "INTERFACE"
+          InterfaceType.define(
+            name: type["name"],
+            description: type["description"],
+            fields: Hash[type["fields"].map { |field|
+              [field["name"], define_type(field.merge("kind" => "FIELD"), type_resolver)]
+            }]
+          )
+        when "INPUT_OBJECT"
+          InputObjectType.define(
+            name: type["name"],
+            description: type["description"],
+            arguments: Hash[type["inputFields"].map { |arg|
+              [arg["name"], define_type(arg.merge("kind" => "ARGUMENT"), type_resolver)]
+            }]
+          )
+        when "OBJECT"
+          ObjectType.define(
+            name: type["name"],
+            description: type["description"],
+            fields: Hash[type["fields"].map { |field|
+              [field["name"], define_type(field.merge("kind" => "FIELD"), type_resolver)]
+            }]
+          )
+        when "FIELD"
+          Field.define(
+            name: type["name"],
+            type: type_resolver.call(type["type"]),
+            description: type["description"],
+            arguments: Hash[type["args"].map { |arg|
+              [arg["name"], define_type(arg.merge("kind" => "ARGUMENT"), type_resolver)]
+            }]
+          )
+        when "ARGUMENT"
+          Argument.define(
+            name: type["name"],
+            type: type_resolver.call(type["type"]),
+            description: type["description"],
+            default_value: type["defaultValue"]
+          )
+        when "SCALAR"
+          case type.fetch("name")
+          when "Int"
+            INT_TYPE
+          when "String"
+            STRING_TYPE
+          when "Float"
+            FLOAT_TYPE
+          when "Boolean"
+            BOOLEAN_TYPE
+          when "ID"
+            ID_TYPE
+          else
+            ScalarType.define(
+              name: type["name"],
+              description: type["description"]
+            )
+          end
+        when "UNION"
+          UnionType.define(
+            name: type["name"],
+            description: type["description"],
+            possible_types: type["possibleTypes"].map { |possible_type|
+              type_resolver.call(possible_type)
+            }
+          )
+        else
+          fail NotImplementedError, "#{type["kind"]} not implemented"
+        end
+      end
+    end
+  end
+end

--- a/spec/graphql/schema/loader_spec.rb
+++ b/spec/graphql/schema/loader_spec.rb
@@ -1,0 +1,147 @@
+require "spec_helper"
+
+describe GraphQL::Schema::Loader do
+  let(:schema) {
+    node_type = GraphQL::InterfaceType.define do
+      name "Node"
+
+      field :id, !types.ID
+    end
+
+    choice_type = GraphQL::EnumType.define do
+      name "Choice"
+
+      value "FOO"
+      value "BAR"
+    end
+
+    sub_input_type = GraphQL::InputObjectType.define do
+      name "Sub"
+      input_field :string, types.String
+    end
+
+    big_int_type = GraphQL::ScalarType.define do
+      name "BigInt"
+      coerce_input -> (value) { value =~ /\d+/ ? Integer(value) : nil }
+      coerce_result -> (value) { value.to_s }
+    end
+
+    variant_input_type = GraphQL::InputObjectType.define do
+      name "Varied"
+      input_field :id, types.ID
+      input_field :int, types.Int
+      input_field :bigint, big_int_type
+      input_field :float, types.Float
+      input_field :bool, types.Boolean
+      input_field :enum, choice_type
+      input_field :sub, types[sub_input_type]
+    end
+
+    comment_type = GraphQL::ObjectType.define do
+      name "Comment"
+      description "A blog comment"
+      interfaces [node_type]
+
+      field :body, !types.String
+    end
+
+    post_type = GraphQL::ObjectType.define do
+      name "Post"
+      description "A blog post"
+
+      field :id, !types.ID
+      field :title, !types.String
+      field :body, !types.String
+      field :comments, types[!comment_type]
+    end
+
+    content_type = GraphQL::UnionType.define do
+      name "Content"
+      description "A post or comment"
+      possible_types [post_type, comment_type]
+    end
+
+    query_root = GraphQL::ObjectType.define do
+      name "Query"
+      description "The query root of this schema"
+
+      field :post do
+        type post_type
+        argument :id, !types.ID
+        argument :varied, variant_input_type, default_value: { id: "123", int: 234, float: 2.3, enum: "FOO", sub: [{ string: "str" }] }
+      end
+
+      field :content do
+        type content_type
+      end
+    end
+
+    GraphQL::Schema.new(query: query_root)
+  }
+
+  let(:schema_json) {
+    schema.execute(GraphQL::Introspection::INTROSPECTION_QUERY)
+  }
+
+  describe "load" do
+    def assert_deep_equal(expected_type, actual_type)
+      assert_equal expected_type.class, actual_type.class
+
+      case actual_type
+      when Array
+        actual_type.each_with_index do |obj, index|
+          assert_deep_equal expected_type[index], obj
+        end
+
+      when GraphQL::Schema
+        assert_equal expected_type.query.name, actual_type.query.name
+        assert_equal expected_type.directives.keys.sort, actual_type.directives.keys.sort
+        assert_equal expected_type.types.keys.sort, actual_type.types.keys.sort
+        assert_deep_equal expected_type.types.values.sort_by(&:name), actual_type.types.values.sort_by(&:name)
+
+      when GraphQL::ObjectType, GraphQL::InterfaceType
+        assert_equal expected_type.name, actual_type.name
+        assert_equal expected_type.description, actual_type.description
+        assert_deep_equal expected_type.all_fields.sort_by(&:name), actual_type.all_fields.sort_by(&:name)
+
+      when GraphQL::Field
+        assert_equal expected_type.name, actual_type.name
+        assert_equal expected_type.description, actual_type.description
+        assert_equal expected_type.arguments.keys, actual_type.arguments.keys
+        assert_deep_equal expected_type.arguments.values, actual_type.arguments.values
+
+      when GraphQL::ScalarType
+        assert_equal expected_type.name, actual_type.name
+
+      when GraphQL::EnumType
+        assert_equal expected_type.name, actual_type.name
+        assert_equal expected_type.description, actual_type.description
+        assert_equal expected_type.values.keys, actual_type.values.keys
+        assert_deep_equal expected_type.values.values, actual_type.values.values
+
+      when GraphQL::EnumType::EnumValue
+        assert_equal expected_type.name, actual_type.name
+        assert_equal expected_type.description, actual_type.description
+
+      when GraphQL::Argument
+        assert_equal expected_type.name, actual_type.name
+        assert_equal expected_type.description, actual_type.description
+        assert_deep_equal expected_type.type, actual_type.type
+
+      when GraphQL::InputObjectType
+        assert_equal expected_type.arguments.keys, actual_type.arguments.keys
+        assert_deep_equal expected_type.arguments.values, actual_type.arguments.values
+
+      when GraphQL::NonNullType, GraphQL::ListType
+        assert_deep_equal expected_type.of_type, actual_type.of_type
+
+      else
+        assert_equal expected_type, actual_type
+      end
+    end
+
+    it "returns the schema" do
+      assert_deep_equal(schema, GraphQL::Schema::Loader.load(schema_json))
+    end
+  end
+end


### PR DESCRIPTION
This library currently defines the introspection query (`GraphQL::Introspection::INTROSPECTION_QUERY`) for dumping a schema, but no mechanize for loading it back in elsewhere.

This initial PR is mostly a spike/PoC. Theres still alot of cases to implement, but I wanted to maintainer feedback first before putting more work into it.

``` ruby
json = JSON.load("swapi-schema.json")
schema = GraphQL::Schema::Loader.load(json)

# executing directly against this schema object will
# not work (as expected) since there are no resolvers
schema.execute(...) 

# however, we can still use it to validate queries
query = GraphQL::Query.new(schema, "query { ... }")
validator.validate(query)
```

-
To: @rmosolgo 
CC: @kdaigle @charliesome