### PR TITLE
Rename validation error `path` key

### DIFF
--- a/lib/graphql/static_validation/message.rb
+++ b/lib/graphql/static_validation/message.rb
@@ -26,7 +26,7 @@ module GraphQL
         {
           "message" => message,
           "locations" => locations,
-          "path" => path,
+          "fields" => path,
         }
       end
 

--- a/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
+++ b/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
@@ -27,42 +27,42 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
     query_root_error = {
       "message"=>"Argument 'id' on Field 'cheese' has an invalid value. Expected type 'Int!'.",
       "locations"=>[{"line"=>3, "column"=>7}],
-      "path"=>["query getCheese", "cheese", "id"],
+      "fields"=>["query getCheese", "cheese", "id"],
     }
     assert_includes(errors, query_root_error)
 
     directive_error = {
       "message"=>"Argument 'if' on Directive 'skip' has an invalid value. Expected type 'Boolean!'.",
       "locations"=>[{"line"=>4, "column"=>30}],
-      "path"=>["query getCheese", "cheese", "source", "if"],
+      "fields"=>["query getCheese", "cheese", "source", "if"],
     }
     assert_includes(errors, directive_error)
 
     input_object_error = {
       "message"=>"Argument 'product' on Field 'badSource' has an invalid value. Expected type '[DairyProductInput]'.",
       "locations"=>[{"line"=>6, "column"=>7}],
-      "path"=>["query getCheese", "badSource", "product"],
+      "fields"=>["query getCheese", "badSource", "product"],
     }
     assert_includes(errors, input_object_error)
 
     input_object_field_error = {
       "message"=>"Argument 'source' on InputObject 'DairyProductInput' has an invalid value. Expected type 'DairyAnimal!'.",
       "locations"=>[{"line"=>6, "column"=>40}],
-      "path"=>["query getCheese", "badSource", "product", "source"],
+      "fields"=>["query getCheese", "badSource", "product", "source"],
     }
     assert_includes(errors, input_object_field_error)
 
     missing_required_field_error = {
       "message"=>"Argument 'product' on Field 'missingSource' has an invalid value. Expected type '[DairyProductInput]'.",
       "locations"=>[{"line"=>7, "column"=>7}],
-      "path"=>["query getCheese", "missingSource", "product"],
+      "fields"=>["query getCheese", "missingSource", "product"],
     }
     assert_includes(errors, missing_required_field_error)
 
     fragment_error = {
       "message"=>"Argument 'source' on Field 'similarCheese' has an invalid value. Expected type '[DairyAnimal!]!'.",
       "locations"=>[{"line"=>13, "column"=>7}],
-      "path"=>["fragment cheeseFields", "similarCheese", "source"],
+      "fields"=>["fragment cheeseFields", "similarCheese", "source"],
     }
     assert_includes(errors, fragment_error)
   end

--- a/spec/graphql/static_validation/rules/arguments_are_defined_spec.rb
+++ b/spec/graphql/static_validation/rules/arguments_are_defined_spec.rb
@@ -24,28 +24,28 @@ describe GraphQL::StaticValidation::ArgumentsAreDefined do
     query_root_error = {
       "message"=>"Field 'cheese' doesn't accept argument 'silly'",
       "locations"=>[{"line"=>4, "column"=>7}],
-      "path"=>["query getCheese", "cheese", "silly"],
+      "fields"=>["query getCheese", "cheese", "silly"],
     }
     assert_includes(errors, query_root_error)
 
     input_obj_record = {
       "message"=>"InputObject 'DairyProductInput' doesn't accept argument 'wacky'",
       "locations"=>[{"line"=>5, "column"=>29}],
-      "path"=>["query getCheese", "searchDairy", "product", "wacky"],
+      "fields"=>["query getCheese", "searchDairy", "product", "wacky"],
     }
     assert_includes(errors, input_obj_record)
 
     fragment_error = {
       "message"=>"Field 'similarCheese' doesn't accept argument 'nonsense'",
       "locations"=>[{"line"=>9, "column"=>7}],
-      "path"=>["fragment cheeseFields", "similarCheese", "nonsense"],
+      "fields"=>["fragment cheeseFields", "similarCheese", "nonsense"],
     }
     assert_includes(errors, fragment_error)
 
     directive_error = {
       "message"=>"Directive 'skip' doesn't accept argument 'something'",
       "locations"=>[{"line"=>10, "column"=>10}],
-      "path"=>["fragment cheeseFields", "id", "something"],
+      "fields"=>["fragment cheeseFields", "id", "something"],
     }
     assert_includes(errors, directive_error)
   end

--- a/spec/graphql/static_validation/rules/directives_are_defined_spec.rb
+++ b/spec/graphql/static_validation/rules/directives_are_defined_spec.rb
@@ -23,11 +23,11 @@ describe GraphQL::StaticValidation::DirectivesAreDefined do
         {
           "message"=>"Directive @nonsense is not defined",
           "locations"=>[{"line"=>5, "column"=>16}],
-          "path"=>["query getCheese", "okCheese", "source"],
+          "fields"=>["query getCheese", "okCheese", "source"],
         }, {
           "message"=>"Directive @moreNonsense is not defined",
           "locations"=>[{"line"=>7, "column"=>18}],
-          "path"=>["query getCheese", "okCheese", "... on Cheese", "flavor"],
+          "fields"=>["query getCheese", "okCheese", "... on Cheese", "flavor"],
         }
       ]
       assert_equal(expected, errors)

--- a/spec/graphql/static_validation/rules/directives_are_in_valid_locations_spec.rb
+++ b/spec/graphql/static_validation/rules/directives_are_in_valid_locations_spec.rb
@@ -27,12 +27,12 @@ describe GraphQL::StaticValidation::DirectivesAreInValidLocations do
         {
           "message"=> "'@skip' can't be applied to queries (allowed: fields, fragment spreads, inline fragments)",
           "locations"=>[{"line"=>2, "column"=>21}],
-          "path"=>["query getCheese"],
+          "fields"=>["query getCheese"],
         },
         {
           "message"=>"'@skip' can't be applied to fragment definitions (allowed: fields, fragment spreads, inline fragments)",
           "locations"=>[{"line"=>12, "column"=>33}],
-           "path"=>["fragment whatever"],
+           "fields"=>["fragment whatever"],
         },
       ]
       assert_equal(expected, errors)

--- a/spec/graphql/static_validation/rules/fields_are_defined_on_type_spec.rb
+++ b/spec/graphql/static_validation/rules/fields_are_defined_on_type_spec.rb
@@ -34,7 +34,7 @@ describe GraphQL::StaticValidation::FieldsAreDefinedOnType do
         {
           "message"=>"Field 'notDefinedField' doesn't exist on type 'Query'",
           "locations"=>[{"line"=>1, "column"=>18}],
-          "path"=>["query getStuff", "notDefinedField"],
+          "fields"=>["query getStuff", "notDefinedField"],
         }
       ]
       assert_equal(expected_errors, errors)
@@ -49,7 +49,7 @@ describe GraphQL::StaticValidation::FieldsAreDefinedOnType do
         {
           "message"=>"Field 'amountThatILikeIt' doesn't exist on type 'Edible'",
           "locations"=>[{"line"=>1, "column"=>35}],
-          "path"=>["query getStuff", "favoriteEdible", "amountThatILikeIt"],
+          "fields"=>["query getStuff", "favoriteEdible", "amountThatILikeIt"],
         }
       ]
       assert_equal(expected_errors, errors)
@@ -71,7 +71,7 @@ describe GraphQL::StaticValidation::FieldsAreDefinedOnType do
           "locations"=>[
             {"line"=>3, "column"=>7}
           ],
-          "path"=>["fragment dbFields", "source"],
+          "fields"=>["fragment dbFields", "source"],
         }
       ]
       assert_equal(expected_errors, errors)

--- a/spec/graphql/static_validation/rules/fields_have_appropriate_selections_spec.rb
+++ b/spec/graphql/static_validation/rules/fields_have_appropriate_selections_spec.rb
@@ -19,14 +19,14 @@ describe GraphQL::StaticValidation::FieldsHaveAppropriateSelections do
     illegal_selection_error = {
       "message"=>"Selections can't be made on scalars (field 'id' returns Int but has selections [something, someFields])",
       "locations"=>[{"line"=>5, "column"=>47}],
-      "path"=>["query getCheese", "illegalSelectionCheese", "id"],
+      "fields"=>["query getCheese", "illegalSelectionCheese", "id"],
     }
     assert_includes(errors, illegal_selection_error, "finds illegal selections on scalarss")
 
     selection_required_error = {
       "message"=>"Objects must have selections (field 'cheese' returns Cheese but has no selections)",
       "locations"=>[{"line"=>4, "column"=>7}],
-      "path"=>["query getCheese", "missingFieldsCheese"],
+      "fields"=>["query getCheese", "missingFieldsCheese"],
     }
     assert_includes(errors, selection_required_error, "finds objects without selections")
   end

--- a/spec/graphql/static_validation/rules/fragment_spreads_are_possible_spec.rb
+++ b/spec/graphql/static_validation/rules/fragment_spreads_are_possible_spec.rb
@@ -32,17 +32,17 @@ describe GraphQL::StaticValidation::FragmentSpreadsArePossible do
       {
         "message"=>"Fragment on Milk can't be spread inside Cheese",
         "locations"=>[{"line"=>6, "column"=>9}],
-        "path"=>["query getCheese", "cheese", "... on Milk"],
+        "fields"=>["query getCheese", "cheese", "... on Milk"],
       },
       {
         "message"=>"Fragment milkFields on Milk can't be spread inside Cheese",
         "locations"=>[{"line"=>4, "column"=>9}],
-        "path"=>["query getCheese", "cheese", "... milkFields"],
+        "fields"=>["query getCheese", "cheese", "... milkFields"],
       },
       {
         "message"=>"Fragment milkFields on Milk can't be spread inside Cheese",
         "locations"=>[{"line"=>18, "column"=>7}],
-        "path"=>["fragment cheeseFields", "... milkFields"],
+        "fields"=>["fragment cheeseFields", "... milkFields"],
       }
     ]
     assert_equal(expected, errors)

--- a/spec/graphql/static_validation/rules/fragment_types_exist_spec.rb
+++ b/spec/graphql/static_validation/rules/fragment_types_exist_spec.rb
@@ -28,13 +28,13 @@ describe GraphQL::StaticValidation::FragmentTypesExist do
     inline_fragment_error =  {
       "message"=>"No such type Something, so it can't be a fragment condition",
       "locations"=>[{"line"=>11, "column"=>5}],
-      "path"=>["fragment somethingFields"],
+      "fields"=>["fragment somethingFields"],
     }
     assert_includes(errors, inline_fragment_error, "on inline fragments")
     fragment_def_error = {
       "message"=>"No such type Nothing, so it can't be a fragment condition",
       "locations"=>[{"line"=>5, "column"=>9}],
-      "path"=>["query getCheese", "cheese", "... on Nothing"],
+      "fields"=>["query getCheese", "cheese", "... on Nothing"],
     }
     assert_includes(errors, fragment_def_error, "on fragment definitions")
   end

--- a/spec/graphql/static_validation/rules/fragments_are_finite_spec.rb
+++ b/spec/graphql/static_validation/rules/fragments_are_finite_spec.rb
@@ -39,12 +39,12 @@ describe GraphQL::StaticValidation::FragmentsAreFinite do
       {
         "message"=>"Fragment sourceField contains an infinite loop",
         "locations"=>[{"line"=>12, "column"=>5}],
-        "path"=>["fragment sourceField"],
+        "fields"=>["fragment sourceField"],
       },
       {
         "message"=>"Fragment flavorField contains an infinite loop",
         "locations"=>[{"line"=>17, "column"=>5}],
-        "path"=>["fragment flavorField"],
+        "fields"=>["fragment flavorField"],
       }
     ]
     assert_equal(expected, errors)

--- a/spec/graphql/static_validation/rules/fragments_are_named_spec.rb
+++ b/spec/graphql/static_validation/rules/fragments_are_named_spec.rb
@@ -17,7 +17,7 @@ describe GraphQL::StaticValidation::FragmentTypesExist do
     fragment_def_error = {
       "message"=>"Fragment definition has no name",
       "locations"=>[{"line"=>2, "column"=>5}],
-      "path"=>["fragment "],
+      "fields"=>["fragment "],
     }
     assert_includes(errors, fragment_def_error, "on fragment definitions")
   end

--- a/spec/graphql/static_validation/rules/fragments_are_on_composite_types_spec.rb
+++ b/spec/graphql/static_validation/rules/fragments_are_on_composite_types_spec.rb
@@ -34,17 +34,17 @@ describe GraphQL::StaticValidation::FragmentsAreOnCompositeTypes do
       {
         "message"=>"Invalid fragment on type Boolean (must be Union, Interface or Object)",
         "locations"=>[{"line"=>6, "column"=>11}],
-        "path"=>["query getCheese", "cheese", "... on Cheese", "... on Boolean"],
+        "fields"=>["query getCheese", "cheese", "... on Cheese", "... on Boolean"],
       },
       {
         "message"=>"Invalid fragment on type DairyProductInput (must be Union, Interface or Object)",
         "locations"=>[{"line"=>14, "column"=>9}],
-        "path"=>["query getCheese", "cheese", "... on DairyProductInput"],
+        "fields"=>["query getCheese", "cheese", "... on DairyProductInput"],
       },
       {
         "message"=>"Invalid fragment on type Int (must be Union, Interface or Object)",
         "locations"=>[{"line"=>20, "column"=>5}],
-        "path"=>["fragment intFields"],
+        "fields"=>["fragment intFields"],
       },
     ]
     assert_equal(expected, errors)

--- a/spec/graphql/static_validation/rules/fragments_are_used_spec.rb
+++ b/spec/graphql/static_validation/rules/fragments_are_used_spec.rb
@@ -19,7 +19,7 @@ describe GraphQL::StaticValidation::FragmentsAreUsed do
     assert_includes(errors, {
       "message"=>"Fragment unusedFields was defined, but not used",
       "locations"=>[{"line"=>8, "column"=>5}],
-      "path"=>[],
+      "fields"=>[],
     })
   end
 
@@ -27,7 +27,7 @@ describe GraphQL::StaticValidation::FragmentsAreUsed do
     assert_includes(errors, {
       "message"=>"Fragment undefinedFields was used, but not defined",
       "locations"=>[{"line"=>5, "column"=>7}],
-      "path"=>["query getCheese", "... undefinedFields"]
+      "fields"=>["query getCheese", "... undefinedFields"]
     })
   end
 

--- a/spec/graphql/static_validation/rules/mutation_root_exists_spec.rb
+++ b/spec/graphql/static_validation/rules/mutation_root_exists_spec.rb
@@ -32,7 +32,7 @@ describe GraphQL::StaticValidation::MutationRootExists do
     missing_mutation_root_error = {
       "message"=>"Schema is not configured for mutations",
       "locations"=>[{"line"=>2, "column"=>5}],
-      "path"=>["mutation addBagel"],
+      "fields"=>["mutation addBagel"],
     }
     assert_includes(errors, missing_mutation_root_error)
   end

--- a/spec/graphql/static_validation/rules/required_arguments_are_present_spec.rb
+++ b/spec/graphql/static_validation/rules/required_arguments_are_present_spec.rb
@@ -24,21 +24,21 @@ describe GraphQL::StaticValidation::RequiredArgumentsArePresent do
     query_root_error = {
       "message"=>"Field 'cheese' is missing required arguments: id",
       "locations"=>[{"line"=>4, "column"=>7}],
-      "path"=>["query getCheese", "cheese"],
+      "fields"=>["query getCheese", "cheese"],
     }
     assert_includes(errors, query_root_error)
 
     fragment_error = {
       "message"=>"Field 'similarCheese' is missing required arguments: source",
       "locations"=>[{"line"=>8, "column"=>7}],
-      "path"=>["fragment cheeseFields", "similarCheese"],
+      "fields"=>["fragment cheeseFields", "similarCheese"],
     }
     assert_includes(errors, fragment_error)
 
     directive_error = {
       "message"=>"Directive 'skip' is missing required arguments: if",
       "locations"=>[{"line"=>10, "column"=>10}],
-      "path"=>["fragment cheeseFields", "id"],
+      "fields"=>["fragment cheeseFields", "id"],
     }
     assert_includes(errors, directive_error)
   end

--- a/spec/graphql/static_validation/rules/subscription_root_exists_spec.rb
+++ b/spec/graphql/static_validation/rules/subscription_root_exists_spec.rb
@@ -27,7 +27,7 @@ describe GraphQL::StaticValidation::SubscriptionRootExists do
     missing_subscription_root_error = {
       "message"=>"Schema is not configured for subscriptions",
       "locations"=>[{"line"=>2, "column"=>5}],
-      "path"=>["subscription"],
+      "fields"=>["subscription"],
     }
     assert_includes(errors, missing_subscription_root_error)
   end

--- a/spec/graphql/static_validation/rules/variable_default_values_are_correctly_typed_spec.rb
+++ b/spec/graphql/static_validation/rules/variable_default_values_are_correctly_typed_spec.rb
@@ -25,22 +25,22 @@ describe GraphQL::StaticValidation::VariableDefaultValuesAreCorrectlyTyped do
       {
         "message"=>"Default value for $badFloat doesn't match type Float",
         "locations"=>[{"line"=>6, "column"=>7}],
-        "path"=>["query getCheese"],
+        "fields"=>["query getCheese"],
       },
       {
         "message"=>"Default value for $badInt doesn't match type Int",
         "locations"=>[{"line"=>7, "column"=>7}],
-        "path"=>["query getCheese"],
+        "fields"=>["query getCheese"],
       },
       {
         "message"=>"Default value for $badInput doesn't match type DairyProductInput",
         "locations"=>[{"line"=>9, "column"=>7}],
-        "path"=>["query getCheese"],
+        "fields"=>["query getCheese"],
       },
       {
         "message"=>"Non-null variable $nonNull can't have a default value",
         "locations"=>[{"line"=>10, "column"=>7}],
-        "path"=>["query getCheese"],
+        "fields"=>["query getCheese"],
       }
     ]
     assert_equal(expected, errors)

--- a/spec/graphql/static_validation/rules/variable_usages_are_allowed_spec.rb
+++ b/spec/graphql/static_validation/rules/variable_usages_are_allowed_spec.rb
@@ -44,22 +44,22 @@ describe GraphQL::StaticValidation::VariableUsagesAreAllowed do
       {
         "message"=>"Nullability mismatch on variable $badInt and argument id (Int / Int!)",
         "locations"=>[{"line"=>14, "column"=>28}],
-        "path"=>["query getCheese", "badCheese", "id"],
+        "fields"=>["query getCheese", "badCheese", "id"],
       },
       {
         "message"=>"Type mismatch on variable $badStr and argument id (String! / Int!)",
         "locations"=>[{"line"=>15, "column"=>28}],
-        "path"=>["query getCheese", "badStrCheese", "id"],
+        "fields"=>["query getCheese", "badStrCheese", "id"],
       },
       {
         "message"=>"Nullability mismatch on variable $badAnimals and argument source ([DairyAnimal]! / [DairyAnimal!]!)",
         "locations"=>[{"line"=>18, "column"=>30}],
-        "path"=>["query getCheese", "cheese", "other", "source"],
+        "fields"=>["query getCheese", "cheese", "other", "source"],
       },
       {
         "message"=>"List dimension mismatch on variable $deepAnimals and argument source ([[DairyAnimal!]!]! / [DairyAnimal!]!)",
         "locations"=>[{"line"=>19, "column"=>32}],
-        "path"=>["query getCheese", "cheese", "tooDeep", "source"],
+        "fields"=>["query getCheese", "cheese", "tooDeep", "source"],
       }
     ]
     assert_equal(expected, errors)

--- a/spec/graphql/static_validation/rules/variables_are_input_types_spec.rb
+++ b/spec/graphql/static_validation/rules/variables_are_input_types_spec.rb
@@ -22,17 +22,17 @@ describe GraphQL::StaticValidation::VariablesAreInputTypes do
       {
         "message"=>"AnimalProduct isn't a valid input type (on $interface)",
         "locations"=>[{"line"=>5, "column"=>7}],
-        "path"=>["query getCheese"],
+        "fields"=>["query getCheese"],
       },
       {
         "message"=>"Milk isn't a valid input type (on $object)",
         "locations"=>[{"line"=>6, "column"=>7}],
-        "path"=>["query getCheese"],
+        "fields"=>["query getCheese"],
       },
       {
         "message"=>"Cheese isn't a valid input type (on $objects)",
         "locations"=>[{"line"=>7, "column"=>7}],
-        "path"=>["query getCheese"],
+        "fields"=>["query getCheese"],
       }
     ]
     assert_equal(expected, errors)

--- a/spec/graphql/static_validation/rules/variables_are_used_and_defined_spec.rb
+++ b/spec/graphql/static_validation/rules/variables_are_used_and_defined_spec.rb
@@ -38,17 +38,17 @@ describe GraphQL::StaticValidation::VariablesAreUsedAndDefined do
       {
         "message"=>"Variable $notUsedVar is declared by getCheese but not used",
         "locations"=>[{"line"=>2, "column"=>5}],
-        "path"=>["query getCheese"],
+        "fields"=>["query getCheese"],
       },
       {
         "message"=>"Variable $undefinedVar is used by getCheese but not declared",
         "locations"=>[{"line"=>11, "column"=>29}],
-        "path"=>["query getCheese", "cheese", "whatever", "undefined"],
+        "fields"=>["query getCheese", "cheese", "whatever", "undefined"],
       },
       {
         "message"=>"Variable $undefinedFragmentVar is used by innerCheeseFields but not declared",
         "locations"=>[{"line"=>24, "column"=>26}],
-        "path"=>["fragment innerCheeseFields", "source", "notDefined"],
+        "fields"=>["fragment innerCheeseFields", "source", "notDefined"],
       },
     ]
     assert_equal(expected, errors)

--- a/spec/graphql/static_validation/validator_spec.rb
+++ b/spec/graphql/static_validation/validator_spec.rb
@@ -73,7 +73,7 @@ describe GraphQL::StaticValidation::Validator do
             {
               "message"=>"Fragment cheeseFields contains an infinite loop",
               "locations"=>[{"line"=>10, "column"=>9}],
-              "path"=>["fragment cheeseFields"]
+              "fields"=>["fragment cheeseFields"]
             }
           ]
           assert_equal(expected, errors)


### PR DESCRIPTION
Conflicts with graphql-js **execution only** error JSON-path which uses the same key name.

https://github.com/graphql/graphql-js/blob/89f3f1a319bb913616f2910e8a806170155ffaf0/src/error/GraphQLError.js#L42-L48

Some other naming ideas:

* `queryPath`
* `documentPath`
* `validationPath`

Personally, this error path isn't that useful to me. `locations` tells me what I need to resolve the query AST node in the query text for reporting. But I don't see the harm in keeping it.

-
To: @rmosolgo 