### PR TITLE
Fix interface typecast

### DIFF
--- a/lib/graphql/execution/typecast.rb
+++ b/lib/graphql/execution/typecast.rb
@@ -22,10 +22,13 @@ module GraphQL
           current_type.resolve_type(value, query_ctx) == potential_type
         elsif potential_type.kind.union?
           potential_type.include?(current_type)
-        elsif current_type.kind.interface?
+        elsif current_type.kind.interface? && potential_type.kind.object?
           current_type.resolve_type(value, query_ctx) == potential_type
-        elsif potential_type.kind.interface?
+        elsif potential_type.kind.interface? && current_type.kind.object?
           current_type.interfaces.include?(potential_type)
+        elsif potential_type.kind.interface? && current_type.kind.interface?
+          resolved_type = current_type.resolve_type(value, query_ctx)
+          resolved_type && resolved_type.interfaces.include?(potential_type)
         else
           false
         end

--- a/lib/graphql/execution/typecast.rb
+++ b/lib/graphql/execution/typecast.rb
@@ -1,11 +1,13 @@
 module GraphQL
   module Execution
-    # GraphQL object `{value, type}` can be cast to `other_type` when:
-    # - `type == other_type`
-    # - `type` is a union and it resolves `value` to `other_type`
-    # - `other_type` is a union and `type` is a member
-    # - `type` is an interface and it resolves `value` to `other_type`
-    # - `other_type` is an interface and `type` implements that interface
+    # GraphQL object `{value, current_type}` can be cast to `potential_type` when:
+    # - `current_type == potential_type`
+    # - `current_type` is a union and it resolves `value` to `potential_type`
+    # - `potential_type` is a union and `current_type` is a member
+    # - `current_type` is an interface, `potential_type` has interfaces,
+    #   and `current_type` is one of those interfaces
+    # - `current_type` is an interface and it resolves `value` to `potential_type`
+    # - `potential_type` is an interface and `current_type` implements that interface
     module Typecast
       # While `value` is exposed by GraphQL as an instance of `current_type`,
       # should it _also_ be treated as an instance of `potential_type`?

--- a/spec/graphql/execution/typecast_spec.rb
+++ b/spec/graphql/execution/typecast_spec.rb
@@ -22,6 +22,10 @@ describe GraphQL::Execution::Typecast do
   end
 
   it "resolve correctly when potential type is an Interface and current type implements it" do
+    assert GraphQL::Execution::Typecast.compatible?(CHEESES[1], EdibleInterface, CheeseType, context)
+  end
+
+  it "resolve correctly when potential type is an Interface and current type implements it" do
     assert GraphQL::Execution::Typecast.compatible?(MILKS[1], EdibleInterface, CheeseType, context)
   end
 

--- a/spec/graphql/execution/typecast_spec.rb
+++ b/spec/graphql/execution/typecast_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+
+describe GraphQL::Execution::Typecast do
+
+  let(:schema) { DummySchema }
+  let(:context) { GraphQL::Query::Context.new(query: OpenStruct.new(schema: schema), values: nil) }
+
+  it "resolves correctly when both types are the same" do
+    assert GraphQL::Execution::Typecast.compatible?(MILKS[1], MilkType, MilkType, context)
+  end
+
+  it "resolves correcty when current type is UnionType and value resolves to potential type" do
+    assert GraphQL::Execution::Typecast.compatible?(MILKS[1], DairyProductUnion, MilkType, context)
+  end
+
+  it "resolves correcty when potential type is UnionType and current type is a member of that union" do
+    assert GraphQL::Execution::Typecast.compatible?(MILKS[1], MilkType, DairyProductUnion, context)
+  end
+
+  it "resolve correctly when current type is an Interface and it resolves to potential type" do
+    assert GraphQL::Execution::Typecast.compatible?(MILKS[1], CheeseType, EdibleInterface, context)
+  end
+
+  it "resolve correctly when potential type is an Interface and current type implements it" do
+    assert GraphQL::Execution::Typecast.compatible?(MILKS[1], EdibleInterface, CheeseType, context)
+  end
+
+end

--- a/spec/graphql/execution/typecast_spec.rb
+++ b/spec/graphql/execution/typecast_spec.rb
@@ -25,8 +25,11 @@ describe GraphQL::Execution::Typecast do
     assert GraphQL::Execution::Typecast.compatible?(CHEESES[1], EdibleInterface, CheeseType, context)
   end
 
-  it "resolve correctly when potential type is an Interface and current type implements it" do
-    assert GraphQL::Execution::Typecast.compatible?(MILKS[1], EdibleInterface, CheeseType, context)
+  it "doesn't cast if the object doesn't resove to the possible type" do
+    assert !GraphQL::Execution::Typecast.compatible?(MILKS[1], EdibleInterface, CheeseType, context)
   end
 
+  it "casts an Interface to an Interface when the object implements both interfaces" do
+    assert GraphQL::Execution::Typecast.compatible?(MILKS[1], LocalProductInterface, EdibleInterface, context)
+  end
 end

--- a/spec/graphql/interface_type_spec.rb
+++ b/spec/graphql/interface_type_spec.rb
@@ -53,4 +53,29 @@ describe GraphQL::InterfaceType do
       assert_equal(interface.resolve_type(123, nil), :custom_resolve)
     end
   end
+
+  describe "fragments" do
+    let(:query_string) {%|
+    {
+      favoriteEdible {
+        fatContent
+        ... on LocalProduct {
+          origin
+        }
+      }
+    }
+    |}
+    let(:result) { DummySchema.execute(query_string) }
+
+    it "can apply interface fragments to an interface" do
+      expected_result = { "data" => {
+        "favoriteEdible" => {
+          "fatContent" => 0.04,
+          "origin" => "Antiquity",
+        }
+      } }
+
+      assert_equal(expected_result, result)
+    end
+  end
 end

--- a/spec/graphql/introspection/type_type_spec.rb
+++ b/spec/graphql/introspection/type_type_spec.rb
@@ -36,7 +36,8 @@ describe GraphQL::Introspection::TypeType do
       "milkType"=>{
         "interfaces"=>[
           {"name"=>"Edible"},
-          {"name"=>"AnimalProduct"}
+          {"name"=>"AnimalProduct"},
+          {"name"=>"LocalProduct"},
         ],
         "fields"=>[
           {"type"=>{"name"=>"Non-Null", "ofType"=>{"name"=>"Float"}}},

--- a/spec/graphql/object_type_spec.rb
+++ b/spec/graphql/object_type_spec.rb
@@ -15,7 +15,7 @@ describe GraphQL::ObjectType do
   end
 
   it "may have interfaces" do
-    assert_equal([EdibleInterface, AnimalProductInterface], type.interfaces)
+    assert_equal([EdibleInterface, AnimalProductInterface, LocalProductInterface], type.interfaces)
   end
 
   describe '#get_field ' do

--- a/spec/graphql/schema/reduce_types_spec.rb
+++ b/spec/graphql/schema/reduce_types_spec.rb
@@ -14,6 +14,7 @@ describe GraphQL::Schema::ReduceTypes do
       "Int" => GraphQL::INT_TYPE,
       "Edible" => EdibleInterface,
       "AnimalProduct" => AnimalProductInterface,
+      "LocalProduct" => LocalProductInterface,
     }
     result = reduce_types([CheeseType])
     assert_equal(expected.keys, result.keys)

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -12,6 +12,12 @@ EdibleInterface = GraphQL::InterfaceType.define do
   field :origin, !types.String, "Place the edible comes from"
 end
 
+LocalProductInterface = GraphQL::InterfaceType.define do
+  name "LocalProduct"
+  description "Something that comes from somewhere"
+  field :origin, !types.String, "Place the thing comes from"
+end
+
 AnimalProductInterface = GraphQL::InterfaceType.define do
   name "AnimalProduct"
   description "Comes from an animal, no joke"
@@ -31,7 +37,7 @@ CheeseType = GraphQL::ObjectType.define do
   name "Cheese"
   class_names ["Cheese"]
   description "Cultured dairy product"
-  interfaces [EdibleInterface, AnimalProductInterface]
+  interfaces [EdibleInterface, AnimalProductInterface, LocalProductInterface]
 
   # Can have (name, type, desc)
   field :id, !types.Int, "Unique identifier"
@@ -78,7 +84,7 @@ end
 MilkType = GraphQL::ObjectType.define do
   name "Milk"
   description "Dairy beverage"
-  interfaces [EdibleInterface, AnimalProductInterface]
+  interfaces [EdibleInterface, AnimalProductInterface, LocalProductInterface]
   field :id, !types.ID
   field :source, DairyAnimalEnum, "Animal which produced this milk", hash_key: :source
   field :origin, !types.String, "Place the milk comes from"

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -24,6 +24,12 @@ AnimalProductInterface = GraphQL::InterfaceType.define do
   field :source, !types.String, "Animal which produced this product"
 end
 
+BeverageUnion = GraphQL::UnionType.define do
+  name "Beverage"
+  description "Something you can drink"
+  possible_types [MilkType]
+end
+
 DairyAnimalEnum = GraphQL::EnumType.define do
   name "DairyAnimal"
   description "An animal which can yield milk"
@@ -323,6 +329,6 @@ DummySchema = GraphQL::Schema.new(
   mutation: DairyAppMutationType,
   subscription: SubscriptionType,
   max_depth: 5,
-  types: [HoneyType],
+  types: [HoneyType, BeverageUnion],
 )
 DummySchema.rescue_from(NoSuchDairyError) { |err| err.message  }


### PR DESCRIPTION
Casting an interface to an interface was broken since 01c163791986c528eb2ddbdb76deb80b4ca2dc59. The previous implementation was _too_ permissive, the new was too restrictive. 

Allow an object to be cast from one interface to another if: 

- It resolves from the current interface to an object type 
- that object type implements the requested interface type

I suspect we have a similar bug with unions, let me see ....