### PR TITLE
Fix bug in schema printer for enum values with custom ruby value.

### DIFF
--- a/lib/graphql/schema/printer.rb
+++ b/lib/graphql/schema/printer.rb
@@ -111,7 +111,7 @@ module GraphQL
             when ScalarType, ID_TYPE, STRING_TYPE
               value.to_s.inspect
             when EnumType
-              value.to_s
+              type.coerce_result(value)
             when InputObjectType
               fields = value.to_h.map{ |field_name, field_value|
                 field_type = type.input_fields.fetch(field_name.to_s).type

--- a/spec/graphql/schema/printer_spec.rb
+++ b/spec/graphql/schema/printer_spec.rb
@@ -11,8 +11,8 @@ describe GraphQL::Schema::Printer do
     choice_type = GraphQL::EnumType.define do
       name "Choice"
 
-      value "FOO"
-      value "BAR"
+      value "FOO", value: :foo
+      value "BAR", value: :bar
       value "BAZ", deprecation_reason: 'Use "BAR".'
       value "WOZ", deprecation_reason: GraphQL::Directive::DEFAULT_DEPRECATION_REASON
     end
@@ -28,7 +28,7 @@ describe GraphQL::Schema::Printer do
       input_field :int, types.Int
       input_field :float, types.Float
       input_field :bool, types.Boolean
-      input_field :enum, choice_type
+      input_field :enum, choice_type, default_value: :foo
       input_field :sub, types[sub_input_type]
     end
 
@@ -58,7 +58,7 @@ describe GraphQL::Schema::Printer do
       field :post do
         type post_type
         argument :id, !types.ID
-        argument :varied, variant_input_type, default_value: { id: "123", int: 234, float: 2.3, enum: "FOO", sub: [{ string: "str" }] }
+        argument :varied, variant_input_type, default_value: { id: "123", int: 234, float: 2.3, enum: :foo, sub: [{ string: "str" }] }
         resolve -> (obj, args, ctx) { Post.find(args["id"]) }
       end
     end
@@ -211,7 +211,7 @@ input Varied {
   int: Int
   float: Float
   bool: Boolean
-  enum: Choice
+  enum: Choice = FOO
   sub: [Sub]
 }
 SCHEMA


### PR DESCRIPTION
cc @xuorig & @cjoudrey 

## Problem

When trying to upgrade to the newest release of this gem we noticed that our schema dump changed for enum values.  This can be seen with this PR's test changes for this regression without the changes to the code under test:

```
GraphQL::Schema::Printer::.print_schema
  test_0001_returns the schema as a string for the defined types  FAIL (0.01s)
Minitest::Assertion:         --- expected
        +++ actual
        @@ -26,7 +26,7 @@
         }

         type Query {
        -  post(id: ID!, varied: Varied = {id: \"123\", int: 234, float: 2.3, enum: FOO, sub: [{string: \"str\"}]}): Post
        +  post(id: ID!, varied: Varied = {id: \"123\", int: 234, float: 2.3, enum: foo, sub: [{string: \"str\"}]}): Post
         }

         input Sub {
        @@ -38,6 +38,6 @@
           int: Int
           float: Float
           bool: Boolean
        -  enum: Choice = FOO
        +  enum: Choice = foo
           sub: [Sub]
         }"
        /Users/dylansmith/src/graphql-ruby/spec/graphql/schema/printer_spec.rb:218:in `block (3 levels) in <top (required)>'
```

It looks like this is a regression from https://github.com/rmosolgo/graphql-ruby/pull/267

## Solution

Use coerce_result to convert the ruby value into the name for the GraphQL enum value in the schema printer.