### PR TITLE
Support partial ExecutionError in lists

### DIFF
--- a/lib/graphql/query/serial_execution/field_resolution.rb
+++ b/lib/graphql/query/serial_execution/field_resolution.rb
@@ -33,10 +33,20 @@ module GraphQL
         # After getting the value from the field's resolve method,
         # continue by "finishing" the value, eg. executing sub-fields or coercing values
         def get_finished_value(raw_value)
-          if raw_value.is_a?(GraphQL::ExecutionError)
+          case raw_value
+          when GraphQL::ExecutionError
             raw_value.ast_node = irep_node.ast_node
             raw_value.path = irep_node.path
             execution_context.add_error(raw_value)
+          when Array
+            list_errors = raw_value.each_with_index.select { |value, _| value.is_a?(GraphQL::ExecutionError) }
+            if list_errors.any?
+              list_errors.each do |error, index|
+                error.ast_node = irep_node.ast_node
+                error.path = irep_node.path + [index]
+                execution_context.add_error(error)
+              end
+            end
           end
 
           strategy_class = GraphQL::Query::SerialExecution::ValueResolution.get_strategy_for_kind(field.type.kind)

--- a/spec/graphql/execution_error_spec.rb
+++ b/spec/graphql/execution_error_spec.rb
@@ -27,6 +27,9 @@ describe GraphQL::ExecutionError do
           executionError
         }
       }
+      dairyErrors: allDairy(executionErrorAtIndex: 1) {
+        __typename
+      }
       dairy {
         milks {
           source
@@ -66,6 +69,12 @@ describe GraphQL::ExecutionError do
               { "flavor" => "Manchego" },
               { "source" => "COW", "executionError" => nil }
             ],
+            "dairyErrors" => [
+              { "__typename" => "Cheese" },
+              nil,
+              { "__typename" => "Cheese" },
+              { "__typename" => "Milk" }
+            ],
             "dairy" => {
               "milks" => [
                 {
@@ -99,18 +108,23 @@ describe GraphQL::ExecutionError do
               "path"=>["allDairy", 3, "executionError"]
             },
             {
+              "message"=>"missing dairy",
+              "locations"=>[{"line"=>25, "column"=>7}],
+              "path"=>["dairyErrors", 1]
+            },
+            {
               "message"=>"There was an execution error",
-              "locations"=>[{"line"=>28, "column"=>11}],
+              "locations"=>[{"line"=>31, "column"=>11}],
               "path"=>["dairy", "milks", 0, "executionError"]
             },
             {
               "message"=>"There was an execution error",
-              "locations"=>[{"line"=>33, "column"=>15}],
+              "locations"=>[{"line"=>36, "column"=>15}],
               "path"=>["dairy", "milks", 0, "allDairy", 3, "executionError"]
             },
             {
               "message"=>"There was an execution error",
-              "locations"=>[{"line"=>38, "column"=>7}],
+              "locations"=>[{"line"=>41, "column"=>7}],
               "path"=>["executionError"]
             },
           ]

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -271,7 +271,12 @@ DairyAppQueryType = GraphQL::ObjectType.define do
   end
 
   field :allDairy, types[DairyProductUnion] do
-    resolve -> (obj, args, ctx) { CHEESES.values + MILKS.values }
+    argument :executionErrorAtIndex, types.Int
+    resolve -> (obj, args, ctx) {
+      result = CHEESES.values + MILKS.values
+      result[args[:executionErrorAtIndex]] = GraphQL::ExecutionError.new("missing dairy") if args[:executionErrorAtIndex]
+      result
+    }
   end
 
   field :allEdible, types[EdibleInterface] do


### PR DESCRIPTION
For single values, resolvers can return a `GraphQL::ExecutionError` instance. It'd be great if lists offered a single ability to fail partially. Its a bit of an implementation edge case since individual list values don't have their own `resolve` function.

For GitHub's GraphQL API, I'd like our root `nodes(ids: [ID!]!): [Node]!` batch lookup to fail partially if a given ID fails to resolve. The returned collection itself is non-nullable, but the list values are nullable `Node`s.

``` graphql
type Query {
  node(id: ID!): Node
  nodes(ids: [ID!]!): [Node]!
}
```