### PR TITLE
Add parent type name to the InvalidNullError message

### DIFF
--- a/lib/graphql/invalid_null_error.rb
+++ b/lib/graphql/invalid_null_error.rb
@@ -2,10 +2,11 @@ module GraphQL
   # Raised automatically when a field's resolve function returns `nil`
   # for a non-null field.
   class InvalidNullError < GraphQL::Error
-    def initialize(field_name, value)
+    def initialize(parent_type_name, field_name, value)
+      @parent_type_name = parent_type_name
       @field_name = field_name
       @value = value
-      super("Cannot return null for non-nullable field #{@field_name}")
+      super("Cannot return null for non-nullable field #{@parent_type_name}.#{@field_name}")
     end
 
     # @return [Hash] An entry for the response's "errors" key

--- a/lib/graphql/query/serial_execution/value_resolution.rb
+++ b/lib/graphql/query/serial_execution/value_resolution.rb
@@ -86,7 +86,7 @@ module GraphQL
           # Get the "wrapped" type and resolve the value according to that type
           def result
             if value.nil? || value.is_a?(GraphQL::ExecutionError)
-              raise GraphQL::InvalidNullError.new(irep_node.definition_name, value)
+              raise GraphQL::InvalidNullError.new(parent_type.name, irep_node.definition_name, value)
             else
               wrapped_type = field_type.of_type
               strategy_class = get_strategy_for_kind(wrapped_type.kind)

--- a/spec/graphql/non_null_type_spec.rb
+++ b/spec/graphql/non_null_type_spec.rb
@@ -6,7 +6,7 @@ describe GraphQL::NonNullType do
       query_string = %|{ cow { name cantBeNullButIs } }|
       result = DummySchema.execute(query_string)
       assert_equal({"cow" => nil }, result["data"])
-      assert_equal([{"message"=>"Cannot return null for non-nullable field cantBeNullButIs"}], result["errors"])
+      assert_equal([{"message"=>"Cannot return null for non-nullable field Cow.cantBeNullButIs"}], result["errors"])
     end
 
     it "propagates the null up to the next nullable field" do
@@ -25,7 +25,7 @@ describe GraphQL::NonNullType do
       |
       result = DummySchema.execute(query_string)
       assert_equal(nil, result["data"])
-      assert_equal([{"message"=>"Cannot return null for non-nullable field nonNullInt"}], result["errors"])
+      assert_equal([{"message"=>"Cannot return null for non-nullable field DeepNonNull.nonNullInt"}], result["errors"])
     end
   end
 end

--- a/spec/graphql/query/executor_spec.rb
+++ b/spec/graphql/query/executor_spec.rb
@@ -127,7 +127,7 @@ describe GraphQL::Query::Executor do
           "data" => { "cow" => nil },
           "errors" => [
             {
-              "message" => "Cannot return null for non-nullable field cantBeNullButIs"
+              "message" => "Cannot return null for non-nullable field Cow.cantBeNullButIs"
             }
           ]
         }


### PR DESCRIPTION
When investigating an invalid null error, the first thing I end up having to do is find the type for the field, which can take a big more work when we have the error occurs on a generic field name.  E.g. multiple object types may have a field named `:name` or `:id`.  Having the type name in the error message would allow us to avoid that extra work to debug an error.