### PR TITLE
Allow interfaces to be compatible with objects that implement said interface

### DIFF
--- a/lib/graphql/execution/typecast.rb
+++ b/lib/graphql/execution/typecast.rb
@@ -22,8 +22,10 @@ module GraphQL
           current_type.resolve_type(value, query_ctx) == potential_type
         elsif potential_type.kind.union?
           potential_type.include?(current_type)
+        elsif current_type.kind.interface? && potential_type.respond_to?(:interfaces)
+          potential_type.interfaces.include?(current_type)
         elsif current_type.kind.interface?
-          current_type.resolve_type(value, query_ctx) == potential_type
+          (current_type.resolve_type(value, query_ctx) == potential_type)
         elsif potential_type.kind.interface?
           current_type.interfaces.include?(potential_type)
         else

--- a/lib/graphql/execution/typecast.rb
+++ b/lib/graphql/execution/typecast.rb
@@ -1,11 +1,13 @@
 module GraphQL
   module Execution
-    # GraphQL object `{value, type}` can be cast to `other_type` when:
-    # - `type == other_type`
-    # - `type` is a union and it resolves `value` to `other_type`
-    # - `other_type` is a union and `type` is a member
-    # - `type` is an interface and it resolves `value` to `other_type`
-    # - `other_type` is an interface and `type` implements that interface
+    # GraphQL object `{value, current_type}` can be cast to `potential_type` when:
+    # - `current_type == potential_type`
+    # - `current_type` is a union and it resolves `value` to `potential_type`
+    # - `potential_type` is a union and `current_type` is a member
+    # - `current_type` is an interface, `potential_type` has interfaces,
+    #   and `current_type` is one of those interfaces
+    # - `current_type` is an interface and it resolves `value` to `potential_type`
+    # - `potential_type` is an interface and `current_type` implements that interface
     module Typecast
       # While `value` is exposed by GraphQL as an instance of `current_type`,
       # should it _also_ be treated as an instance of `potential_type`?

--- a/spec/graphql/execution/typecast_spec.rb
+++ b/spec/graphql/execution/typecast_spec.rb
@@ -22,6 +22,10 @@ describe GraphQL::Execution::Typecast do
   end
 
   it "resolve correctly when potential type is an Interface and current type implements it" do
+    assert GraphQL::Execution::Typecast.compatible?(CHEESES[1], EdibleInterface, CheeseType, context)
+  end
+
+  it "resolve correctly when potential type is an Interface and current type implements it" do
     assert GraphQL::Execution::Typecast.compatible?(MILKS[1], EdibleInterface, CheeseType, context)
   end
 

--- a/spec/graphql/execution/typecast_spec.rb
+++ b/spec/graphql/execution/typecast_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+
+describe GraphQL::Execution::Typecast do
+
+  let(:schema) { DummySchema }
+  let(:context) { GraphQL::Query::Context.new(query: OpenStruct.new(schema: schema), values: nil) }
+
+  it "resolves correctly when both types are the same" do
+    assert GraphQL::Execution::Typecast.compatible?(MILKS[1], MilkType, MilkType, context)
+  end
+
+  it "resolves correcty when current type is UnionType and value resolves to potential type" do
+    assert GraphQL::Execution::Typecast.compatible?(MILKS[1], DairyProductUnion, MilkType, context)
+  end
+
+  it "resolves correcty when potential type is UnionType and current type is a member of that union" do
+    assert GraphQL::Execution::Typecast.compatible?(MILKS[1], MilkType, DairyProductUnion, context)
+  end
+
+  it "resolve correctly when current type is an Interface and it resolves to potential type" do
+    assert GraphQL::Execution::Typecast.compatible?(MILKS[1], CheeseType, EdibleInterface, context)
+  end
+
+  it "resolve correctly when potential type is an Interface and current type implements it" do
+    assert GraphQL::Execution::Typecast.compatible?(MILKS[1], EdibleInterface, CheeseType, context)
+  end
+
+end


### PR DESCRIPTION
In `0.18.2` (but it was working in `0.18.1`), it appears some functionality was implicitly broken. The new version seemingly broke the ability to have a query fragment on an interface. For example...

```
{
  node(id:"abc123") {
    ...repoInfo
  }
}

fragment repoInfo on RepositoryInfo {
  owner {
    login
  }
}
```

... where `RepositoryInfo` is an Interface and the `node` returned is an Object that implements the `RepositoryInfo` interface.

I'm not entirely confident I'm not breaking something here or if I'm breaking the letter of GraphQL. I just know the functionality changed. :smile: I put together 79431da and cf65366 to show a failing test case.