### PR TITLE
refactor(Schema) create schemas with Schema.define

### DIFF
--- a/guides/defining_your_schema.md
+++ b/guides/defining_your_schema.md
@@ -238,11 +238,11 @@ Some parts of schema definition take types as an input. There are two good ways 
 Your schema can be initialized with some options:
 
 ```ruby
-MySchema = GraphQL::Schema.new(
-  query: QueryType,       # root type for read-only queries
-  mutation: MutationType, # root type for mutations
-  max_depth: 7,           # if present, the max depth for incoming queries
-)
+MySchema = GraphQL::Schema.define do
+  query QueryType,       # root type for read-only queries
+  mutation MutationType, # root type for mutations
+  max_depth 7,           # if present, the max depth for incoming queries
+end
 ```
 
 Additionally, you can define error handling and custom middleware as described below.

--- a/guides/executing_queries.md
+++ b/guides/executing_queries.md
@@ -64,7 +64,7 @@ result = MySchema.execute(query_string, validate: false)
 
 `graphql` includes a serial execution strategy, but you can also create custom strategies to support advanced behavior. See `GraphQL::SerialExecution#execute` the required behavior.
 
-Then, set your schema to use your custom execution strategy with `GraphQL::Schema#mutation_execution_strategy` or `GraphQL::Schema#query_execution_strategy`
+Then, set your schema to use your custom execution strategy with `GraphQL::Schema#{query|mutation|subscription}_execution_strategy`
 
 For example:
 
@@ -81,7 +81,9 @@ end
 
 # ... define your types ...
 
-MySchema = GraphQL::Schema.new(query: MyQueryType, mutation: MyMutationType)
-# Use your custom strategy:
-MySchema.query_execution_strategy = CustomQueryExecutionStrategy
+MySchema = GraphQL::Schema.define do
+  query MyQueryType
+  mutation MyMutationType
+  # Use your custom strategy:
+  query_execution_strategy = CustomQueryExecutionStrategy
 ```

--- a/guides/introduction.md
+++ b/guides/introduction.md
@@ -10,7 +10,10 @@ A GraphQL system exposes your application to the world according to its _schema_
 Once you've defined your query root and mutation root, you can make a schema:
 
 ```ruby
-ApplicationSchema = GraphQL::Schema.new(query: QueryRoot, mutation: MutationRoot)
+ApplicationSchema = GraphQL::Schema.define do
+  query QueryRoot
+  mutation MutationRoot
+end
 ```
 
 At that time, `graphql-ruby` will validate all types and fields.
@@ -80,7 +83,9 @@ The query root has one field, `post`,  which finds a `Post` by ID. The `resolve`
 Lastly, create the schema:
 
 ```ruby
-Schema = GraphQL::Schema.new(query: QueryRoot)
+Schema = GraphQL::Schema.define do
+  query QueryRoot
+end
 ```
 
 This schema could handle queries like:
@@ -136,7 +141,10 @@ end
 After defining your schema, you can evaluate queries with `GraphQL::Query`. For example:
 
 ```ruby
-Schema = GraphQL::Schema.new(query: QueryRoot) # QueryRoot defined above
+Schema = GraphQL::Schema.define do
+  query QueryRoot # QueryRoot defined above
+end
+
 query_string = "query getPost { post(id: 1) { id, title, comments { body } } }"
 
 result_hash = Schema.execute(query_string)

--- a/guides/relay.md
+++ b/guides/relay.md
@@ -55,9 +55,11 @@ end
 Then assign it to the schema:
 
 ```ruby
-MySchema = GraphQL::Schema.new(...)
-# Assign your node identification helper:
-MySchema.node_identification = NodeIdentification
+MySchema = GraphQL::Schema.define do
+  # ...
+  # Declare your node identification helper:
+  node_identification NodeIdentification
+end
 ```
 
 ### UUID fields
@@ -365,10 +367,10 @@ MutationType = GraphQL::ObjectType.define do
 end
 
 # and pass it to the schema
-MySchema = GraphQL::Schema.new(
-  query: QueryType,
-  mutation: MutationType
-)
+MySchema = GraphQL::Schema.define do
+  query QueryType,
+  mutation MutationType
+end
 ```
 
 Like `QueryType`, `MutationType` is a root of the schema.

--- a/guides/security.md
+++ b/guides/security.md
@@ -70,10 +70,10 @@ end
 Then, define your `max_complexity` at the schema-level:
 
 ```ruby
-MySchema = GraphQL::Schema.new(
+MySchema = GraphQL::Schema.define do
  # ...
- max_complexity: 100
-)
+ max_complexity 100
+end
 ```
 
 Or, at the query-level, which overrides the schema-level setting:
@@ -102,10 +102,10 @@ You can also reject queries based on the depth of their nesting. You can define 
 
 ```ruby
 # Schema-level:
-MySchema = GraphQL::Schema.new(
+MySchema = GraphQL::Schema.define do
   # ...
   max_depth: 10
-)
+end
 
 # Query-level, which overrides the schema-level setting:
 MySchema.execute(query_string, max_depth: 10)

--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -1,7 +1,6 @@
 require "json"
 require "set"
 require "singleton"
-require "forwardable"
 
 module GraphQL
   class Error < StandardError

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -50,7 +50,6 @@ module GraphQL
       @operations = {}
       @provided_variables = variables
       @query_string = query_string
-
       @document = document || GraphQL.parse(query_string)
       @document.definitions.each do |part|
         if part.is_a?(GraphQL::Language::Nodes::FragmentDefinition)

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -11,33 +11,83 @@ require "graphql/schema/validation"
 
 module GraphQL
   # A GraphQL schema which may be queried with {GraphQL::Query}.
+  #
+  # The {Schema} contains:
+  #
+  #  - types for exposing your application
+  #  - query analyzers for assessing incoming queries (including max depth & max complexity restrictions)
+  #  - execution strategies for running incoming queries
+  #  - middleware for interacting with execution
+  #
+  # Schemas start with root types, {Schema#query}, {Schema#mutation} and {Schema#subscription}.
+  # The schema will traverse the tree of fields & types, using those as starting points.
+  # Any undiscoverable types may be provided with the `types` configuration.
+  #
+  # Schemas can restrict large incoming queries with `max_depth` and `max_complexity` configurations.
+  # (These configurations can be overridden by specific calls to {Schema#execute})
+  #
+  # Schemas can specify how queries should be executed against them.
+  # `query_execution_strategy`, `mutation_execution_strategy` and `subscription_execution_strategy`
+  # each apply to corresponding root types.
+  #
+  # A schema accepts a `Relay::GlobalNodeIdentification` instance for use with Relay IDs.
+  #
+  # @example defining a schema
+  #   MySchema = GraphQL::Schema.define do
+  #     query QueryType
+  #     middleware PermissionMiddleware
+  #     rescue_from(ActiveRecord::RecordNotFound) { "Not found" }
+  #     # If types are only connected by way of interfaces, they must be added here
+  #     orphan_types ImageType, AudioType
+  #   end
+  #
   class Schema
-    extend Forwardable
+    include GraphQL::Define::InstanceDefinable
+    accepts_definitions \
+      :query, :mutation, :subscription,
+      :query_execution_strategy, :mutation_execution_strategy, :subscription_execution_strategy,
+      :max_depth, :max_complexity,
+      :node_identification,
+      :orphan_types,
+      query_analyzer: -> (schema, analyzer) { schema.query_analyzers << analyzer },
+      middleware: -> (schema, middleware) { schema.middleware << middleware },
+      rescue_from: -> (schema, err_class, &block) { schema.rescue_from(err_class, &block)}
+
+    lazy_defined_attr_accessor \
+      :query, :mutation, :subscription,
+      :query_execution_strategy, :mutation_execution_strategy, :subscription_execution_strategy,
+      :max_depth, :max_complexity,
+      :node_identification,
+      :orphan_types,
+      :query_analyzers, :middleware
+
 
     DIRECTIVES = [GraphQL::Directive::SkipDirective, GraphQL::Directive::IncludeDirective]
     DYNAMIC_FIELDS = ["__type", "__typename", "__schema"]
 
-    attr_reader :query, :mutation, :subscription, :directives, :static_validator, :query_analyzers
-    attr_accessor :max_depth
-    attr_accessor :max_complexity
-
-    # Override these if you don't want the default executor:
-    attr_accessor :query_execution_strategy,
-      :mutation_execution_strategy,
-      :subscription_execution_strategy
+    attr_reader :directives, :static_validator
 
     # @return [GraphQL::Relay::GlobalNodeIdentification] the node identification instance for this schema, when using Relay
-    attr_accessor :node_identification
+    def node_identification
+      ensure_defined
+      @node_identification
+    end
 
     # @return [Array<#call>] Middlewares suitable for MiddlewareChain, applied to fields during execution
-    attr_reader :middleware
+    def middleware
+      ensure_defined
+      @middleware
+    end
 
     # @param query [GraphQL::ObjectType]  the query root for the schema
     # @param mutation [GraphQL::ObjectType] the mutation root for the schema
     # @param subscription [GraphQL::ObjectType] the subscription root for the schema
     # @param max_depth [Integer] maximum query nesting (if it's greater, raise an error)
     # @param types [Array<GraphQL::BaseType>] additional types to include in this schema
-    def initialize(query:, mutation: nil, subscription: nil, max_depth: nil, max_complexity: nil, types: [])
+    def initialize(query: nil, mutation: nil, subscription: nil, max_depth: nil, max_complexity: nil, types: [])
+      if query
+        warn("Schema.new is deprecated, use Schema.define instead")
+      end
       @query    = query
       @mutation = mutation
       @subscription = subscription
@@ -50,17 +100,26 @@ module GraphQL
       @middleware = [@rescue_middleware]
       @query_analyzers = []
       # Default to the built-in execution strategy:
-      self.query_execution_strategy = GraphQL::Query::SerialExecution
-      self.mutation_execution_strategy = GraphQL::Query::SerialExecution
-      self.subscription_execution_strategy = GraphQL::Query::SerialExecution
+      @query_execution_strategy = GraphQL::Query::SerialExecution
+      @mutation_execution_strategy = GraphQL::Query::SerialExecution
+      @subscription_execution_strategy = GraphQL::Query::SerialExecution
     end
 
-    def_delegators :@rescue_middleware, :rescue_from, :remove_handler
+    def rescue_from(*args, &block)
+      ensure_defined
+      @rescue_middleware.rescue_from(*args, &block)
+    end
+
+    def remove_handler(*args, &block)
+      ensure_defined
+      @rescue_middleware.remove_handler(*args, &block)
+    end
 
     # @return [GraphQL::Schema::TypeMap] `{ name => type }` pairs of types in this schema
     def types
       @types ||= begin
-        all_types = @orphan_types + [query, mutation, subscription, GraphQL::Introspection::SchemaType]
+        ensure_defined
+        all_types = orphan_types + [query, mutation, subscription, GraphQL::Introspection::SchemaType]
         GraphQL::Schema::ReduceTypes.reduce(all_types.compact)
       end
     end
@@ -69,13 +128,14 @@ module GraphQL
     # See {Query#initialize} for arguments.
     # @return [Hash] query result, ready to be serialized as JSON
     def execute(*args)
-      query = GraphQL::Query.new(self, *args)
-      query.result
+      query_obj = GraphQL::Query.new(self, *args)
+      query_obj.result
     end
 
     # Resolve field named `field_name` for type `parent_type`.
     # Handles dynamic fields `__typename`, `__type` and `__schema`, too
     def get_field(parent_type, field_name)
+      ensure_defined
       defined_field = parent_type.get_field(field_name)
       if defined_field
         defined_field
@@ -91,12 +151,14 @@ module GraphQL
     end
 
     def type_from_ast(ast_node)
+      ensure_defined
       GraphQL::Schema::TypeExpression.build_type(self, ast_node)
     end
 
     # @param type_defn [GraphQL::InterfaceType, GraphQL::UnionType] the type whose members you want to retrieve
     # @return [Array<GraphQL::ObjectType>] types which belong to `type_defn` in this schema
     def possible_types(type_defn)
+      ensure_defined
       @interface_possible_types ||= GraphQL::Schema::PossibleTypes.new(self)
       @interface_possible_types.possible_types(type_defn)
     end

--- a/lib/graphql/schema/printer.rb
+++ b/lib/graphql/schema/printer.rb
@@ -3,8 +3,8 @@ module GraphQL
     # Used to convert your {GraphQL::Schema} to a GraphQL schema string
     #
     # @example print your schema to standard output
-    #   Schema = GraphQL::Schema.new(query: QueryType)
-    #   puts GraphQL::Schema::Printer.print_schema(Schema)
+    #   MySchema = GraphQL::Schema.define(query: QueryType)
+    #   puts GraphQL::Schema::Printer.print_schema(MySchema)
     #
     module Printer
       extend self
@@ -20,7 +20,7 @@ module GraphQL
         query_root = ObjectType.define do
           name "Query"
         end
-        schema = Schema.new(query: query_root)
+        schema = GraphQL::Schema.define(query: query_root)
         print_filtered_schema(schema, method(:is_introspection_type))
       end
 

--- a/readme.md
+++ b/readme.md
@@ -62,10 +62,10 @@ QueryType = GraphQL::ObjectType.define do
 end
 
 # Then create your schema
-Schema = GraphQL::Schema.new(
-  query: QueryType,
-  max_depth: 8,
-)
+Schema = GraphQL::Schema.define do
+  query QueryType,
+  max_depth 8,
+end
 ```
 
 #### Execute queries

--- a/spec/graphql/analysis/query_complexity_spec.rb
+++ b/spec/graphql/analysis/query_complexity_spec.rb
@@ -255,7 +255,7 @@ describe GraphQL::Analysis::QueryComplexity do
         end
       end
 
-      GraphQL::Schema.new(query: query_type, types: [double_complexity_type])
+      GraphQL::Schema.define(query: query_type, orphan_types: [double_complexity_type])
     }
     let(:query_string) {%|
       {

--- a/spec/graphql/argument_spec.rb
+++ b/spec/graphql/argument_spec.rb
@@ -10,7 +10,7 @@ describe GraphQL::Argument do
     end
 
     err = assert_raises(GraphQL::Schema::InvalidTypeError) {
-      schema = GraphQL::Schema.new(query: query_type)
+      schema = GraphQL::Schema.define(query: query_type)
       schema.types
     }
 

--- a/spec/graphql/field_spec.rb
+++ b/spec/graphql/field_spec.rb
@@ -82,7 +82,7 @@ describe GraphQL::Field do
       invalid_field.name = :symbol_name
 
       dummy_query.fields["symbol_name"] = invalid_field
-      dummy_schema = GraphQL::Schema.new(query: dummy_query)
+      dummy_schema = GraphQL::Schema.define(query: dummy_query)
 
       err = assert_raises(GraphQL::Schema::InvalidTypeError) { dummy_schema.types }
       assert_equal "QueryType is invalid: field :symbol_name name must return String, not Symbol (:symbol_name)", err.message

--- a/spec/graphql/query/context_spec.rb
+++ b/spec/graphql/query/context_spec.rb
@@ -16,7 +16,7 @@ describe GraphQL::Query::Context do
       resolve -> (target, args, ctx) { ctx.query.class.name }
     end
   }}
-  let(:schema) { GraphQL::Schema.new(query: query_type, mutation: nil)}
+  let(:schema) { GraphQL::Schema.define(query: query_type, mutation: nil)}
   let(:result) { schema.execute(query_string, context: {"some_key" => "some value"})}
 
   describe "access to passed-in values" do

--- a/spec/graphql/query/executor_spec.rb
+++ b/spec/graphql/query/executor_spec.rb
@@ -85,7 +85,7 @@ describe GraphQL::Query::Executor do
         end
       end
 
-      GraphQL::Schema.new(query: DummyQueryType, mutation: MutationType)
+      GraphQL::Schema.define(query: DummyQueryType, mutation: MutationType)
     }
     let(:variables) { nil }
     let(:query_string) { %|

--- a/spec/graphql/query/serial_execution/value_resolution_spec.rb
+++ b/spec/graphql/query/serial_execution/value_resolution_spec.rb
@@ -30,7 +30,7 @@ describe GraphQL::Query::SerialExecution::ValueResolution do
       end
     end
   }
-  let(:schema) { GraphQL::Schema.new(query: query_root) }
+  let(:schema) { GraphQL::Schema.define(query: query_root) }
   let(:result) { schema.execute(
     query_string,
   )}

--- a/spec/graphql/relay/array_connection_spec.rb
+++ b/spec/graphql/relay/array_connection_spec.rb
@@ -33,7 +33,7 @@ describe GraphQL::Relay::ArrayConnection do
     |}
 
     it 'limits the result' do
-      result = query(query_string, "first" => 2)
+      result = star_wars_query(query_string, "first" => 2)
       number_of_ships = get_names(result).length
       assert_equal(2, number_of_ships)
       assert_equal(true, result["data"]["rebels"]["ships"]["pageInfo"]["hasNextPage"])
@@ -41,19 +41,19 @@ describe GraphQL::Relay::ArrayConnection do
       assert_equal("MQ==", result["data"]["rebels"]["ships"]["pageInfo"]["startCursor"])
       assert_equal("Mg==", result["data"]["rebels"]["ships"]["pageInfo"]["endCursor"])
 
-      result = query(query_string, "first" => 3)
+      result = star_wars_query(query_string, "first" => 3)
       number_of_ships = get_names(result).length
       assert_equal(3, number_of_ships)
     end
 
     it 'provides pageInfo' do
-      result = query(query_string, "first" => 2)
+      result = star_wars_query(query_string, "first" => 2)
       assert_equal(true, result["data"]["rebels"]["ships"]["pageInfo"]["hasNextPage"])
       assert_equal(false, result["data"]["rebels"]["ships"]["pageInfo"]["hasPreviousPage"])
       assert_equal("MQ==", result["data"]["rebels"]["ships"]["pageInfo"]["startCursor"])
       assert_equal("Mg==", result["data"]["rebels"]["ships"]["pageInfo"]["endCursor"])
 
-      result = query(query_string, "first" => 100)
+      result = star_wars_query(query_string, "first" => 100)
       assert_equal(false, result["data"]["rebels"]["ships"]["pageInfo"]["hasNextPage"])
       assert_equal(false, result["data"]["rebels"]["ships"]["pageInfo"]["hasPreviousPage"])
       assert_equal("MQ==", result["data"]["rebels"]["ships"]["pageInfo"]["startCursor"])
@@ -61,38 +61,38 @@ describe GraphQL::Relay::ArrayConnection do
     end
 
     it 'slices the result' do
-      result = query(query_string, "first" => 1)
+      result = star_wars_query(query_string, "first" => 1)
       assert_equal(["X-Wing"], get_names(result))
 
       # After the last result, find the next 2:
       last_cursor = get_last_cursor(result)
 
-      result = query(query_string, "after" => last_cursor, "first" => 2)
+      result = star_wars_query(query_string, "after" => last_cursor, "first" => 2)
       assert_equal(["Y-Wing", "A-Wing"], get_names(result))
 
       # After the last result, find the next 2:
       last_cursor = get_last_cursor(result)
 
-      result = query(query_string, "after" => last_cursor, "first" => 2)
+      result = star_wars_query(query_string, "after" => last_cursor, "first" => 2)
       assert_equal(["Millenium Falcon", "Home One"], get_names(result))
 
-      result = query(query_string, "before" => last_cursor, "last" => 2)
+      result = star_wars_query(query_string, "before" => last_cursor, "last" => 2)
       assert_equal(["X-Wing", "Y-Wing"], get_names(result))
     end
 
     it 'applies custom arguments' do
-      result = query(query_string, "nameIncludes" => "Wing", "first" => 2)
+      result = star_wars_query(query_string, "nameIncludes" => "Wing", "first" => 2)
       names = get_names(result)
       assert_equal(2, names.length)
 
       after = get_last_cursor(result)
-      result = query(query_string, "nameIncludes" => "Wing", "after" => after, "first" => 3)
+      result = star_wars_query(query_string, "nameIncludes" => "Wing", "after" => after, "first" => 3)
       names = get_names(result)
       assert_equal(1, names.length)
     end
 
     it 'works without first/last/after/before' do
-      result = query(query_string)
+      result = star_wars_query(query_string)
 
       assert_equal(false, result["data"]["rebels"]["ships"]["pageInfo"]["hasNextPage"])
       assert_equal(false, result["data"]["rebels"]["ships"]["pageInfo"]["hasPreviousPage"])
@@ -130,12 +130,12 @@ describe GraphQL::Relay::ArrayConnection do
       |}
 
       it "applies to queries by `first`" do
-        result = query(query_string, "first" => 100)
+        result = star_wars_query(query_string, "first" => 100)
         assert_equal(["Yavin", "Echo Base"], get_names(result))
         assert_equal(true, get_page_info(result)["hasNextPage"])
 
         # Max page size is applied _without_ `first`, also
-        result = query(query_string)
+        result = star_wars_query(query_string)
         assert_equal(["Yavin", "Echo Base"], get_names(result))
         assert_equal(false, get_page_info(result)["hasNextPage"], "hasNextPage is false when first is not specified")
       end
@@ -143,20 +143,20 @@ describe GraphQL::Relay::ArrayConnection do
       it "applies to queries by `last`" do
         last_cursor = "Ng=="
         second_to_last_two_names = ["Death Star", "Shield Generator"]
-        result = query(query_string, "last" => 100, "before" => last_cursor)
+        result = star_wars_query(query_string, "last" => 100, "before" => last_cursor)
         assert_equal(second_to_last_two_names, get_names(result))
         assert_equal(true, get_page_info(result)["hasPreviousPage"])
 
-        result = query(query_string, "before" => last_cursor)
+        result = star_wars_query(query_string, "before" => last_cursor)
         assert_equal(second_to_last_two_names, get_names(result))
         assert_equal(false, get_page_info(result)["hasPreviousPage"], "hasPreviousPage is false when last is not specified")
 
         third_cursor = "Mw=="
         first_and_second_names = ["Yavin", "Echo Base"]
-        result = query(query_string, "last" => 100, "before" => third_cursor)
+        result = star_wars_query(query_string, "last" => 100, "before" => third_cursor)
         assert_equal(first_and_second_names, get_names(result))
 
-        result = query(query_string, "before" => third_cursor)
+        result = star_wars_query(query_string, "before" => third_cursor)
         assert_equal(first_and_second_names, get_names(result))
       end
     end

--- a/spec/graphql/relay/connection_type_spec.rb
+++ b/spec/graphql/relay/connection_type_spec.rb
@@ -24,7 +24,7 @@ describe GraphQL::Relay::ConnectionType do
       |}
 
       it "uses the custom edge and custom connection" do
-        result = query(query_string)
+        result = star_wars_query(query_string)
         bases = result["data"]["rebels"]["basesWithCustomEdge"]
         assert_equal 300, bases["totalCountTimes100"]
         assert_equal 'basesWithCustomEdge', bases["fieldName"]

--- a/spec/graphql/relay/global_node_identification_spec.rb
+++ b/spec/graphql/relay/global_node_identification_spec.rb
@@ -5,7 +5,7 @@ describe GraphQL::Relay::GlobalNodeIdentification do
   describe 'NodeField' do
     it 'finds objects by id' do
       global_id = node_identification.to_global_id("Faction", "1")
-      result = query(%|{
+      result = star_wars_query(%|{
         node(id: "#{global_id}") {
           id,
           ... on Faction {
@@ -107,7 +107,7 @@ describe GraphQL::Relay::GlobalNodeIdentification do
 
       describe "generating IDs" do
         it "Applies custom-defined ID generation" do
-          result = query(%| { largestBase { id } }|)
+          result = star_wars_query(%| { largestBase { id } }|)
           generated_id = result["data"]["largestBase"]["id"]
           assert_equal "Base/3", generated_id
         end
@@ -115,7 +115,7 @@ describe GraphQL::Relay::GlobalNodeIdentification do
 
       describe "fetching by ID" do
         it "Deconstructs the ID by the custom proc" do
-          result = query(%| { node(id: "Base/1") { ... on Base { name } } }|)
+          result = star_wars_query(%| { node(id: "Base/1") { ... on Base { name } } }|)
           base_name = result["data"]["node"]["name"]
           assert_equal "Yavin", base_name
         end

--- a/spec/graphql/relay/mutation_spec.rb
+++ b/spec/graphql/relay/mutation_spec.rb
@@ -26,7 +26,7 @@ describe GraphQL::Relay::Mutation do
   end
 
   it "returns the result & clientMutationId" do
-    result = query(query_string, "clientMutationId" => "1234")
+    result = star_wars_query(query_string, "clientMutationId" => "1234")
     expected = {"data" => {
       "introduceShip" => {
         "clientMutationId" => "1234",
@@ -43,7 +43,7 @@ describe GraphQL::Relay::Mutation do
   end
 
   it "doesn't require a clientMutationId to perform mutations" do
-    result = query(query_string)
+    result = star_wars_query(query_string)
     new_ship_name = result["data"]["introduceShip"]["shipEdge"]["node"]["name"]
     assert_equal("Bagel", new_ship_name)
   end

--- a/spec/graphql/relay/page_info_spec.rb
+++ b/spec/graphql/relay/page_info_spec.rb
@@ -14,7 +14,7 @@ describe GraphQL::Relay::PageInfo do
   end
 
   let(:cursor_of_last_base) {
-    result = query(query_string, "first" => 100)
+    result = star_wars_query(query_string, "first" => 100)
     last_cursor = get_last_cursor(result)
   }
 
@@ -38,14 +38,14 @@ describe GraphQL::Relay::PageInfo do
 
   describe 'hasNextPage / hasPreviousPage' do
     it "hasNextPage is true if there are more items" do
-      result = query(query_string, "first" => 2)
+      result = star_wars_query(query_string, "first" => 2)
       assert_equal(true, get_page_info(result)["hasNextPage"])
       assert_equal(false, get_page_info(result)["hasPreviousPage"], "hasPreviousPage is false if 'last' is missing")
       assert_equal("MQ==", get_page_info(result)["startCursor"])
       assert_equal("Mg==", get_page_info(result)["endCursor"])
 
       last_cursor = get_last_cursor(result)
-      result = query(query_string, "first" => 100, "after" => last_cursor)
+      result = star_wars_query(query_string, "first" => 100, "after" => last_cursor)
       assert_equal(false, get_page_info(result)["hasNextPage"])
       assert_equal(false, get_page_info(result)["hasPreviousPage"])
       assert_equal("Mw==", get_page_info(result)["startCursor"])
@@ -53,13 +53,13 @@ describe GraphQL::Relay::PageInfo do
     end
 
     it "hasPreviousPage if there are more items" do
-      result = query(query_string, "last" => 100, "before" => cursor_of_last_base)
+      result = star_wars_query(query_string, "last" => 100, "before" => cursor_of_last_base)
       assert_equal(false, get_page_info(result)["hasNextPage"])
       assert_equal(false, get_page_info(result)["hasPreviousPage"])
       assert_equal("MQ==", get_page_info(result)["startCursor"])
       assert_equal("Mg==", get_page_info(result)["endCursor"])
 
-      result = query(query_string, "last" => 1, "before" => cursor_of_last_base)
+      result = star_wars_query(query_string, "last" => 1, "before" => cursor_of_last_base)
       assert_equal(false, get_page_info(result)["hasNextPage"])
       assert_equal(true, get_page_info(result)["hasPreviousPage"])
       assert_equal("Mg==", get_page_info(result)["startCursor"])
@@ -67,7 +67,7 @@ describe GraphQL::Relay::PageInfo do
     end
 
     it "has both if first and last are present" do
-      result = query(query_string, "last" => 1, "first" => 1, "before" => cursor_of_last_base)
+      result = star_wars_query(query_string, "last" => 1, "first" => 1, "before" => cursor_of_last_base)
       assert_equal(true, get_page_info(result)["hasNextPage"])
       assert_equal(true, get_page_info(result)["hasPreviousPage"])
       assert_equal("Mg==", get_page_info(result)["startCursor"])
@@ -75,7 +75,7 @@ describe GraphQL::Relay::PageInfo do
     end
 
     it "startCursor and endCursor are the cursors of the first and last edge" do
-      result = query(query_string, "first" => 2)
+      result = star_wars_query(query_string, "first" => 2)
       assert_equal(true, get_page_info(result)["hasNextPage"])
       assert_equal(false, get_page_info(result)["hasPreviousPage"])
       assert_equal("MQ==", get_page_info(result)["startCursor"])
@@ -83,7 +83,7 @@ describe GraphQL::Relay::PageInfo do
       assert_equal("MQ==", get_first_cursor(result))
       assert_equal("Mg==", get_last_cursor(result))
 
-      result = query(query_string, "first" => 1, "after" => get_page_info(result)["endCursor"])
+      result = star_wars_query(query_string, "first" => 1, "after" => get_page_info(result)["endCursor"])
       assert_equal(false, get_page_info(result)["hasNextPage"])
       assert_equal(false, get_page_info(result)["hasPreviousPage"])
       assert_equal("Mw==", get_page_info(result)["startCursor"])
@@ -91,7 +91,7 @@ describe GraphQL::Relay::PageInfo do
       assert_equal("Mw==", get_first_cursor(result))
       assert_equal("Mw==", get_last_cursor(result))
 
-      result = query(query_string, "last" => 1, "before" => get_page_info(result)["endCursor"])
+      result = star_wars_query(query_string, "last" => 1, "before" => get_page_info(result)["endCursor"])
       assert_equal(false, get_page_info(result)["hasNextPage"])
       assert_equal(true, get_page_info(result)["hasPreviousPage"])
       assert_equal("Mg==", get_page_info(result)["startCursor"])

--- a/spec/graphql/relay/relation_connection_spec.rb
+++ b/spec/graphql/relay/relation_connection_spec.rb
@@ -46,7 +46,7 @@ describe GraphQL::Relay::RelationConnection do
     |}
 
     it 'limits the result' do
-      result = query(query_string, "first" => 2)
+      result = star_wars_query(query_string, "first" => 2)
       assert_equal(2, get_names(result).length)
       assert_equal(true, get_page_info(result)["hasNextPage"])
       assert_equal(false, get_page_info(result)["hasPreviousPage"])
@@ -55,7 +55,7 @@ describe GraphQL::Relay::RelationConnection do
       assert_equal("MQ==", get_first_cursor(result))
       assert_equal("Mg==", get_last_cursor(result))
 
-      result = query(query_string, "first" => 3)
+      result = star_wars_query(query_string, "first" => 3)
       assert_equal(3, get_names(result).length)
       assert_equal(false, get_page_info(result)["hasNextPage"])
       assert_equal(false, get_page_info(result)["hasPreviousPage"])
@@ -66,7 +66,7 @@ describe GraphQL::Relay::RelationConnection do
     end
 
     it 'provides custom fields on the connection type' do
-      result = query(query_string, "first" => 2)
+      result = star_wars_query(query_string, "first" => 2)
       assert_equal(
         Base.where(faction_id: 2).count,
         result["data"]["empire"]["bases"]["totalCount"]
@@ -74,44 +74,44 @@ describe GraphQL::Relay::RelationConnection do
     end
 
     it 'slices the result' do
-      result = query(query_string, "first" => 2)
+      result = star_wars_query(query_string, "first" => 2)
       assert_equal(["Death Star", "Shield Generator"], get_names(result))
 
       # After the last result, find the next 2:
       last_cursor = get_last_cursor(result)
 
-      result = query(query_string, "after" => last_cursor, "first" => 2)
+      result = star_wars_query(query_string, "after" => last_cursor, "first" => 2)
       assert_equal(["Headquarters"], get_names(result))
 
       last_cursor = get_last_cursor(result)
 
-      result = query(query_string, "before" => last_cursor, "last" => 1)
+      result = star_wars_query(query_string, "before" => last_cursor, "last" => 1)
       assert_equal(["Shield Generator"], get_names(result))
 
-      result = query(query_string, "before" => last_cursor, "last" => 2)
+      result = star_wars_query(query_string, "before" => last_cursor, "last" => 2)
       assert_equal(["Death Star", "Shield Generator"], get_names(result))
 
-      result = query(query_string, "before" => last_cursor, "last" => 10)
+      result = star_wars_query(query_string, "before" => last_cursor, "last" => 10)
       assert_equal(["Death Star", "Shield Generator"], get_names(result))
 
     end
 
     it "applies custom arguments" do
-      result = query(query_string, "first" => 1, "nameIncludes" => "ea")
+      result = star_wars_query(query_string, "first" => 1, "nameIncludes" => "ea")
       assert_equal(["Death Star"], get_names(result))
 
       after = get_last_cursor(result)
 
-      result = query(query_string, "first" => 2, "nameIncludes" => "ea", "after" => after )
+      result = star_wars_query(query_string, "first" => 2, "nameIncludes" => "ea", "after" => after )
       assert_equal(["Headquarters"], get_names(result))
       before = get_last_cursor(result)
 
-      result = query(query_string, "last" => 1, "nameIncludes" => "ea", "before" => before)
+      result = star_wars_query(query_string, "last" => 1, "nameIncludes" => "ea", "before" => before)
       assert_equal(["Death Star"], get_names(result))
     end
 
     it 'works without first/last/after/before' do
-      result = query(query_string)
+      result = star_wars_query(query_string)
 
       assert_equal(3, result["data"]["empire"]["bases"]["edges"].length)
     end
@@ -143,12 +143,12 @@ describe GraphQL::Relay::RelationConnection do
       |}
 
       it "applies to queries by `first`" do
-        result = query(query_string, "first" => 100)
+        result = star_wars_query(query_string, "first" => 100)
         assert_equal(2, result["data"]["empire"]["bases"]["edges"].size)
         assert_equal(true, result["data"]["empire"]["bases"]["pageInfo"]["hasNextPage"])
 
         # Max page size is applied _without_ `first`, also
-        result = query(query_string)
+        result = star_wars_query(query_string)
         assert_equal(2, result["data"]["empire"]["bases"]["edges"].size)
         assert_equal(false, result["data"]["empire"]["bases"]["pageInfo"]["hasNextPage"], "hasNextPage is false when first is not specified")
       end
@@ -156,20 +156,20 @@ describe GraphQL::Relay::RelationConnection do
       it "applies to queries by `last`" do
         last_cursor = "Ng=="
         second_to_last_two_names = ["Death Star", "Shield Generator"]
-        result = query(query_string, "last" => 100, "before" => last_cursor)
+        result = star_wars_query(query_string, "last" => 100, "before" => last_cursor)
         assert_equal(second_to_last_two_names, get_names(result))
         assert_equal(true, result["data"]["empire"]["bases"]["pageInfo"]["hasPreviousPage"])
 
-        result = query(query_string, "before" => last_cursor)
+        result = star_wars_query(query_string, "before" => last_cursor)
         assert_equal(second_to_last_two_names, get_names(result))
         assert_equal(false, result["data"]["empire"]["bases"]["pageInfo"]["hasPreviousPage"], "hasPreviousPage is false when last is not specified")
 
         third_cursor = "Mw=="
         first_and_second_names = ["Yavin", "Echo Base"]
-        result = query(query_string, "last" => 100, "before" => third_cursor)
+        result = star_wars_query(query_string, "last" => 100, "before" => third_cursor)
         assert_equal(first_and_second_names, get_names(result))
 
-        result = query(query_string, "before" => third_cursor)
+        result = star_wars_query(query_string, "before" => third_cursor)
         assert_equal(first_and_second_names, get_names(result))
       end
     end
@@ -189,7 +189,7 @@ describe GraphQL::Relay::RelationConnection do
         }
     }|}
     it "uses default resolve" do
-      result = query(query_string)
+      result = star_wars_query(query_string)
       bases = result["data"]["empire"]["basesClone"]["edges"]
       assert_equal(3, bases.length)
     end
@@ -225,7 +225,7 @@ describe GraphQL::Relay::RelationConnection do
     end
 
     it "applies the default value" do
-      result = query(query_string)
+      result = star_wars_query(query_string)
       bases_by_id   = ["Death Star", "Shield Generator", "Headquarters"]
       bases_by_name = ["Death Star", "Headquarters", "Shield Generator"]
 
@@ -280,7 +280,7 @@ describe GraphQL::Relay::RelationConnection do
       |}
 
       it 'limits the result' do
-        result = query(query_string, "first" => 2)
+        result = star_wars_query(query_string, "first" => 2)
         assert_equal(2, get_names(result).length)
         assert_equal(true, get_page_info(result)["hasNextPage"])
         assert_equal(false, get_page_info(result)["hasPreviousPage"])
@@ -289,7 +289,7 @@ describe GraphQL::Relay::RelationConnection do
         assert_equal("MQ==", get_first_cursor(result))
         assert_equal("Mg==", get_last_cursor(result))
 
-        result = query(query_string, "first" => 3)
+        result = star_wars_query(query_string, "first" => 3)
         assert_equal(3, get_names(result).length)
         assert_equal(false, get_page_info(result)["hasNextPage"])
         assert_equal(false, get_page_info(result)["hasPreviousPage"])
@@ -300,7 +300,7 @@ describe GraphQL::Relay::RelationConnection do
       end
 
       it 'provides custom fields on the connection type' do
-        result = query(query_string, "first" => 2)
+        result = star_wars_query(query_string, "first" => 2)
         assert_equal(
           Base.where(faction_id: 2).count,
           result["data"]["empire"]["basesAsSequelDataset"]["totalCount"]
@@ -308,39 +308,39 @@ describe GraphQL::Relay::RelationConnection do
       end
 
       it 'slices the result' do
-        result = query(query_string, "first" => 2)
+        result = star_wars_query(query_string, "first" => 2)
         assert_equal(["Death Star", "Shield Generator"], get_names(result))
 
         # After the last result, find the next 2:
         last_cursor = get_last_cursor(result)
 
-        result = query(query_string, "after" => last_cursor, "first" => 2)
+        result = star_wars_query(query_string, "after" => last_cursor, "first" => 2)
         assert_equal(["Headquarters"], get_names(result))
 
         last_cursor = get_last_cursor(result)
 
-        result = query(query_string, "before" => last_cursor, "last" => 1)
+        result = star_wars_query(query_string, "before" => last_cursor, "last" => 1)
         assert_equal(["Shield Generator"], get_names(result))
 
-        result = query(query_string, "before" => last_cursor, "last" => 2)
+        result = star_wars_query(query_string, "before" => last_cursor, "last" => 2)
         assert_equal(["Death Star", "Shield Generator"], get_names(result))
 
-        result = query(query_string, "before" => last_cursor, "last" => 10)
+        result = star_wars_query(query_string, "before" => last_cursor, "last" => 10)
         assert_equal(["Death Star", "Shield Generator"], get_names(result))
 
       end
 
       it "applies custom arguments" do
-        result = query(query_string, "first" => 1, "nameIncludes" => "ea")
+        result = star_wars_query(query_string, "first" => 1, "nameIncludes" => "ea")
         assert_equal(["Death Star"], get_names(result))
 
         after = get_last_cursor(result)
 
-        result = query(query_string, "first" => 2, "nameIncludes" => "ea", "after" => after )
+        result = star_wars_query(query_string, "first" => 2, "nameIncludes" => "ea", "after" => after )
         assert_equal(["Headquarters"], get_names(result))
         before = get_last_cursor(result)
 
-        result = query(query_string, "last" => 1, "nameIncludes" => "ea", "before" => before)
+        result = star_wars_query(query_string, "last" => 1, "nameIncludes" => "ea", "before" => before)
         assert_equal(["Death Star"], get_names(result))
       end
     end

--- a/spec/graphql/schema/printer_spec.rb
+++ b/spec/graphql/schema/printer_spec.rb
@@ -60,7 +60,7 @@ describe GraphQL::Schema::Printer do
       end
     end
 
-    GraphQL::Schema.new(query: query_root)
+    GraphQL::Schema.define(query: query_root)
   }
 
   describe ".print_introspection_schema" do

--- a/spec/graphql/schema/reduce_types_spec.rb
+++ b/spec/graphql/schema/reduce_types_spec.rb
@@ -96,7 +96,7 @@ describe GraphQL::Schema::ReduceTypes do
   end
 
   describe "when a field is only accessible through an interface" do
-    it "is found through Schema.new(types:)" do
+    it "is found through Schema.define(types:)" do
       assert_equal HoneyType, DummySchema.types["Honey"]
     end
   end

--- a/spec/graphql/schema/timeout_middleware_spec.rb
+++ b/spec/graphql/schema/timeout_middleware_spec.rb
@@ -35,7 +35,7 @@ describe GraphQL::Schema::TimeoutMiddleware do
       end
     end
 
-    schema = GraphQL::Schema.new(query: query_type)
+    schema = GraphQL::Schema.define(query: query_type)
     schema.middleware << timeout_middleware
     schema
   }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,6 @@ Minitest.backtrace_filter = Minitest::BacktraceFilter.new
 # # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
-def query(string, variables={})
+def star_wars_query(string, variables={})
   GraphQL::Query.new(StarWarsSchema, string, variables: variables).result
 end

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -333,11 +333,12 @@ SubscriptionType = GraphQL::ObjectType.define do
   end
 end
 
-DummySchema = GraphQL::Schema.new(
-  query: DairyAppQueryType,
-  mutation: DairyAppMutationType,
-  subscription: SubscriptionType,
-  max_depth: 5,
-  types: [HoneyType, BeverageUnion],
-)
-DummySchema.rescue_from(NoSuchDairyError) { |err| err.message  }
+DummySchema = GraphQL::Schema.define do
+  query DairyAppQueryType
+  mutation DairyAppMutationType
+  subscription SubscriptionType
+  max_depth 5
+  orphan_types [HoneyType, BeverageUnion]
+
+  rescue_from(NoSuchDairyError) { |err| err.message  }
+end

--- a/spec/support/star_wars_schema.rb
+++ b/spec/support/star_wars_schema.rb
@@ -215,5 +215,5 @@ MutationType = GraphQL::ObjectType.define do
   field :introduceShip, field: IntroduceShipMutation.field
 end
 
-StarWarsSchema = GraphQL::Schema.new(query: QueryType, mutation: MutationType)
+StarWarsSchema = GraphQL::Schema.define(query: QueryType, mutation: MutationType)
 StarWarsSchema.node_identification = NodeIdentification


### PR DESCRIPTION
Schema initialization has slowly grown unwieldy: 

- some values are passed to `.new` (eg `query:`, `mutation:`, `max_depth:`)
- others are reassigned _after_ initialization (eg `schema.query_execution_strategy = `) 
- others are added by mutating the schema (eg `middleware << MyMiddleware.new`).
- others are defined by calling methods on the schema (eg `schema.rescue_from(err_class, &block)`)

To me, this is sloppy and confusing (and hard to maintain). This gem already includes a DSL for configuring GraphQL-related objects, so let's apply it here too. So, you can create schemas using the same `.define` API as types, fields and arguments. 

```ruby 
MySchema = GraphQL::Schema.define do 
  query QueryType 
  mutation MutationType 
end 
```

This also provides `Schema#metadata`, which makes schema extensible & ready for schema-level values.

## Todo 

- [x] Update docs 
- [x] Update inline schemas in test 