### PR TITLE
Argument type fix

### DIFF
--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -85,7 +85,7 @@ module GraphQL
         end
       end
 
-      GraphQL::Query::Arguments.new(input_values)
+      GraphQL::Query::Arguments.new(input_values, argument_definitions: arguments)
     end
 
     def coerce_result(value)

--- a/lib/graphql/query/literal_input.rb
+++ b/lib/graphql/query/literal_input.rb
@@ -36,7 +36,7 @@ module GraphQL
             values_hash[arg_name] = arg_value
           end
         end
-        GraphQL::Query::Arguments.new(values_hash)
+        GraphQL::Query::Arguments.new(values_hash, argument_definitions: argument_defns)
       end
 
       module LiteralKindCoercers
@@ -60,7 +60,7 @@ module GraphQL
           def self.coerce(value, type, variables)
             hash = {}
             value.arguments.each do |arg|
-              field_type = type.input_fields[arg.name].type
+              field_type = type.arguments[arg.name].type
               hash[arg.name] = LiteralInput.coerce(field_type, arg.value, variables)
             end
             type.input_fields.each do |arg_name, arg_defn|
@@ -71,7 +71,7 @@ module GraphQL
                 end
               end
             end
-            Arguments.new(hash)
+            Arguments.new(hash, argument_definitions: type.arguments)
           end
         end
 

--- a/spec/graphql/query/arguments_spec.rb
+++ b/spec/graphql/query/arguments_spec.rb
@@ -12,7 +12,7 @@ describe GraphQL::Query::Arguments do
       name "TestInput2"
       argument :a, types.Int
       argument :b, types.Int
-      argument :c, test_input_1
+      argument :c, !test_input_1
     end
 
     GraphQL::Query::Arguments.new({


### PR DESCRIPTION
Some people have a "JSON Scalar" that parses a string into a Ruby hash. Previously, we were wrapping that in a `Query::Arguments` instead of passing the plain hash to the resolve function. Now, we don't wrap it in `Arguments` unless it's an input object!