### PR TITLE
fix(FragmentsAreFinite) find fragment spreads below the first level of a fragment definition

### DIFF
--- a/lib/graphql/static_validation/rules/fragments_are_finite.rb
+++ b/lib/graphql/static_validation/rules/fragments_are_finite.rb
@@ -14,12 +14,23 @@ module GraphQL
       private
 
       def has_nested_spread(fragment_def, parent_fragment_names, context)
-        nested_spreads = fragment_def.selections
-          .select {|f| f.is_a?(GraphQL::Language::Nodes::FragmentSpread)}
+        nested_spreads = get_spreads(fragment_def.selections)
 
         nested_spreads.any? do |spread|
           nested_def = context.fragments[spread.name]
           parent_fragment_names.include?(spread.name) || has_nested_spread(nested_def, parent_fragment_names + [fragment_def.name], context)
+        end
+      end
+
+      # Find spreads contained in this selection & return them in a flat array
+      def get_spreads(selection)
+        case selection
+        when GraphQL::Language::Nodes::FragmentSpread
+          [selection]
+        when GraphQL::Language::Nodes::Field, GraphQL::Language::Nodes::InlineFragment
+          get_spreads(selection.selections)
+        when Array
+          selection.map { |s| get_spreads(s) }.flatten
         end
       end
     end

--- a/spec/graphql/static_validation/rules/fragments_are_finite_spec.rb
+++ b/spec/graphql/static_validation/rules/fragments_are_finite_spec.rb
@@ -6,7 +6,9 @@ describe GraphQL::StaticValidation::FragmentsAreFinite do
       cheese(id: 1) {
         ... idField
         ... sourceField
-        ... flavorField
+        similarCheese {
+          ... flavorField
+        }
       }
     }
 
@@ -17,7 +19,9 @@ describe GraphQL::StaticValidation::FragmentsAreFinite do
     }
     fragment flavorField on Cheese {
       flavor,
-      ... sourceField
+      similarCheese {
+        ... sourceField
+      }
     }
     fragment idField on Cheese {
       id
@@ -32,12 +36,12 @@ describe GraphQL::StaticValidation::FragmentsAreFinite do
     expected = [
       {
         "message"=>"Fragment sourceField contains an infinite loop",
-        "locations"=>[{"line"=>10, "column"=>5}],
+        "locations"=>[{"line"=>12, "column"=>5}],
         "path"=>["fragment sourceField"],
       },
       {
         "message"=>"Fragment flavorField contains an infinite loop",
-        "locations"=>[{"line"=>15, "column"=>5}],
+        "locations"=>[{"line"=>17, "column"=>5}],
         "path"=>["fragment flavorField"],
       }
     ]

--- a/spec/graphql/static_validation/validator_spec.rb
+++ b/spec/graphql/static_validation/validator_spec.rb
@@ -39,7 +39,9 @@ describe GraphQL::StaticValidation::Validator do
           }
         }
         fragment cheeseFields on Cheese {
-          id, ... cheeseFields
+          ... on Cheese {
+            id, ... cheeseFields
+          }
         }
       |}
 


### PR DESCRIPTION
Oops, the previous implementation of validating infinite loops only checked the _first level_ of fragment definitions! Now, it checks deeply.

Closes #257 