### PR TITLE
Support 7 level introspection query instead of 3

### DIFF
--- a/lib/graphql/introspection/introspection_query.rb
+++ b/lib/graphql/introspection/introspection_query.rb
@@ -69,6 +69,22 @@ fragment TypeRef on __Type {
       ofType {
         kind
         name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/spec/graphql/introspection/introspection_query_spec.rb
+++ b/spec/graphql/introspection/introspection_query_spec.rb
@@ -7,4 +7,52 @@ describe "GraphQL::Introspection::INTROSPECTION_QUERY" do
   it "runs" do
     assert(result["data"])
   end
+
+  it "handles deeply nested (<= 7) schemas" do
+     query_type =  GraphQL::ObjectType.define do
+        name "DeepQuery"
+        field :foo do
+          type !GraphQL::ListType.new(
+            of_type: !GraphQL::ListType.new(
+              of_type: !GraphQL::ListType.new(
+                of_type: GraphQL::FLOAT_TYPE
+              )
+            )
+          )
+        end
+     end
+
+     deep_schema = GraphQL::Schema.define do
+       query query_type
+     end
+
+     result = deep_schema.execute(query_string)
+     assert(GraphQL::Schema::Loader.load(result))
+  end
+
+  it "doesn't handle too deeply nested (< 8) schemas" do
+     query_type =  GraphQL::ObjectType.define do
+        name "DeepQuery"
+        field :foo do
+          type !GraphQL::ListType.new(
+            of_type: !GraphQL::ListType.new(
+              of_type: !GraphQL::ListType.new(
+                of_type: !GraphQL::ListType.new(
+                  of_type: GraphQL::FLOAT_TYPE
+                )
+              )
+            )
+          )
+        end
+     end
+
+     deep_schema = GraphQL::Schema.define do
+       query query_type
+     end
+
+     result = deep_schema.execute(query_string)
+     assert_raises(KeyError) {
+       GraphQL::Schema::Loader.load(result)
+     }
+  end
 end


### PR DESCRIPTION
There are some schemas that require deeply nested types, such as a 3-dimensional array of non-null Ints (`[[[Int!]!]!]!`) that the current introspection query does not handle. Instead of 3, change the `ofType` query to go 7 deep.

It looks like graphql-js added support for this https://github.com/graphql/graphql-js/pull/364. As the introspection query in the gem is from that repo, I think it's safe to pull this is an as well.

Is there a better spot for this test?