### PR TITLE
Fix: remove pluralization of argument in docs for object_type

### DIFF
--- a/lib/graphql/object_type.rb
+++ b/lib/graphql/object_type.rb
@@ -11,7 +11,7 @@ module GraphQL
   #     field :director, PersonType
   #     field :cast, CastType
   #     field :starring, types[PersonType] do
-  #       arguments :limit, types.Int
+  #       argument :limit, types.Int
   #       resolve -> (object, args, ctx) {
   #         stars = object.cast.stars
   #         args[:limit] && stars = stars.limit(args[:limit])


### PR DESCRIPTION
Note, I believe that the guide was misleading for the object_type.  Using the argument `arguments` (plural) seems to have thrown an exception.  I see that in other examples, it is `argument`, so I believe that this may have been an error.