### PR TITLE
Remove extra space between ...FooFragment

### DIFF
--- a/lib/graphql/language/generation.rb
+++ b/lib/graphql/language/generation.rb
@@ -29,7 +29,7 @@ module GraphQL
           out
 
         when Nodes::FragmentSpread
-          out = "#{indent}... #{node.name}"
+          out = "#{indent}...#{node.name}"
           out << generate_directives(node.directives)
           out
         when Nodes::InlineFragment

--- a/spec/graphql/language/generation_spec.rb
+++ b/spec/graphql/language/generation_spec.rb
@@ -7,7 +7,7 @@ describe GraphQL::Language::Generation do
       myField: someField(someArg: $someVar, ok: 1.4) @skip(if: $anotherVar) @thing(or: "Whatever")
       anotherField(someArg: [1, 2, 3]) {
         nestedField
-        ... moreNestedFields @skip(if: $skipNested)
+        ...moreNestedFields @skip(if: $skipNested)
       }
       ... on OtherType @include(unless: false) {
         field(arg: [{ key: "value", anotherKey: 0.9, anotherAnotherKey: WHATEVER }])


### PR DESCRIPTION
This has been bugging me 😁 

Just `...friendFields` is more conventional than `... friendFields`.