### PR TITLE
Validation: Report field doesn't exist error on field, not parent

### DIFF
--- a/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb
+++ b/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb
@@ -23,7 +23,7 @@ module GraphQL
 
         field =  parent_type.get_field(ast_field.name)
         if field.nil?
-          context.errors << message("Field '#{ast_field.name}' doesn't exist on type '#{parent_type.name}'", parent, context: context)
+          context.errors << message("Field '#{ast_field.name}' doesn't exist on type '#{parent_type.name}'", ast_field, context: context)
           return GraphQL::Language::Visitor::SKIP
         end
       end

--- a/spec/graphql/static_validation/rules/fields_are_defined_on_type_spec.rb
+++ b/spec/graphql/static_validation/rules/fields_are_defined_on_type_spec.rb
@@ -26,6 +26,21 @@ describe GraphQL::StaticValidation::FieldsAreDefinedOnType do
     assert_equal(expected_errors, error_messages)
   end
 
+  describe "on objects" do
+    let(:query_string) { "query getStuff { notDefinedField }"}
+
+    it "finds invalid fields" do
+      expected_errors = [
+        {
+          "message"=>"Field 'notDefinedField' doesn't exist on type 'Query'",
+          "locations"=>[{"line"=>1, "column"=>18}],
+          "path"=>["query getStuff", "notDefinedField"],
+        }
+      ]
+      assert_equal(expected_errors, errors)
+    end
+  end
+
   describe "on interfaces" do
     let(:query_string) { "query getStuff { favoriteEdible { amountThatILikeIt } }"}
 
@@ -33,7 +48,7 @@ describe GraphQL::StaticValidation::FieldsAreDefinedOnType do
       expected_errors = [
         {
           "message"=>"Field 'amountThatILikeIt' doesn't exist on type 'Edible'",
-          "locations"=>[{"line"=>1, "column"=>18}],
+          "locations"=>[{"line"=>1, "column"=>35}],
           "path"=>["query getStuff", "favoriteEdible", "amountThatILikeIt"],
         }
       ]


### PR DESCRIPTION
Unless I'm missing some edge case, doesn't it make more sense to report the line/column of the invalid field than the parent object?

``` graphql
query {          # 1
  viewer {       # 2
    id           # 3          
    missingField # 4
  }              # 5
}                # 6
```

I'd expect `"Field 'missingField' doesn't exist on type 'User'"` on line `4` rather than line `2`.