### PR TITLE
A few Schema loader bug fixes

### DIFF
--- a/lib/graphql/schema/loader.rb
+++ b/lib/graphql/schema/loader.rb
@@ -65,7 +65,7 @@ module GraphQL
             InterfaceType.define(
               name: type["name"],
               description: type["description"],
-              fields: Hash[type["fields"].map { |field|
+              fields: Hash[(type["fields"] || []).map { |field|
                 [field["name"], define_type(field.merge("kind" => "FIELD"), type_resolver)]
               }]
             )
@@ -81,6 +81,9 @@ module GraphQL
             ObjectType.define(
               name: type["name"],
               description: type["description"],
+              interfaces: (type["interfaces"] || []).map { |interface|
+                define_type(interface.merge("kind" => "INTERFACE"), type_resolver)
+              },
               fields: Hash[type["fields"].map { |field|
                 [field["name"], define_type(field.merge("kind" => "FIELD"), type_resolver)]
               }]

--- a/lib/graphql/schema/loader.rb
+++ b/lib/graphql/schema/loader.rb
@@ -22,7 +22,7 @@ module GraphQL
           types[type_object.name] = type_object
         end
 
-        kargs = {}
+        kargs = { :orphan_types => types.values }
         [:query, :mutation, :subscription].each do |root|
           type = schema["#{root}Type"]
           kargs[root] = types.fetch(type.fetch("name")) if type
@@ -82,7 +82,7 @@ module GraphQL
               name: type["name"],
               description: type["description"],
               interfaces: (type["interfaces"] || []).map { |interface|
-                define_type(interface.merge("kind" => "INTERFACE"), type_resolver)
+                type_resolver.call(interface)
               },
               fields: Hash[type["fields"].map { |field|
                 [field["name"], define_type(field.merge("kind" => "FIELD"), type_resolver)]

--- a/lib/graphql/schema/loader.rb
+++ b/lib/graphql/schema/loader.rb
@@ -22,9 +22,13 @@ module GraphQL
           types[type_object.name] = type_object
         end
 
-        query = types.fetch(schema.fetch("queryType").fetch("name"))
+        kargs = {}
+        [:query, :mutation, :subscription].each do |root|
+          type = schema["#{root}Type"]
+          kargs[root] = types.fetch(type.fetch("name")) if type
+        end
 
-        Schema.new(query: query, types: types.values)
+        Schema.define(**kargs)
       end
 
       class << self

--- a/spec/graphql/schema/loader_spec.rb
+++ b/spec/graphql/schema/loader_spec.rb
@@ -76,7 +76,17 @@ describe GraphQL::Schema::Loader do
       end
     end
 
-    GraphQL::Schema.define(query: query_root)
+    PingMutation = GraphQL::Relay::Mutation.define do
+      name "Ping"
+    end
+
+    mutation_root = GraphQL::ObjectType.define do
+      name "Mutation"
+      # The mutation object exposes a field:
+      field :ping, field: PingMutation.field
+    end
+
+    GraphQL::Schema.define(query: query_root, mutation: mutation_root)
   }
 
   let(:schema_json) {

--- a/spec/graphql/schema/loader_spec.rb
+++ b/spec/graphql/schema/loader_spec.rb
@@ -76,7 +76,7 @@ describe GraphQL::Schema::Loader do
       end
     end
 
-    GraphQL::Schema.new(query: query_root)
+    GraphQL::Schema.define(query: query_root)
   }
 
   let(:schema_json) {

--- a/spec/graphql/schema/loader_spec.rb
+++ b/spec/graphql/schema/loader_spec.rb
@@ -45,6 +45,22 @@ describe GraphQL::Schema::Loader do
       field :body, !types.String
     end
 
+    media_type = GraphQL::InterfaceType.define do
+      name "Media"
+      description "!!!"
+      field :type, !types.String
+    end
+
+    video_type = GraphQL::ObjectType.define do
+      name "Video"
+      interfaces [media_type]
+    end
+
+    audio_type = GraphQL::ObjectType.define do
+      name "Audio"
+      interfaces [media_type]
+    end
+
     post_type = GraphQL::ObjectType.define do
       name "Post"
       description "A blog post"
@@ -53,6 +69,7 @@ describe GraphQL::Schema::Loader do
       field :title, !types.String
       field :body, !types.String
       field :comments, types[!comment_type]
+      field :attachment, media_type
     end
 
     content_type = GraphQL::UnionType.define do
@@ -76,17 +93,16 @@ describe GraphQL::Schema::Loader do
       end
     end
 
-    PingMutation = GraphQL::Relay::Mutation.define do
+    ping_mutation = GraphQL::Relay::Mutation.define do
       name "Ping"
     end
 
     mutation_root = GraphQL::ObjectType.define do
       name "Mutation"
-      # The mutation object exposes a field:
-      field :ping, field: PingMutation.field
+      field :ping, field: ping_mutation.field
     end
 
-    GraphQL::Schema.define(query: query_root, mutation: mutation_root)
+    GraphQL::Schema.define(query: query_root, mutation: mutation_root, orphan_types: [audio_type, video_type])
   }
 
   let(:schema_json) {


### PR DESCRIPTION
1. Fix "Schema.new is deprecated, use Schema.define instead" deprecation warning.
2. Fix loading `ObjectType`'s interfaces
3. Fix loading other root types: mutation and subscriptions

I discovered the interface bug after switching from `Schema.new` to `Schema.define`. As `Schema.define` discovers all types from the roots, I noticed that the interface in the test file was no longer being discovered. So this case already has test coverage.