### PR TITLE
refactor(Interface) remove type-level resolve_type hook

### DIFF
--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -54,48 +54,6 @@ module GraphQL
       self
     end
 
-    module HasPossibleTypes
-
-      # If a (deprecated) `resolve_type` function was provided, call that and warn.
-      # Otherwise call `schema.resolve_type` (the proper behavior)
-      def legacy_resolve_type(object, ctx)
-        if @resolve_type_proc
-          resolve_type(object, ctx)
-        else
-          ctx.schema.resolve_type(object, ctx)
-        end
-      end
-
-      # Return the implementing type for `object`.
-      # The default implementation assumes that there's a type with the same name as `object.class.name`.
-      # Maybe you'll need to override this in your own interfaces!
-      #
-      # @param object [Object] the object which needs a type to expose it
-      # @param ctx [GraphQL::Query::Context]
-      # @return [GraphQL::ObjectType] the type which should expose `object`
-      def resolve_type(object, ctx)
-        ensure_defined
-        warn_resolve_type_deprecated
-        instance_exec(object, ctx, &(@resolve_type_proc || DEFAULT_RESOLVE_TYPE))
-      end
-
-      # The default implementation of {#resolve_type} gets `object.class.name`
-      # and finds a type with the same name
-      DEFAULT_RESOLVE_TYPE = -> (object, ctx) {
-        type_name = object.class.name
-        ctx.schema.possible_types(self).find {|t| t.name == type_name}
-      }
-
-      def resolve_type=(new_proc)
-        warn_resolve_type_deprecated
-        @resolve_type_proc = new_proc || DEFAULT_RESOLVE_TYPE
-      end
-
-      def warn_resolve_type_deprecated
-        warn("#{self.name}.resolve_type is deprecated; define Schema.resolve_type instead")
-      end
-    end
-
     # Print the human-readable name of this type using the query-string naming pattern
     def to_s
       name

--- a/lib/graphql/interface_type.rb
+++ b/lib/graphql/interface_type.rb
@@ -22,8 +22,7 @@ module GraphQL
   #   end
   #
   class InterfaceType < GraphQL::BaseType
-    include GraphQL::BaseType::HasPossibleTypes
-    accepts_definitions :resolve_type, :fields, field: GraphQL::Define::AssignObjectField
+    accepts_definitions :fields, field: GraphQL::Define::AssignObjectField
 
     lazy_defined_attr_accessor :fields
 

--- a/lib/graphql/query/serial_execution/value_resolution.rb
+++ b/lib/graphql/query/serial_execution/value_resolution.rb
@@ -57,9 +57,7 @@ module GraphQL
 
         class HasPossibleTypeResolution < BaseResolution
           def non_null_result
-            # When deprecations are removed:
-            # resolved_type = execution_context.schema.resolve_type(value)
-            resolved_type = field_type.legacy_resolve_type(value, execution_context)
+            resolved_type = execution_context.schema.resolve_type(value, execution_context.query.context)
 
             unless resolved_type.is_a?(GraphQL::ObjectType)
               raise GraphQL::ObjectType::UnresolvedTypeError.new(irep_node.definition_name, field_type, parent_type)

--- a/lib/graphql/union_type.rb
+++ b/lib/graphql/union_type.rb
@@ -23,7 +23,6 @@ module GraphQL
   #  }
   #
   class UnionType < GraphQL::BaseType
-    include GraphQL::BaseType::HasPossibleTypes
     accepts_definitions :possible_types, :resolve_type
 
     def kind

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -9,11 +9,6 @@ LocalProductInterface = GraphQL::InterfaceType.define do
   name "LocalProduct"
   description "Something that comes from somewhere"
   field :origin, !types.String, "Place the thing comes from"
-  # This is a "bug" in the dummy app:
-  # it should actually check the incoming object to determine the type.
-  # But this is here so we can check _where_ misbehaving resolve_type
-  # functions wreak their havoc.
-  resolve_type -> (o, c) { MilkType }
 end
 
 EdibleInterface = GraphQL::InterfaceType.define do


### PR DESCRIPTION
Interface-level `resolve_type` was previously deprecated in favor of `Schema#resolve_type`. Now it's time to remove it.