### PR TITLE
Move invalid null rescue for graphql-batch execution strategy.

### DIFF
--- a/lib/graphql/query/serial_execution/field_resolution.rb
+++ b/lib/graphql/query/serial_execution/field_resolution.rb
@@ -15,17 +15,8 @@ module GraphQL
 
         def result
           result_name = irep_node.name
-          begin
-            raw_value = get_raw_value
-            { result_name => get_finished_value(raw_value) }
-          rescue GraphQL::InvalidNullError => err
-            if field.type.kind.non_null?
-              raise(err)
-            else
-              err.parent_error? || execution_context.add_error(err)
-              {result_name => nil}
-            end
-          end
+          raw_value = get_raw_value
+          { result_name => get_finished_value(raw_value) }
         end
 
         private
@@ -41,7 +32,16 @@ module GraphQL
 
           strategy_class = GraphQL::Query::SerialExecution::ValueResolution.get_strategy_for_kind(field.type.kind)
           result_strategy = strategy_class.new(raw_value, field.type, target, parent_type, irep_node, execution_context)
-          result_strategy.result
+          begin
+            result_strategy.result
+          rescue GraphQL::InvalidNullError => err
+            if field.type.kind.non_null?
+              raise(err)
+            else
+              err.parent_error? || execution_context.add_error(err)
+              nil
+            end
+          end
         end
 
 


### PR DESCRIPTION
For https://github.com/Shopify/graphql-batch/issues/18

The execution strategy in the graphql-batch gem overrides FieldResolution#get_finished_value because the resolution hasn't been completed, so it chains the promise to passes the resolved result using `super` rather than the promise object.

However, https://github.com/rmosolgo/graphql-ruby/pull/174 added error handling into FieldResolution#result, which only receives a promise from get_finished_value, so the rescue effectively gets skipped when using graphql-batch.

This pull request moves the rescue into FieldResolution#get_finished_value to avoid the need to have to duplicate the invalid null rescue in the graphql-batch execution strategy.