### PR TITLE
Remove definition name from error `path`

### DIFF
--- a/lib/graphql/internal_representation/node.rb
+++ b/lib/graphql/internal_representation/node.rb
@@ -82,10 +82,14 @@ module GraphQL
       end
 
       def path
-        path = parent ? parent.path : []
-        path << name if name
-        path << @index if @index
-        path
+        if parent
+          path = parent.path
+          path << name
+          path << @index if @index
+          path
+        else
+          []
+        end
       end
 
       attr_writer :index

--- a/spec/graphql/query/executor_spec.rb
+++ b/spec/graphql/query/executor_spec.rb
@@ -144,7 +144,7 @@ describe GraphQL::Query::Executor do
             {
               "message" => "BOOM",
               "locations" => [ { "line" => 1, "column" => 28 } ],
-              "path" => ["noMilk", "cow", "cantBeNullButRaisesExecutionError"]
+              "path" => ["cow", "cantBeNullButRaisesExecutionError"]
             }
           ]
         }
@@ -169,7 +169,7 @@ describe GraphQL::Query::Executor do
             {
               "message"=>"Error was handled!",
               "locations" => [{"line"=>1, "column"=>17}],
-              "path"=>["noMilk", "error"]
+              "path"=>["error"]
             }
           ]
         }

--- a/spec/graphql/schema/catchall_middleware_spec.rb
+++ b/spec/graphql/schema/catchall_middleware_spec.rb
@@ -22,7 +22,7 @@ describe GraphQL::Schema::CatchallMiddleware do
           {
             "message"=>"Internal error",
             "locations"=>[{"line"=>1, "column"=>17}],
-            "path"=>["noMilk", "error"]
+            "path"=>["error"]
           },
         ]
       }


### PR DESCRIPTION
Was correct for anonymous query definitions, but I forgot to test what would happen if a query name was set. It incorrectly gets prepended to the `"path"` array.

-
To: @rmosolgo 