### PR TITLE
[minor] Adding missing descriptions to default relay objects

### DIFF
--- a/lib/graphql/relay/connection_type.rb
+++ b/lib/graphql/relay/connection_type.rb
@@ -10,11 +10,12 @@ module GraphQL
         connection_type = ObjectType.define do
           name(connection_type_name)
           field :edges, types[edge_type] do
+            description "A list of edges."
             resolve -> (obj, args, ctx) {
               obj.edge_nodes.map { |item| edge_class.new(item, obj) }
             }
           end
-          field :pageInfo, !PageInfo, property: :page_info
+          field :pageInfo, !PageInfo, "Information to aid in pagination.", property: :page_info
           block && instance_eval(&block)
         end
 

--- a/lib/graphql/relay/edge_type.rb
+++ b/lib/graphql/relay/edge_type.rb
@@ -5,8 +5,8 @@ module GraphQL
         GraphQL::ObjectType.define do
           name("#{wrapped_type.name}Edge")
           description "An edge in a connection."
-          field :node, "The item at the end of the edge.", wrapped_type
-          field :cursor, "A cursor for use in pagination.", !types.String
+          field :node, wrapped_type, "The item at the end of the edge."
+          field :cursor, !types.String, "A cursor for use in pagination."
           block && instance_eval(&block)
         end
       end

--- a/lib/graphql/relay/edge_type.rb
+++ b/lib/graphql/relay/edge_type.rb
@@ -4,8 +4,9 @@ module GraphQL
       def self.create_type(wrapped_type, name: nil, &block)
         GraphQL::ObjectType.define do
           name("#{wrapped_type.name}Edge")
-          field :node, wrapped_type
-          field :cursor, !types.String
+          description "An edge in a connection."
+          field :node, "The item at the end of the edge.", wrapped_type
+          field :cursor, "A cursor for use in pagination.", !types.String
           block && instance_eval(&block)
         end
       end

--- a/lib/graphql/relay/node.rb
+++ b/lib/graphql/relay/node.rb
@@ -9,8 +9,8 @@ module GraphQL
         # _may_ be modified.
         node_field = GraphQL::Field.define do
           type(GraphQL::Relay::Node.interface)
-          description("Fetches an object given its ID")
-          argument(:id, !types.ID, "ID of the object")
+          description("Fetches an object given its ID.")
+          argument(:id, !types.ID, "ID of the object.")
           resolve(GraphQL::Relay::Node::FindNode)
         end
 
@@ -24,7 +24,8 @@ module GraphQL
       def self.interface
         @interface ||= GraphQL::InterfaceType.define do
           name "Node"
-          field :id, !types.ID
+          description "An object with an ID."
+          field :id, !types.ID, "ID of the object."
         end
       end
 

--- a/lib/graphql/relay/page_info.rb
+++ b/lib/graphql/relay/page_info.rb
@@ -3,7 +3,7 @@ module GraphQL
     # Wrap a Connection and expose its page info
     PageInfo = GraphQL::ObjectType.define do
       name("PageInfo")
-      description("Metadata about a connection")
+      description("Information about pagination in a connection.")
       field :hasNextPage, !types.Boolean, "Indicates if there are more pages to fetch", property: :has_next_page
       field :hasPreviousPage, !types.Boolean, "Indicates if there are any pages prior to the current page", property: :has_previous_page
       field :startCursor, types.String, "When paginating backwards, the cursor to continue", property: :start_cursor


### PR DESCRIPTION
We recently noticed that [some default relay objects were missing descriptions](https://developer.github.com/early-access/graphql/interface/node/). This super minor PR pulls in descriptions for edges, nodes, cursors, etc. to match what can be found the reference implemtation for relay over in [graphql/graphql-relay-js](https://github.com/graphql/graphql-relay-js).

This is of course, just default documentation mirroring graphql-relay-js and descriptions can be overridden at will.