### PR TITLE
Add additional Type.define convenience arguments

### DIFF
--- a/lib/graphql/argument.rb
+++ b/lib/graphql/argument.rb
@@ -26,5 +26,19 @@ module GraphQL
     end
 
     attr_writer :name
+
+    def type=(new_return_type)
+      ensure_defined
+      @clean_type = nil
+      @dirty_type = new_return_type
+    end
+
+    # Get the return type for this field.
+    def type
+      @clean_type ||= begin
+        ensure_defined
+        GraphQL::BaseType.resolve_related_type(@dirty_type)
+      end
+    end
   end
 end

--- a/lib/graphql/enum_type.rb
+++ b/lib/graphql/enum_type.rb
@@ -56,7 +56,7 @@ module GraphQL
   #   }
   #
   class EnumType < GraphQL::BaseType
-    accepts_definitions value: GraphQL::Define::AssignEnumValue
+    accepts_definitions :values, value: GraphQL::Define::AssignEnumValue
 
     def initialize
       @values_by_name = {}
@@ -124,6 +124,10 @@ module GraphQL
     #
     # Created with the `value` helper
     class EnumValue
+      def self.define(name:, description: nil, deprecation_reason: nil, value: nil)
+        new(name: name, description: description, deprecation_reason: deprecation_reason, value: value)
+      end
+
       attr_accessor :name, :description, :deprecation_reason, :value
       def initialize(name:, description:, deprecation_reason:, value:)
         @name = name

--- a/lib/graphql/field.rb
+++ b/lib/graphql/field.rb
@@ -120,7 +120,7 @@ module GraphQL
   #
   class Field
     include GraphQL::Define::InstanceDefinable
-    accepts_definitions :name, :description, :resolve, :type, :property, :deprecation_reason, :complexity, :hash_key, argument: GraphQL::Define::AssignArgument
+    accepts_definitions :name, :description, :resolve, :type, :property, :deprecation_reason, :complexity, :hash_key, :arguments, argument: GraphQL::Define::AssignArgument
 
     lazy_defined_attr_accessor :deprecation_reason, :description, :property, :hash_key
 

--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -24,6 +24,7 @@ module GraphQL
   #
   class InputObjectType < GraphQL::BaseType
     accepts_definitions(
+      :arguments,
       input_field: GraphQL::Define::AssignArgument,
       argument: GraphQL::Define::AssignArgument
     )

--- a/lib/graphql/object_type.rb
+++ b/lib/graphql/object_type.rb
@@ -21,7 +21,7 @@ module GraphQL
   #   end
   #
   class ObjectType < GraphQL::BaseType
-    accepts_definitions :interfaces, field: GraphQL::Define::AssignObjectField
+    accepts_definitions :interfaces, :fields, field: GraphQL::Define::AssignObjectField
 
     # @return [Hash<String => GraphQL::Field>] Map String fieldnames to their {GraphQL::Field} implementations
     lazy_defined_attr_accessor :fields

--- a/spec/graphql/argument_spec.rb
+++ b/spec/graphql/argument_spec.rb
@@ -17,4 +17,9 @@ describe GraphQL::Argument do
     expected_error = %|Query is invalid: field "invalid" argument "invalid" default value ["123"] is not valid for type Float|
     assert_equal expected_error, err.message
   end
+
+  it "accepts proc type" do
+    argument = GraphQL::Argument.define(name: :favoriteFood, type: -> { GraphQL::STRING_TYPE })
+    assert_equal GraphQL::STRING_TYPE, argument.type
+  end
 end

--- a/spec/graphql/enum_type_spec.rb
+++ b/spec/graphql/enum_type_spec.rb
@@ -28,4 +28,11 @@ describe GraphQL::EnumType do
       assert(!result.valid?)
     end
   end
+
+  it "accepts values array" do
+    cow = GraphQL::EnumType::EnumValue.define(name: "COW")
+    goat = GraphQL::EnumType::EnumValue.define(name: "GOAT")
+    enum = GraphQL::EnumType.define(name: "DairyAnimal", values: [cow, goat])
+    assert_equal({ "COW" => cow, "GOAT" => goat }, enum.values)
+  end
 end

--- a/spec/graphql/field_spec.rb
+++ b/spec/graphql/field_spec.rb
@@ -17,6 +17,12 @@ describe GraphQL::Field do
     assert_equal(DairyProductUnion, field.type)
   end
 
+  it "accepts arguments definition" do
+    number = GraphQL::Argument.define(name: :number, type: -> { GraphQL::INT_TYPE })
+    field = GraphQL::Field.define(type: DairyProductUnion, arguments: [number])
+    assert_equal([number], field.arguments)
+  end
+
   describe ".property " do
     let(:field) do
       GraphQL::Field.define do

--- a/spec/graphql/object_type_spec.rb
+++ b/spec/graphql/object_type_spec.rb
@@ -18,6 +18,12 @@ describe GraphQL::ObjectType do
     assert_equal([EdibleInterface, AnimalProductInterface, LocalProductInterface], type.interfaces)
   end
 
+  it "accepts fields definition" do
+    last_produced_dairy = GraphQL::Field.define(name: :last_produced_dairy, type: DairyProductUnion)
+    cow_type = GraphQL::ObjectType.define(name: "Cow", fields: [last_produced_dairy])
+    assert_equal([last_produced_dairy], cow_type.fields)
+  end
+
   describe '#get_field ' do
     it "exposes fields" do
       field = type.get_field("id")


### PR DESCRIPTION
(Extraction from #207)

Suggestion from https://github.com/rmosolgo/graphql-ruby/pull/207#issuecomment-240608269.

Adds some additional parameters to `Type.define` to allow types to be constructed without a lazy `define do` block.

-
To: @rmosolgo 