### PR TITLE
Update @skip and @include processing with specs

### DIFF
--- a/lib/graphql/analysis/query_complexity.rb
+++ b/lib/graphql/analysis/query_complexity.rb
@@ -18,10 +18,13 @@ module GraphQL
       # State for the query complexity calcuation:
       # - `query` is needed for variables, then passed to handler
       # - `complexities_on_type` holds complexity scores for each type in an IRep node
+      # - `skip_depth` increments for each skipped node, then decrements on the way out.
+      #   While it's greater than `0`, we're visiting a skipped part of the query.
       def initial_value(query)
         {
           query: query,
           complexities_on_type: [TypeComplexity.new],
+          skip_depth: 0,
         }
       end
 
@@ -29,16 +32,22 @@ module GraphQL
       def call(memo, visit_type, irep_node)
         if irep_node.ast_node.is_a?(GraphQL::Language::Nodes::Field)
           if visit_type == :enter
-            memo[:complexities_on_type].push(TypeComplexity.new)
-          else
-            type_complexities = memo[:complexities_on_type].pop
-            own_complexity = if GraphQL::Execution::DirectiveChecks.skip?(irep_node, memo[:query])
-              0
-            else
-              child_complexity = type_complexities.max_possible_complexity
-              get_complexity(irep_node, memo[:query], child_complexity)
+            if irep_node.skipped?
+              memo[:skip_depth] += 1
+            elsif memo[:skip_depth] == 0
+              memo[:complexities_on_type].push(TypeComplexity.new)
             end
-            memo[:complexities_on_type].last.merge(irep_node.definitions, own_complexity)
+          else
+            if memo[:skip_depth] > 0
+              if irep_node.skipped?
+                memo[:skip_depth] -= 1
+              end
+            else
+              type_complexities = memo[:complexities_on_type].pop
+              child_complexity = type_complexities.max_possible_complexity
+              own_complexity = get_complexity(irep_node, memo[:query], child_complexity)
+              memo[:complexities_on_type].last.merge(irep_node.definitions, own_complexity)
+            end
           end
         end
         memo

--- a/lib/graphql/directive.rb
+++ b/lib/graphql/directive.rb
@@ -7,9 +7,9 @@ module GraphQL
   #
   class Directive
     include GraphQL::Define::InstanceDefinable
-    accepts_definitions :locations, :name, :description, :include_proc, argument: GraphQL::Define::AssignArgument
+    accepts_definitions :locations, :name, :description, argument: GraphQL::Define::AssignArgument
 
-    lazy_defined_attr_accessor :locations, :arguments, :name, :description, :include_proc
+    lazy_defined_attr_accessor :locations, :arguments, :name, :description
 
     LOCATIONS = [
       QUERY =               :QUERY,
@@ -23,10 +23,6 @@ module GraphQL
 
     def initialize
       @arguments = {}
-    end
-
-    def include?(arguments)
-      include_proc.call(arguments)
     end
 
     def to_s

--- a/lib/graphql/directive/include_directive.rb
+++ b/lib/graphql/directive/include_directive.rb
@@ -3,8 +3,4 @@ GraphQL::Directive::IncludeDirective = GraphQL::Directive.define do
   description "Include this part of the query if `if` is true"
   locations([GraphQL::Directive::FIELD, GraphQL::Directive::FRAGMENT_SPREAD, GraphQL::Directive::INLINE_FRAGMENT])
   argument :if, !GraphQL::BOOLEAN_TYPE
-
-  include_proc -> (arguments) {
-    arguments["if"]
-  }
 end

--- a/lib/graphql/directive/skip_directive.rb
+++ b/lib/graphql/directive/skip_directive.rb
@@ -4,8 +4,4 @@ GraphQL::Directive::SkipDirective = GraphQL::Directive.define do
   locations([GraphQL::Directive::FIELD, GraphQL::Directive::FRAGMENT_SPREAD, GraphQL::Directive::INLINE_FRAGMENT])
 
   argument :if, !GraphQL::BOOLEAN_TYPE
-
-  include_proc -> (arguments) {
-    !arguments["if"]
-  }
 end

--- a/lib/graphql/execution/directive_checks.rb
+++ b/lib/graphql/execution/directive_checks.rb
@@ -11,21 +11,22 @@ module GraphQL
       # This covers `@include(if:)` & `@skip(if:)`
       # @return [Boolean] Should this node be skipped altogether?
       def skip?(irep_node, query)
-        irep_node.directives.each do |directive_node|
-          if directive_node.name == SKIP || directive_node.name == INCLUDE
-            directive_defn = directive_node.definitions.first
-            args = query.arguments_for(directive_node, directive_defn)
-            if !directive_defn.include?(args)
-              return true
-            end
-          end
-        end
-        false
+        !include?(irep_node, query)
       end
 
       # @return [Boolean] Should this node be included in the query?
       def include?(irep_node, query)
-        !skip?(irep_node, query)
+        irep_node.directives.each do |directive|
+          name = directive.name
+          return false if name == SKIP && args(directive, query)['if'] == true
+          return false if name == INCLUDE && args(directive, query)['if'] == false
+        end
+        true
+      end
+
+      def args(directive_node, query)
+        directive_defn = directive_node.definitions.first
+        query.arguments_for(directive_node, directive_defn)
       end
     end
   end

--- a/lib/graphql/internal_representation/rewrite.rb
+++ b/lib/graphql/internal_representation/rewrite.rb
@@ -24,7 +24,7 @@ module GraphQL
         # This tracks dependencies from fragment to Node where it was used
         # { frag_name => [dependent_node, dependent_node]}
         @fragment_spreads = Hash.new { |h, k| h[k] = []}
-        # [Nodes::Directive ... ] directive affecting the current scope
+        # [[Nodes::Directive ...]] directive affecting the current scope
         @parent_directives = []
       end
 
@@ -55,6 +55,7 @@ module GraphQL
               name: node_name,
               definition_name: ast_node.name,
               parent: parent_node,
+              included: false, # may be set to true on leaving the node
             )
           end
           object_type = context.parent_type_definition.unwrap
@@ -64,20 +65,21 @@ module GraphQL
         }
 
         visitor[Nodes::InlineFragment].enter << -> (ast_node, prev_ast_node) {
-          @parent_directives.push([])
+          @parent_directives.push(InlineFragmentDirectives.new)
         }
 
         visitor[Nodes::Directive].enter << -> (ast_node, prev_ast_node) {
           # It could be a query error where a directive is somewhere it shouldn't be
           if @parent_directives.any?
-            @parent_directives.last << Node.new(
+            directive_irep_node = Node.new(
               name: ast_node.name,
               definition_name: ast_node.name,
               ast_node: ast_node,
-              definitions: [context.directive_definition],
+              definitions: {context.directive_definition => context.directive_definition},
               # This isn't used, the directive may have many parents in the case of inline fragment
               parent: nil,
             )
+            @parent_directives.last.push(directive_irep_node)
           end
         }
 
@@ -88,6 +90,7 @@ module GraphQL
             parent: parent_node,
             name: ast_node.name,
             ast_node: ast_node,
+            included: false, # this may be set to true on leaving the node
           )
           # The parent node has a reference to the fragment
           parent_node.spreads.push(spread_node)
@@ -117,8 +120,9 @@ module GraphQL
           # so that they can be applied to fields when
           # the fragment is merged in later
           spread_node = @nodes.pop
-          spread_node.directives.merge(@parent_directives.flatten)
-          @parent_directives.pop
+          applicable_directives = pop_applicable_directives(@parent_directives)
+          spread_node.included ||= GraphQL::Execution::DirectiveChecks.include?(applicable_directives, context.query)
+          spread_node.directives.merge(applicable_directives)
         }
 
         visitor[Nodes::FragmentDefinition].leave << -> (ast_node, prev_ast_node) {
@@ -139,8 +143,9 @@ module GraphQL
           # and record any directives that were visited
           # during this field & before it (eg, inline fragments)
           field_node = @nodes.pop
-          field_node.directives.merge(@parent_directives.flatten)
-          @parent_directives.pop
+          applicable_directives = pop_applicable_directives(@parent_directives)
+          field_node.directives.merge(applicable_directives)
+          field_node.included ||= GraphQL::Execution::DirectiveChecks.include?(applicable_directives, context.query)
         }
 
         visitor[Nodes::Document].leave << -> (ast_node, prev_ast_node) {
@@ -149,12 +154,14 @@ module GraphQL
           while fragment_node = @independent_fragments.pop
             fragment_usages = @fragment_spreads[fragment_node.name]
             while dependent_node = fragment_usages.pop
-              # remove self from dependent_node.spreads
-              rejected_spread_nodes = dependent_node.spreads.select { |spr| spr.name == fragment_node.name }
-              rejected_spread_nodes.each { |r_node| dependent_node.spreads.delete(r_node) }
+              # Find the spreads for this reference
+              resolved_spread_nodes = dependent_node.spreads.select { |spr| spr.name == fragment_node.name }
+              spread_is_included = resolved_spread_nodes.any?(&:included?)
+              # Since we're going to resolve them, remove them from the dependcies
+              resolved_spread_nodes.each { |r_node| dependent_node.spreads.delete(r_node) }
 
               # resolve the dependency (merge into dependent node)
-              deep_merge(dependent_node, fragment_node, rejected_spread_nodes.first.directives)
+              deep_merge(dependent_node, fragment_node, spread_is_included)
               owner = dependent_node.owner
               if owner.ast_node.is_a?(Nodes::FragmentDefinition) && !any_fragment_spreads?(owner)
                 @independent_fragments.push(owner)
@@ -166,26 +173,65 @@ module GraphQL
 
       private
 
-      # Merge the chilren from `fragment_node` into `parent_node`. Merge `directives` into each of those fields.
-      def deep_merge(parent_node, fragment_node, directives)
+      # Merge the children from `fragment_node` into `parent_node`.
+      # This is an implementation of "fragment inlining"
+      def deep_merge(parent_node, fragment_node, included)
         fragment_node.children.each do |name, child_node|
-          deep_merge_child(parent_node, name, child_node, directives)
+          deep_merge_child(parent_node, name, child_node, included)
         end
       end
 
-      # Merge `node` into `parent_node`'s children, as `name`, applying `extra_directives`
-      def deep_merge_child(parent_node, name, node, extra_directives)
-        child_node = parent_node.children[name] ||= node.dup
-        child_node.definitions.merge!(node.definitions)
-        node.children.each do |merge_child_name, merge_child_node|
-          deep_merge_child(child_node, merge_child_name, merge_child_node, [])
+      # Merge `node` into `parent_node`'s children, as `name`, applying `extra_included`
+      # `extra_included` comes from the spread node:
+      # - If the spread was included, first-level children should be included if _either_ node was included
+      # - If the spread was _not_ included, first-level children should be included if _a pre-existing_ node was included
+      #   (A copied node should be excluded)
+      def deep_merge_child(parent_node, name, node, extra_included)
+        child_node = parent_node.children[name]
+        previously_included = child_node.nil? ? false : child_node.included?
+        next_included = extra_included ? (previously_included || node.included?) : previously_included
+
+        if child_node.nil?
+          child_node = parent_node.children[name] = node.dup
         end
-        child_node.directives.merge(extra_directives)
+
+        child_node.definitions.merge!(node.definitions)
+
+        child_node.included = next_included
+
+
+
+        node.children.each do |merge_child_name, merge_child_node|
+          deep_merge_child(child_node, merge_child_name, merge_child_node, node.included)
+        end
       end
 
       # return true if node or _any_ children have a fragment spread
       def any_fragment_spreads?(node)
         node.spreads.any? || node.children.any? { |name, node| any_fragment_spreads?(node) }
+      end
+
+      # pop off own directives,
+      # then check the last one to see if it's directives
+      # from an inline fragment. If it is, add them in
+      # @return [Array<Node>]
+      def pop_applicable_directives(directive_stack)
+        own_directives = directive_stack.pop
+        if directive_stack.last.is_a?(InlineFragmentDirectives)
+          own_directives = directive_stack.last + own_directives
+        end
+        own_directives
+      end
+
+
+      # It's an array, but can be identified with `is_a?`
+      class InlineFragmentDirectives
+        extend Forwardable
+        def initialize
+          @storage = []
+        end
+
+        def_delegators :@storage, :push, :+
       end
     end
   end

--- a/lib/graphql/query/serial_execution/selection_resolution.rb
+++ b/lib/graphql/query/serial_execution/selection_resolution.rb
@@ -13,7 +13,7 @@ module GraphQL
 
         def result
           irep_node.children.each_with_object({}) do |(name, irep_node), memo|
-            if GraphQL::Execution::DirectiveChecks.include?(irep_node, execution_context.query) && applies_to_type?(irep_node, type)
+            if irep_node.included? && applies_to_type?(irep_node, type)
               field_result = execution_context.strategy.field_resolution.new(
                 irep_node,
                 type,

--- a/spec/graphql/directive_spec.rb
+++ b/spec/graphql/directive_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
 
 describe GraphQL::Directive do
-  let(:result) { DummySchema.execute(query_string, variables: {"t" => true, "f" => false}) }
+  let(:variables) { {"t" => true, "f" => false} }
+  let(:result) { DummySchema.execute(query_string, variables: variables) }
   describe "on fields" do
     let(:query_string) { %|query directives($t: Boolean!, $f: Boolean!) {
       cheese(id: 1) {
@@ -72,6 +73,137 @@ describe GraphQL::Directive do
         },
       }}
       assert_equal(expected, result)
+    end
+  end
+  describe "merging @skip and @include" do
+    let(:field_included?) { r = result["data"]["cheese"]; r.has_key?('flavor') && r.has_key?('withVariables') }
+    let(:skip?) { false }
+    let(:include?) { true }
+    let(:variables) { {"skip" => skip?, "include" => include?} }
+    let(:query_string) {"
+      query getCheese ($include: Boolean!, $skip: Boolean!) {
+        cheese(id: 1) {
+          flavor @include(if: #{include?}) @skip(if: #{skip?}),
+          withVariables: flavor @include(if: $include) @skip(if: $skip)
+        }
+      }
+    "}
+    # behavior as defined in
+    # https://github.com/facebook/graphql/blob/master/spec/Section%203%20--%20Type%20System.md#include
+    describe "when @skip=false and @include=true" do
+      let(:skip?) { false }
+      let(:include?) { true }
+      it "is included" do assert field_included? end
+    end
+    describe "when @skip=false and @include=false" do
+      let(:skip?) { false }
+      let(:include?) { false }
+      it "is not included" do assert !field_included? end
+    end
+    describe "when @skip=true and @include=true" do
+      let(:skip?) { true }
+      let(:include?) { true }
+      it "is not included" do assert !field_included? end
+    end
+    describe "when @skip=true and @include=false" do
+      let(:skip?) { true }
+      let(:include?) { false }
+      it "is not included" do assert !field_included? end
+    end
+    describe "when evaluating skip on query selection and fragment" do
+      describe "with @skip" do
+        let(:query_string) {"
+          query getCheese ($skip: Boolean!) {
+            cheese(id: 1) {
+              flavor,
+              withVariables: flavor,
+              ...F0
+            }
+          }
+          fragment F0 on Cheese {
+            flavor @skip(if: #{skip?})
+            withVariables: flavor @skip(if: $skip)
+          }
+        "}
+        describe "and @skip=false" do
+          let(:skip?) { false }
+          it "is included" do assert field_included? end
+        end
+        describe "and @skip=true" do
+          let(:skip?) { true }
+          it "is included" do assert field_included? end
+        end
+      end      
+    end
+    describe "when evaluating conflicting @skip and @include on query selection and fragment" do
+      let(:query_string) {"
+        query getCheese ($include: Boolean!, $skip: Boolean!) {
+          cheese(id: 1) {
+            flavor @include(if: #{include?}),
+            withVariables: flavor @include(if: $include),
+            ...F0
+          }
+        }
+        fragment F0 on Cheese {
+          flavor @skip(if: #{skip?}),
+          withVariables: flavor @skip(if: $skip)
+        }
+      "}
+      describe "when @skip=false and @include=true" do
+        let(:skip?) { false }
+        let(:include?) { true }
+        it "is included" do assert field_included? end
+      end
+      describe "when @skip=false and @include=false" do
+        let(:skip?) { false }
+        let(:include?) { false }
+        it "is included" do assert field_included? end
+      end
+      describe "when @skip=true and @include=true" do
+        let(:skip?) { true }
+        let(:include?) { true }
+        it "is included" do assert field_included? end
+      end
+      describe "when @skip=true and @include=false" do
+        let(:skip?) { true }
+        let(:include?) { false }
+        it "is not included" do assert !field_included? end
+      end
+    end
+
+    describe "when handling multiple fields at the same level" do
+      describe "when at least one occurance would be included" do
+        let(:query_string) {"
+          query getCheese ($include: Boolean!, $skip: Boolean!) {
+            cheese(id: 1) {
+              flavor,
+              flavor @include(if: #{include?}),
+              flavor @skip(if: #{skip?}),
+              withVariables: flavor,
+              withVariables: flavor @include(if: $include),
+              withVariables: flavor @skip(if: $skip)
+            }
+          }
+        "}
+        let(:skip?) { true }
+        let(:include?) { false }
+        it "is included" do assert field_included? end
+      end
+      describe "when no occurance would be included" do
+        let(:query_string) {"
+          query getCheese ($include: Boolean!, $skip: Boolean!) {
+            cheese(id: 1) {
+              flavor @include(if: #{include?}),
+              flavor @skip(if: #{skip?}),
+              withVariables: flavor @include(if: $include),
+              withVariables: flavor @skip(if: $skip)
+            }
+          }
+        "}
+        let(:skip?) { true }
+        let(:include?) { false }
+        it "is not included" do assert !field_included? end
+      end
     end
   end
 end

--- a/spec/graphql/directive_spec.rb
+++ b/spec/graphql/directive_spec.rb
@@ -139,7 +139,9 @@ describe GraphQL::Directive do
       let(:query_string) {"
         query getCheese ($include: Boolean!, $skip: Boolean!) {
           cheese(id: 1) {
-            flavor @include(if: #{include?}),
+            ... on Cheese @include(if: #{include?}) {
+              flavor
+            }
             withVariables: flavor @include(if: $include),
             ...F0
           }
@@ -167,16 +169,20 @@ describe GraphQL::Directive do
       describe "when @skip=true and @include=false" do
         let(:skip?) { true }
         let(:include?) { false }
-        it "is not included" do assert !field_included? end
+        it "is not included" do
+          assert !field_included?
+        end
       end
     end
 
     describe "when handling multiple fields at the same level" do
-      describe "when at least one occurance would be included" do
+      describe "when at least one occurrence would be included" do
         let(:query_string) {"
           query getCheese ($include: Boolean!, $skip: Boolean!) {
             cheese(id: 1) {
-              flavor,
+              ... on Cheese {
+                flavor
+              }
               flavor @include(if: #{include?}),
               flavor @skip(if: #{skip?}),
               withVariables: flavor,
@@ -189,7 +195,7 @@ describe GraphQL::Directive do
         let(:include?) { false }
         it "is included" do assert field_included? end
       end
-      describe "when no occurance would be included" do
+      describe "when no occurrence would be included" do
         let(:query_string) {"
           query getCheese ($include: Boolean!, $skip: Boolean!) {
             cheese(id: 1) {


### PR DESCRIPTION
This PR corrects some of the behavior around @skip and @include directives.

# in summary, this PR
- fixes `@skip` and `@include` execution in graphql-ruby to be in line with spec and graphql-js behavior

## example of a valid graphql query that errors without this PR
```graphql
      query getCheese ($include: Boolean!, $skip: Boolean!) {
        cheese(id: 1) {
          flavor @include(if: false) @skip(if: true),
          withVariables: flavor @include(if: $include) @skip(if: $skip)
        }
      }
```
with variables
```
skip: true,
include: false
```

The expected result is that `flavor` would not be included in the result document, but it is. The spec updates in this PR include other cases.

# details

We encountered this error in production with queries that were being generated with Relay (0.9.2) for queries where the same field in some cases had `@include` directives on one fragment but not on another.

The GraphQL spec [defines the semantics](https://github.com/facebook/graphql/blob/master/spec/Section%203%20--%20Type%20System.md#include) when merging multiple `@skip` and `@include` directives.

After fixing directive validating in #263, I encountered some subtle bugs in the current implementation of `@skip` and `@include` in this gem where the observed behavior differs from the GraphQL spec. The spec mentions that skipped fields do not need to be present during execution, so my strategy was to skip over including these Field nodes in the internal representation when parsing the query.

I wrote specs for this behavior, included in this PR. To validate this behavior, I also implemented these same specs in javascript against Facebook's graphqljs. These other tests can be found at https://github.com/jsdnxx/graphql-js-test

Also, feel free to ping me on the graphql slack, username `@jsdn`