### PR TITLE
Eager load schema

### DIFF
--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -66,6 +66,7 @@ require "graphql/schema/printer"
 
 require "graphql/analysis_error"
 require "graphql/invalid_null_error"
+require "graphql/unresolved_type_error"
 require "graphql/query"
 require "graphql/internal_representation"
 require "graphql/static_validation"

--- a/lib/graphql/define/instance_definable.rb
+++ b/lib/graphql/define/instance_definable.rb
@@ -82,6 +82,9 @@ module GraphQL
       # one of the defined fields is needed.
       # @return [void]
       def define(**kwargs, &block)
+        # make sure the previous definition_proc was executed:
+        ensure_defined
+
         @definition_proc = -> (obj) {
           kwargs.each do |keyword, value|
             public_send(keyword, value)

--- a/lib/graphql/object_type.rb
+++ b/lib/graphql/object_type.rb
@@ -91,6 +91,7 @@ module GraphQL
       private
 
       def exception_message
+        # TODO: more descriptive message -- what did it get or not get?
         "The value returned for field #{field_name} on #{parent_type} could not be resolved "\
         "to one of the possible types for #{field_type}."
       end

--- a/lib/graphql/object_type.rb
+++ b/lib/graphql/object_type.rb
@@ -74,27 +74,5 @@ module GraphQL
         memo.merge!(iface.fields)
       end
     end
-
-
-    # Error raised when the value provided for a field can't be resolved to one of the possible types
-    # for the field.
-    class UnresolvedTypeError < GraphQL::Error
-      attr_reader :field_name, :field_type, :parent_type
-
-      def initialize(field_name, field_type, parent_type)
-        @field_name = field_name
-        @field_type = field_type
-        @parent_type = parent_type
-        super(exception_message)
-      end
-
-      private
-
-      def exception_message
-        # TODO: more descriptive message -- what did it get or not get?
-        "The value returned for field #{field_name} on #{parent_type} could not be resolved "\
-        "to one of the possible types for #{field_type}."
-      end
-    end
   end
 end

--- a/lib/graphql/query/serial_execution/value_resolution.rb
+++ b/lib/graphql/query/serial_execution/value_resolution.rb
@@ -61,8 +61,8 @@ module GraphQL
             # resolved_type = execution_context.schema.resolve_type(value)
             resolved_type = field_type.legacy_resolve_type(value, execution_context)
 
-            unless resolved_type.is_a?(GraphQL::ObjectType)
-              raise GraphQL::ObjectType::UnresolvedTypeError.new(irep_node.definition_name, field_type, parent_type)
+            if !resolved_type.is_a?(GraphQL::ObjectType)
+              raise GraphQL::UnresolvedTypeError.new(irep_node.definition_name, execution_context.schema, field_type, parent_type, resolved_type)
             end
 
             strategy_class = get_strategy_for_kind(resolved_type.kind)

--- a/lib/graphql/relay/node.rb
+++ b/lib/graphql/relay/node.rb
@@ -7,12 +7,17 @@ module GraphQL
         # We have to define it fresh each time because
         # its name will be modified and its description
         # _may_ be modified.
-        GraphQL::Field.define do
+        node_field = GraphQL::Field.define do
           type(GraphQL::Relay::Node.interface)
           description("Fetches an object given its ID")
           argument(:id, !types.ID, "ID of the object")
           resolve(GraphQL::Relay::Node::FindNode)
         end
+
+        # This is used to identify generated fields in the schema
+        node_field.metadata[:relay_node_field] = true
+
+        node_field
       end
 
       # @return [GraphQL::InterfaceType] The interface which all Relay types must implement

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -63,11 +63,10 @@ module GraphQL
 
     DIRECTIVES = [GraphQL::Directive::SkipDirective, GraphQL::Directive::IncludeDirective, GraphQL::Directive::DeprecatedDirective]
     DYNAMIC_FIELDS = ["__type", "__typename", "__schema"]
-    RESOLVE_TYPE_PROC_REQUIRED = -> (obj, ctx) { raise(NotImplementedError, "Schema.resolve_type is undefined, can't resolve type for #{obj.inspect}") }
     OBJECT_FROM_ID_PROC_REQUIRED = -> (id, ctx) { raise(NotImplementedError, "Schema.object_from_id is undefined, can't fetch object for #{id.inspect}") }
     ID_FROM_OBJECT_PROC_REQUIRED = -> (obj, type, ctx) { raise(NotImplementedError, "Schema.id_from_object is undefined, can't return an ID for #{obj.inspect}") }
 
-    attr_reader :directives, :static_validator, :object_from_id_proc, :id_from_object_proc
+    attr_reader :directives, :static_validator, :object_from_id_proc, :id_from_object_proc, :resolve_type_proc
 
     # @!attribute [r] middleware
     #   @return [Array<#call>] Middlewares suitable for MiddlewareChain, applied to fields during execution
@@ -92,7 +91,7 @@ module GraphQL
       @rescue_middleware = GraphQL::Schema::RescueMiddleware.new
       @middleware = [@rescue_middleware]
       @query_analyzers = []
-      @resolve_type_proc = RESOLVE_TYPE_PROC_REQUIRED
+      @resolve_type_proc = nil
       @object_from_id_proc = OBJECT_FROM_ID_PROC_REQUIRED
       @id_from_object_proc = ID_FROM_OBJECT_PROC_REQUIRED
       # Default to the built-in execution strategy:
@@ -109,6 +108,14 @@ module GraphQL
     def remove_handler(*args, &block)
       ensure_defined
       @rescue_middleware.remove_handler(*args, &block)
+    end
+
+    def define(**kwargs, &block)
+      super
+      types
+      validation_error = Validation.validate(self)
+      validation_error && raise(validation_error)
+      nil
     end
 
     # @return [GraphQL::Schema::TypeMap] `{ name => type }` pairs of types in this schema
@@ -193,6 +200,11 @@ module GraphQL
     # @return [GraphQL::ObjectType] The type for exposing `object` in GraphQL
     def resolve_type(object, ctx)
       ensure_defined
+
+      if @resolve_type_proc.nil?
+        raise(NotImplementedError, "Can't determine GraphQL type for: #{object.inspect}, define `resolve_type (obj, ctx) -> { ... }` inside `Schema.define`.")
+      end
+
       type_result = @resolve_type_proc.call(object, ctx)
       if type_result.nil?
         nil

--- a/lib/graphql/schema/loader.rb
+++ b/lib/graphql/schema/loader.rb
@@ -22,7 +22,7 @@ module GraphQL
           types[type_object.name] = type_object
         end
 
-        kargs = { :orphan_types => types.values }
+        kargs = { orphan_types: types.values, resolve_type: NullResolveType }
         [:query, :mutation, :subscription].each do |root|
           type = schema["#{root}Type"]
           kargs[root] = types.fetch(type.fetch("name")) if type
@@ -30,6 +30,10 @@ module GraphQL
 
         Schema.define(**kargs)
       end
+
+      NullResolveType = -> (obj, ctx) {
+        raise(NotImplementedError, "This schema was loaded from string, so it can't resolve types for objects")
+      }
 
       class << self
         private

--- a/lib/graphql/schema/validation.rb
+++ b/lib/graphql/schema/validation.rb
@@ -125,6 +125,14 @@ module GraphQL
             "type must be a valid input type (Scalar or InputObject), not #{outer_type.class} (#{outer_type})"
           end
         }
+
+        SCHEMA_CAN_RESOLVE_TYPES = -> (schema) {
+          if schema.types.values.any? { |type| type.kind.resolves? } && schema.resolve_type_proc.nil?
+            "schema contains Interfaces or Unions, so you must define a `resolve_type (obj, ctx) -> { ... }` function"
+          else
+            # :+1:
+          end
+        }
       end
 
       # A mapping of `{Class => [Proc, Proc...]}` pairs.
@@ -164,6 +172,9 @@ module GraphQL
         ],
         GraphQL::InterfaceType => [
           Rules::FIELDS_ARE_VALID,
+        ],
+        GraphQL::Schema => [
+          Rules::SCHEMA_CAN_RESOLVE_TYPES,
         ],
       }
     end

--- a/lib/graphql/schema/validation.rb
+++ b/lib/graphql/schema/validation.rb
@@ -133,6 +133,24 @@ module GraphQL
             # :+1:
           end
         }
+
+        SCHEMA_CAN_FETCH_IDS = -> (schema) {
+          has_node_field = schema.query && schema.query.all_fields.any? { |f| f.metadata[:relay_node_field] }
+          if has_node_field && schema.object_from_id_proc.nil?
+            "schema contains `node(id:...)` field, so you must define a `object_from_id (id, ctx) -> { ... }` function"
+          else
+            # :rocket:
+          end
+        }
+
+        SCHEMA_CAN_GENERATE_IDS = -> (schema) {
+          has_id_field = schema.types.values.any? { |t| t.kind.fields? && t.all_fields.any? { |f| f.resolve_proc.is_a?(GraphQL::Relay::GlobalIdResolve) } }
+          if has_id_field && schema.id_from_object_proc.nil?
+            "schema contains `global_id_field`, so you must define a `id_from_object (obj, type, ctx) -> { ... }` function"
+          else
+            # :ok_hand:
+          end
+        }
       end
 
       # A mapping of `{Class => [Proc, Proc...]}` pairs.
@@ -175,6 +193,8 @@ module GraphQL
         ],
         GraphQL::Schema => [
           Rules::SCHEMA_CAN_RESOLVE_TYPES,
+          Rules::SCHEMA_CAN_FETCH_IDS,
+          Rules::SCHEMA_CAN_GENERATE_IDS,
         ],
       }
     end

--- a/lib/graphql/unresolved_type_error.rb
+++ b/lib/graphql/unresolved_type_error.rb
@@ -1,0 +1,16 @@
+module GraphQL
+  # Error raised when the value provided for a field can't be resolved to one of the possible types
+  # for the field.
+  class UnresolvedTypeError < GraphQL::Error
+    def initialize(field_name, schema, field_type, parent_type, received_type)
+      possible_types = field_type.kind.resolves? ? schema.possible_types(field_type) : [field_type]
+      message = %|The value from "#{field_name}" on "#{parent_type}" could not be resolved to "#{field_type}". (Received: #{received_type.inspect}, Expected: [#{possible_types.map(&:inspect).join(", ")}])|
+      super(message)
+    end
+  end
+
+  class ObjectType
+    # @deprecated Use {GraphQL::UnresolvedTypeError} instead
+    UnresolvedTypeError = GraphQL::UnresolvedTypeError
+  end
+end

--- a/spec/graphql/analysis/query_complexity_spec.rb
+++ b/spec/graphql/analysis/query_complexity_spec.rb
@@ -255,7 +255,11 @@ describe GraphQL::Analysis::QueryComplexity do
         end
       end
 
-      GraphQL::Schema.define(query: query_type, orphan_types: [double_complexity_type])
+      GraphQL::Schema.define(
+        query: query_type,
+        orphan_types: [double_complexity_type],
+        resolve_type: :pass
+      )
     }
     let(:query_string) {%|
       {

--- a/spec/graphql/define/instance_definable_spec.rb
+++ b/spec/graphql/define/instance_definable_spec.rb
@@ -62,6 +62,17 @@ describe GraphQL::Define::InstanceDefinable do
     end
   end
 
+  describe "#define" do
+    it "applies new definitions to an object" do
+      okra = Garden::Vegetable.define(name: "Okra", plant_between: Date.new(2000, 5, 1)..Date.new(2000, 7, 1))
+      assert_equal "Okra", okra.name
+      okra.define(name: "Gumbo")
+      assert_equal "Gumbo", okra.name
+      okra.define { name "Okra" }
+      assert_equal "Okra", okra.name
+    end
+  end
+
   describe "#metadata" do
     it "gets values from definitions" do
       arugula = Garden::Vegetable.define(name: "Arugula", color: :green)

--- a/spec/graphql/field_spec.rb
+++ b/spec/graphql/field_spec.rb
@@ -88,9 +88,10 @@ describe GraphQL::Field do
       invalid_field.name = :symbol_name
 
       dummy_query.fields["symbol_name"] = invalid_field
-      dummy_schema = GraphQL::Schema.define(query: dummy_query)
 
-      err = assert_raises(GraphQL::Schema::InvalidTypeError) { dummy_schema.types }
+      err = assert_raises(GraphQL::Schema::InvalidTypeError) {
+        GraphQL::Schema.define(query: dummy_query)
+      }
       assert_equal "QueryType is invalid: field :symbol_name name must return String, not Symbol (:symbol_name)", err.message
     end
   end

--- a/spec/graphql/query/context_spec.rb
+++ b/spec/graphql/query/context_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 describe GraphQL::Query::Context do
   let(:query_type) { GraphQL::ObjectType.define {
+    name "Query"
     field :context, types.String do
       argument :key, !types.String
       resolve -> (target, args, ctx) { ctx[args[:key]] }

--- a/spec/graphql/query/executor_spec.rb
+++ b/spec/graphql/query/executor_spec.rb
@@ -85,7 +85,7 @@ describe GraphQL::Query::Executor do
         end
       end
 
-      GraphQL::Schema.define(query: DummyQueryType, mutation: MutationType)
+      GraphQL::Schema.define(query: DummyQueryType, mutation: MutationType, resolve_type: :pass, id_from_object: :pass)
     }
     let(:variables) { nil }
     let(:query_string) { %|

--- a/spec/graphql/query/serial_execution/value_resolution_spec.rb
+++ b/spec/graphql/query/serial_execution/value_resolution_spec.rb
@@ -18,6 +18,11 @@ describe GraphQL::Query::SerialExecution::ValueResolution do
       field :someField, !types.Int
     end
 
+    some_object = GraphQL::ObjectType.define do
+      name "SomeObject"
+      interfaces [interface]
+    end
+
     query_root = GraphQL::ObjectType.define do
       name "Query"
       field :tomorrow, day_of_week_enum do
@@ -31,6 +36,7 @@ describe GraphQL::Query::SerialExecution::ValueResolution do
 
     GraphQL::Schema.define do
       query(query_root)
+      orphan_types [some_object]
       resolve_type -> (obj, ctx) { nil }
     end
   }
@@ -64,7 +70,9 @@ describe GraphQL::Query::SerialExecution::ValueResolution do
     |}
 
     it "raises an error if it cannot resolve the type of an interface" do
-      assert_raises(GraphQL::ObjectType::UnresolvedTypeError) { result }
+      err = assert_raises(GraphQL::ObjectType::UnresolvedTypeError) { result }
+      expected_message = %|The value from "misbehavedInterface" on "Query" could not be resolved to "SomeInterface". (Received: nil, Expected: [SomeObject])|
+      assert_equal expected_message, err.message
     end
   end
 end

--- a/spec/graphql/schema/loader_spec.rb
+++ b/spec/graphql/schema/loader_spec.rb
@@ -106,7 +106,12 @@ describe GraphQL::Schema::Loader do
       field :ping, field: ping_mutation.field
     end
 
-    GraphQL::Schema.define(query: query_root, mutation: mutation_root, orphan_types: [audio_type, video_type])
+    GraphQL::Schema.define(
+      query: query_root,
+      mutation: mutation_root,
+      orphan_types: [audio_type, video_type],
+      resolve_type: :pass,
+    )
   }
 
   let(:schema_json) {

--- a/spec/graphql/schema/printer_spec.rb
+++ b/spec/graphql/schema/printer_spec.rb
@@ -63,7 +63,7 @@ describe GraphQL::Schema::Printer do
       end
     end
 
-    GraphQL::Schema.define(query: query_root)
+    GraphQL::Schema.define(query: query_root, resolve_type: :pass)
   }
 
   describe ".print_introspection_schema" do

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -47,6 +47,25 @@ describe GraphQL::Schema do
         }
       end
     end
+
+    describe "when a schema is defined with abstract types, but no resolve type hook" do
+      it "raises not implemented" do
+        interface = GraphQL::InterfaceType.define do
+          name "SomeInterface"
+        end
+
+        query_type = GraphQL::ObjectType.define do
+          name "Query"
+          field :something, interface
+        end
+
+        assert_raises(RuntimeError) {
+          GraphQL::Schema.define do
+            query(query_type)
+          end
+        }
+      end
+    end
   end
 
   describe "object_from_id" do
@@ -57,6 +76,10 @@ describe GraphQL::Schema do
         }
       end
     end
+
+    describe "when a schema is defined with a node field, but no hook" do
+      it "raises not implemented"
+    end
   end
 
   describe "id_from_object" do
@@ -66,6 +89,10 @@ describe GraphQL::Schema do
           empty_schema.id_from_object(nil, nil, nil)
         }
       end
+    end
+
+    describe "when a schema is defined with a node field, but no hook" do
+      it "raises not implemented"
     end
   end
 end

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -59,7 +59,7 @@ describe GraphQL::Schema do
           field :something, interface
         end
 
-        assert_raises(RuntimeError) {
+        assert_raises(NotImplementedError) {
           GraphQL::Schema.define do
             query(query_type)
           end
@@ -77,8 +77,25 @@ describe GraphQL::Schema do
       end
     end
 
-    describe "when a schema is defined with a node field, but no hook" do
-      it "raises not implemented"
+    describe "when a schema is defined with a relay ID field, but no hook" do
+      it "raises not implemented" do
+        thing_type = GraphQL::ObjectType.define do
+          name "Thing"
+          global_id_field :id
+        end
+
+        query_type = GraphQL::ObjectType.define do
+          name "Query"
+          field :thing, thing_type
+        end
+
+        assert_raises(NotImplementedError) {
+          GraphQL::Schema.define do
+            query(query_type)
+            resolve_type -> (obj, ctx) { :whatever }
+          end
+        }
+      end
     end
   end
 
@@ -92,7 +109,19 @@ describe GraphQL::Schema do
     end
 
     describe "when a schema is defined with a node field, but no hook" do
-      it "raises not implemented"
+      it "raises not implemented" do
+        query_type = GraphQL::ObjectType.define do
+          name "Query"
+          field :node, GraphQL::Relay::Node.field
+        end
+
+        assert_raises(NotImplementedError) {
+          GraphQL::Schema.define do
+            query(query_type)
+            resolve_type -> (obj, ctx) { :whatever }
+          end
+        }
+      end
     end
   end
 end

--- a/spec/graphql/static_validation/rules/mutation_root_exists_spec.rb
+++ b/spec/graphql/static_validation/rules/mutation_root_exists_spec.rb
@@ -15,7 +15,7 @@ describe GraphQL::StaticValidation::MutationRootExists do
   |}
 
   let(:schema) {
-    query_root = GraphQL::Field.define do
+    query_root = GraphQL::ObjectType.define do
       name "Query"
       description "Query root of the system"
     end

--- a/spec/graphql/static_validation/rules/subscription_root_exists_spec.rb
+++ b/spec/graphql/static_validation/rules/subscription_root_exists_spec.rb
@@ -10,7 +10,7 @@ describe GraphQL::StaticValidation::SubscriptionRootExists do
   |}
 
   let(:schema) {
-    query_root = GraphQL::Field.define do
+    query_root = GraphQL::ObjectType.define do
       name "Query"
       description "Query root of the system"
     end


### PR DESCRIPTION
Previously, schema validation was deferred until the first call to `Schema#types`. This call constructed the `TypeMap` and validated each entry. This means you might start up your app and get an error backtrace that points to validation, which is annoying. 

Also, it might have been the culprit in some thread-safety bugs. If you start accepting requests on different threads, one thread might start building the schema's type map, then the other thread might see that the type map was already there, and try to use it, but it's not complete, so :boom: .

Now, run validations as part of `Schema.define`. This will find errors earlier and reduce the likelihood of thread-unsafety with the `TypeMap`.