### PR TITLE
Query with nothing but comments causes stack overflow

### DIFF
--- a/spec/graphql/static_validation/rules/fragments_are_used_spec.rb
+++ b/spec/graphql/static_validation/rules/fragments_are_used_spec.rb
@@ -30,4 +30,15 @@ describe GraphQL::StaticValidation::FragmentsAreUsed do
       "path"=>["query getCheese", "... undefinedFields"]
     })
   end
+
+  describe "queries that are comments" do
+    let(:query_string) {%|
+      # I am a comment.
+    |}
+    let(:document) { GraphQL.parse(query_string) }
+    let(:result) { DummySchema.execute(document: document) }
+    it "handles them gracefully" do
+      assert_equal nil, result
+    end
+  end
 end


### PR DESCRIPTION
We noticed a weird edge case where, if a query is nothing but a comment, an endless loop occurs with the fragment validator. The test I've pushed demonstrates the issue:

<details>
GraphQL::StaticValidation::FragmentsAreUsed::queries that are comments
  test_0001_handles them gracefully                              ERROR (0.25s)
SystemStackError:         SystemStackError: stack level too deep
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/static_validation/type_stack.rb:44:in `block in initialize'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/language/visitor.rb:73:in `call'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/language/visitor.rb:73:in `block in apply_hooks'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/language/visitor.rb:73:in `each'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/language/visitor.rb:73:in `reduce'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/language/visitor.rb:73:in `apply_hooks'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/language/visitor.rb:59:in `begin_visit'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/language/visitor.rb:51:in `visit_node'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/language/visitor.rb:45:in `visit'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/static_validation/validator.rb:33:in `validate'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/query.rb:134:in `perform_validation'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/query.rb:86:in `selected_operation'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/query.rb:99:in `variables'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/query.rb:139:in `perform_validation'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/query.rb:86:in `selected_operation'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/query.rb:99:in `variables'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/query.rb:139:in `perform_validation'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/query.rb:86:in `selected_operation'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/query.rb:99:in `variables'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/query.rb:139:in `perform_validation'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/query.rb:86:in `selected_operation'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/query.rb:99:in `variables'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/query.rb:139:in `perform_validation'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/query.rb:86:in `selected_operation'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/query.rb:99:in `variables'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/query.rb:139:in `perform_validation'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/query.rb:86:in `selected_operation'
            /Users/gjtorikian/Development/graphql-ruby/lib/graphql/query.rb:99:in `variables'
 ...
</details>

I thought I could simply fix the issue myself, but got stuck. In short, there needs to be some way to bail out from an endless loop of trying to check the variables for validity. 