### PR TITLE
Deep freeze nodes

### DIFF
--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -68,6 +68,20 @@ module GraphQL
         def to_query_string
           Generation.generate(self)
         end
+
+        def freeze
+          self.class.child_attributes.each do |attr_name|
+            public_send(attr_name).freeze.each(&:freeze)
+          end
+
+          self.class.scalar_attributes.each do |attr_name|
+            if object = public_send(attr_name)
+              object.freeze
+            end
+          end
+          
+          super
+        end
       end
 
       class WrapperType < AbstractNode

--- a/spec/graphql/language/parser_spec.rb
+++ b/spec/graphql/language/parser_spec.rb
@@ -18,6 +18,20 @@ describe GraphQL::Language::Parser do
         assert document
       end
 
+      it "freeze deep freezes child nodes" do
+        refute document.frozen?
+        refute document.definitions.frozen?
+        refute document.definitions.first.frozen?
+        refute document.definitions.first.type.frozen?
+
+        document.freeze
+
+        assert document.frozen?
+        assert document.definitions.frozen?
+        assert document.definitions.first.frozen?
+        assert document.definitions.first.type.frozen?
+      end
+
       describe "visited nodes" do
         let(:fragment) { document.definitions.first }
 


### PR DESCRIPTION
Return of #156.

Addresses the original issue of scalars not being frozen. https://github.com/rmosolgo/graphql-ruby/pull/156#issuecomment-220033187