### PR TITLE
Set exception message in InvalidNullError

### DIFF
--- a/lib/graphql/invalid_null_error.rb
+++ b/lib/graphql/invalid_null_error.rb
@@ -5,13 +5,12 @@ module GraphQL
     def initialize(field_name, value)
       @field_name = field_name
       @value = value
+      super("Cannot return null for non-nullable field #{@field_name}")
     end
 
     # @return [Hash] An entry for the response's "errors" key
     def to_h
-      {
-        "message" => "Cannot return null for non-nullable field #{@field_name}"
-      }
+      { "message" => message }
     end
 
     # @return [Boolean] Whether the null in question was caused by another error


### PR DESCRIPTION
I'm seeing some `GraphQL::InvalidNullError` exceptions bubble through to our exception tracker and without any message set it's really hard to figure out where this exception is coming from.

This pull request changes `initialize` to call super with the existing message in the `to_h` method.