### PR TITLE
Parity with graphql-js' introspection schema

### DIFF
--- a/lib/graphql/directive.rb
+++ b/lib/graphql/directive.rb
@@ -12,18 +12,47 @@ module GraphQL
     lazy_defined_attr_accessor :locations, :arguments, :name, :description
 
     LOCATIONS = [
-      QUERY =               :QUERY,
-      MUTATION =            :MUTATION,
-      SUBSCRIPTION =        :SUBSCRIPTION,
-      FIELD =               :FIELD,
-      FIELD_DEFINITION =    :FIELD_DEFINITION,
-      FRAGMENT_DEFINITION = :FRAGMENT_DEFINITION,
-      FRAGMENT_SPREAD =     :FRAGMENT_SPREAD,
-      INLINE_FRAGMENT =     :INLINE_FRAGMENT,
-      ENUM_VALUE =          :ENUM_VALUE,
+      QUERY =                  :QUERY,
+      MUTATION =               :MUTATION,
+      SUBSCRIPTION =           :SUBSCRIPTION,
+      FIELD =                  :FIELD,
+      FRAGMENT_DEFINITION =    :FRAGMENT_DEFINITION,
+      FRAGMENT_SPREAD =        :FRAGMENT_SPREAD,
+      INLINE_FRAGMENT =        :INLINE_FRAGMENT,
+      SCHEMA =                 :SCHEMA,
+      SCALAR =                 :SCALAR,
+      OBJECT =                 :OBJECT,
+      FIELD_DEFINITION =       :FIELD_DEFINITION,
+      ARGUMENT_DEFINITION =    :ARGUMENT_DEFINITION,
+      INTERFACE =              :INTERFACE,
+      UNION =                  :UNION,
+      ENUM =                   :ENUM,
+      ENUM_VALUE =             :ENUM_VALUE,
+      INPUT_OBJECT =           :INPUT_OBJECT,
+      INPUT_FIELD_DEFINITION = :INPUT_FIELD_DEFINITION,
     ]
 
     DEFAULT_DEPRECATION_REASON = 'No longer supported'
+    LOCATION_DESCRIPTIONS = {
+      QUERY:                    'Location adjacent to a query operation.',
+      MUTATION:                 'Location adjacent to a mutation operation.',
+      SUBSCRIPTION:             'Location adjacent to a subscription operation.',
+      FIELD:                    'Location adjacent to a field.',
+      FRAGMENT_DEFINITION:      'Location adjacent to a fragment definition.',
+      FRAGMENT_SPREAD:          'Location adjacent to a fragment spread.',
+      INLINE_FRAGMENT:          'Location adjacent to an inline fragment.',
+      SCHEMA:                   'Location adjacent to a schema definition.',
+      SCALAR:                   'Location adjacent to a scalar definition.',
+      OBJECT:                   'Location adjacent to an object type definition.',
+      FIELD_DEFINITION:         'Location adjacent to a field definition.',
+      ARGUMENT_DEFINITION:      'Location adjacent to an argument definition.',
+      INTERFACE:                'Location adjacent to an interface definition.',
+      UNION:                    'Location adjacent to a union definition.',
+      ENUM:                     'Location adjacent to an enum definition.',
+      ENUM_VALUE:               'Location adjacent to an enum value definition.',
+      INPUT_OBJECT:             'Location adjacent to an input object type definition.',
+      INPUT_FIELD_DEFINITION:   'Location adjacent to an input object field definition.',
+    }
 
     def initialize
       @arguments = {}

--- a/lib/graphql/directive/deprecated_directive.rb
+++ b/lib/graphql/directive/deprecated_directive.rb
@@ -7,5 +7,5 @@ GraphQL::Directive::DeprecatedDirective = GraphQL::Directive.define do
     "suggestion for how to access supported similar data. Formatted "\
     "in [Markdown](https://daringfireball.net/projects/markdown/)."
 
-  argument :reason, !GraphQL::STRING_TYPE, reason_description, default_value: GraphQL::Directive::DEFAULT_DEPRECATION_REASON
+  argument :reason, GraphQL::STRING_TYPE, reason_description, default_value: GraphQL::Directive::DEFAULT_DEPRECATION_REASON
 end

--- a/lib/graphql/directive/include_directive.rb
+++ b/lib/graphql/directive/include_directive.rb
@@ -1,6 +1,6 @@
 GraphQL::Directive::IncludeDirective = GraphQL::Directive.define do
   name "include"
-  description "Include this part of the query if `if` is true"
+  description "Directs the executor to include this field or fragment only when the `if` argument is true."
   locations([GraphQL::Directive::FIELD, GraphQL::Directive::FRAGMENT_SPREAD, GraphQL::Directive::INLINE_FRAGMENT])
-  argument :if, !GraphQL::BOOLEAN_TYPE
+  argument :if, !GraphQL::BOOLEAN_TYPE, 'Included when true.'
 end

--- a/lib/graphql/directive/skip_directive.rb
+++ b/lib/graphql/directive/skip_directive.rb
@@ -1,7 +1,7 @@
 GraphQL::Directive::SkipDirective = GraphQL::Directive.define do
   name "skip"
-  description "Ignore this part of the query if `if` is true"
+  description "Directs the executor to skip this field or fragment when the `if` argument is true."
   locations([GraphQL::Directive::FIELD, GraphQL::Directive::FRAGMENT_SPREAD, GraphQL::Directive::INLINE_FRAGMENT])
 
-  argument :if, !GraphQL::BOOLEAN_TYPE
+  argument :if, !GraphQL::BOOLEAN_TYPE, 'Skipped when true.'
 end

--- a/lib/graphql/introspection/arguments_field.rb
+++ b/lib/graphql/introspection/arguments_field.rb
@@ -1,5 +1,4 @@
 GraphQL::Introspection::ArgumentsField = GraphQL::Field.define do
-  description "Arguments allowed to this object"
   type !GraphQL::ListType.new(of_type: !GraphQL::Introspection::InputValueType)
   resolve -> (target, a, c) { target.arguments.values }
 end

--- a/lib/graphql/introspection/directive_location_enum.rb
+++ b/lib/graphql/introspection/directive_location_enum.rb
@@ -1,8 +1,9 @@
 GraphQL::Introspection::DirectiveLocationEnum = GraphQL::EnumType.define do
   name "__DirectiveLocation"
-  description "Parts of the query where a directive may be located"
+  description "A Directive can be adjacent to many parts of the GraphQL language, a "\
+              "__DirectiveLocation describes one such possible adjacencies."
 
   GraphQL::Directive::LOCATIONS.each do |location|
-    value(location.to_s, value: location)
+    value(location.to_s, GraphQL::Directive::LOCATION_DESCRIPTIONS[location], value: location)
   end
 end

--- a/lib/graphql/introspection/directive_type.rb
+++ b/lib/graphql/introspection/directive_type.rb
@@ -1,11 +1,16 @@
 GraphQL::Introspection::DirectiveType = GraphQL::ObjectType.define do
   name "__Directive"
-  description "A query directive in this schema"
-  field :name, !types.String, "The name of this directive"
-  field :description, types.String, "The description for this type"
-  field :args, field: GraphQL::Introspection::ArgumentsField
+  description "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document."\
+              "\n\n"\
+              "In some cases, you need to provide options to alter GraphQL's execution behavior "\
+              "in ways field arguments will not suffice, such as conditionally including or "\
+              "skipping a field. Directives provide this by describing additional information "\
+              "to the executor."
+  field :name, !types.String
+  field :description, types.String
   field :locations, !types[!GraphQL::Introspection::DirectiveLocationEnum]
-  field :onOperation, !types.Boolean, "Does this directive apply to operations?", deprecation_reason: "Moved to 'locations' field", property: :on_operation?
-  field :onFragment, !types.Boolean, "Does this directive apply to fragments?", deprecation_reason: "Moved to 'locations' field", property: :on_fragment?
-  field :onField, !types.Boolean, "Does this directive apply to fields?", deprecation_reason: "Moved to 'locations' field", property: :on_field?
+  field :args, field: GraphQL::Introspection::ArgumentsField
+  field :onOperation, !types.Boolean, deprecation_reason: "Use `locations`.", property: :on_operation?
+  field :onFragment, !types.Boolean, deprecation_reason: "Use `locations`.", property: :on_fragment?
+  field :onField, !types.Boolean, deprecation_reason: "Use `locations`.", property: :on_field?
 end

--- a/lib/graphql/introspection/enum_value_type.rb
+++ b/lib/graphql/introspection/enum_value_type.rb
@@ -1,10 +1,12 @@
 GraphQL::Introspection::EnumValueType = GraphQL::ObjectType.define do
   name "__EnumValue"
-  description "A possible value for an Enum"
+  description "One possible value for a given Enum. Enum values are unique values, not a "\
+              "placeholder for a string or numeric value. However an Enum value is returned in "\
+              "a JSON response as a string."
   field :name, !types.String
   field :description, types.String
-  field :deprecationReason, types.String, property: :deprecation_reason
   field :isDeprecated, !types.Boolean do
     resolve -> (obj, a, c) { !!obj.deprecation_reason }
   end
+  field :deprecationReason, types.String, property: :deprecation_reason
 end

--- a/lib/graphql/introspection/enum_values_field.rb
+++ b/lib/graphql/introspection/enum_values_field.rb
@@ -1,5 +1,4 @@
 GraphQL::Introspection::EnumValuesField = GraphQL::Field.define do
-  description "Values for this enum"
   type types[!GraphQL::Introspection::EnumValueType]
   argument :includeDeprecated, types.Boolean, default_value: false
   resolve -> (object, arguments, context) do

--- a/lib/graphql/introspection/field_type.rb
+++ b/lib/graphql/introspection/field_type.rb
@@ -1,12 +1,13 @@
 GraphQL::Introspection::FieldType = GraphQL::ObjectType.define do
   name "__Field"
-  description "Field on a GraphQL type"
-  field :name, !types.String, "The name for accessing this field"
-  field :description, types.String, "The description of this field"
-  field :type, !GraphQL::Introspection::TypeType, "The return type of this field"
-  field :isDeprecated, !types.Boolean, "Is this field deprecated?" do
+  description "Object and Interface types are described by a list of Fields, each of which has "\
+              "a name, potentially a list of arguments, and a return type."
+  field :name, !types.String
+  field :description, types.String
+  field :args, GraphQL::Introspection::ArgumentsField
+  field :type, !GraphQL::Introspection::TypeType
+  field :isDeprecated, !types.Boolean do
     resolve -> (obj, a, c) { !!obj.deprecation_reason }
   end
-  field :args, GraphQL::Introspection::ArgumentsField
-  field :deprecationReason, types.String,  "Why this field was deprecated", property: :deprecation_reason
+  field :deprecationReason, types.String, property: :deprecation_reason
 end

--- a/lib/graphql/introspection/fields_field.rb
+++ b/lib/graphql/introspection/fields_field.rb
@@ -1,5 +1,4 @@
 GraphQL::Introspection::FieldsField = GraphQL::Field.define do
-  description "List of fields on this object"
   type -> { types[!GraphQL::Introspection::FieldType] }
   argument :includeDeprecated, GraphQL::BOOLEAN_TYPE, default_value: false
   resolve -> (object, arguments, context) {

--- a/lib/graphql/introspection/input_fields_field.rb
+++ b/lib/graphql/introspection/input_fields_field.rb
@@ -1,6 +1,5 @@
 GraphQL::Introspection::InputFieldsField = GraphQL::Field.define do
   name "inputFields"
-  description "fields on this input object"
   type types[!GraphQL::Introspection::InputValueType]
   resolve -> (target, a, c) {
     if target.kind.input_object?

--- a/lib/graphql/introspection/input_value_type.rb
+++ b/lib/graphql/introspection/input_value_type.rb
@@ -1,10 +1,12 @@
 GraphQL::Introspection::InputValueType = GraphQL::ObjectType.define do
   name "__InputValue"
-  description "An input for a field or InputObject"
-  field :name, !types.String, "The key for this value"
-  field :description, types.String, "What this value is used for"
-  field :type, !GraphQL::Introspection::TypeType, "The expected type for this value"
-  field :defaultValue, types.String, "The value applied if no other value is provided" do
+  description "Arguments provided to Fields or Directives and the input fields of an "\
+              "InputObject are represented as Input Values which describe their type and "\
+              "optionally a default value."
+  field :name, !types.String
+  field :description, types.String
+  field :type, !GraphQL::Introspection::TypeType
+  field :defaultValue, types.String, "A GraphQL-formatted string representing the default value for this input value." do
     resolve -> (obj, args, ctx) {
       value = obj.default_value
       value.nil? ? nil : JSON.dump(obj.type.coerce_result(value))

--- a/lib/graphql/introspection/interfaces_field.rb
+++ b/lib/graphql/introspection/interfaces_field.rb
@@ -1,5 +1,4 @@
 GraphQL::Introspection::InterfacesField = GraphQL::Field.define do
-  description "Interfaces which this object implements"
   type -> { types[!GraphQL::Introspection::TypeType] }
   resolve -> (target, a, c) { target.kind.object? ? target.interfaces : nil }
 end

--- a/lib/graphql/introspection/of_type_field.rb
+++ b/lib/graphql/introspection/of_type_field.rb
@@ -1,6 +1,5 @@
 GraphQL::Introspection::OfTypeField = GraphQL::Field.define do
   name "ofType"
-  description "The modified type of this type"
   type -> { GraphQL::Introspection::TypeType }
   resolve -> (obj, args, ctx) { obj.kind.wraps? ? obj.of_type : nil }
 end

--- a/lib/graphql/introspection/possible_types_field.rb
+++ b/lib/graphql/introspection/possible_types_field.rb
@@ -1,5 +1,4 @@
 GraphQL::Introspection::PossibleTypesField = GraphQL::Field.define do
-  description "Types which compose this Union or Interface"
   type -> { types[!GraphQL::Introspection::TypeType] }
   resolve -> (target, args, ctx) {
     if target.kind.resolves?

--- a/lib/graphql/introspection/schema_type.rb
+++ b/lib/graphql/introspection/schema_type.rb
@@ -1,24 +1,26 @@
 GraphQL::Introspection::SchemaType = GraphQL::ObjectType.define do
   name "__Schema"
-  description "A GraphQL schema"
+  description "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all "\
+              "available types and directives on the server, as well as the entry points for "\
+              "query, mutation, and subscription operations."
 
-  field :types, !types[!GraphQL::Introspection::TypeType], "Types in this schema" do
+  field :types, !types[!GraphQL::Introspection::TypeType], "A list of all types supported by this server." do
     resolve -> (obj, arg, ctx) { obj.types.values }
   end
 
-  field :directives, !types[!GraphQL::Introspection::DirectiveType], "Directives in this schema" do
-    resolve -> (obj, arg, ctx) { obj.directives.values }
-  end
-
-  field :queryType, !GraphQL::Introspection::TypeType, "The query root of this schema" do
+  field :queryType, !GraphQL::Introspection::TypeType, "The type that query operations will be rooted at." do
     resolve -> (obj, arg, ctx) { obj.query }
   end
 
-  field :mutationType, GraphQL::Introspection::TypeType, "The mutation root of this schema" do
+  field :mutationType, GraphQL::Introspection::TypeType, "If this server supports mutation, the type that mutation operations will be rooted at." do
     resolve -> (obj, arg, ctx) { obj.mutation }
   end
 
-  field :subscriptionType, GraphQL::Introspection::TypeType, "The subscription root of this schema" do
+  field :subscriptionType, GraphQL::Introspection::TypeType, "If this server support subscription, the type that subscription operations will be rooted at." do
     resolve -> (obj, arg, ctx) { obj.subscription }
+  end
+
+  field :directives, !types[!GraphQL::Introspection::DirectiveType], "A list of all directives supported by this server." do
+    resolve -> (obj, arg, ctx) { obj.directives.values }
   end
 end

--- a/lib/graphql/introspection/type_kind_enum.rb
+++ b/lib/graphql/introspection/type_kind_enum.rb
@@ -1,7 +1,7 @@
 GraphQL::Introspection::TypeKindEnum = GraphQL::EnumType.define do
   name "__TypeKind"
-  description "The kinds of types in this GraphQL system"
+  description "An enum describing what kind of type a given `__Type` is."
   GraphQL::TypeKinds::KIND_NAMES.each do |kind_name|
-    value(kind_name)
+    value(kind_name, GraphQL::TypeKinds::TYPE_KIND_DESCRIPTIONS[kind_name.to_sym])
   end
 end

--- a/lib/graphql/introspection/type_kind_enum.rb
+++ b/lib/graphql/introspection/type_kind_enum.rb
@@ -1,7 +1,7 @@
 GraphQL::Introspection::TypeKindEnum = GraphQL::EnumType.define do
   name "__TypeKind"
   description "An enum describing what kind of type a given `__Type` is."
-  GraphQL::TypeKinds::KIND_NAMES.each do |kind_name|
-    value(kind_name, GraphQL::TypeKinds::TYPE_KIND_DESCRIPTIONS[kind_name.to_sym])
+  GraphQL::TypeKinds::TYPE_KINDS.each do |type_kind|
+    value(type_kind.name, type_kind.description)
   end
 end

--- a/lib/graphql/introspection/type_type.rb
+++ b/lib/graphql/introspection/type_type.rb
@@ -1,16 +1,19 @@
 GraphQL::Introspection::TypeType = GraphQL::ObjectType.define do
   name "__Type"
-  description "A type in the GraphQL schema"
+  description "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in "\
+              "GraphQL as represented by the `__TypeKind` enum.\n\n"\
+              "Depending on the kind of a type, certain fields describe information about that type. "\
+              "Scalar types provide no information beyond a name and description, while "\
+              "Enum types provide their values. Object and Interface types provide the fields "\
+              "they describe. Abstract types, Union and Interface, provide the Object types "\
+              "possible at runtime. List and NonNull types compose other types."
 
-  field :name, types.String,  "The name of this type"
-  field :description, types.String, "What this type represents"
-
+  field :name, types.String
+  field :description, types.String
   field :kind do
     type !GraphQL::Introspection::TypeKindEnum
-    description "The kind of this type"
     resolve -> (target, a, c) { target.kind.name }
   end
-
   field :fields,          field: GraphQL::Introspection::FieldsField
   field :ofType,          field: GraphQL::Introspection::OfTypeField
   field :inputFields,     field: GraphQL::Introspection::InputFieldsField

--- a/lib/graphql/type_kinds.rb
+++ b/lib/graphql/type_kinds.rb
@@ -37,6 +37,17 @@ module GraphQL
       NON_NULL =      TypeKind.new("NON_NULL", wraps: true),
     ]
 
+    TYPE_KIND_DESCRIPTIONS = {
+      SCALAR:       'Indicates this type is a scalar.',
+      OBJECT:       'Indicates this type is an object. `fields` and `interfaces` are valid fields.',
+      INTERFACE:    'Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.',
+      UNION:        'Indicates this type is a union. `possibleTypes` is a valid field.',
+      ENUM:         'Indicates this type is an enum. `enumValues` is a valid field.',
+      INPUT_OBJECT: 'Indicates this type is an input object. `inputFields` is a valid field.',
+      LIST:         'Indicates this type is a list. `ofType` is a valid field.',
+      NON_NULL:     'Indicates this type is a non-null. `ofType` is a valid field.',
+    }
+
     KIND_NAMES = TYPE_KINDS.map(&:name)
     class TypeKind
       KIND_NAMES.each do |kind_name|

--- a/lib/graphql/type_kinds.rb
+++ b/lib/graphql/type_kinds.rb
@@ -3,14 +3,15 @@ module GraphQL
   module TypeKinds
     # These objects are singletons, eg `GraphQL::TypeKinds::UNION`, `GraphQL::TypeKinds::SCALAR`.
     class TypeKind
-      attr_reader :name
-      def initialize(name, resolves: false, fields: false, wraps: false, input: false)
+      attr_reader :name, :description
+      def initialize(name, resolves: false, fields: false, wraps: false, input: false, description: nil)
         @name = name
         @resolves = resolves
         @fields = fields
         @wraps = wraps
         @input = input
         @composite = fields? || resolves?
+        @description = description
       end
 
       # Does this TypeKind have multiple possible implementors?
@@ -27,30 +28,18 @@ module GraphQL
     end
 
     TYPE_KINDS = [
-      SCALAR =        TypeKind.new("SCALAR", input: true),
-      OBJECT =        TypeKind.new("OBJECT", fields: true),
-      INTERFACE =     TypeKind.new("INTERFACE", resolves: true, fields: true),
-      UNION =         TypeKind.new("UNION", resolves: true),
-      ENUM =          TypeKind.new("ENUM", input: true),
-      INPUT_OBJECT =  TypeKind.new("INPUT_OBJECT", input: true),
-      LIST =          TypeKind.new("LIST", wraps: true),
-      NON_NULL =      TypeKind.new("NON_NULL", wraps: true),
+      SCALAR =        TypeKind.new("SCALAR", input: true, description: 'Indicates this type is a scalar.'),
+      OBJECT =        TypeKind.new("OBJECT", fields: true, description: 'Indicates this type is an object. `fields` and `interfaces` are valid fields.'),
+      INTERFACE =     TypeKind.new("INTERFACE", resolves: true, fields: true, description: 'Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.'),
+      UNION =         TypeKind.new("UNION", resolves: true, description: 'Indicates this type is a union. `possibleTypes` is a valid field.'),
+      ENUM =          TypeKind.new("ENUM", input: true, description: 'Indicates this type is an enum. `enumValues` is a valid field.'),
+      INPUT_OBJECT =  TypeKind.new("INPUT_OBJECT", input: true, description: 'Indicates this type is an input object. `inputFields` is a valid field.'),
+      LIST =          TypeKind.new("LIST", wraps: true, description: 'Indicates this type is a list. `ofType` is a valid field.'),
+      NON_NULL =      TypeKind.new("NON_NULL", wraps: true, description: 'Indicates this type is a non-null. `ofType` is a valid field.'),
     ]
 
-    TYPE_KIND_DESCRIPTIONS = {
-      SCALAR:       'Indicates this type is a scalar.',
-      OBJECT:       'Indicates this type is an object. `fields` and `interfaces` are valid fields.',
-      INTERFACE:    'Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.',
-      UNION:        'Indicates this type is a union. `possibleTypes` is a valid field.',
-      ENUM:         'Indicates this type is an enum. `enumValues` is a valid field.',
-      INPUT_OBJECT: 'Indicates this type is an input object. `inputFields` is a valid field.',
-      LIST:         'Indicates this type is a list. `ofType` is a valid field.',
-      NON_NULL:     'Indicates this type is a non-null. `ofType` is a valid field.',
-    }
-
-    KIND_NAMES = TYPE_KINDS.map(&:name)
     class TypeKind
-      KIND_NAMES.each do |kind_name|
+      TYPE_KINDS.map(&:name).each do |kind_name|
         define_method("#{kind_name.downcase}?") do
           self.name == kind_name
         end

--- a/spec/graphql/introspection/directive_type_spec.rb
+++ b/spec/graphql/introspection/directive_type_spec.rb
@@ -45,7 +45,7 @@ describe GraphQL::Introspection::DirectiveType do
           {
             "name" => "deprecated",
             "args" => [
-              {"name"=>"reason", "type"=>{"name"=>"Non-Null", "ofType"=>{"name"=>"String"}}}
+              {"name"=>"reason", "type"=>{"name"=>"String", "ofType"=>nil}}
             ],
             "locations"=>["FIELD_DEFINITION", "ENUM_VALUE"],
             "onField" => false,

--- a/spec/graphql/schema/printer_spec.rb
+++ b/spec/graphql/schema/printer_spec.rb
@@ -82,11 +82,11 @@ directive @deprecated(reason: String = \"No longer supported\") on FIELD_DEFINIT
 type __Directive {
   name: String!
   description: String
-  args: [__InputValue!]!
   locations: [__DirectiveLocation!]!
-  onOperation: Boolean! @deprecated(reason: \"Moved to 'locations' field\")
-  onFragment: Boolean! @deprecated(reason: \"Moved to 'locations' field\")
-  onField: Boolean! @deprecated(reason: \"Moved to 'locations' field\")
+  args: [__InputValue!]!
+  onOperation: Boolean! @deprecated(reason: \"Use `locations`.\")
+  onFragment: Boolean! @deprecated(reason: \"Use `locations`.\")
+  onField: Boolean! @deprecated(reason: \"Use `locations`.\")
 }
 
 enum __DirectiveLocation {
@@ -94,26 +94,35 @@ enum __DirectiveLocation {
   MUTATION
   SUBSCRIPTION
   FIELD
-  FIELD_DEFINITION
   FRAGMENT_DEFINITION
   FRAGMENT_SPREAD
   INLINE_FRAGMENT
+  SCHEMA
+  SCALAR
+  OBJECT
+  FIELD_DEFINITION
+  ARGUMENT_DEFINITION
+  INTERFACE
+  UNION
+  ENUM
   ENUM_VALUE
+  INPUT_OBJECT
+  INPUT_FIELD_DEFINITION
 }
 
 type __EnumValue {
   name: String!
   description: String
-  deprecationReason: String
   isDeprecated: Boolean!
+  deprecationReason: String
 }
 
 type __Field {
   name: String!
   description: String
+  args: [__InputValue!]!
   type: __Type!
   isDeprecated: Boolean!
-  args: [__InputValue!]!
   deprecationReason: String
 }
 
@@ -126,10 +135,10 @@ type __InputValue {
 
 type __Schema {
   types: [__Type!]!
-  directives: [__Directive!]!
   queryType: __Type!
   mutationType: __Type
   subscriptionType: __Type
+  directives: [__Directive!]!
 }
 
 type __Type {

--- a/spec/graphql/schema/printer_spec.rb
+++ b/spec/graphql/schema/printer_spec.rb
@@ -77,7 +77,7 @@ directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
 directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-directive @deprecated(reason: String! = \"No longer supported\") on FIELD_DEFINITION | ENUM_VALUE
+directive @deprecated(reason: String = \"No longer supported\") on FIELD_DEFINITION | ENUM_VALUE
 
 type __Directive {
   name: String!


### PR DESCRIPTION
While working [on adding descriptions to the schema dumper](https://github.com/graphql/graphql-js/pull/464), I noticed our introspection schema descriptions don't match graphql-js'.

This means we need to maintain [our own copy of the introspection schema](https://github.com/rmosolgo/graphql-ruby/blob/9c6ebbda48b59c0a23467ab9dd45179654279282/spec/graphql/schema/printer_spec.rb#L71).

This PR brings us back to parity with graphql-js by [using their introspection schema](https://github.com/graphql/graphql-js/blob/a725499b155285c2e33647a93393c82689b20b0f/src/utilities/__tests__/schemaPrinter-test.js#L600-L797) in our tests.

As graphql-js evolves this means we'll be able to easily copy over their introspection schema to ensure the gem remains compliant.

👀 @rmosolgo 