### PR TITLE
feat(Arguments#key?) show when arguments were missing from the query

### DIFF
--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -20,6 +20,12 @@ module GraphQL
         @argument_values[key.to_s]
       end
 
+      # @param key [String, Symbol] name of value to access
+      # @return [Boolean] true if the argument was present in this field
+      def key?(key)
+        @argument_values.key?(key.to_s)
+      end
+
       # Get the original Ruby hash
       # @return [Hash] the original values hash
       def to_h

--- a/spec/graphql/query/arguments_spec.rb
+++ b/spec/graphql/query/arguments_spec.rb
@@ -69,6 +69,7 @@ describe GraphQL::Query::Arguments do
       # This is present from default value:
       assert_equal true, last_args.key?(:b)
       assert_equal false, last_args.key?(:c)
+      assert_equal({"a" => 1, "b" => 2}, last_args.to_h)
     end
 
     it "works from variables" do
@@ -85,6 +86,8 @@ describe GraphQL::Query::Arguments do
       # This _was_ present in the variables,
       # but it was nil, which is not allowed in GraphQL
       assert_equal false, test_inputs.key?(:d)
+
+      assert_equal({"a" => 1, "b" => 2}, test_inputs.to_h)
     end
 
     it "works with variable default values" do
@@ -98,6 +101,7 @@ describe GraphQL::Query::Arguments do
 
       assert_equal false, test_defaults.key?(:c)
       assert_equal false, test_defaults.key?(:d)
+      assert_equal({"a" => 1, "b" => 2}, test_defaults.to_h)
     end
   end
 end

--- a/spec/graphql/query/arguments_spec.rb
+++ b/spec/graphql/query/arguments_spec.rb
@@ -33,6 +33,7 @@ describe GraphQL::Query::Arguments do
         argument :a, types.Int
         argument :b, types.Int, default_value: 2
         argument :c, types.Int
+        argument :d, types.Int
       end
 
       query = GraphQL::ObjectType.define do
@@ -52,7 +53,7 @@ describe GraphQL::Query::Arguments do
       GraphQL::Schema.define(query: query)
     }
 
-    it "detects missing keys" do
+    it "detects missing keys by string or symbol" do
       assert_equal true, arguments.key?(:a)
       assert_equal true, arguments.key?("a")
       assert_equal false, arguments.key?(:f)
@@ -65,29 +66,25 @@ describe GraphQL::Query::Arguments do
       last_args = arg_values.last
 
       assert_equal true, last_args.key?(:a)
-      assert_equal true, last_args.key?("a")
       # This is present from default value:
       assert_equal true, last_args.key?(:b)
-      assert_equal true, last_args.key?("b")
-
       assert_equal false, last_args.key?(:c)
-      assert_equal false, last_args.key?("c")
     end
 
     it "works from variables" do
-      variables = { "arg" => { "a" => 1 } }
+      variables = { "arg" => { "a" => 1, "d" => nil } }
       schema.execute("query ArgTest($arg: TestInput){ argTest(d: $arg) }", variables: variables)
 
       test_inputs = arg_values.last["d"]
 
       assert_equal true, test_inputs.key?(:a)
-      assert_equal true, test_inputs.key?("a")
       # This is present from default value:
       assert_equal true, test_inputs.key?(:b)
-      assert_equal true, test_inputs.key?("b")
 
       assert_equal false, test_inputs.key?(:c)
-      assert_equal false, test_inputs.key?("c")
+      # This _was_ present in the variables,
+      # but it was nil, which is not allowed in GraphQL
+      assert_equal false, test_inputs.key?(:d)
     end
 
     it "works with variable default values" do
@@ -96,12 +93,11 @@ describe GraphQL::Query::Arguments do
       test_defaults = arg_values.last["d"]
 
       assert_equal true, test_defaults.key?(:a)
-      assert_equal true, test_defaults.key?("a")
-      # This is present from default value:
+      # This is present from default val
       assert_equal true, test_defaults.key?(:b)
-      assert_equal true, test_defaults.key?("b")
+
       assert_equal false, test_defaults.key?(:c)
-      assert_equal false, test_defaults.key?("c")
+      assert_equal false, test_defaults.key?(:d)
     end
   end
 end

--- a/spec/graphql/query/arguments_spec.rb
+++ b/spec/graphql/query/arguments_spec.rb
@@ -22,4 +22,86 @@ describe GraphQL::Query::Arguments do
   it "returns original Ruby hash values with to_h" do
     assert_equal({ a: 1, b: 2, c: { d: 3, e: 4 } }, arguments.to_h)
   end
+
+  describe "#key?" do
+    let(:arg_values) { [] }
+    let(:schema) {
+      arg_values_array = arg_values
+
+      test_input_type = GraphQL::InputObjectType.define do
+        name "TestInput"
+        argument :a, types.Int
+        argument :b, types.Int, default_value: 2
+        argument :c, types.Int
+      end
+
+      query = GraphQL::ObjectType.define do
+        name "Query"
+        field :argTest, types.Int do
+          argument :a, types.Int
+          argument :b, types.Int, default_value: 2
+          argument :c, types.Int
+          argument :d, test_input_type
+          resolve -> (obj, args, ctx) {
+            arg_values_array << args
+            1
+          }
+        end
+      end
+
+      GraphQL::Schema.define(query: query)
+    }
+
+    it "detects missing keys" do
+      assert_equal true, arguments.key?(:a)
+      assert_equal true, arguments.key?("a")
+      assert_equal false, arguments.key?(:f)
+      assert_equal false, arguments.key?("f")
+    end
+
+    it "works from query literals" do
+      schema.execute("{ argTest(a: 1) }")
+
+      last_args = arg_values.last
+
+      assert_equal true, last_args.key?(:a)
+      assert_equal true, last_args.key?("a")
+      # This is present from default value:
+      assert_equal true, last_args.key?(:b)
+      assert_equal true, last_args.key?("b")
+
+      assert_equal false, last_args.key?(:c)
+      assert_equal false, last_args.key?("c")
+    end
+
+    it "works from variables" do
+      variables = { "arg" => { "a" => 1 } }
+      schema.execute("query ArgTest($arg: TestInput){ argTest(d: $arg) }", variables: variables)
+
+      test_inputs = arg_values.last["d"]
+
+      assert_equal true, test_inputs.key?(:a)
+      assert_equal true, test_inputs.key?("a")
+      # This is present from default value:
+      assert_equal true, test_inputs.key?(:b)
+      assert_equal true, test_inputs.key?("b")
+
+      assert_equal false, test_inputs.key?(:c)
+      assert_equal false, test_inputs.key?("c")
+    end
+
+    it "works with variable default values" do
+      schema.execute("query ArgTest($arg: TestInput = {a: 1}){ argTest(d: $arg) }")
+
+      test_defaults = arg_values.last["d"]
+
+      assert_equal true, test_defaults.key?(:a)
+      assert_equal true, test_defaults.key?("a")
+      # This is present from default value:
+      assert_equal true, test_defaults.key?(:b)
+      assert_equal true, test_defaults.key?("b")
+      assert_equal false, test_defaults.key?(:c)
+      assert_equal false, test_defaults.key?("c")
+    end
+  end
 end


### PR DESCRIPTION
Only put keys in the `Arguments` instance if the key was present in the query in some way. And use `#key?` to show whether it was present or missing.