### PR TITLE
Handle nonnullable root query execution errors

### DIFF
--- a/spec/graphql/execution_error_spec.rb
+++ b/spec/graphql/execution_error_spec.rb
@@ -171,4 +171,27 @@ describe GraphQL::ExecutionError do
       assert_equal(expected_result, result)
     end
   end
+
+  describe "error on root query field" do
+    let(:query_string) {%|
+    query MilkQuery {
+      root
+      nonnullableExecutionError
+    }
+    |}
+
+    it "data is empty" do
+      expected_result = {
+        "data" => nil,
+        "errors" => [
+          {
+            "message" => "There was an execution error",
+            "locations" => [{"line" => 4, "column" => 7}],
+            "path" => []
+          }
+        ]
+      }
+      assert_equal(expected_result, result)
+    end
+  end
 end

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -289,6 +289,11 @@ DairyAppQueryType = GraphQL::ObjectType.define do
     resolve -> (t, a, c) { raise(GraphQL::ExecutionError, "There was an execution error") }
   end
 
+  field :nonnullableExecutionError do
+    type !GraphQL::STRING_TYPE
+    resolve -> (t, a, c) { raise(GraphQL::ExecutionError, "There was an execution error") }
+  end
+
   # To test possibly-null fields
   field :maybeNull, MaybeNullType do
     resolve -> (t, a, c) { OpenStruct.new(cheese: nil) }


### PR DESCRIPTION
The new `"path"` on errors is looking good, but I think I came up with an edge case that I'm unsure if the correct behavior or not.

When an execution error comes from a root query field that is nonnullable it forces `"data"` to be entirely `null`. That makes sense, but how should `"path"` behave in this case? The current implementation records the field that errored as `"path"`, however it doesn't exist at all.

I was kinda expecting that for any error `"path"`, you could access `data[path[0]][path[1][path[2]...`. Should we ensure this property holds true for this root edge case and return an empty `[]` path?

Would be interesting to check how `graphql-js` handles this.