### PR TITLE
feat(Introspection) sort lists by name

### DIFF
--- a/lib/graphql/introspection/arguments_field.rb
+++ b/lib/graphql/introspection/arguments_field.rb
@@ -1,5 +1,5 @@
 GraphQL::Introspection::ArgumentsField = GraphQL::Field.define do
   description "Arguments allowed to this object"
   type !GraphQL::ListType.new(of_type: !GraphQL::Introspection::InputValueType)
-  resolve -> (target, a, c) { target.arguments.values }
+  resolve -> (target, a, c) { target.arguments.values.sort_by(&:name) }
 end

--- a/lib/graphql/introspection/enum_values_field.rb
+++ b/lib/graphql/introspection/enum_values_field.rb
@@ -8,6 +8,6 @@ GraphQL::Introspection::EnumValuesField = GraphQL::Field.define do
     if !arguments["includeDeprecated"]
       fields = fields.select {|f| !f.deprecation_reason }
     end
-    fields
+    fields.sort_by(&:name)
   end
 end

--- a/lib/graphql/introspection/input_fields_field.rb
+++ b/lib/graphql/introspection/input_fields_field.rb
@@ -4,7 +4,7 @@ GraphQL::Introspection::InputFieldsField = GraphQL::Field.define do
   type types[!GraphQL::Introspection::InputValueType]
   resolve -> (target, a, c) {
     if target.kind.input_object?
-      target.input_fields.values
+      target.input_fields.values.sort_by(&:name)
     else
       nil
     end

--- a/lib/graphql/introspection/interfaces_field.rb
+++ b/lib/graphql/introspection/interfaces_field.rb
@@ -1,5 +1,5 @@
 GraphQL::Introspection::InterfacesField = GraphQL::Field.define do
   description "Interfaces which this object implements"
   type -> { types[!GraphQL::Introspection::TypeType] }
-  resolve -> (target, a, c) { target.kind.object? ? target.interfaces : nil }
+  resolve -> (target, a, c) { target.kind.object? ? target.interfaces.sort_by(&:name) : nil }
 end

--- a/lib/graphql/introspection/possible_types_field.rb
+++ b/lib/graphql/introspection/possible_types_field.rb
@@ -3,7 +3,7 @@ GraphQL::Introspection::PossibleTypesField = GraphQL::Field.define do
   type -> { types[!GraphQL::Introspection::TypeType] }
   resolve -> (target, args, ctx) {
     if target.kind.resolves?
-      ctx.schema.possible_types(target)
+      ctx.schema.possible_types(target).sort_by(&:name)
     else
       nil
     end

--- a/lib/graphql/introspection/schema_type.rb
+++ b/lib/graphql/introspection/schema_type.rb
@@ -3,11 +3,11 @@ GraphQL::Introspection::SchemaType = GraphQL::ObjectType.define do
   description "A GraphQL schema"
 
   field :types, !types[!GraphQL::Introspection::TypeType], "Types in this schema" do
-    resolve -> (obj, arg, ctx) { obj.types.values }
+    resolve -> (obj, arg, ctx) { obj.types.values.sort_by(&:name) }
   end
 
   field :directives, !types[!GraphQL::Introspection::DirectiveType], "Directives in this schema" do
-    resolve -> (obj, arg, ctx) { obj.directives.values }
+    resolve -> (obj, arg, ctx) { obj.directives.values.sort_by(&:name) }
   end
 
   field :queryType, !GraphQL::Introspection::TypeType, "The query root of this schema" do

--- a/spec/graphql/introspection/directive_type_spec.rb
+++ b/spec/graphql/introspection/directive_type_spec.rb
@@ -23,7 +23,7 @@ describe GraphQL::Introspection::DirectiveType do
       "__schema" => {
         "directives" => [
           {
-            "name" => "skip",
+            "name" => "include",
             "args" => [
               {"name"=>"if", "type"=>{"name"=>"Non-Null", "ofType"=>{"name"=>"Boolean"}}}
             ],
@@ -33,7 +33,7 @@ describe GraphQL::Introspection::DirectiveType do
             "onOperation" => false,
           },
           {
-            "name" => "include",
+            "name" => "skip",
             "args" => [
               {"name"=>"if", "type"=>{"name"=>"Non-Null", "ofType"=>{"name"=>"Boolean"}}}
             ],

--- a/spec/graphql/introspection/input_value_type_spec.rb
+++ b/spec/graphql/introspection/input_value_type_spec.rb
@@ -26,14 +26,10 @@ describe GraphQL::Introspection::InputValueType do
           "description"=>"Properties for finding a dairy product",
           "kind"=>"INPUT_OBJECT",
           "inputFields"=>[
-            {"name"=>"source", "type"=>{ "name" => "Non-Null"}, "defaultValue"=>nil,
-             "description" => "Where it came from"},
-            {"name"=>"originDairy", "type"=>{ "name" => "String"}, "defaultValue"=>"\"Sugar Hollow Dairy\"",
-             "description" => "Dairy which produced it"},
-            {"name"=>"fatContent", "type"=>{ "name" => "Float"}, "defaultValue"=>"0.3",
-             "description" => "How much fat it has"},
-            {"name"=>"organic", "type"=>{ "name" => "Boolean"}, "defaultValue"=>"false",
-             "description" => nil}
+            {"name"=>"fatContent", "type"=>{ "name" => "Float"}, "defaultValue"=>"0.3","description" => "How much fat it has"},
+            {"name"=>"organic", "type"=>{ "name" => "Boolean"}, "defaultValue"=>"false","description" => nil},
+            {"name"=>"originDairy", "type"=>{ "name" => "String"}, "defaultValue"=>"\"Sugar Hollow Dairy\"","description" => "Dairy which produced it"},
+            {"name"=>"source", "type"=>{ "name" => "Non-Null"}, "defaultValue"=>nil,"description" => "Where it came from"},
           ]
         }
       }}

--- a/spec/graphql/introspection/schema_type_spec.rb
+++ b/spec/graphql/introspection/schema_type_spec.rb
@@ -13,9 +13,15 @@ describe GraphQL::Introspection::SchemaType do
   let(:result) { DummySchema.execute(query_string) }
 
   it "exposes the schema" do
+    expected_type_names = DummySchema
+      .types
+      .values
+      .sort_by(&:name)
+      .map { |t| t.name.nil? ? (p t; raise("no name for #{t}")) : {"name" => t.name} }
+
     expected = { "data" => {
       "__schema" => {
-        "types" => DummySchema.types.values.map { |t| t.name.nil? ? (p t; raise("no name for #{t}")) : {"name" => t.name} },
+        "types" => expected_type_names,
         "queryType"=>{
           "fields"=>[
             {"name"=>"allDairy"},

--- a/spec/graphql/introspection/type_type_spec.rb
+++ b/spec/graphql/introspection/type_type_spec.rb
@@ -36,8 +36,8 @@ describe GraphQL::Introspection::TypeType do
       },
       "milkType"=>{
         "interfaces"=>[
-          {"name"=>"Edible"},
           {"name"=>"AnimalProduct"},
+          {"name"=>"Edible"},
           {"name"=>"LocalProduct"},
         ],
         "fields"=>[
@@ -56,7 +56,7 @@ describe GraphQL::Introspection::TypeType do
       "dairyProduct"=>{
         "name"=>"DairyProduct",
         "kind"=>"UNION",
-        "possibleTypes"=>[{"name"=>"Milk"}, {"name"=>"Cheese"}],
+        "possibleTypes"=>[{"name"=>"Cheese"}, {"name"=>"Milk"},],
       },
       "animalProduct" => {
         "name"=>"AnimalProduct",
@@ -111,10 +111,10 @@ describe GraphQL::Introspection::TypeType do
               "description"=>"Properties for finding a dairy product",
               "kind"=>"INPUT_OBJECT",
               "inputFields"=>[
-                {"name"=>"source", "type"=>{ "name" => "Non-Null"}, "defaultValue"=>nil},
-                {"name"=>"originDairy", "type"=>{"name"=>"String"}, "defaultValue"=>"\"Sugar Hollow Dairy\""},
                 {"name"=>"fatContent", "type"=>{ "name" => "Float"}, "defaultValue"=>"0.3"},
                 {"name"=>"organic", "type"=>{ "name" => "Boolean"}, "defaultValue"=>"false"},
+                {"name"=>"originDairy", "type"=>{"name"=>"String"}, "defaultValue"=>"\"Sugar Hollow Dairy\""},
+                {"name"=>"source", "type"=>{ "name" => "Non-Null"}, "defaultValue"=>nil},
               ]
             }
           }}

--- a/spec/graphql/schema/loader_spec.rb
+++ b/spec/graphql/schema/loader_spec.rb
@@ -142,8 +142,8 @@ describe GraphQL::Schema::Loader do
       when GraphQL::EnumType
         assert_equal expected_type.name, actual_type.name
         assert_equal expected_type.description, actual_type.description
-        assert_equal expected_type.values.keys, actual_type.values.keys
-        assert_deep_equal expected_type.values.values, actual_type.values.values
+        assert_equal expected_type.values.keys.sort, actual_type.values.keys.sort
+        assert_deep_equal expected_type.values.values.sort_by(&:name), actual_type.values.values.sort_by(&:name)
 
       when GraphQL::EnumType::EnumValue
         assert_equal expected_type.name, actual_type.name
@@ -155,8 +155,8 @@ describe GraphQL::Schema::Loader do
         assert_deep_equal expected_type.type, actual_type.type
 
       when GraphQL::InputObjectType
-        assert_equal expected_type.arguments.keys, actual_type.arguments.keys
-        assert_deep_equal expected_type.arguments.values, actual_type.arguments.values
+        assert_equal expected_type.arguments.keys.sort, actual_type.arguments.keys.sort
+        assert_deep_equal expected_type.arguments.values.sort_by(&:name), actual_type.arguments.values.sort_by(&:name)
 
       when GraphQL::NonNullType, GraphQL::ListType
         assert_deep_equal expected_type.of_type, actual_type.of_type


### PR DESCRIPTION
For a normal human, the introspection result is not useful because the results are in a meaningless order. It could be better for normal humans if they're sorted. 

However, this is basically the wrong approach. Assuming your endpoint executes an introspection query _every time_ someone opens up GraphiQL, we should _maintain_ sorted lists instead of sorting them _again_ every time!

__TODO__

- [ ] find a way to not sort every time (each object maintains sorted members? maintain a sorted cache in `Introspection` somewhere?)