### PR TITLE
Update `fields_will_merge` validation to ignore directives

### DIFF
--- a/lib/graphql/static_validation/rules/fields_will_merge.rb
+++ b/lib/graphql/static_validation/rules/fields_will_merge.rb
@@ -76,16 +76,6 @@ module GraphQL
             errors << message("Field '#{name}' has an argument conflict: #{args.map {|a| JSON.dump(a) }.join(" or ")}?", defs.first, context: context)
           end
 
-          directive_names = defs.map { |defn| defn.directives.map(&:name) }.uniq
-          if directive_names.length != 1
-            errors << message("Field '#{name}' has a directive conflict: #{directive_names.map {|names| "[#{names.join(", ")}]"}.join(" or ")}?", defs.first, context: context)
-          end
-
-          directive_args = defs.map {|defn| defn.directives.map {|d| reduce_list(d.arguments) } }.uniq
-          if directive_args.length != 1
-            errors << message("Field '#{name}' has a directive argument conflict: #{directive_args.map {|args| JSON.dump(args)}.join(" or ")}?", defs.first, context: context)
-          end
-
           @errors = errors
         end
 

--- a/spec/graphql/static_validation/rules/fields_will_merge_spec.rb
+++ b/spec/graphql/static_validation/rules/fields_will_merge_spec.rb
@@ -36,8 +36,6 @@ describe GraphQL::StaticValidation::FieldsWillMerge do
 
   it "finds field naming conflicts" do
     expected_errors = [
-      "Field 'id' has a directive conflict: [] or [someFlag]?",                 # different directives
-      "Field 'id' has a directive argument conflict: [] or [{}]?",              # not sure this is a great way to handle it but here we are!
       "Field 'nickname' has a field conflict: name or fatContent?",             # alias conflict in query
       "Field 'fatContent' has a field conflict: fatContent or name?",           # alias/name conflict in query and fragment
       "Field 'similarCheese' has an argument conflict: {\"source\":\"sourceVar\"} or {\"source\":\"SHEEP\"}?", # different arguments


### PR DESCRIPTION
⚠️  blocked on #256 ⚠️ 

This PR skips "fields will merge" validation for @skip and @include directives, since they can be safely merged with behavior defined in the GraphQL spec.

## example of a valid graphql query that errors without this PR
```graphql
query {
  hello,
  ...F0
}
fragment F0 on RootQueryType {
   hello @include(if: true)
}
```

The issue is where directives cannot merge cleanly unless their semantics are known. However, in the case of `@skip` and `@include` in particular, their [semantics are specified](https://github.com/facebook/graphql/blob/master/spec/Section%203%20--%20Type%20System.md#include), so they should not generate these validation errors.

I wrote specs for this behavior, included in this PR. To validate this behavior, I also implemented these same specs in javascript against Facebook's graphqljs. These other tests can be found at https://github.com/jsdnxx/graphql-js-test

### note

With the updated validation logic in this PR, some queries that were previously rejected will be permitted which may still be resolved incorrectly by graphql-ruby due to the way `@skip` and `@include` directives are resolved. Specifically, some fields may be erroneously skipped from the result when one fragment has a field with `@skip(if: true)` and another fragment or query selection has the same field without any directives. See #256 for more details and discussion.