### PR TITLE
Fix empty queries

### DIFF
--- a/spec/graphql/static_validation/rules/fragment_types_exist_spec.rb
+++ b/spec/graphql/static_validation/rules/fragment_types_exist_spec.rb
@@ -20,7 +20,7 @@ describe GraphQL::StaticValidation::FragmentTypesExist do
   "}
 
   let(:validator) { GraphQL::StaticValidation::Validator.new(schema: DummySchema, rules: [GraphQL::StaticValidation::FragmentTypesExist]) }
-  let(:query) { GraphQL::Query.new(DummySchema, query_string) }
+  let(:query) { GraphQL::Query.new(DummySchema, query_string, validate: false) }
   let(:errors) { validator.validate(query)[:errors] }
 
   it "finds non-existent types on fragments" do

--- a/spec/graphql/static_validation/rules/fragment_types_exist_spec.rb
+++ b/spec/graphql/static_validation/rules/fragment_types_exist_spec.rb
@@ -20,7 +20,7 @@ describe GraphQL::StaticValidation::FragmentTypesExist do
   "}
 
   let(:validator) { GraphQL::StaticValidation::Validator.new(schema: DummySchema, rules: [GraphQL::StaticValidation::FragmentTypesExist]) }
-  let(:query) { GraphQL::Query.new(DummySchema, query_string, validate: false) }
+  let(:query) { GraphQL::Query.new(DummySchema, query_string) }
   let(:errors) { validator.validate(query)[:errors] }
 
   it "finds non-existent types on fragments" do

--- a/spec/graphql/static_validation/rules/fragments_are_used_spec.rb
+++ b/spec/graphql/static_validation/rules/fragments_are_used_spec.rb
@@ -30,4 +30,15 @@ describe GraphQL::StaticValidation::FragmentsAreUsed do
       "path"=>["query getCheese", "... undefinedFields"]
     })
   end
+
+  describe "queries that are comments" do
+    let(:query_string) {%|
+      # I am a comment.
+    |}
+    let(:document) { GraphQL.parse(query_string) }
+    let(:result) { DummySchema.execute(document: document) }
+    it "handles them gracefully" do
+      assert_equal nil, result
+    end
+  end
 end

--- a/spec/graphql/static_validation/rules/fragments_are_used_spec.rb
+++ b/spec/graphql/static_validation/rules/fragments_are_used_spec.rb
@@ -35,10 +35,9 @@ describe GraphQL::StaticValidation::FragmentsAreUsed do
     let(:query_string) {%|
       # I am a comment.
     |}
-    let(:document) { GraphQL.parse(query_string) }
-    let(:result) { DummySchema.execute(document: document) }
+    let(:result) { DummySchema.execute(query_string) }
     it "handles them gracefully" do
-      assert_equal nil, result
+      assert_equal({}, result)
     end
   end
 end


### PR DESCRIPTION
Currently, a query with no operations causes an infinite loop ( #218 ). This is because query validation is a trainwreck! What I _want_ to do is: 

- Provide enough public API on `Query` that other parts of the system don't have to worry about whether the query was previously validated or not, eg: 
  - `AnalyzeQuery` can just ask for `query.internal_representation` and _get it_.
  - `Executor` can just ask for `query.selected_operation` and _get it_.
- Make validation a lazy operation -- only run it if needed (is this pointless? is there a case where you make a query but don't try to execute it? The only _really_ public API for `GraphQL::Query` is via `Schema#execute`). 
- Make the steps in the process decoupled enough that they can be tested in isolation 


~~These are all 👎  in this patch:~~
- ~~Passing an unvalidated Query to AnalyzeQuery would give `{}` for internal representation, that's bogus~~ 
- ~~Validation is ahead-of-time, not lazy~~
- ~~Validation is not decoupled from the query itself, see added `validate: false` to test suite~~

~~But this is a step in the right direction -- at least the _phases_ of validation have been separated and explicitly put in sequence.~~

~~I think another commit can get validation back to an as-needed operation~~ 

Ok, it's lazy again 😀 

@gjtorikian for whatever reason, returning `nil` from `Query#execute` returns a result of `{}`, I changed your test, is that ok? 