### PR TITLE
Definition slicing

### DIFF
--- a/lib/graphql/language.rb
+++ b/lib/graphql/language.rb
@@ -1,3 +1,4 @@
+require "graphql/language/definition_slice"
 require "graphql/language/generation"
 require "graphql/language/lexer"
 require "graphql/language/nodes"

--- a/lib/graphql/language/definition_slice.rb
+++ b/lib/graphql/language/definition_slice.rb
@@ -1,0 +1,29 @@
+module GraphQL
+  module Language
+    module DefinitionSlice
+      extend self
+
+      def slice(document, name)
+        definitions = {}
+        document.definitions.each { |d| definitions[d.name] = d }
+        names = find_definition_dependencies(definitions, name)
+        definitions = document.definitions.select { |d| names.include?(d.name) }
+        Nodes::Document.new(definitions: definitions)
+      end
+
+      private
+
+      def find_definition_dependencies(definitions, name)
+        names = Set.new([name])
+        visitor = Visitor.new(definitions[name])
+        visitor[Nodes::FragmentSpread] << -> (node, parent) {
+          if fragment = definitions[node.name]
+            names.merge(find_definition_dependencies(definitions, fragment.name))
+          end
+        }
+        visitor.visit
+        names
+      end
+    end
+  end
+end

--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -129,6 +129,10 @@ module GraphQL
         def initialize_node(definitions: [])
           @definitions = definitions
         end
+
+        def slice_definition(name)
+          GraphQL::Language::DefinitionSlice.slice(self, name)
+        end
       end
 
       class Enum < NameOnlyNode; end

--- a/spec/graphql/language/definition_slice_spec.rb
+++ b/spec/graphql/language/definition_slice_spec.rb
@@ -1,0 +1,225 @@
+require "spec_helper"
+
+describe GraphQL::Language::DefinitionSlice do
+  let(:document) { GraphQL::Language::Parser.parse(query_string) }
+
+  describe "anonymous query with no dependencies" do
+    let(:query_string) {%|
+      {
+        version
+      }
+    |}
+
+    it "is already the smallest slice" do
+      assert_equal document.to_query_string,
+        document.slice_definition(nil).to_query_string
+    end
+  end
+
+  describe "anonymous mutation with no dependencies" do
+    let(:query_string) {%|
+      mutation {
+        ping {
+          message
+        }
+      }
+    |}
+
+    it "is already the smallest slice" do
+      assert_equal document.to_query_string,
+        document.slice_definition(nil).to_query_string
+    end
+  end
+
+  describe "anonymous fragment with no dependencies" do
+    let(:query_string) {%|
+      fragment on User {
+        name
+      }
+    |}
+
+    it "is already the smallest slice" do
+      assert_equal document.to_query_string,
+        document.slice_definition(nil).to_query_string
+    end
+  end
+
+  describe "named query with no dependencies" do
+    let(:query_string) {%|
+      query getVersion {
+        version
+      }
+    |}
+
+    it "is already the smallest slice" do
+      assert_equal document.to_query_string,
+        document.slice_definition("getVersion").to_query_string
+    end
+  end
+
+  describe "named fragment with no dependencies" do
+    let(:query_string) {%|
+      fragment profileFields on User {
+        firstName
+        lastName
+      }
+    |}
+
+    it "is already the smallest slice" do
+      assert_equal document.to_query_string,
+        document.slice_definition("profileFields").to_query_string
+    end
+  end
+
+  describe "document with multiple queries but no subdependencies" do
+    let(:query_string) {%|
+      query getVersion {
+        version
+      }
+
+      query getTime {
+        time
+      }
+    |}
+
+    it "returns just the query definition" do
+      assert_equal GraphQL::Language::Nodes::Document.new(definitions: [document.definitions[0]]).to_query_string,
+        document.slice_definition("getVersion").to_query_string
+      assert_equal GraphQL::Language::Nodes::Document.new(definitions: [document.definitions[1]]).to_query_string,
+        document.slice_definition("getTime").to_query_string
+    end
+  end
+
+  describe "document with multiple fragments but no subdependencies" do
+    let(:query_string) {%|
+      fragment profileFields on User {
+        firstName
+        lastName
+      }
+
+      fragment avatarFields on User {
+        avatarURL(size: 80)
+      }
+    |}
+
+    it "returns just the fragment definition" do
+      assert_equal GraphQL::Language::Nodes::Document.new(definitions: [document.definitions[0]]).to_query_string,
+        document.slice_definition("profileFields").to_query_string
+      assert_equal GraphQL::Language::Nodes::Document.new(definitions: [document.definitions[1]]).to_query_string,
+        document.slice_definition("avatarFields").to_query_string
+    end
+  end
+
+  describe "query with missing spread" do
+    let(:query_string) {%|
+      query getUser {
+        viewer {
+          ...profileFields
+        }
+      }
+    |}
+
+    it "is ignored" do
+      assert_equal document.to_query_string,
+        document.slice_definition("getUser").to_query_string
+    end
+  end
+
+  describe "query and fragment subdependency" do
+    let(:query_string) {%|
+      query getUser {
+        viewer {
+          ...profileFields
+        }
+      }
+
+      fragment profileFields on User {
+        firstName
+        lastName
+      }
+    |}
+
+    it "returns query and fragment dependency" do
+      assert_equal document.to_query_string,
+        document.slice_definition("getUser").to_query_string
+    end
+  end
+
+  describe "query and fragment nested subdependencies" do
+    let(:query_string) {%|
+      query getUser {
+        viewer {
+          ...viewerInfo
+        }
+      }
+
+      fragment viewerInfo on User {
+        ...profileFields
+      }
+
+      fragment profileFields on User {
+        firstName
+        lastName
+        ...avatarFields
+      }
+
+      fragment avatarFields on User {
+        avatarURL(size: 80)
+      }
+    |}
+
+    it "returns query and all fragment dependencies" do
+      assert_equal document.to_query_string,
+        document.slice_definition("getUser").to_query_string
+    end
+  end
+
+  describe "fragment subdependency referenced multiple times" do
+    let(:query_string) {%|
+      query getUser {
+        viewer {
+          ...viewerInfo
+          ...moreViewerInfo
+        }
+      }
+
+      fragment viewerInfo on User {
+        ...profileFields
+      }
+
+      fragment moreViewerInfo on User {
+        ...profileFields
+      }
+
+      fragment profileFields on User {
+        firstName
+        lastName
+      }
+    |}
+
+    it "is only returned once" do
+      assert_equal document.to_query_string,
+        document.slice_definition("getUser").to_query_string
+    end
+  end
+
+  describe "query and unused fragment" do
+    let(:query_string) {%|
+      query getUser {
+        viewer {
+          id
+        }
+      }
+
+      fragment profileFields on User {
+        firstName
+        lastName
+      }
+    |}
+
+    it "returns just the query definition" do
+      assert_equal GraphQL::Language::Nodes::Document.new(definitions: [document.definitions[0]]).to_query_string,
+        document.slice_definition("getUser").to_query_string
+    end
+  end
+end


### PR DESCRIPTION
Follow up discussion from #236.

``` ruby
document = GraphQL.parse <<-'GRAPHQL' 
query FooQuery { ...FooFragment }
query BarQuery { ...BarFragment }
query BazQuery { ...BarFragment }
mutation FooMutation { ... }
fragment FooFragment on Foo { ... }
fragment BarFragment on Bar { ... }
GRAPHQL

sliced_document = document.slice_definition("FooQuery")
sliced_document == <<-'GRAPHQL'
query FooQuery { ...FooFragment }
fragment FooFragment on Foo { ... }
GRAPHQL
```

I think the name "slice" is okay, but I don't love it. Trying to brainstorm some other terminology for this algorithm.