### PR TITLE
Make default_value behavior consistent

### DIFF
--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -76,8 +76,14 @@ module GraphQL
         field_value = input_field_defn.type.coerce_input(field_value)
 
         # Try getting the default value
-        if field_value.nil?
-          field_value = input_field_defn.default_value
+        # First, assume that the default_value contains un-coerced input
+        if field_value.nil? && !input_field_defn.default_value.nil?
+          field_value = input_field_defn.type.coerce_input(input_field_defn.default_value)
+
+          # If it's still nil, then it must have already-coerced input
+          if field_value.nil?
+            field_value = input_field_defn.default_value
+          end
         end
 
         if !field_value.nil?

--- a/lib/graphql/query/literal_input.rb
+++ b/lib/graphql/query/literal_input.rb
@@ -16,7 +16,18 @@ module GraphQL
         values_hash = {}
         argument_defns.each do |arg_name, arg_defn|
           ast_arg = ast_arguments.find { |ast_arg| ast_arg.name == arg_name }
-          arg_default_value = arg_defn.type.coerce_input(arg_defn.default_value)
+          arg_default_value = nil
+
+          # First, assume that the default_value contains un-coerced input
+          if !arg_defn.default_value.nil?
+            arg_default_value = arg_defn.type.coerce_input(arg_defn.default_value)
+
+            # If it's still nil, then it must have already-coerced input
+            if arg_default_value.nil?
+              arg_default_value = arg_defn.default_value
+            end
+          end
+
           if ast_arg.nil? && arg_default_value.nil?
             # If it wasn't in the document,
             # and there's no provided default,


### PR DESCRIPTION
The behavior for default values is inconsistent between arguments and input fields. Arguments assume that you are providing them with un-coerced values, whereas input fields assume you're giving them coerced values.

So if you wanted to have an argument of type `DairyAnimal` that defaulted to COW, it'd be:
```ruby
argument :source, DairyAnimalEnum, default_value: 'COW'
```

But if you wanted the same thing as an input field, it'd be:
```ruby
input_field :source, DairyAnimalEnum do
  default_value 1
end
```

This PR makes the behavior consistent by assuming that you're always providing un-coerced values in both cases. However, if a default value is present, but coercion fails, it will instead give you the exact value you specified as the default.

Note, this is probably a breaking change for input field default values, since they previously _always_ assumed that the default value was coerced, and now assume that it is un-coerced.

TODO:
- [ ] Add some tests around this behavior

### An Alternative Approach
An alternative approach, which I personally prefer, would be to instead assume that the default value provided is already coerced (i.e., `default_value: 1` instead of `default_value: 'COW'`). I think that this is more natural, because if you've taken the trouble to make the internal and external representations different, it's likely because the internal representation is easier to work with.

For example, we often use different internal values for our enum's, so we might do something like:
```ruby
WEEKDAYS = [1, 2, 3, 4, 5]
# ...
argument :days, types[DayOfWeekEnum], default_value: WEEKDAYS
```

That seems more natural, and is probably more likely to re-use code, than:
```ruby
argument :days, types[DayOfWeekEnum], default_value: ['MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY']
```

I think this would also work a little more nicely in introspection:
```ruby
field :defaultValue, types.String, "The value applied if no other value is provided" do
  resolve -> (obj, args, ctx) {
    value = obj.default_value
    value ? obj.type.coerce_result(value).to_json : nil
  }
end
```

Lastly, this would make it possible to provide default values for complex types (such as a list of objects).

The big downside of this alternative approach is that it's a lot more likely to be a big breaking change. ☹️  But perhaps that could be mitigated by providing a way to monkey-patch the old behavior back in?