### PR TITLE
Fix leaked global constant

### DIFF
--- a/lib/graphql/boolean_type.rb
+++ b/lib/graphql/boolean_type.rb
@@ -1,10 +1,7 @@
 GraphQL::BOOLEAN_TYPE = GraphQL::ScalarType.define do
-  # Everything else is nil
-  ALLOWED_INPUTS = [true, false]
-
   name "Boolean"
   description "Represents `true` or `false` values."
 
-  coerce_input -> (value) { ALLOWED_INPUTS.include?(value) ? value : nil }
+  coerce_input -> (value) { (value == true || value == false) ? value : nil }
   coerce_result -> (value) { !!value }
 end


### PR DESCRIPTION
Constants defined in blocks are hoisted into the parent module scope. In this `GraphQL::BOOLEAN_TYPE` case, the global `Object` scope.

``` ruby
require 'graphql'
GraphQL::BOOLEAN_TYPE.name
::ALLOWED_INPUTS #=> [true, false]
```

In this case I simply replaced the constant with an equality test. Its probably faster in some micro benchmark since it doesn't need to go through `Array#include?` first.