### PR TITLE
Connection#initialize(field:) is optional

### DIFF
--- a/lib/graphql/relay/base_connection.rb
+++ b/lib/graphql/relay/base_connection.rb
@@ -61,7 +61,7 @@ module GraphQL
       # @param field [Object] The underlying field
       # @param max_page_size [Int] The maximum number of results to return
       # @param parent [Object] The object which this collection belongs to
-      def initialize(nodes, arguments, field:, max_page_size: nil, parent: nil)
+      def initialize(nodes, arguments, field: nil, max_page_size: nil, parent: nil)
         @nodes = nodes
         @arguments = arguments
         @max_page_size = max_page_size

--- a/spec/graphql/relay/mutation_spec.rb
+++ b/spec/graphql/relay/mutation_spec.rb
@@ -5,7 +5,9 @@ describe GraphQL::Relay::Mutation do
     mutation addBagel($clientMutationId: String) {
       introduceShip(input: {shipName: "Bagel", factionId: "1", clientMutationId: $clientMutationId}) {
         clientMutationId
-        ship { name, id }
+        shipEdge {
+          node { name, id }
+        }
         faction { name }
       }
     }
@@ -28,9 +30,11 @@ describe GraphQL::Relay::Mutation do
     expected = {"data" => {
       "introduceShip" => {
         "clientMutationId" => "1234",
-        "ship" => {
-          "name" => "Bagel",
-          "id" => NodeIdentification.to_global_id("Ship", "9"),
+        "shipEdge" => {
+          "node" => {
+            "name" => "Bagel",
+            "id" => NodeIdentification.to_global_id("Ship", "9"),
+          },
         },
         "faction" => {"name" => STAR_WARS_DATA["Faction"]["1"].name }
       }
@@ -40,16 +44,7 @@ describe GraphQL::Relay::Mutation do
 
   it "doesn't require a clientMutationId to perform mutations" do
     result = query(query_string)
-    expected = {"data" => {
-      "introduceShip" => {
-        "clientMutationId" => nil,
-        "ship" => {
-          "name" => "Bagel",
-          "id" => NodeIdentification.to_global_id("Ship", "9"),
-        },
-        "faction" => {"name" => STAR_WARS_DATA["Faction"]["1"].name }
-      }
-    }}
-    assert_equal(expected, result)
+    new_ship_name = result["data"]["introduceShip"]["shipEdge"]["node"]["name"]
+    assert_equal("Bagel", new_ship_name)
   end
 end

--- a/spec/support/star_wars_schema.rb
+++ b/spec/support/star_wars_schema.rb
@@ -177,7 +177,7 @@ IntroduceShipMutation = GraphQL::Relay::Mutation.define do
   input_field :factionId, !types.ID
 
   # Result may have access to these fields:
-  return_field :ship, Ship
+  return_field :shipEdge, Ship.edge_type
   return_field :faction, Faction
 
   # Here's the mutation operation:
@@ -185,7 +185,10 @@ IntroduceShipMutation = GraphQL::Relay::Mutation.define do
     faction_id = inputs["factionId"]
     ship = STAR_WARS_DATA.create_ship(inputs["shipName"], faction_id)
     faction = STAR_WARS_DATA["Faction"][faction_id]
-    { ship: ship, faction: faction }
+    connection_class = GraphQL::Relay::BaseConnection.connection_for_nodes(faction.ships)
+    ships_connection = connection_class.new(faction.ships, inputs)
+    ship_edge = GraphQL::Relay::Edge.new(ship, ships_connection)
+    { shipEdge: ship_edge, faction: faction }
   }
 end
 


### PR DESCRIPTION
Oops, when I merged #206, I forgot about the use case of creating connection objects during range-add mutations (eg #213) 

In that case, I think it's safe to allow fields to be nil. Previously, I supported requiring it, so we didn't forget it in any internal code, but I think it's important support this case. 

I've also "fixed" the mutation spec to be a proper RANGE_ADD example. 

@gauravtiwari & @gjtorikian, does this look alright to you? Did I miss anything?