### PR TITLE
Unify type resolution

### DIFF
--- a/guides/defining_your_schema.md
+++ b/guides/defining_your_schema.md
@@ -51,16 +51,15 @@ CoffeeType = GraphQL::ObjectType.define do
 end
 ```
 
-In order for your schema to expose members of an interface, it must be able to determine the GraphQL type for a given Ruby object. `InterfaceType` has a default `resolve_type` definition, or you can provide your own. Here's the default:
+In order for your schema to expose members of an interface, it must be able to determine the GraphQL type for a given Ruby object. You must define `resolve_type` in your schema:
 
 ```ruby
-BeverageInterface = GraphQL::InterfaceType.define do
+MySchema = GraphQL::Schema.define do
  # ...
  resolve_type -> (object, ctx) {
+   # for example, look up types by class name
    type_name = object.class.name
-   # you can access the interface's `possible_types` inside the proc
-   possible_types = ctx.schema.possible_types(self)
-   possible_types.find {|t| t.name == type_name}
+   MySchema.types[type_name]
  }
 end
 ```
@@ -77,18 +76,7 @@ MediaSearchResultUnion = GraphQL::UnionType.define do
 end
 ```
 
-In order to expose a union, you must also define how the concrete type of each object can be determined. `UnionType` provides a default, shown here:
-
-```ruby
-MediaSearchResultUnion = GraphQL::UnionType.define do
-  # This is the default if you don't provide a custom `resolve_type` proc:
-  resolve_type -> (object, ctx) {
-    type_name = object.class.name
-    # You can access the union's `possible_types` inside the proc
-    possible_types.find {|t| t.name == type_name}
-  }
-end
-```
+In order to expose a union, you must also define how the concrete type of each object can be determined. This is defined with `Schema`'s `resolve_type` function (see Interface docs).
 
 ### Enum Types
 
@@ -379,13 +367,13 @@ end
 Access `type.metadata` later:
 
 ```ruby
-SearchResultUnion = GraphQL::Union.define do
+MySchema = GraphQL::Schema.define do
   # ...
   # Use the type's declared `resolves_to_class_names`
   # to figure out if `obj` is a member of that type
   resolve_type -> (obj, ctx) {
     class_name = obj.class.name
-    possible_types.find { |type| type.metadata[:resolves_to_class_names].include?(class_name) }
+    MySchema.types.values.find { |type| type.metadata[:resolves_to_class_names].include?(class_name) }
   }
 end
 ```

--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -56,7 +56,7 @@ module GraphQL
         if @resolve_type_proc
           resolve_type(object, ctx)
         else
-          ctx.schema.resolve_type(object)
+          ctx.schema.resolve_type(object, ctx)
         end
       end
 

--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -49,6 +49,17 @@ module GraphQL
     end
 
     module HasPossibleTypes
+
+      # If a (deprecated) `resolve_type` function was provided, call that and warn.
+      # Otherwise call `schema.resolve_type` (the proper behavior)
+      def legacy_resolve_type(object, ctx)
+        if @resolve_type_proc
+          resolve_type(object, ctx)
+        else
+          ctx.schema.resolve_type(object)
+        end
+      end
+
       # Return the implementing type for `object`.
       # The default implementation assumes that there's a type with the same name as `object.class.name`.
       # Maybe you'll need to override this in your own interfaces!
@@ -58,6 +69,7 @@ module GraphQL
       # @return [GraphQL::ObjectType] the type which should expose `object`
       def resolve_type(object, ctx)
         ensure_defined
+        warn_resolve_type_deprecated
         instance_exec(object, ctx, &(@resolve_type_proc || DEFAULT_RESOLVE_TYPE))
       end
 
@@ -69,7 +81,12 @@ module GraphQL
       }
 
       def resolve_type=(new_proc)
+        warn_resolve_type_deprecated
         @resolve_type_proc = new_proc || DEFAULT_RESOLVE_TYPE
+      end
+
+      def warn_resolve_type_deprecated
+        warn("#{self.name}.resolve_type is deprecated; define Schema.resolve_type instead")
       end
     end
 

--- a/lib/graphql/object_type.rb
+++ b/lib/graphql/object_type.rb
@@ -1,12 +1,5 @@
 module GraphQL
-  # An object type has _fields_ which expose values from your application.
-  # The fields are _typed_. Fields may return object types (including the same object type).
-  #
-  # See {GraphQL::Field} for details about defining fields.
-  #
-  # Objects which fulfill many of the same fields may implement _interfaces_, see {GraphQL::InterfaceType}.
-  #
-  # ObjectTypes which occur in the same place in the schema may be grouped in a {GraphQL::UnionType}.
+  # This type exposes fields on an object.
   #
   # @example defining a type for your IMDB clone
   #   MovieType = GraphQL::ObjectType.define do

--- a/lib/graphql/query/serial_execution/value_resolution.rb
+++ b/lib/graphql/query/serial_execution/value_resolution.rb
@@ -54,7 +54,9 @@ module GraphQL
 
         class HasPossibleTypeResolution < BaseResolution
           def non_null_result
-            resolved_type = field_type.resolve_type(value, execution_context)
+            # When deprecations are removed:
+            # resolved_type = execution_context.schema.resolve_type(value)
+            resolved_type = field_type.legacy_resolve_type(value, execution_context)
 
             unless resolved_type.is_a?(GraphQL::ObjectType)
               raise GraphQL::ObjectType::UnresolvedTypeError.new(irep_node.definition_name, field_type, parent_type)

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -199,9 +199,9 @@ module GraphQL
     # Determine the GraphQL type for a given object.
     # This is required for unions and interfaces (include Relay's node interface)
     # @return [GraphQL::ObjectType] The type for exposing `object` in GraphQL
-    def resolve_type(object)
+    def resolve_type(object, ctx)
       ensure_defined
-      type_result = @resolve_type_proc.call(object)
+      type_result = @resolve_type_proc.call(object, ctx)
       if type_result.nil?
         nil
       elsif !type_result.is_a?(GraphQL::BaseType)

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -48,7 +48,7 @@ module GraphQL
       :query_execution_strategy, :mutation_execution_strategy, :subscription_execution_strategy,
       :max_depth, :max_complexity,
       :node_identification,
-      :orphan_types,
+      :orphan_types, :resolve_type,
       query_analyzer: -> (schema, analyzer) { schema.query_analyzers << analyzer },
       middleware: -> (schema, middleware) { schema.middleware << middleware },
       rescue_from: -> (schema, err_class, &block) { schema.rescue_from(err_class, &block)}
@@ -57,13 +57,13 @@ module GraphQL
       :query, :mutation, :subscription,
       :query_execution_strategy, :mutation_execution_strategy, :subscription_execution_strategy,
       :max_depth, :max_complexity,
-      :node_identification,
       :orphan_types,
       :query_analyzers, :middleware
 
 
     DIRECTIVES = [GraphQL::Directive::SkipDirective, GraphQL::Directive::IncludeDirective]
     DYNAMIC_FIELDS = ["__type", "__typename", "__schema"]
+    RESOLVE_TYPE_PROC_REQUIRED = -> (obj) { raise("Schema.resolve_type is undefined, can't resolve type for #{obj}") }
 
     attr_reader :directives, :static_validator
 
@@ -71,6 +71,11 @@ module GraphQL
     def node_identification
       ensure_defined
       @node_identification
+    end
+
+    def node_identification=(new_node_ident)
+      new_node_ident.schema = self
+      @node_identification = new_node_ident
     end
 
     # @return [Array<#call>] Middlewares suitable for MiddlewareChain, applied to fields during execution
@@ -99,6 +104,7 @@ module GraphQL
       @rescue_middleware = GraphQL::Schema::RescueMiddleware.new
       @middleware = [@rescue_middleware]
       @query_analyzers = []
+      @resolve_type_proc = RESOLVE_TYPE_PROC_REQUIRED
       # Default to the built-in execution strategy:
       @query_execution_strategy = GraphQL::Query::SerialExecution
       @mutation_execution_strategy = GraphQL::Query::SerialExecution
@@ -187,6 +193,25 @@ module GraphQL
       else
         raise ArgumentError, "unknown operation type: #{operation}"
       end
+    end
+
+    # Determine the GraphQL type for a given object.
+    # This is required for unions and interfaces (include Relay's node interface)
+    # @return [GraphQL::ObjectType] The type for exposing `object` in GraphQL
+    def resolve_type(object)
+      type_result = @resolve_type_proc.call(object)
+      if type_result.nil?
+        nil
+      elsif !type_result.is_a?(GraphQL::BaseType)
+        type_str = "#{type_result} (#{type_result.class.name})"
+        raise "resolve_type(#{object}) returned #{type_str}, but it should return a GraphQL type"
+      else
+        type_result
+      end
+    end
+
+    def resolve_type=(new_resolve_type_proc)
+      @resolve_type_proc = new_resolve_type_proc
     end
   end
 end

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -161,6 +161,7 @@ module GraphQL
       GraphQL::Schema::TypeExpression.build_type(self, ast_node)
     end
 
+    # TODO: when `resolve_type` is schema level, can this be removed?
     # @param type_defn [GraphQL::InterfaceType, GraphQL::UnionType] the type whose members you want to retrieve
     # @return [Array<GraphQL::ObjectType>] types which belong to `type_defn` in this schema
     def possible_types(type_defn)
@@ -199,6 +200,7 @@ module GraphQL
     # This is required for unions and interfaces (include Relay's node interface)
     # @return [GraphQL::ObjectType] The type for exposing `object` in GraphQL
     def resolve_type(object)
+      ensure_defined
       type_result = @resolve_type_proc.call(object)
       if type_result.nil?
         nil
@@ -211,6 +213,7 @@ module GraphQL
     end
 
     def resolve_type=(new_resolve_type_proc)
+      ensure_defined
       @resolve_type_proc = new_resolve_type_proc
     end
   end

--- a/spec/graphql/interface_type_spec.rb
+++ b/spec/graphql/interface_type_spec.rb
@@ -8,11 +8,6 @@ describe GraphQL::InterfaceType do
     assert_equal([CheeseType, HoneyType, MilkType], DummySchema.possible_types(interface))
   end
 
-  it "resolves types for objects" do
-    assert_equal(CheeseType, interface.resolve_type(CHEESES.values.first, dummy_query_context))
-    assert_equal(MilkType, interface.resolve_type(MILKS.values.first, dummy_query_context))
-  end
-
   describe "query evaluation" do
     let(:result) { DummySchema.execute(query_string, variables: {"cheeseId" => 2})}
     let(:query_string) {%|
@@ -37,20 +32,6 @@ describe GraphQL::InterfaceType do
     it "gets fields from the type for the given object" do
       expected = {"data"=>{"favoriteEdible"=>{"fatContent"=>0.04, "origin"=>"Antiquity"}}}
       assert_equal(expected, result)
-    end
-  end
-
-  describe '#resolve_type' do
-    let(:interface) {
-      GraphQL::InterfaceType.define do
-        resolve_type -> (object, ctx) {
-          :custom_resolve
-        }
-      end
-    }
-
-    it "can be overriden in the definition" do
-      assert_equal(interface.resolve_type(123, nil), :custom_resolve)
     end
   end
 

--- a/spec/graphql/query/serial_execution/value_resolution_spec.rb
+++ b/spec/graphql/query/serial_execution/value_resolution_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe GraphQL::Query::SerialExecution::ValueResolution do
-  let(:query_root) {
+  let(:schema) {
     day_of_week_enum = GraphQL::EnumType.define do
       name "DayOfWeek"
       value("MONDAY", value: 0)
@@ -16,10 +16,9 @@ describe GraphQL::Query::SerialExecution::ValueResolution do
     interface = GraphQL::InterfaceType.define do
       name "SomeInterface"
       field :someField, !types.Int
-      resolve_type ->(obj, ctx) { nil }
     end
 
-    GraphQL::ObjectType.define do
+    query_root = GraphQL::ObjectType.define do
       name "Query"
       field :tomorrow, day_of_week_enum do
         argument :today, day_of_week_enum
@@ -29,8 +28,13 @@ describe GraphQL::Query::SerialExecution::ValueResolution do
         resolve ->(obj, args, ctx) { Object.new }
       end
     end
+
+    GraphQL::Schema.define do
+      query(query_root)
+      resolve_type -> (obj) { nil }
+    end
   }
-  let(:schema) { GraphQL::Schema.define(query: query_root) }
+
   let(:result) { schema.execute(
     query_string,
   )}

--- a/spec/graphql/query/serial_execution/value_resolution_spec.rb
+++ b/spec/graphql/query/serial_execution/value_resolution_spec.rb
@@ -31,7 +31,7 @@ describe GraphQL::Query::SerialExecution::ValueResolution do
 
     GraphQL::Schema.define do
       query(query_root)
-      resolve_type -> (obj) { nil }
+      resolve_type -> (obj, ctx) { nil }
     end
   }
 

--- a/spec/graphql/relay/global_node_identification_spec.rb
+++ b/spec/graphql/relay/global_node_identification_spec.rb
@@ -128,22 +128,4 @@ describe GraphQL::Relay::GlobalNodeIdentification do
       end
     end
   end
-
-  describe "type_from_object" do
-    describe "when the return value is nil" do
-      it "returns nil" do
-        result = node_identification.type_from_object(123)
-        assert_equal(nil, result)
-      end
-    end
-
-    describe "when the return value is not a BaseType" do
-      it "raises an error " do
-        err = assert_raises(RuntimeError) {
-          node_identification.type_from_object(:test_error)
-        }
-        assert_includes err.message, "not_a_type (Symbol)"
-      end
-    end
-  end
 end

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -20,4 +20,22 @@ describe GraphQL::Schema do
       assert_equal("Test", res["data"]["test"])
     end
   end
+
+  describe "#resolve_type" do
+    describe "when the return value is nil" do
+      it "returns nil" do
+        result = StarWarsSchema.resolve_type(123)
+        assert_equal(nil, result)
+      end
+    end
+
+    describe "when the return value is not a BaseType" do
+      it "raises an error " do
+        err = assert_raises(RuntimeError) {
+          StarWarsSchema.resolve_type(:test_error)
+        }
+        assert_includes err.message, "not_a_type (Symbol)"
+      end
+    end
+  end
 end

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -24,7 +24,7 @@ describe GraphQL::Schema do
   describe "#resolve_type" do
     describe "when the return value is nil" do
       it "returns nil" do
-        result = StarWarsSchema.resolve_type(123)
+        result = StarWarsSchema.resolve_type(123, nil)
         assert_equal(nil, result)
       end
     end
@@ -32,7 +32,7 @@ describe GraphQL::Schema do
     describe "when the return value is not a BaseType" do
       it "raises an error " do
         err = assert_raises(RuntimeError) {
-          StarWarsSchema.resolve_type(:test_error)
+          StarWarsSchema.resolve_type(:test_error, nil)
         }
         assert_includes err.message, "not_a_type (Symbol)"
       end

--- a/spec/graphql/union_type_spec.rb
+++ b/spec/graphql/union_type_spec.rb
@@ -17,10 +17,6 @@ describe GraphQL::UnionType do
     assert_equal("MyUnion", union.name)
   end
 
-  it "infers type from an object" do
-    assert_equal(CheeseType, DairyProductUnion.resolve_type(CHEESES[1], OpenStruct.new(schema: DummySchema)))
-  end
-
   it '#include? returns true if type in in possible_types' do
     assert union.include?(type_1)
   end

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -342,7 +342,7 @@ DummySchema = GraphQL::Schema.define do
 
   rescue_from(NoSuchDairyError) { |err| err.message  }
 
-  resolve_type -> (obj) {
+  resolve_type -> (obj, ctx) {
     DummySchema.types[obj.class.name]
   }
 end

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -341,4 +341,8 @@ DummySchema = GraphQL::Schema.define do
   orphan_types [HoneyType, BeverageUnion]
 
   rescue_from(NoSuchDairyError) { |err| err.message  }
+
+  resolve_type -> (obj) {
+    DummySchema.types[obj.class.name]
+  }
 end

--- a/spec/support/star_wars_schema.rb
+++ b/spec/support/star_wars_schema.rb
@@ -11,20 +11,6 @@ NodeIdentification = GraphQL::Relay::GlobalNodeIdentification.define do
     type_name, id = NodeIdentification.from_global_id(node_id)
     STAR_WARS_DATA[type_name][id]
   end
-
-  type_from_object -> (object) do
-    if object == :test_error
-      :not_a_type
-    elsif object.is_a?(Base)
-      BaseType
-    elsif STAR_WARS_DATA["Faction"].values.include?(object)
-      Faction
-    elsif STAR_WARS_DATA["Ship"].values.include?(object)
-      Ship
-    else
-      nil
-    end
-  end
 end
 
 Ship = GraphQL::ObjectType.define do
@@ -215,5 +201,21 @@ MutationType = GraphQL::ObjectType.define do
   field :introduceShip, field: IntroduceShipMutation.field
 end
 
-StarWarsSchema = GraphQL::Schema.define(query: QueryType, mutation: MutationType)
-StarWarsSchema.node_identification = NodeIdentification
+StarWarsSchema = GraphQL::Schema.define do
+  query(QueryType)
+  mutation(MutationType)
+  node_identification(NodeIdentification)
+  resolve_type -> (object) {
+    if object == :test_error
+      :not_a_type
+    elsif object.is_a?(Base)
+      BaseType
+    elsif STAR_WARS_DATA["Faction"].values.include?(object)
+      Faction
+    elsif STAR_WARS_DATA["Ship"].values.include?(object)
+      Ship
+    else
+      nil
+    end
+  }
+end

--- a/spec/support/star_wars_schema.rb
+++ b/spec/support/star_wars_schema.rb
@@ -205,7 +205,7 @@ StarWarsSchema = GraphQL::Schema.define do
   query(QueryType)
   mutation(MutationType)
   node_identification(NodeIdentification)
-  resolve_type -> (object) {
+  resolve_type -> (object, ctx) {
     if object == :test_error
       :not_a_type
     elsif object.is_a?(Base)


### PR DESCRIPTION
(This depends on #208)

The previous design of interface & union resolution could lead to undefined behavior when `.resolve_type` functions returned different results for the same object. This is especially possible in Relay, where `Node` uses the `type_from_object` function, but each _other_ interface uses its own `resolve_type` (which defaults to `HasPossibleTypes::DEFAULT_RESOLVE_TYPE`)

Is there a use case for treating the same object as two different object types? I can't think of one, and indeed, it's completely disallowed by Relay, which is GraphQL's largest use case. 

So, I think we should adopt Relay's "once and for all" object-to-type function as a member of `GraphQL::Schema`. Then, all type resolution can be passed to that function. It removes the possibility that functions would return different results for the same value. 

There is no default value anymore. If the function isn't defined, we raise an error. This won't affect users who don't have interfaces or unions in their schema. Relay users can simply copy their `type_from_object` to `Schema.resolve_type`.

This PR deprecates previous type resolution approaches (`type_from_object` and interface `resolve_type` functions) but still supports them. 


