### PR TITLE
Include expected type in validation error message

### DIFF
--- a/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb
+++ b/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb
@@ -10,7 +10,7 @@ module GraphQL
         if !valid
           kind_of_node = node_type(parent)
           error_arg_name = parent_name(parent, defn)
-          context.errors << message("Argument '#{node.name}' on #{kind_of_node} '#{error_arg_name}' has an invalid value", parent, context: context)
+          context.errors << message("Argument '#{node.name}' on #{kind_of_node} '#{error_arg_name}' has an invalid value. Expected type '#{arg_defn.type}'.", parent, context: context)
         end
       end
     end

--- a/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
+++ b/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
@@ -25,42 +25,42 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
     assert_equal(6, errors.length)
 
     query_root_error = {
-      "message"=>"Argument 'id' on Field 'cheese' has an invalid value",
+      "message"=>"Argument 'id' on Field 'cheese' has an invalid value. Expected type 'Int!'.",
       "locations"=>[{"line"=>3, "column"=>7}],
       "path"=>["query getCheese", "cheese", "id"],
     }
     assert_includes(errors, query_root_error)
 
     directive_error = {
-      "message"=>"Argument 'if' on Directive 'skip' has an invalid value",
+      "message"=>"Argument 'if' on Directive 'skip' has an invalid value. Expected type 'Boolean!'.",
       "locations"=>[{"line"=>4, "column"=>30}],
       "path"=>["query getCheese", "cheese", "source", "if"],
     }
     assert_includes(errors, directive_error)
 
     input_object_error = {
-      "message"=>"Argument 'product' on Field 'badSource' has an invalid value",
+      "message"=>"Argument 'product' on Field 'badSource' has an invalid value. Expected type '[DairyProductInput]'.",
       "locations"=>[{"line"=>6, "column"=>7}],
       "path"=>["query getCheese", "badSource", "product"],
     }
     assert_includes(errors, input_object_error)
 
     input_object_field_error = {
-      "message"=>"Argument 'source' on InputObject 'DairyProductInput' has an invalid value",
+      "message"=>"Argument 'source' on InputObject 'DairyProductInput' has an invalid value. Expected type 'DairyAnimal!'.",
       "locations"=>[{"line"=>6, "column"=>40}],
       "path"=>["query getCheese", "badSource", "product", "source"],
     }
     assert_includes(errors, input_object_field_error)
 
     missing_required_field_error = {
-      "message"=>"Argument 'product' on Field 'missingSource' has an invalid value",
+      "message"=>"Argument 'product' on Field 'missingSource' has an invalid value. Expected type '[DairyProductInput]'.",
       "locations"=>[{"line"=>7, "column"=>7}],
       "path"=>["query getCheese", "missingSource", "product"],
     }
     assert_includes(errors, missing_required_field_error)
 
     fragment_error = {
-      "message"=>"Argument 'source' on Field 'similarCheese' has an invalid value",
+      "message"=>"Argument 'source' on Field 'similarCheese' has an invalid value. Expected type '[DairyAnimal!]!'.",
       "locations"=>[{"line"=>13, "column"=>7}],
       "path"=>["fragment cheeseFields", "similarCheese", "source"],
     }


### PR DESCRIPTION
The inspiration behind this was the more helpful error messages that GraphiQL has.

![image](https://cloud.githubusercontent.com/assets/295605/18011175/fd764ff8-6b81-11e6-875e-30fea6d963d9.png)

Two questions/possible changes:

1. I could unwrap `arg_defn` but I'm on the fence as to what's more helpful.
2. I initially wanted to output `node.value` as well but it could be nested with arguments. I couldn't find an existing way to get to the underlying value so leaving it out for now.

This is still an improvement regardless.
