### PR TITLE
Require forwardable explicitly

### DIFF
--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -1,6 +1,7 @@
 require "json"
 require "set"
 require "singleton"
+require "forwardable"
 
 module GraphQL
   class Error < StandardError


### PR DESCRIPTION
Hey,

I created a simple file like:

```ruby
# dump_schema.rb

require 'graphql'
require 'faraday'

introspection_query = GraphQL::Introspection::INTROSPECTION_QUERY.gsub("\n", "")
response = Faraday.post(ENV['GRAPHQL_URL'], "{\"query\": \"#{introspection_query}\"}")
File.write('graph/schema.json', response.body)
```

And when I try to run it:

```
> GRAPHQL_URL="http://127.0.0.1:5000/graphql" ruby lib/dump_schema.rb
```

I raises an error:

```
graphql-0.18.7/lib/graphql/schema/type_map.rb:10:in `<class:TypeMap>': 
uninitialized constant GraphQL::Schema::TypeMap::Forwardable (NameError)
```

In my opinion, `graphql` should require `Forwardable` explicitly as it's a part of Ruby `stdlib` (not `core`).