### PR TITLE
refactor(specs) test all validators through the whole set

### DIFF
--- a/lib/graphql/static_validation/rules/fields_will_merge.rb
+++ b/lib/graphql/static_validation/rules/fields_will_merge.rb
@@ -76,7 +76,7 @@ module GraphQL
 
           args = defs.map { |defn| reduce_list(defn.arguments)}.uniq
           if args.length != 1
-            errors << message("Field '#{name}' has an argument conflict: #{args.map {|a| JSON.dump(a) }.join(" or ")}?", defs.first, context: context)
+            errors << message("Field '#{name}' has an argument conflict: #{args.map {|a| print_arg(a) }.join(" or ")}?", defs.first, context: context)
           end
 
           @errors = errors
@@ -84,6 +84,14 @@ module GraphQL
 
         private
 
+        def print_arg(arg)
+          case arg
+          when GraphQL::Language::Nodes::VariableIdentifier
+            "$#{arg.name}"
+          else
+            JSON.dump(arg)
+          end
+        end
         # Turn AST tree into a hash
         # can't look up args, the names just have to match
         def reduce_list(args)

--- a/spec/graphql/static_validation/rules/directives_are_defined_spec.rb
+++ b/spec/graphql/static_validation/rules/directives_are_defined_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 
 describe GraphQL::StaticValidation::DirectivesAreDefined do
+  include StaticValidationHelpers
   let(:query_string) {"
     query getCheese {
       okCheese: cheese(id: 1) {
@@ -12,11 +13,6 @@ describe GraphQL::StaticValidation::DirectivesAreDefined do
       }
     }
   "}
-
-  let(:validator) { GraphQL::StaticValidation::Validator.new(schema: DummySchema, rules: [GraphQL::StaticValidation::DirectivesAreDefined]) }
-  let(:query) { GraphQL::Query.new(DummySchema, query_string) }
-  let(:errors) { validator.validate(query)[:errors] }
-
   describe "non-existent directives" do
     it "makes errors for them" do
       expected = [

--- a/spec/graphql/static_validation/rules/directives_are_in_valid_locations_spec.rb
+++ b/spec/graphql/static_validation/rules/directives_are_in_valid_locations_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 
 describe GraphQL::StaticValidation::DirectivesAreInValidLocations do
+  include StaticValidationHelpers
   let(:query_string) {"
     query getCheese @skip(if: true) {
       okCheese: cheese(id: 1) {
@@ -8,6 +9,7 @@ describe GraphQL::StaticValidation::DirectivesAreInValidLocations do
         source
         ... on Cheese @skip(if: true) {
           flavor
+          ... whatever
         }
       }
     }
@@ -16,10 +18,6 @@ describe GraphQL::StaticValidation::DirectivesAreInValidLocations do
       id
     }
   "}
-
-  let(:validator) { GraphQL::StaticValidation::Validator.new(schema: DummySchema, rules: [GraphQL::StaticValidation::DirectivesAreInValidLocations]) }
-  let(:query) { GraphQL::Query.new(DummySchema, query_string) }
-  let(:errors) { validator.validate(query)[:errors] }
 
   describe "invalid directive locations" do
     it "makes errors for them" do
@@ -31,7 +29,7 @@ describe GraphQL::StaticValidation::DirectivesAreInValidLocations do
         },
         {
           "message"=>"'@skip' can't be applied to fragment definitions (allowed: fields, fragment spreads, inline fragments)",
-          "locations"=>[{"line"=>12, "column"=>33}],
+          "locations"=>[{"line"=>13, "column"=>33}],
            "fields"=>["fragment whatever"],
         },
       ]

--- a/spec/graphql/static_validation/rules/fields_have_appropriate_selections_spec.rb
+++ b/spec/graphql/static_validation/rules/fields_have_appropriate_selections_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 
 describe GraphQL::StaticValidation::FieldsHaveAppropriateSelections do
+  include StaticValidationHelpers
   let(:query_string) {"
     query getCheese {
       okCheese: cheese(id: 1) { fatContent, similarCheese(source: YAK) { source } }
@@ -8,10 +9,6 @@ describe GraphQL::StaticValidation::FieldsHaveAppropriateSelections do
       illegalSelectionCheese: cheese(id: 1) { id { something, ... someFields } }
     }
   "}
-
-  let(:validator) { GraphQL::StaticValidation::Validator.new(schema: DummySchema, rules: [GraphQL::StaticValidation::FieldsHaveAppropriateSelections]) }
-  let(:query) { GraphQL::Query.new(DummySchema, query_string) }
-  let(:errors) { validator.validate(query)[:errors] }
 
   it "adds errors for selections on scalars" do
     assert_equal(2, errors.length)

--- a/spec/graphql/static_validation/rules/fragment_spreads_are_possible_spec.rb
+++ b/spec/graphql/static_validation/rules/fragment_spreads_are_possible_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 describe GraphQL::StaticValidation::FragmentSpreadsArePossible do
+  include StaticValidationHelpers
+
   let(:query_string) {%|
     query getCheese {
       cheese(id: 1) {
@@ -9,7 +11,7 @@ describe GraphQL::StaticValidation::FragmentSpreadsArePossible do
         ... on Milk { fatContent }
         ... on AnimalProduct { source }
         ... on DairyProduct {
-          fatContent
+          ... on Cheese { fatContent }
           ... on Edible { fatContent }
         }
       }
@@ -21,10 +23,6 @@ describe GraphQL::StaticValidation::FragmentSpreadsArePossible do
       ... milkFields
     }
   |}
-
-  let(:validator) { GraphQL::StaticValidation::Validator.new(schema: DummySchema, rules: [GraphQL::StaticValidation::FragmentSpreadsArePossible]) }
-  let(:query) { GraphQL::Query.new(DummySchema, query_string) }
-  let(:errors) { validator.validate(query)[:errors] }
 
   it "doesnt allow spreads where they'll never apply" do
     # TODO: more negative, abstract examples here, add stuff to the schema

--- a/spec/graphql/static_validation/rules/fragment_types_exist_spec.rb
+++ b/spec/graphql/static_validation/rules/fragment_types_exist_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 describe GraphQL::StaticValidation::FragmentTypesExist do
+  include StaticValidationHelpers
+
   let(:query_string) {"
     query getCheese {
       cheese(id: 1) {
@@ -18,10 +20,6 @@ describe GraphQL::StaticValidation::FragmentTypesExist do
       fatContent
     }
   "}
-
-  let(:validator) { GraphQL::StaticValidation::Validator.new(schema: DummySchema, rules: [GraphQL::StaticValidation::FragmentTypesExist]) }
-  let(:query) { GraphQL::Query.new(DummySchema, query_string) }
-  let(:errors) { validator.validate(query)[:errors] }
 
   it "finds non-existent types on fragments" do
     assert_equal(2, errors.length)

--- a/spec/graphql/static_validation/rules/fragments_are_finite_spec.rb
+++ b/spec/graphql/static_validation/rules/fragments_are_finite_spec.rb
@@ -1,12 +1,14 @@
 require "spec_helper"
 
 describe GraphQL::StaticValidation::FragmentsAreFinite do
+  include StaticValidationHelpers
+
   let(:query_string) {%|
     query getCheese {
       cheese(id: 1) {
         ... idField
         ... sourceField
-        similarCheese {
+        similarCheese(source: SHEEP) {
           ... flavorField
         }
       }
@@ -19,7 +21,7 @@ describe GraphQL::StaticValidation::FragmentsAreFinite do
     }
     fragment flavorField on Cheese {
       flavor,
-      similarCheese {
+      similarCheese(source: SHEEP) {
         ... on Cheese {
           ... sourceField
         }
@@ -29,10 +31,6 @@ describe GraphQL::StaticValidation::FragmentsAreFinite do
       id
     }
   |}
-
-  let(:validator) { GraphQL::StaticValidation::Validator.new(schema: DummySchema, rules: [GraphQL::StaticValidation::FragmentsAreFinite]) }
-  let(:query) { GraphQL::Query.new(DummySchema, query_string) }
-  let(:errors) { validator.validate(query)[:errors] }
 
   it "doesnt allow infinite loops" do
     expected = [

--- a/spec/graphql/static_validation/rules/fragments_are_named_spec.rb
+++ b/spec/graphql/static_validation/rules/fragments_are_named_spec.rb
@@ -1,16 +1,14 @@
 require "spec_helper"
 
 describe GraphQL::StaticValidation::FragmentTypesExist do
+  include StaticValidationHelpers
+
   let(:query_string) {"
     fragment on Cheese {
       id
       flavor
     }
   "}
-
-  let(:validator) { GraphQL::StaticValidation::Validator.new(schema: DummySchema, rules: [GraphQL::StaticValidation::FragmentsAreNamed]) }
-  let(:query) { GraphQL::Query.new(DummySchema, query_string) }
-  let(:errors) { validator.validate(query)[:errors] }
 
   it "finds non-existent types on fragments" do
     assert_equal(1, errors.length)

--- a/spec/graphql/static_validation/rules/fragments_are_on_composite_types_spec.rb
+++ b/spec/graphql/static_validation/rules/fragments_are_on_composite_types_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 describe GraphQL::StaticValidation::FragmentsAreOnCompositeTypes do
+  include StaticValidationHelpers
+
   let(:query_string) {%|
     query getCheese {
       cheese(id: 1) {
@@ -12,7 +14,9 @@ describe GraphQL::StaticValidation::FragmentsAreOnCompositeTypes do
         }
         ... intFields
         ... on DairyProduct {
-          name
+          ... on Cheese {
+            flavor
+          }
         }
         ... on DairyProductInput {
           something
@@ -25,10 +29,6 @@ describe GraphQL::StaticValidation::FragmentsAreOnCompositeTypes do
     }
   |}
 
-  let(:validator) { GraphQL::StaticValidation::Validator.new(schema: DummySchema, rules: [GraphQL::StaticValidation::FragmentsAreOnCompositeTypes]) }
-  let(:query) { GraphQL::Query.new(DummySchema, query_string) }
-  let(:errors) { validator.validate(query)[:errors] }
-
   it "requires Object/Union/Interface fragment types" do
     expected = [
       {
@@ -38,12 +38,12 @@ describe GraphQL::StaticValidation::FragmentsAreOnCompositeTypes do
       },
       {
         "message"=>"Invalid fragment on type DairyProductInput (must be Union, Interface or Object)",
-        "locations"=>[{"line"=>14, "column"=>9}],
+        "locations"=>[{"line"=>16, "column"=>9}],
         "fields"=>["query getCheese", "cheese", "... on DairyProductInput"],
       },
       {
         "message"=>"Invalid fragment on type Int (must be Union, Interface or Object)",
-        "locations"=>[{"line"=>20, "column"=>5}],
+        "locations"=>[{"line"=>22, "column"=>5}],
         "fields"=>["fragment intFields"],
       },
     ]

--- a/spec/graphql/static_validation/rules/fragments_are_used_spec.rb
+++ b/spec/graphql/static_validation/rules/fragments_are_used_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 
 describe GraphQL::StaticValidation::FragmentsAreUsed do
+  include StaticValidationHelpers
   let(:query_string) {"
     query getCheese {
       name,
@@ -10,10 +11,6 @@ describe GraphQL::StaticValidation::FragmentsAreUsed do
     fragment cheeseFields on Cheese { fatContent }
     fragment unusedFields on Cheese { is, not, used }
   "}
-
-  let(:validator) { GraphQL::StaticValidation::Validator.new(schema: DummySchema, rules: [GraphQL::StaticValidation::FragmentsAreUsed]) }
-  let(:query) { GraphQL::Query.new(DummySchema, query_string) }
-  let(:errors) { validator.validate(query)[:errors] }
 
   it "adds errors for unused fragment definitions" do
     assert_includes(errors, {

--- a/spec/graphql/static_validation/rules/mutation_root_exists_spec.rb
+++ b/spec/graphql/static_validation/rules/mutation_root_exists_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 describe GraphQL::StaticValidation::MutationRootExists do
+  include StaticValidationHelpers
+
   let(:query_string) {%|
     mutation addBagel {
       introduceShip(input: {shipName: "Bagel"}) {
@@ -22,10 +24,6 @@ describe GraphQL::StaticValidation::MutationRootExists do
       query query_root
     end
   }
-
-  let(:validator) { GraphQL::StaticValidation::Validator.new(schema: schema, rules: [GraphQL::StaticValidation::MutationRootExists]) }
-  let(:query) { GraphQL::Query.new(schema, query_string) }
-  let(:errors) { validator.validate(query)[:errors] }
 
   it "errors when a mutation is performed on a schema without a mutation root" do
     assert_equal(1, errors.length)

--- a/spec/graphql/static_validation/rules/required_arguments_are_present_spec.rb
+++ b/spec/graphql/static_validation/rules/required_arguments_are_present_spec.rb
@@ -1,22 +1,19 @@
 require "spec_helper"
 
 describe GraphQL::StaticValidation::RequiredArgumentsArePresent do
+  include StaticValidationHelpers
   let(:query_string) {"
     query getCheese {
-      cheese(id: 1) { source }
+      okCheese: cheese(id: 1) { ...cheeseFields }
       cheese { source }
     }
 
     fragment cheeseFields on Cheese {
-      similarCheese(id: 1)
+      similarCheese() { __typename }
       flavor @include(if: true)
       id @skip
     }
   "}
-
-  let(:validator) { GraphQL::StaticValidation::Validator.new(schema: DummySchema, rules: [GraphQL::StaticValidation::RequiredArgumentsArePresent]) }
-  let(:query) { GraphQL::Query.new(DummySchema, query_string) }
-  let(:errors) { validator.validate(query)[:errors] }
 
   it "finds undefined arguments to fields and directives" do
     assert_equal(3, errors.length)

--- a/spec/graphql/static_validation/rules/subscription_root_exists_spec.rb
+++ b/spec/graphql/static_validation/rules/subscription_root_exists_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 describe GraphQL::StaticValidation::SubscriptionRootExists do
+  include StaticValidationHelpers
+
   let(:query_string) {%|
     subscription {
       test
@@ -17,10 +19,6 @@ describe GraphQL::StaticValidation::SubscriptionRootExists do
       query query_root
     end
   }
-
-  let(:validator) { GraphQL::StaticValidation::Validator.new(schema: schema, rules: [GraphQL::StaticValidation::SubscriptionRootExists]) }
-  let(:query) { GraphQL::Query.new(schema, query_string) }
-  let(:errors) { validator.validate(query)[:errors] }
 
   it "errors when a subscription is performed on a schema without a subscription root" do
     assert_equal(1, errors.length)

--- a/spec/graphql/static_validation/rules/variable_default_values_are_correctly_typed_spec.rb
+++ b/spec/graphql/static_validation/rules/variable_default_values_are_correctly_typed_spec.rb
@@ -1,45 +1,43 @@
 require "spec_helper"
 
 describe GraphQL::StaticValidation::VariableDefaultValuesAreCorrectlyTyped do
+  include StaticValidationHelpers
+
   let(:query_string) {%|
     query getCheese(
       $id:        Int = 1,
       $int:       Int = 3.4e24, # can be coerced
       $str:       String!,
-      $badFloat:  Float = true,
       $badInt:    Int = "abc",
       $input:     DairyProductInput = {source: YAK, fatContent: 1},
       $badInput:  DairyProductInput = {source: YAK, fatContent: true},
       $nonNull:  Int! = 1,
     ) {
-      cheese(id: $id) { source }
+      cheese1: cheese(id: $id) { source }
+      cheese4: cheese(id: $int) { source }
+      cheese2: cheese(id: $badInt) { source }
+      cheese3: cheese(id: $nonNull) { source }
+      search1: searchDairy(product: [$input]) { __typename }
+      search2: searchDairy(product: [$badInput]) { __typename }
+      __type(name: $str) { name }
     }
   |}
-
-  let(:validator) { GraphQL::StaticValidation::Validator.new(schema: DummySchema, rules: [GraphQL::StaticValidation::VariableDefaultValuesAreCorrectlyTyped]) }
-  let(:query) { GraphQL::Query.new(DummySchema, query_string) }
-  let(:errors) { validator.validate(query)[:errors] }
 
   it "finds default values that don't match their types" do
     expected = [
       {
-        "message"=>"Default value for $badFloat doesn't match type Float",
+        "message"=>"Default value for $badInt doesn't match type Int",
         "locations"=>[{"line"=>6, "column"=>7}],
         "fields"=>["query getCheese"],
       },
       {
-        "message"=>"Default value for $badInt doesn't match type Int",
-        "locations"=>[{"line"=>7, "column"=>7}],
-        "fields"=>["query getCheese"],
-      },
-      {
         "message"=>"Default value for $badInput doesn't match type DairyProductInput",
-        "locations"=>[{"line"=>9, "column"=>7}],
+        "locations"=>[{"line"=>8, "column"=>7}],
         "fields"=>["query getCheese"],
       },
       {
         "message"=>"Non-null variable $nonNull can't have a default value",
-        "locations"=>[{"line"=>10, "column"=>7}],
+        "locations"=>[{"line"=>9, "column"=>7}],
         "fields"=>["query getCheese"],
       }
     ]

--- a/spec/graphql/static_validation/rules/variable_usages_are_allowed_spec.rb
+++ b/spec/graphql/static_validation/rules/variable_usages_are_allowed_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 describe GraphQL::StaticValidation::VariableUsagesAreAllowed do
+  include StaticValidationHelpers
+
   let(:query_string) {'
     query getCheese(
         $goodInt: Int = 1,
@@ -17,11 +19,11 @@ describe GraphQL::StaticValidation::VariableUsagesAreAllowed do
       badCheese:    cheese(id: $badInt)   { source }
       badStrCheese: cheese(id: $badStr)   { source }
       cheese(id: 1) {
-        similarCheese(source: $goodAnimals)
-        other: similarCheese(source: $badAnimals)
-        tooDeep: similarCheese(source: $deepAnimals)
-        nullableCheese(source: $goodAnimals)
-        deeplyNullableCheese(source: $deepAnimals)
+        similarCheese(source: $goodAnimals) { source }
+        other: similarCheese(source: $badAnimals) { source }
+        tooDeep: similarCheese(source: $deepAnimals) { source }
+        nullableCheese(source: $goodAnimals) { source }
+        deeplyNullableCheese(source: $deepAnimals) { source }
       }
 
       milk(id: 1) {
@@ -33,10 +35,6 @@ describe GraphQL::StaticValidation::VariableUsagesAreAllowed do
       }
     }
   '}
-
-  let(:validator) { GraphQL::StaticValidation::Validator.new(schema: DummySchema, rules: [GraphQL::StaticValidation::VariableUsagesAreAllowed]) }
-  let(:query) { GraphQL::Query.new(DummySchema, query_string) }
-  let(:errors) { validator.validate(query)[:errors] }
 
   it "finds variables used as arguments but don't match the argument's type" do
     assert_equal(4, errors.length)

--- a/spec/graphql/static_validation/rules/variables_are_input_types_spec.rb
+++ b/spec/graphql/static_validation/rules/variables_are_input_types_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 describe GraphQL::StaticValidation::VariablesAreInputTypes do
+  include StaticValidationHelpers
+
   let(:query_string) {'
     query getCheese(
       $id:        Int = 1,
@@ -10,31 +12,27 @@ describe GraphQL::StaticValidation::VariablesAreInputTypes do
       $objects:   [Cheese]!,
     ) {
       cheese(id: $id) { source }
+      __type(name: $str) { name }
     }
   '}
 
-  let(:validator) { GraphQL::StaticValidation::Validator.new(schema: DummySchema, rules: [GraphQL::StaticValidation::VariablesAreInputTypes]) }
-  let(:query) { GraphQL::Query.new(DummySchema, query_string) }
-  let(:errors) { validator.validate(query)[:errors] }
-
   it "finds variables whose types are invalid" do
-    expected = [
-      {
-        "message"=>"AnimalProduct isn't a valid input type (on $interface)",
-        "locations"=>[{"line"=>5, "column"=>7}],
-        "fields"=>["query getCheese"],
-      },
-      {
-        "message"=>"Milk isn't a valid input type (on $object)",
-        "locations"=>[{"line"=>6, "column"=>7}],
-        "fields"=>["query getCheese"],
-      },
-      {
-        "message"=>"Cheese isn't a valid input type (on $objects)",
-        "locations"=>[{"line"=>7, "column"=>7}],
-        "fields"=>["query getCheese"],
-      }
-    ]
-    assert_equal(expected, errors)
+    assert_includes(errors, {
+      "message"=>"AnimalProduct isn't a valid input type (on $interface)",
+      "locations"=>[{"line"=>5, "column"=>7}],
+      "fields"=>["query getCheese"],
+    })
+
+    assert_includes(errors, {
+      "message"=>"Milk isn't a valid input type (on $object)",
+      "locations"=>[{"line"=>6, "column"=>7}],
+      "fields"=>["query getCheese"],
+    })
+
+    assert_includes(errors, {
+      "message"=>"Cheese isn't a valid input type (on $objects)",
+      "locations"=>[{"line"=>7, "column"=>7}],
+      "fields"=>["query getCheese"],
+    })
   end
 end

--- a/spec/support/static_validation_helpers.rb
+++ b/spec/support/static_validation_helpers.rb
@@ -1,0 +1,27 @@
+# This module assumes you have `let(:query_string)` in your spec.
+# It provides `errors` which are the validation errors for that string,
+# as validated against `DummySchema`.
+# You can override `schema` to provide another schema
+# @example testing static validation
+#   include StaticValidationHelpers
+#   let(:query_string) { " ... " }
+#   it "validates" do
+#     assert_equal(errors, [ ... ])
+#     assert_equal(error_messages, [ ... ])
+#   end
+module StaticValidationHelpers
+  def errors
+    target_schema = schema
+    validator = GraphQL::StaticValidation::Validator.new(schema: target_schema)
+    query = GraphQL::Query.new(target_schema, query_string)
+    validator.validate(query)[:errors]
+  end
+
+  def error_messages
+    errors.map { |e| e["message"] }
+  end
+
+  def schema
+    DummySchema
+  end
+end


### PR DESCRIPTION
This is a refactor of the "test harness" for query validation in preparation for #268 . 

Although the current code is not so good, it does have quite a lot of test coverage. I'd like to keep that coverage during the "switch", so that: 

- I can avoid any regressions 
- Any specific changes in behavior will be evident from a diff (ie, changes to the test code) 

In order to accomplish that, I: 

- DRYed up the `query_string -> errors` pipeline so that all validation tests pass through the same code. (This way, to migrate, I just have to update `StaticValidationHelpers` to point at the new implementation) 
- Changed the validation tests to pass through _all_ rules, not just the one named by the spec file. The previous testing arrangement made for easy testing, but it led to bugs: it was unclear how validation rules would work _together_ (or, more annoyingly, _not_ work together), so a passing test suite _wasn't_ a good indicator of correct source code.
- Updated the tests to support _all_ rules at once. Some tests took advantage of the fact that some elements of the document weren't being validated. So I updated those tests ... or loosened the assertions on the returned `errors` to check for certain entries among many.