### PR TITLE
Fix typecast api

### DIFF
--- a/lib/graphql/execution/typecast.rb
+++ b/lib/graphql/execution/typecast.rb
@@ -1,20 +1,24 @@
 module GraphQL
   module Execution
-    # GraphQL object `{value, type}` can be cast to `other_type` when:
-    # - `type == other_type`
-    # - `type` is a union and it resolves `value` to `other_type`
-    # - `other_type` is a union and `type` is a member
-    # - `type` is an interface and it resolves `value` to `other_type`
-    # - `other_type` is an interface and `type` implements that interface
+    # GraphQL object `{value, current_type}` can be cast to `potential_type` when:
+    # - `current_type == potential_type`
+    # - `current_type` is a union and it resolves `value` to `potential_type`
+    # - `potential_type` is a union and `current_type` is a member
+    # - `current_type` is an interface and it resolves `value` to `potential_type`
+    # - `potential_type` is an interface and `current_type` implements that interface
     module Typecast
       # While `value` is exposed by GraphQL as an instance of `current_type`,
       # should it _also_ be treated as an instance of `potential_type`?
       #
       # This is used for checking whether fragments apply to an object.
       #
-      # @return [Boolean] Can `value` be evaluated as a `potential_type`?
+      # @param [Object] the value which GraphQL is currently exposing
+      # @param [GraphQL::BaseType] the type which GraphQL is using for `value` now
+      # @param [GraphQL::BaseType] can `value` be exposed using this type?
+      # @param [GraphQL::Query::Context] the context for the current query
+      # @return [Boolean] true if `value` be evaluated as a `potential_type`
       def self.compatible?(value, current_type, potential_type, query_ctx)
-        if potential_type == current_type
+        if current_type == potential_type
           true
         elsif current_type.kind.union?
           current_type.resolve_type(value, query_ctx) == potential_type

--- a/lib/graphql/execution/typecast.rb
+++ b/lib/graphql/execution/typecast.rb
@@ -2,10 +2,10 @@ module GraphQL
   module Execution
     # GraphQL object `{value, current_type}` can be cast to `potential_type` when:
     # - `current_type == potential_type`
-    # - `current_type` is a union and it resolves `value` to `potential_type`
-    # - `potential_type` is a union and `current_type` is a member
-    # - `current_type` is an interface and it resolves `value` to `potential_type`
-    # - `potential_type` is an interface and `current_type` implements that interface
+    # - `current_type` is a union and it contains `potential_type`
+    # - `potential_type` is a union and it contains `current_type`
+    # - `current_type` is an interface and `potential_type` implements it
+    # - `potential_type` is an interface and `current_type` implements it
     module Typecast
       # While `value` is exposed by GraphQL as an instance of `current_type`,
       # should it _also_ be treated as an instance of `potential_type`?
@@ -17,16 +17,16 @@ module GraphQL
       # @param [GraphQL::BaseType] can `value` be exposed using this type?
       # @param [GraphQL::Query::Context] the context for the current query
       # @return [Boolean] true if `value` be evaluated as a `potential_type`
-      def self.compatible?(value, current_type, potential_type, query_ctx)
+      def self.compatible?(current_type, potential_type, query_ctx)
         if current_type == potential_type
           true
         elsif current_type.kind.union?
-          current_type.resolve_type(value, query_ctx) == potential_type
+          current_type.possible_types.include?(potential_type)
         elsif potential_type.kind.union?
           potential_type.include?(current_type)
-        elsif current_type.kind.interface?
-          current_type.resolve_type(value, query_ctx) == potential_type
-        elsif potential_type.kind.interface?
+        elsif current_type.kind.interface? && potential_type.kind.object?
+          potential_type.interfaces.include?(current_type)
+        elsif potential_type.kind.interface? && current_type.kind.object?
           current_type.interfaces.include?(potential_type)
         else
           false

--- a/lib/graphql/query/serial_execution/selection_resolution.rb
+++ b/lib/graphql/query/serial_execution/selection_resolution.rb
@@ -13,7 +13,7 @@ module GraphQL
 
         def result
           irep_node.children.each_with_object({}) do |(name, irep_node), memo|
-            if GraphQL::Execution::DirectiveChecks.include?(irep_node, execution_context.query) && applies_to_type?(irep_node, type, target)
+            if GraphQL::Execution::DirectiveChecks.include?(irep_node, execution_context.query) && applies_to_type?(irep_node, type)
               field_result = execution_context.strategy.field_resolution.new(
                 irep_node,
                 type,
@@ -27,9 +27,9 @@ module GraphQL
 
         private
 
-        def applies_to_type?(irep_node, current_type, value)
+        def applies_to_type?(irep_node, current_type)
           irep_node.definitions.any? { |potential_type, field_defn|
-            GraphQL::Execution::Typecast.compatible?(value, current_type, potential_type, execution_context.query.context)
+            GraphQL::Execution::Typecast.compatible?(current_type, potential_type, execution_context.query.context)
           }
         end
       end

--- a/lib/graphql/query/serial_execution/selection_resolution.rb
+++ b/lib/graphql/query/serial_execution/selection_resolution.rb
@@ -27,9 +27,9 @@ module GraphQL
 
         private
 
-        def applies_to_type?(irep_node, type, target)
-          irep_node.definitions.any? { |child_type, field_defn|
-            GraphQL::Execution::Typecast.compatible?(target, child_type, type, execution_context.query.context)
+        def applies_to_type?(irep_node, current_type, value)
+          irep_node.definitions.any? { |potential_type, field_defn|
+            GraphQL::Execution::Typecast.compatible?(value, current_type, potential_type, execution_context.query.context)
           }
         end
       end

--- a/spec/graphql/execution/typecast_spec.rb
+++ b/spec/graphql/execution/typecast_spec.rb
@@ -8,42 +8,44 @@ describe GraphQL::Execution::Typecast do
   let(:context) { GraphQL::Query::Context.new(query: OpenStruct.new(schema: schema), values: nil) }
 
   def compatible?(*args)
-     GraphQL::Execution::Typecast.compatible?(*args)
-   end
+    GraphQL::Execution::Typecast.compatible?(*args)
+  end
+
   it "resolves correctly when both types are the same" do
-    assert compatible?(milk_value, MilkType, MilkType, context)
-    assert !compatible?(milk_value, MilkType, CheeseType, context)
+    assert compatible?(MilkType, MilkType, context)
+
+    assert !compatible?(MilkType, CheeseType, context)
   end
 
   it "resolves a union type to a matching member" do
-    assert compatible?(milk_value, DairyProductUnion, MilkType, context)
-    assert compatible?(cheese_value, DairyProductUnion, CheeseType, context)
+    assert compatible?(DairyProductUnion, MilkType, context)
+    assert compatible?(DairyProductUnion, CheeseType, context)
 
-    assert !compatible?(cheese_value, DairyProductUnion, MilkType, context)
-    assert !compatible?(nil, DairyProductUnion, MilkType, context)
+    assert !compatible?(DairyProductUnion, GraphQL::INT_TYPE, context)
+    assert !compatible?(DairyProductUnion, HoneyType, context)
   end
 
   it "resolves correcty when potential type is UnionType and current type is a member of that union" do
-    assert compatible?(milk_value, MilkType, DairyProductUnion, context)
-    assert compatible?(cheese_value, CheeseType, DairyProductUnion, context)
+    assert compatible?(MilkType, DairyProductUnion, context)
+    assert compatible?(CheeseType, DairyProductUnion, context)
 
-    # assert !compatible?(nil, CheeseType, DairyProductUnion, context)
-    # assert !compatible?(cheese_value, MilkType, DairyProductUnion, context)
+    assert !compatible?(QueryType, DairyProductUnion, context)
+    assert !compatible?(EdibleInterface, DairyProductUnion, context)
   end
 
   it "resolves an object type to one of its interfaces" do
-    assert compatible?(cheese_value, CheeseType, EdibleInterface, context)
-    assert compatible?(milk_value, MilkType, EdibleInterface, context)
+    assert compatible?(CheeseType, EdibleInterface, context)
+    assert compatible?(MilkType, EdibleInterface, context)
 
-    # assert !compatible?(nil, MilkType, EdibleInterface, context)
-    # assert !compatible?(milk_value, CheeseType, EdibleInterface, context)
+    assert !compatible?(QueryType, EdibleInterface, context)
+    assert !compatible?(LocalProductInterface, EdibleInterface, context)
   end
 
   it "resolves an interface to a matching member" do
-    assert compatible?(cheese_value, EdibleInterface, CheeseType, context)
-    assert compatible?(milk_value, EdibleInterface, MilkType, context)
+    assert compatible?(EdibleInterface, CheeseType, context)
+    assert compatible?(EdibleInterface, MilkType, context)
 
-    assert !compatible?(nil, EdibleInterface, MilkType, context)
-    assert !compatible?(cheese_value, EdibleInterface, MilkType, context)
+    assert !compatible?(EdibleInterface, GraphQL::STRING_TYPE, context)
+    assert !compatible?(EdibleInterface, DairyProductInputType, context)
   end
 end

--- a/spec/graphql/execution/typecast_spec.rb
+++ b/spec/graphql/execution/typecast_spec.rb
@@ -22,6 +22,10 @@ describe GraphQL::Execution::Typecast do
   end
 
   it "resolve correctly when potential type is an Interface and current type implements it" do
+    assert GraphQL::Execution::Typecast.compatible?(CHEESES[1], EdibleInterface, CheeseType, context)
+  end
+
+  it "resolve correctly when potential type is an Interface and current type implements it" do
     assert GraphQL::Execution::Typecast.compatible?(MILKS[1], EdibleInterface, CheeseType, context)
   end
 

--- a/spec/graphql/execution/typecast_spec.rb
+++ b/spec/graphql/execution/typecast_spec.rb
@@ -1,32 +1,49 @@
 require "spec_helper"
 
 describe GraphQL::Execution::Typecast do
+  let(:milk_value) { MILKS[1] }
+  let(:cheese_value) { CHEESES[1] }
 
   let(:schema) { DummySchema }
   let(:context) { GraphQL::Query::Context.new(query: OpenStruct.new(schema: schema), values: nil) }
 
+  def compatible?(*args)
+     GraphQL::Execution::Typecast.compatible?(*args)
+   end
   it "resolves correctly when both types are the same" do
-    assert GraphQL::Execution::Typecast.compatible?(MILKS[1], MilkType, MilkType, context)
+    assert compatible?(milk_value, MilkType, MilkType, context)
+    assert !compatible?(milk_value, MilkType, CheeseType, context)
   end
 
-  it "resolves correcty when current type is UnionType and value resolves to potential type" do
-    assert GraphQL::Execution::Typecast.compatible?(MILKS[1], DairyProductUnion, MilkType, context)
+  it "resolves a union type to a matching member" do
+    assert compatible?(milk_value, DairyProductUnion, MilkType, context)
+    assert compatible?(cheese_value, DairyProductUnion, CheeseType, context)
+
+    assert !compatible?(cheese_value, DairyProductUnion, MilkType, context)
+    assert !compatible?(nil, DairyProductUnion, MilkType, context)
   end
 
   it "resolves correcty when potential type is UnionType and current type is a member of that union" do
-    assert GraphQL::Execution::Typecast.compatible?(MILKS[1], MilkType, DairyProductUnion, context)
+    assert compatible?(milk_value, MilkType, DairyProductUnion, context)
+    assert compatible?(cheese_value, CheeseType, DairyProductUnion, context)
+
+    # assert !compatible?(nil, CheeseType, DairyProductUnion, context)
+    # assert !compatible?(cheese_value, MilkType, DairyProductUnion, context)
   end
 
-  it "resolve correctly when current type is an Interface and it resolves to potential type" do
-    assert GraphQL::Execution::Typecast.compatible?(MILKS[1], CheeseType, EdibleInterface, context)
+  it "resolves an object type to one of its interfaces" do
+    assert compatible?(cheese_value, CheeseType, EdibleInterface, context)
+    assert compatible?(milk_value, MilkType, EdibleInterface, context)
+
+    # assert !compatible?(nil, MilkType, EdibleInterface, context)
+    # assert !compatible?(milk_value, CheeseType, EdibleInterface, context)
   end
 
-  it "resolve correctly when potential type is an Interface and current type implements it" do
-    assert GraphQL::Execution::Typecast.compatible?(CHEESES[1], EdibleInterface, CheeseType, context)
-  end
+  it "resolves an interface to a matching member" do
+    assert compatible?(cheese_value, EdibleInterface, CheeseType, context)
+    assert compatible?(milk_value, EdibleInterface, MilkType, context)
 
-  it "resolve correctly when potential type is an Interface and current type implements it" do
-    assert GraphQL::Execution::Typecast.compatible?(MILKS[1], EdibleInterface, CheeseType, context)
+    assert !compatible?(nil, EdibleInterface, MilkType, context)
+    assert !compatible?(cheese_value, EdibleInterface, MilkType, context)
   end
-
 end

--- a/spec/graphql/execution/typecast_spec.rb
+++ b/spec/graphql/execution/typecast_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+
+describe GraphQL::Execution::Typecast do
+
+  let(:schema) { DummySchema }
+  let(:context) { GraphQL::Query::Context.new(query: OpenStruct.new(schema: schema), values: nil) }
+
+  it "resolves correctly when both types are the same" do
+    assert GraphQL::Execution::Typecast.compatible?(MILKS[1], MilkType, MilkType, context)
+  end
+
+  it "resolves correcty when current type is UnionType and value resolves to potential type" do
+    assert GraphQL::Execution::Typecast.compatible?(MILKS[1], DairyProductUnion, MilkType, context)
+  end
+
+  it "resolves correcty when potential type is UnionType and current type is a member of that union" do
+    assert GraphQL::Execution::Typecast.compatible?(MILKS[1], MilkType, DairyProductUnion, context)
+  end
+
+  it "resolve correctly when current type is an Interface and it resolves to potential type" do
+    assert GraphQL::Execution::Typecast.compatible?(MILKS[1], CheeseType, EdibleInterface, context)
+  end
+
+  it "resolve correctly when potential type is an Interface and current type implements it" do
+    assert GraphQL::Execution::Typecast.compatible?(MILKS[1], EdibleInterface, CheeseType, context)
+  end
+
+end

--- a/spec/graphql/interface_type_spec.rb
+++ b/spec/graphql/interface_type_spec.rb
@@ -77,5 +77,29 @@ describe GraphQL::InterfaceType do
 
       assert_equal(expected_result, result)
     end
+
+    describe "filtering members by type" do
+      let(:query_string) {%|
+      {
+        allEdible {
+          __typename
+          ... on LocalProduct {
+            origin
+          }
+        }
+      }
+      |}
+
+      it "only applies fields to the right object" do
+        expected_data = [
+          {"__typename"=>"Cheese", "origin"=>"France"},
+          {"__typename"=>"Cheese", "origin"=>"Netherlands"},
+          {"__typename"=>"Cheese", "origin"=>"Spain"},
+          {"__typename"=>"Milk", "origin"=>"Antiquity"},
+        ]
+
+        assert_equal expected_data, result["data"]["allEdible"]
+      end
+    end
   end
 end

--- a/spec/graphql/introspection/schema_type_spec.rb
+++ b/spec/graphql/introspection/schema_type_spec.rb
@@ -19,6 +19,7 @@ describe GraphQL::Introspection::SchemaType do
         "queryType"=>{
           "fields"=>[
             {"name"=>"allDairy"},
+            {"name"=>"allEdible"},
             {"name"=>"cheese"},
             {"name"=>"cow"},
             {"name"=>"dairy"},

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -9,6 +9,11 @@ LocalProductInterface = GraphQL::InterfaceType.define do
   name "LocalProduct"
   description "Something that comes from somewhere"
   field :origin, !types.String, "Place the thing comes from"
+  # This is a "bug" in the dummy app:
+  # it should actually check the incoming object to determine the type.
+  # But this is here so we can check _where_ misbehaving resolve_type
+  # functions wreak their havoc.
+  resolve_type -> (o, c) { MilkType }
 end
 
 EdibleInterface = GraphQL::InterfaceType.define do
@@ -263,6 +268,10 @@ DairyAppQueryType = GraphQL::ObjectType.define do
   end
 
   field :allDairy, types[DairyProductUnion] do
+    resolve -> (obj, args, ctx) { CHEESES.values + MILKS.values }
+  end
+
+  field :allEdible, types[EdibleInterface] do
     resolve -> (obj, args, ctx) { CHEESES.values + MILKS.values }
   end
 


### PR DESCRIPTION
- Stop checking `value` when typecasting -- only use info from types at hand 
- Reorder values passed to `compatible?`, they were passed in the wrong order :S 
- Include the tests from #209 and add some negative examples

I think issues can arise when different interfaces return different results for `resolve_type` -- but it's hard for me to figure out exactly which cases affect which things. 

Maybe it would be better to adopt a "full-Relay" strategy for the whole schema: the user defines a `resolve_type` function for the _schema_, rather than individual interfaces, that way you never get conflicting results.