### PR TITLE
Gracefully handle mutations when there is no mutation root

### DIFF
--- a/lib/graphql/internal_representation/rewrite.rb
+++ b/lib/graphql/internal_representation/rewrite.rb
@@ -33,7 +33,7 @@ module GraphQL
 
         visitor[Nodes::OperationDefinition].enter << -> (ast_node, prev_ast_node) {
           node = Node.new(
-            return_type: context.type_definition.unwrap,
+            return_type: context.type_definition && context.type_definition.unwrap,
             ast_node: ast_node,
             name: ast_node.name,
             parent: nil,

--- a/lib/graphql/static_validation/all_rules.rb
+++ b/lib/graphql/static_validation/all_rules.rb
@@ -25,6 +25,7 @@ module GraphQL
       GraphQL::StaticValidation::VariablesAreUsedAndDefined,
       GraphQL::StaticValidation::VariableUsagesAreAllowed,
       GraphQL::StaticValidation::MutationRootExists,
+      GraphQL::StaticValidation::SubscriptionRootExists,
     ]
   end
 end

--- a/lib/graphql/static_validation/all_rules.rb
+++ b/lib/graphql/static_validation/all_rules.rb
@@ -24,6 +24,7 @@ module GraphQL
       GraphQL::StaticValidation::VariableDefaultValuesAreCorrectlyTyped,
       GraphQL::StaticValidation::VariablesAreUsedAndDefined,
       GraphQL::StaticValidation::VariableUsagesAreAllowed,
+      GraphQL::StaticValidation::MutationRootExists,
     ]
   end
 end

--- a/lib/graphql/static_validation/rules/mutation_root_exists.rb
+++ b/lib/graphql/static_validation/rules/mutation_root_exists.rb
@@ -1,0 +1,20 @@
+module GraphQL
+  module StaticValidation
+    class MutationRootExists
+      include GraphQL::StaticValidation::Message::MessageHelper
+
+      def validate(context)
+        return if context.schema.mutation
+
+        visitor = context.visitor
+
+        visitor[GraphQL::Language::Nodes::OperationDefinition].enter << -> (ast_node, prev_ast_node) {
+          if ast_node.operation_type == 'mutation'
+            context.errors << message('Schema is not configured for mutations', ast_node, context: context)
+            return GraphQL::Language::Visitor::SKIP
+          end
+        }
+      end
+    end
+  end
+end

--- a/lib/graphql/static_validation/rules/subscription_root_exists.rb
+++ b/lib/graphql/static_validation/rules/subscription_root_exists.rb
@@ -1,0 +1,20 @@
+module GraphQL
+  module StaticValidation
+    class SubscriptionRootExists
+      include GraphQL::StaticValidation::Message::MessageHelper
+
+      def validate(context)
+        return if context.schema.subscription
+
+        visitor = context.visitor
+
+        visitor[GraphQL::Language::Nodes::OperationDefinition].enter << -> (ast_node, prev_ast_node) {
+          if ast_node.operation_type == 'subscription'
+            context.errors << message('Schema is not configured for subscriptions', ast_node, context: context)
+            return GraphQL::Language::Visitor::SKIP
+          end
+        }
+      end
+    end
+  end
+end

--- a/spec/graphql/static_validation/rules/mutation_root_exists_spec.rb
+++ b/spec/graphql/static_validation/rules/mutation_root_exists_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+describe GraphQL::StaticValidation::MutationRootExists do
+  let(:query_string) {%|
+    mutation addBagel {
+      introduceShip(input: {shipName: "Bagel"}) {
+        clientMutationId
+        shipEdge {
+          node { name, id }
+        }
+      }
+    }
+  |}
+
+  let(:schema) {
+    query_root = GraphQL::Field.define do
+      name "Query"
+      description "Query root of the system"
+    end
+
+    GraphQL::Schema.define do
+      query query_root
+    end
+  }
+
+  let(:validator) { GraphQL::StaticValidation::Validator.new(schema: schema, rules: [GraphQL::StaticValidation::MutationRootExists]) }
+  let(:query) { GraphQL::Query.new(schema, query_string) }
+  let(:errors) { validator.validate(query)[:errors] }
+
+  it "errors when a mutation is performed on a schema without a mutation root" do
+    assert_equal(1, errors.length)
+    missing_mutation_root_error = {
+      "message"=>"Schema is not configured for mutations",
+      "locations"=>[{"line"=>2, "column"=>5}],
+      "path"=>["mutation addBagel"],
+    }
+    assert_includes(errors, missing_mutation_root_error)
+  end
+end

--- a/spec/graphql/static_validation/rules/subscription_root_exists_spec.rb
+++ b/spec/graphql/static_validation/rules/subscription_root_exists_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+describe GraphQL::StaticValidation::SubscriptionRootExists do
+  let(:query_string) {%|
+    subscription {
+      test
+    }
+  |}
+
+  let(:schema) {
+    query_root = GraphQL::Field.define do
+      name "Query"
+      description "Query root of the system"
+    end
+
+    GraphQL::Schema.define do
+      query query_root
+    end
+  }
+
+  let(:validator) { GraphQL::StaticValidation::Validator.new(schema: schema, rules: [GraphQL::StaticValidation::SubscriptionRootExists]) }
+  let(:query) { GraphQL::Query.new(schema, query_string) }
+  let(:errors) { validator.validate(query)[:errors] }
+
+  it "errors when a subscription is performed on a schema without a subscription root" do
+    assert_equal(1, errors.length)
+    missing_subscription_root_error = {
+      "message"=>"Schema is not configured for subscriptions",
+      "locations"=>[{"line"=>2, "column"=>5}],
+      "path"=>["subscription"],
+    }
+    assert_includes(errors, missing_subscription_root_error)
+  end
+end


### PR DESCRIPTION
If a mutation is attempted on a schema that does not have a mutation root a `NoMethodError: undefined method unwrap for nil:NilClass` will occur originating from [lib/graphql/static_validation/type_stack.rb:108](https://github.com/rmosolgo/graphql-ruby/blob/dccbe895ca0cd194a0a8971850a7e13d37c37138/lib/graphql/static_validation/type_stack.rb#L108):

I noticed `graphql-js` handles this case by [returning a GraphQL error](https://github.com/graphql/graphql-js/blob/988508c9ee8e64e549b1028ffebdbbf4d22b4047/src/execution/execute.js#L268-L275).

@rmosolgo is a `StaticValidation` rule the right place for this?