### PR TITLE
fix(connection) use the field name, not the module name

### DIFF
--- a/lib/graphql/define/assign_connection.rb
+++ b/lib/graphql/define/assign_connection.rb
@@ -4,7 +4,7 @@ module GraphQL
       def self.call(type_defn, *field_args, max_page_size: nil, **field_kwargs, &field_block)
         underlying_field = GraphQL::Define::AssignObjectField.call(type_defn, *field_args, **field_kwargs, &field_block)
         connection_field = GraphQL::Relay::ConnectionField.create(underlying_field, max_page_size: max_page_size)
-        type_defn.fields[name.to_s] = connection_field
+        type_defn.fields[underlying_field.name] = connection_field
       end
     end
   end


### PR DESCRIPTION
Derp, this was definitely from a faulty refactor, let me try to find that commit. Fixes #234 

Amazingly, it still worked because `ConnectionField` _modifies_ the incoming field instead of creating a new one. I guess if it had made a new field, we would have noticed this right away though, since tests would have broken.

cc @gjtorikian 