### PR TITLE
Adds conversion of a passed block to an argument if needed

### DIFF
--- a/lib/graphql/define/defined_object_proxy.rb
+++ b/lib/graphql/define/defined_object_proxy.rb
@@ -13,6 +13,7 @@ module GraphQL
       def method_missing(name, *args, &block)
         definition = @dictionary[name]
         if definition
+          args = args + [block] if args.count == definition.method(:call).arity - 2 && block
           definition.call(@target, *args, &block)
         else
           p "Failed to find config #{name} in #{inspect}"

--- a/spec/graphql/define/defined_object_proxy_spec.rb
+++ b/spec/graphql/define/defined_object_proxy_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+class Target
+  class Test
+    attr_reader :target, :attribute, :value
+
+    def call(target, attribute, value)
+      @target = target
+      @attribute = attribute
+      @value = value
+    end
+  end
+
+  def self.dictionary
+    @dictionary ||= {
+      test: Test.new,
+    }
+  end
+end
+
+describe GraphQL::Define::DefinedObjectProxy do
+  let(:proxy){ GraphQL::Define::DefinedObjectProxy.new(Target.new) }
+
+  it "converts a passed block to an argument if needed" do
+    proxy.test "an attribute" do
+      "some block"
+    end
+
+    target = Target.dictionary[:test]
+    assert_equal target.attribute, "an attribute"
+    assert_equal target.value.call, "some block"
+  end
+end


### PR DESCRIPTION
With this patch it's now possible to call all methods ruby style with blocks:

Before (still works of course):

```
connection :users, UserType.connection_type do
    resolve ->(object, args, ctx){
      User.all
    }
end
```

Now also possible:

```
connection :users, UserType.connection_type do
  resolve do |object, args, ctx|
    User.all
  end
end
```
