### PR TITLE
Resolve __type to null for type that doesn't exist

### DIFF
--- a/lib/graphql/introspection/type_by_name_field.rb
+++ b/lib/graphql/introspection/type_by_name_field.rb
@@ -6,9 +6,9 @@ module GraphQL
         GraphQL::Field.define do
           name("__type")
           description("A type in the GraphQL system")
-          type(!GraphQL::Introspection::TypeType)
+          type(GraphQL::Introspection::TypeType)
           argument :name, !types.String
-          resolve -> (o, args, c) { type_hash[args["name"]] }
+          resolve -> (o, args, c) { type_hash.fetch(args["name"], nil) }
         end
       end
     end

--- a/spec/graphql/introspection/type_type_spec.rb
+++ b/spec/graphql/introspection/type_type_spec.rb
@@ -8,6 +8,7 @@ describe GraphQL::Introspection::TypeType do
        dairyAnimal:   __type(name: "DairyAnimal") { name, kind, enumValues(includeDeprecated: false) { name, isDeprecated } }
        dairyProduct:  __type(name: "DairyProduct") { name, kind, possibleTypes { name } }
        animalProduct: __type(name: "AnimalProduct") { name, kind, possibleTypes { name }, fields { name } }
+       missingType:   __type(name: "NotAType") { name }
      }
   |}
   let(:result) { DummySchema.execute(query_string, context: {}, variables: {"cheeseId" => 2}) }
@@ -64,7 +65,8 @@ describe GraphQL::Introspection::TypeType do
         "fields"=>[
           {"name"=>"source"},
         ]
-      }
+      },
+      "missingType" => nil,
     }}
     assert_equal(expected, result)
   end


### PR DESCRIPTION
## Problem

The `__type` introspection field in the GraphQL spec is

```
__type(name: String!) : __Type
```

but graphql-ruby made it a non-null type, which gets a runtime error when the type isn't found.

## Solution

Make the result type nullable and return null if the type doesn't exist