### PR TITLE
Raise when resolved_type not part of possible types

### DIFF
--- a/lib/graphql/query/serial_execution/value_resolution.rb
+++ b/lib/graphql/query/serial_execution/value_resolution.rb
@@ -58,8 +58,9 @@ module GraphQL
         class HasPossibleTypeResolution < BaseResolution
           def non_null_result
             resolved_type = execution_context.schema.resolve_type(value, execution_context.query.context)
+            possible_types = execution_context.schema.possible_types(field_type)
 
-            if !resolved_type.is_a?(GraphQL::ObjectType)
+            unless resolved_type.is_a?(GraphQL::ObjectType) && possible_types.include?(resolved_type)
               raise GraphQL::UnresolvedTypeError.new(irep_node.definition_name, execution_context.schema, field_type, parent_type, resolved_type)
             end
 


### PR DESCRIPTION
Raise when Schema resolves an object to a Type, but that Type does not implement the interface. ( Is not part of possilbe_types)

Example in tests :)

@rmosolgo 