### PR TITLE
feat(Mutation) accept a user-defined return_type

### DIFF
--- a/guides/relay.md
+++ b/guides/relay.md
@@ -438,3 +438,19 @@ The resolve proc:
   - Takes `inputs`, which is a hash whose keys are the ones defined by `input_field`
   - Takes `ctx`, which is the query context you passed with the `context:` keyword
   - Must return a hash with keys matching your defined `return_field`s
+
+### Specify a Return Type
+
+Instead of specifying `return_field`s, you can specify a `return_type` for a mutation. This type will be used to expose the object returned from `resolve`.
+
+```ruby
+CreateUser = GraphQL::Relay::Mutation.define do
+  return_type UserType
+  # ...
+  resolve -> (input, ctx) {
+    user = User.create(input)
+    # `user` will be treated as `UserType`
+    user
+  }
+end
+```

--- a/guides/relay.md
+++ b/guides/relay.md
@@ -435,9 +435,10 @@ Under the hood, GraphQL creates:
   - A derived `ObjectType` for return values
 
 The resolve proc:
+  - Takes `obj`, which is the `root_value:` provided to `Schema.execute`
   - Takes `inputs`, which is a hash whose keys are the ones defined by `input_field`
   - Takes `ctx`, which is the query context you passed with the `context:` keyword
-  - Must return a hash with keys matching your defined `return_field`s
+  - Must return a hash with keys matching your defined `return_field`s (unless you provide a `return_type`, see below)
 
 ### Specify a Return Type
 
@@ -445,12 +446,14 @@ Instead of specifying `return_field`s, you can specify a `return_type` for a mut
 
 ```ruby
 CreateUser = GraphQL::Relay::Mutation.define do
-  return_type UserType
+  return_type UserMutationResultType
   # ...
-  resolve -> (input, ctx) {
+  resolve -> (obj, input, ctx) {
     user = User.create(input)
-    # `user` will be treated as `UserType`
-    user
+    # this object will be treated as `UserMutationResultType`
+    UserMutationResult.new(user, client_mutation_id: input[:clientMutationId])
   }
 end
 ```
+
+If you provide your own return type, it's up to you to support `clientMutationId`

--- a/lib/graphql/relay/mutation.rb
+++ b/lib/graphql/relay/mutation.rb
@@ -51,11 +51,12 @@ module GraphQL
       include GraphQL::Define::InstanceDefinable
       accepts_definitions(
         :name, :description, :resolve,
+        :return_type,
         input_field: GraphQL::Define::AssignArgument,
         return_field: GraphQL::Define::AssignObjectField,
       )
       lazy_defined_attr_accessor :name, :description
-      lazy_defined_attr_accessor :fields, :arguments
+      lazy_defined_attr_accessor :fields, :arguments, :return_type
 
       # For backwards compat, but do we need this separate API?
       alias :return_fields :fields
@@ -95,8 +96,8 @@ module GraphQL
       end
 
       def return_type
+        ensure_defined
         @return_type ||= begin
-          ensure_defined
           relay_mutation = self
           GraphQL::ObjectType.define do
             name("#{relay_mutation.name}Payload")

--- a/lib/graphql/relay/mutation.rb
+++ b/lib/graphql/relay/mutation.rb
@@ -152,6 +152,8 @@ module GraphQL
         end
       end
 
+      # Use this when the mutation's return type was generated from `return_field`s.
+      # It delegates field lookups to the hash returned from `resolve`.
       class Result
         attr_reader :client_mutation_id
         def initialize(client_mutation_id:, result:)
@@ -192,8 +194,12 @@ module GraphQL
         end
 
         def call(obj, args, ctx)
-          result_hash = @resolve.call(obj, args[:input], ctx)
-          @mutation.result_class.new(client_mutation_id: args[:input][:clientMutationId], result: result_hash)
+          mutation_result = @resolve.call(obj, args[:input], ctx)
+          if @wrap_result
+            @mutation.result_class.new(client_mutation_id: args[:input][:clientMutationId], result: mutation_result)
+          else
+            mutation_result
+          end
         end
       end
     end

--- a/spec/graphql/relay/mutation_spec.rb
+++ b/spec/graphql/relay/mutation_spec.rb
@@ -72,12 +72,31 @@ describe GraphQL::Relay::Mutation do
       GraphQL::Relay::Mutation.define do
         name "CustomReturnTypeTest"
         return_type custom_type
+        resolve -> (input, ctx) {
+          OpenStruct.new(name: "Custom Return Type Test")
+        }
+      end
+    }
+
+    let(:schema) {
+      mutation_field = mutation.field
+
+      mutation_root = GraphQL::ObjectType.define do
+        name "Mutation"
+        field :custom, mutation_field
+      end
+
+      GraphQL::Schema.define do
+        mutation(mutation_root)
       end
     }
 
     it "uses the provided type" do
       assert_equal custom_return_type, mutation.return_type
       assert_equal custom_return_type, mutation.field.type
+
+      result = schema.execute("mutation { custom(input: {}) { name } }")
+      assert_equal "Custom Return Type Test", result["data"]["custom"]["name"]
     end
 
     it "doesn't get a mutation in the metadata" do

--- a/spec/graphql/relay/mutation_spec.rb
+++ b/spec/graphql/relay/mutation_spec.rb
@@ -58,4 +58,30 @@ describe GraphQL::Relay::Mutation do
     assert_equal IntroduceShipMutation, IntroduceShipMutation.input_type.mutation
     assert_equal IntroduceShipMutation, IntroduceShipMutation.result_class.mutation
   end
+
+  describe "providing a return type" do
+    let(:custom_return_type) {
+      GraphQL::ObjectType.define do
+        name "CustomReturnType"
+        field :name, types.String
+      end
+    }
+
+    let(:mutation) {
+      custom_type = custom_return_type
+      GraphQL::Relay::Mutation.define do
+        name "CustomReturnTypeTest"
+        return_type custom_type
+      end
+    }
+
+    it "uses the provided type" do
+      assert_equal custom_return_type, mutation.return_type
+      assert_equal custom_return_type, mutation.field.type
+    end
+
+    it "doesn't get a mutation in the metadata" do
+      assert_equal nil, custom_return_type.mutation
+    end
+  end
 end


### PR DESCRIPTION
Previously, we would only dynamically generate a type based on the `return_fields`, but we can do this too 

```ruby 
Mutation.define do 
  name "CreatePost"
  return_type PostType 
  # ... 
  resolve -> (obj, input, ctx) { Post.create!(input) } 
end 
```

You have to handle `clientMutationId` on the `return_type` yourself, though