### PR TITLE
Cleanup order in base connection

### DIFF
--- a/lib/graphql/relay/base_connection.rb
+++ b/lib/graphql/relay/base_connection.rb
@@ -74,7 +74,7 @@ module GraphQL
       deprecate(:object, :nodes, 2016, 9)
 
       # Provide easy access to provided arguments:
-      METHODS_FROM_ARGUMENTS = [:first, :after, :last, :before, :order]
+      METHODS_FROM_ARGUMENTS = [:first, :after, :last, :before]
 
       # @!method first
       #   The value passed as `first:`, if there was one
@@ -84,8 +84,6 @@ module GraphQL
       #   The value passed as `last:`, if there was one
       # @!method before
       #   The value passed as `before:`, if there was one
-      # @!method order
-      #   The value passed as `order:`, if there was one
       METHODS_FROM_ARGUMENTS.each do |arg_name|
         define_method(arg_name) do
           arguments[arg_name]


### PR DESCRIPTION
Looking at the API docs and seeing http://www.rubydoc.info/github/rmosolgo/graphql-ruby/GraphQL/Relay/BaseConnection#order-instance_method confused me for a good 15 minutes, so I dug through history and found https://github.com/rmosolgo/graphql-relay-ruby/pull/33.

It doesn't seem like this was cleaned up 100% and artifacts are still showing in the docs, so I'm hoping this is the right PR here. Let me know if it needs any changes, or if I have the wrong understanding. Thanks!