### PR TITLE
Remove errant commas and equals in documentation.

### DIFF
--- a/guides/defining_your_schema.md
+++ b/guides/defining_your_schema.md
@@ -231,9 +231,9 @@ Your schema can be initialized with some options:
 
 ```ruby
 MySchema = GraphQL::Schema.define do
-  query QueryType,       # root type for read-only queries
-  mutation MutationType, # root type for mutations
-  max_depth 7,           # if present, the max depth for incoming queries
+  query QueryType       # root type for read-only queries
+  mutation MutationType # root type for mutations
+  max_depth 7           # if present, the max depth for incoming queries
 end
 ```
 

--- a/guides/relay.md
+++ b/guides/relay.md
@@ -22,13 +22,13 @@ You must provide a function for generating UUIDs and fetching objects with them.
 
 ```ruby
 MySchema = GraphQL::Schema.define do
-  id_from_object = -> (object, type_definition, query_ctx) {
+  id_from_object -> (object, type_definition, query_ctx) {
     # Call your application's UUID method here
     # It should return a string
     MyApp::GlobalId.encrypt(object.class.name, object.id)
   }
 
-  object_from_id = -> (id, query_ctx) {
+  object_from_id -> (id, query_ctx) {
     class_name, item_id = MyApp::GlobalId.decrypt(id)
     # "Post" => Post.find(id)
     Object.const_get(class_name).find(item_id)
@@ -41,11 +41,11 @@ An unencrypted ID generator is provided in the gem. It uses `Base64` to encode v
 ```ruby
 MySchema = GraphQL::Schema.define do
   # Create UUIDs by joining the type name & ID, then base64-encoding it
-  id_from_object = -> (object, type_definition, query_ctx) {
+  id_from_object -> (object, type_definition, query_ctx) {
     GraphQL::Schema::UniqueWithinType.encode(type_definition.name, object.id)
   }
 
-  object_from_id = -> (id, query_ctx) {
+  object_from_id -> (id, query_ctx) {
     type_name, item_id = GraphQL::Schema::UniqueWithinType.decode(id)
     # Now, based on `type_name` and `id`
     # find an object in your application


### PR DESCRIPTION
A simple fix but helpful when you're getting started.