### PR TITLE
Replace `-> (...)` with `->(...)` to be Ruby 1.9.3 compatible

### DIFF
--- a/CHANGELOG-relay.md
+++ b/CHANGELOG-relay.md
@@ -109,7 +109,7 @@
    ```ruby
    field :cities, CityType.connection_type do
      argument :order, types.String, default_value: "name"
-     resolve -> (obj, args, ctx) {
+     resolve ->(obj, args, ctx) {
        obj.order(args[:order])
      }
    end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,13 @@
   Previously, it was called with two arguments:
 
   ```ruby
-  resolve -> (inputs, ctx) { ... }
+  resolve ->(inputs, ctx) { ... }
   ```
 
   Now, it's called with three inputs:
 
   ```ruby
-  resolve -> (obj, inputs, ctx) { ... }
+  resolve ->(obj, inputs, ctx) { ... }
   ```
 
   `obj` is the value of `root_value:` given to `Schema#execute`, as with other root-level fields.
@@ -92,11 +92,11 @@
     ```ruby
     MySchema = GraphQL::Schema.define do
       # Fetch an object by UUID
-      object_from_id -> (id, ctx) {
+      object_from_id ->(id, ctx) {
         MyApp::RelayLookup.find(id)
       }
       # Generate a UUID for this object
-      id_from_object -> (obj, type_defn, ctx) {
+      id_from_object ->(obj, type_defn, ctx) {
         MyApp::RelayLookup.to_id(obj)
       }
     end
@@ -106,14 +106,14 @@
 
       ```ruby
       MySchema = GraphQL::Schema.define do
-        object_from_id -> (id, ctx) {
+        object_from_id ->(id, ctx) {
           # Break the id into its parts:
           type_name, object_id = GraphQL::Schema::UniqueWithinType.decode(id)
           # Fetch the identified object
           # ...
         }
 
-        id_from_object -> (obj, type_defn, ctx) {
+        id_from_object ->(obj, type_defn, ctx) {
           # Provide the the type name & the object's `id`:
           GraphQL::Schema::UniqueWithinType.encode(type_defn.name, obj.id)
         }
@@ -133,7 +133,7 @@
     ```ruby
     MySchema = GraphQL::Schema.define do
       # ...
-      resolve_type -> (obj, ctx) {
+      resolve_type ->(obj, ctx) {
         # based on `obj` and `ctx`,
         # figure out which GraphQL type to use
         # and return the type
@@ -346,11 +346,11 @@
 
   ```ruby
   GraphQL::Relay::GlobalNodeIdentification.define do
-    type_from_object -> (obj) { ... }
+    type_from_object ->(obj) { ... }
   end
 
   GraphQL::InterfaceType.define do
-    resolve_type -> (obj, ctx) { ... }
+    resolve_type ->(obj, ctx) { ... }
   end
   ```
 
@@ -358,7 +358,7 @@
 
   ```ruby
   GraphQL::Schema.define do
-    resolve_type -> (obj, ctx) { ... }
+    resolve_type ->(obj, ctx) { ... }
   end
   ```
 
@@ -625,9 +625,9 @@
 
   ```ruby
   # Previous coerce behavior for scalars:
-  GraphQL::BOOLEAN_TYPE.coerce = -> (value) { !!value }
-  GraphQL::ID_TYPE.coerce = -> (value) { value.to_s }
-  GraphQL::STRING_TYPE.coerce = ->  (value) { value.to_s }
+  GraphQL::BOOLEAN_TYPE.coerce = ->(value) { !!value }
+  GraphQL::ID_TYPE.coerce = ->(value) { value.to_s }
+  GraphQL::STRING_TYPE.coerce = ->(value) { value.to_s }
   # INT_TYPE and FLOAT_TYPE were unchanged
   ```
 

--- a/guides/code_reuse.md
+++ b/guides/code_reuse.md
@@ -19,7 +19,7 @@ Many examples use a Proc literal for a field's `resolve`, for example:
 ```ruby
 field :name, types.String do
   # Resolve taking a Proc literal:
-  resolve -> (obj, args, ctx) { obj.name }
+  resolve ->(obj, args, ctx) { obj.name }
 end
 ```
 
@@ -66,7 +66,7 @@ Or, you can generate the `resolve` Proc dynamically:
 ```ruby
 # @return [Proc] A resolve proc which calls `method_name` on `obj`
 def resolve_with_method(method_name)
-  -> (obj, args, ctx) { obj.public_send(method_name) }
+  ->(obj, args, ctx) { obj.public_send(method_name) }
 end
 
 # ...
@@ -163,7 +163,7 @@ module Auth
   # @yieldreturn [Object] The return value for this field
   # @return [Proc] the passed-in block, modified to check for `can_read?(item_name)`
   def self.can_read(item_name, &block)
-    -> (obj, args, ctx) do
+    ->(obj, args, ctx) do
       if ctx[:current_user].can_read?(item_name)
         # continue to the next call:
         block.call(obj, args, ctx)

--- a/guides/defining_your_schema.md
+++ b/guides/defining_your_schema.md
@@ -58,7 +58,7 @@ In order for your schema to expose members of an interface, it must be able to d
 ```ruby
 MySchema = GraphQL::Schema.define do
  # ...
- resolve_type -> (object, ctx) {
+ resolve_type ->(object, ctx) {
    # for example, look up types by class name
    type_name = object.class.name
    MySchema.types[type_name]
@@ -178,7 +178,7 @@ field :comments do
 
   argument :moderated, types.Boolean, default_value: true
 
-  resolve -> (obj, args, ctx) do
+  resolve ->(obj, args, ctx) do
      Comment.where(
        post_id: obj.id,
        moderated: args["moderated"]
@@ -324,7 +324,7 @@ Query analyzers are like middleware for the validation phase. They're called at 
 The minimal API is `.call(memo, visit_type, internal_representation_node)`. For example:
 
 ```ruby
-ast_node_logger = -> (memo, visit_type, internal_representation_node) {
+ast_node_logger = ->(memo, visit_type, internal_representation_node) {
   if visit_type == :enter
     puts "Visiting #{internal_representation_node.name}!"
   end
@@ -409,7 +409,7 @@ MySchema = GraphQL::Schema.define do
   # ...
   # Use the type's declared `resolves_to_class_names`
   # to figure out if `obj` is a member of that type
-  resolve_type -> (obj, ctx) {
+  resolve_type ->(obj, ctx) {
     class_name = obj.class.name
     MySchema.types.values.find { |type| type.metadata[:resolves_to_class_names].include?(class_name) }
   }

--- a/guides/executing_queries.md
+++ b/guides/executing_queries.md
@@ -39,7 +39,7 @@ These values will be accessible by key inside `resolve` functions. For example, 
 SecretStringField = GraphQL::Field.new do |f|
   f.type !GraphQL::STRING_TYPE
   f.description "A string that's only visible to authorized users"
-  f.resolve -> (obj, args, ctx) { ctx[:current_user].authorized? ? obj.secret_string : nil }
+  f.resolve ->(obj, args, ctx) { ctx[:current_user].authorized? ? obj.secret_string : nil }
 end
 ```
 

--- a/guides/introduction.md
+++ b/guides/introduction.md
@@ -66,7 +66,7 @@ QueryRoot = GraphQL::ObjectType.define do
     type PostType
     description "Find a Post by id"
     argument :id, !types.ID
-    resolve -> (object, arguments, context) {
+    resolve ->(object, arguments, context) {
       Post.find(arguments["id"])
     }
   end

--- a/guides/security.md
+++ b/guides/security.md
@@ -11,7 +11,7 @@ Always limit the number of items which can be returned from a list field. For ex
 ```ruby
 field :items, types[ItemType] do
   argument :limit, types.Int, default_value: 20
-  resolve -> (obj, args, ctx) {
+  resolve ->(obj, args, ctx) {
     # Cap the number of items at 30
     limit = [args[:limit], 30].min
     obj.items.limit(limit)
@@ -52,7 +52,7 @@ field :top_score, types.Int, complexity: 10
 # Dynamic complexity:
 field :top_scorers, types[PlayerType] do
   argument :limit, types.Int, default_value: 5
-  complexity -> (ctx, args, child_complexity) {
+  complexity ->(ctx, args, child_complexity) {
     if ctx[:current_user].staff?
       # no limit for staff users
       0

--- a/guides/testing.md
+++ b/guides/testing.md
@@ -19,7 +19,7 @@ For example, consider a field which calculates its own value:
 PostType = GraphQL::ObjectType.define do
   # ...
   field :isTrending, types.Boolean do
-    resolve -> (obj, args, ctx) {
+    resolve ->(obj, args, ctx) {
       recent_comments = comments.where("created_at < ?", 1.day.ago)
       recent_comments.count > 100
     }
@@ -50,7 +50,7 @@ end
 PostType = GraphQL::ObjectType.define do
   # ...
   field :isTrending, types.Boolean do
-    resolve -> (obj, args, ctx) {
+    resolve ->(obj, args, ctx) {
       # Use the Post::Trending class to calculate the value
       Post::Trending.new(obj).value
     }

--- a/lib/graphql/analysis/max_query_complexity.rb
+++ b/lib/graphql/analysis/max_query_complexity.rb
@@ -11,7 +11,7 @@ module GraphQL
     #
     class MaxQueryComplexity < GraphQL::Analysis::QueryComplexity
       def initialize(max_complexity)
-        disallow_excessive_complexity = -> (query, complexity) {
+        disallow_excessive_complexity = ->(query, complexity) {
           if complexity > max_complexity
             GraphQL::AnalysisError.new("Query has complexity of #{complexity}, which exceeds max complexity of #{max_complexity}")
           else

--- a/lib/graphql/analysis/max_query_depth.rb
+++ b/lib/graphql/analysis/max_query_depth.rb
@@ -11,7 +11,7 @@ module GraphQL
     #
     class MaxQueryDepth < GraphQL::Analysis::QueryDepth
       def initialize(max_depth)
-        disallow_excessive_depth = -> (query, depth) {
+        disallow_excessive_depth = ->(query, depth) {
           if depth > max_depth
             GraphQL::AnalysisError.new("Query has depth of #{depth}, which exceeds max depth of #{max_depth}")
           else

--- a/lib/graphql/boolean_type.rb
+++ b/lib/graphql/boolean_type.rb
@@ -2,6 +2,6 @@ GraphQL::BOOLEAN_TYPE = GraphQL::ScalarType.define do
   name "Boolean"
   description "Represents `true` or `false` values."
 
-  coerce_input -> (value) { (value == true || value == false) ? value : nil }
-  coerce_result -> (value) { !!value }
+  coerce_input ->(value) { (value == true || value == false) ? value : nil }
+  coerce_result ->(value) { !!value }
 end

--- a/lib/graphql/define/instance_definable.rb
+++ b/lib/graphql/define/instance_definable.rb
@@ -25,7 +25,7 @@ module GraphQL
     #       # These attrs will be defined with plain setters, `{attr}=`
     #       :make, :model,
     #       # This attr has a custom definition which applies the config to the target
-    #       doors: -> (car, doors_count) { doors_count.times { car.doors << Door.new } }
+    #       doors: ->(car, doors_count) { doors_count.times { car.doors << Door.new } }
     #     )
     #
     #     def initialize
@@ -85,7 +85,7 @@ module GraphQL
         # make sure the previous definition_proc was executed:
         ensure_defined
 
-        @definition_proc = -> (obj) {
+        @definition_proc = ->(obj) {
           kwargs.each do |keyword, value|
             public_send(keyword, value)
           end

--- a/lib/graphql/enum_type.rb
+++ b/lib/graphql/enum_type.rb
@@ -28,7 +28,7 @@ module GraphQL
   # @example Defining an enum input
   #    field :coders, types[CoderType] do
   #      argument :knowing, types[LanguageType]
-  #      resolve -> (obj, args, ctx) {
+  #      resolve ->(obj, args, ctx) {
   #        Coder.where(language: args[:knowing])
   #      }
   #    end
@@ -51,7 +51,7 @@ module GraphQL
   #
   #   # Now, resolve functions will receive `:rb` instead of `"RUBY"`
   #   field :favoriteLanguage, LanguageEnum
-  #   resolve -> (obj, args, ctx) {
+  #   resolve ->(obj, args, ctx) {
   #     args[:favoriteLanguage] # => :rb
   #   }
   #

--- a/lib/graphql/field.rb
+++ b/lib/graphql/field.rb
@@ -55,7 +55,7 @@ module GraphQL
   # @example Create a field with an argument
   #   field :students, types[StudentType] do
   #     argument :grade, types.Int
-  #     resolve -> (obj, args, ctx) {
+  #     resolve ->(obj, args, ctx) {
   #       Student.where(grade: args[:grade])
   #     }
   #   end
@@ -66,7 +66,7 @@ module GraphQL
   #   field :events, types[EventType] do
   #     # by default, don't include past events
   #     argument :includePast, types.Boolean, default_value: false
-  #     resolve -> (obj, args, ctx) {
+  #     resolve ->(obj, args, ctx) {
   #       args[:includePast] # => false if no value was provided in the query
   #       # ...
   #     }
@@ -95,14 +95,14 @@ module GraphQL
   #
   #   # Or inside the block:
   #   field :expensive_calculation_2, !types.Int do
-  #     complexity -> (ctx, args, child_complexity) { ctx[:current_user].staff? ? 0 : 10 }
+  #     complexity ->(ctx, args, child_complexity) { ctx[:current_user].staff? ? 0 : 10 }
   #   end
   #
   # @example Calculating the complexity of a list field
   #   field :items, types[ItemType] do
   #     argument :limit, !types.Int
   #     # Mulitply the child complexity by the possible items on the list
-  #     complexity -> (ctx, args, child_complexity) { child_complexity * args[:limit] }
+  #     complexity ->(ctx, args, child_complexity) { child_complexity * args[:limit] }
   #   end
   #
   # @example Creating a field, then assigning it to a type
@@ -110,7 +110,7 @@ module GraphQL
   #     name("Name")
   #     type(!types.String)
   #     description("The name of this thing")
-  #     resolve -> (object, arguments, context) { object.name }
+  #     resolve ->(object, arguments, context) { object.name }
   #   end
   #
   #   NamedType = GraphQL::ObjectType.define do
@@ -142,7 +142,7 @@ module GraphQL
     #   @return [GraphQL::Relay::Mutation, nil] The mutation this field was derived from, if it was derived from a mutation
 
     # @!attribute complexity
-    #   @return [Numeric, Proc] The complexity for this field (default: 1), as a constant or a proc like `-> (query_ctx, args, child_complexity) { } # Numeric`
+    #   @return [Numeric, Proc] The complexity for this field (default: 1), as a constant or a proc like `->(query_ctx, args, child_complexity) { } # Numeric`
 
     def initialize
       @complexity = 1

--- a/lib/graphql/float_type.rb
+++ b/lib/graphql/float_type.rb
@@ -2,6 +2,6 @@ GraphQL::FLOAT_TYPE = GraphQL::ScalarType.define do
   name "Float"
   description "Represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point)."
 
-  coerce_input -> (value) { value.is_a?(Numeric) ? value.to_f : nil }
-  coerce_result -> (value) { value.to_f }
+  coerce_input ->(value) { value.is_a?(Numeric) ? value.to_f : nil }
+  coerce_result ->(value) { value.to_f }
 end

--- a/lib/graphql/id_type.rb
+++ b/lib/graphql/id_type.rb
@@ -2,8 +2,8 @@ GraphQL::ID_TYPE = GraphQL::ScalarType.define do
   name "ID"
   description "Represents a unique identifier that is Base64 obfuscated. It is often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"VXNlci0xMA==\"`) or integer (such as `4`) input value will be accepted as an ID."
 
-  coerce_result -> (value) { value.to_s }
-  coerce_input -> (value) {
+  coerce_result ->(value) { value.to_s }
+  coerce_input ->(value) {
     case value
     when String, Fixnum, Bignum
       value.to_s

--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -15,7 +15,7 @@ module GraphQL
   # In a `resolve` function, you can access the values by making nested lookups on `args`.
   #
   # @example Accessing input values in a resolve function
-  #   resolve -> (obj, args, ctx) {
+  #   resolve ->(obj, args, ctx) {
   #     args[:player][:name]    # => "Tony Gwynn"
   #     args[:player][:number]  # => 19
   #     args[:player].to_h      # { "name" => "Tony Gwynn", "number" => 19 }

--- a/lib/graphql/int_type.rb
+++ b/lib/graphql/int_type.rb
@@ -2,6 +2,6 @@ GraphQL::INT_TYPE = GraphQL::ScalarType.define do
   name "Int"
   description "Represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
 
-  coerce_input -> (value) { value.is_a?(Numeric) ? value.to_i : nil }
-  coerce_result -> (value) { value.to_i }
+  coerce_input ->(value) { value.is_a?(Numeric) ? value.to_i : nil }
+  coerce_result ->(value) { value.to_i }
 end

--- a/lib/graphql/introspection/arguments_field.rb
+++ b/lib/graphql/introspection/arguments_field.rb
@@ -1,4 +1,4 @@
 GraphQL::Introspection::ArgumentsField = GraphQL::Field.define do
   type !GraphQL::ListType.new(of_type: !GraphQL::Introspection::InputValueType)
-  resolve -> (target, a, c) { target.arguments.values }
+  resolve ->(target, a, c) { target.arguments.values }
 end

--- a/lib/graphql/introspection/enum_value_type.rb
+++ b/lib/graphql/introspection/enum_value_type.rb
@@ -6,7 +6,7 @@ GraphQL::Introspection::EnumValueType = GraphQL::ObjectType.define do
   field :name, !types.String
   field :description, types.String
   field :isDeprecated, !types.Boolean do
-    resolve -> (obj, a, c) { !!obj.deprecation_reason }
+    resolve ->(obj, a, c) { !!obj.deprecation_reason }
   end
   field :deprecationReason, types.String, property: :deprecation_reason
 end

--- a/lib/graphql/introspection/enum_values_field.rb
+++ b/lib/graphql/introspection/enum_values_field.rb
@@ -1,7 +1,7 @@
 GraphQL::Introspection::EnumValuesField = GraphQL::Field.define do
   type types[!GraphQL::Introspection::EnumValueType]
   argument :includeDeprecated, types.Boolean, default_value: false
-  resolve -> (object, arguments, context) do
+  resolve ->(object, arguments, context) do
     return nil if !object.kind.enum?
     fields = object.values.values
     if !arguments["includeDeprecated"]

--- a/lib/graphql/introspection/field_type.rb
+++ b/lib/graphql/introspection/field_type.rb
@@ -7,7 +7,7 @@ GraphQL::Introspection::FieldType = GraphQL::ObjectType.define do
   field :args, GraphQL::Introspection::ArgumentsField
   field :type, !GraphQL::Introspection::TypeType
   field :isDeprecated, !types.Boolean do
-    resolve -> (obj, a, c) { !!obj.deprecation_reason }
+    resolve ->(obj, a, c) { !!obj.deprecation_reason }
   end
   field :deprecationReason, types.String, property: :deprecation_reason
 end

--- a/lib/graphql/introspection/fields_field.rb
+++ b/lib/graphql/introspection/fields_field.rb
@@ -1,7 +1,7 @@
 GraphQL::Introspection::FieldsField = GraphQL::Field.define do
   type -> { types[!GraphQL::Introspection::FieldType] }
   argument :includeDeprecated, GraphQL::BOOLEAN_TYPE, default_value: false
-  resolve -> (object, arguments, context) {
+  resolve ->(object, arguments, context) {
     return nil if !object.kind.fields?
     fields = object.all_fields
     if !arguments["includeDeprecated"]

--- a/lib/graphql/introspection/input_fields_field.rb
+++ b/lib/graphql/introspection/input_fields_field.rb
@@ -1,7 +1,7 @@
 GraphQL::Introspection::InputFieldsField = GraphQL::Field.define do
   name "inputFields"
   type types[!GraphQL::Introspection::InputValueType]
-  resolve -> (target, a, c) {
+  resolve ->(target, a, c) {
     if target.kind.input_object?
       target.input_fields.values
     else

--- a/lib/graphql/introspection/input_value_type.rb
+++ b/lib/graphql/introspection/input_value_type.rb
@@ -7,7 +7,7 @@ GraphQL::Introspection::InputValueType = GraphQL::ObjectType.define do
   field :description, types.String
   field :type, !GraphQL::Introspection::TypeType
   field :defaultValue, types.String, "A GraphQL-formatted string representing the default value for this input value." do
-    resolve -> (obj, args, ctx) {
+    resolve ->(obj, args, ctx) {
       value = obj.default_value
       value.nil? ? nil : JSON.dump(obj.type.coerce_result(value))
     }

--- a/lib/graphql/introspection/interfaces_field.rb
+++ b/lib/graphql/introspection/interfaces_field.rb
@@ -1,4 +1,4 @@
 GraphQL::Introspection::InterfacesField = GraphQL::Field.define do
   type -> { types[!GraphQL::Introspection::TypeType] }
-  resolve -> (target, a, c) { target.kind.object? ? target.interfaces : nil }
+  resolve ->(target, a, c) { target.kind.object? ? target.interfaces : nil }
 end

--- a/lib/graphql/introspection/of_type_field.rb
+++ b/lib/graphql/introspection/of_type_field.rb
@@ -1,5 +1,5 @@
 GraphQL::Introspection::OfTypeField = GraphQL::Field.define do
   name "ofType"
   type -> { GraphQL::Introspection::TypeType }
-  resolve -> (obj, args, ctx) { obj.kind.wraps? ? obj.of_type : nil }
+  resolve ->(obj, args, ctx) { obj.kind.wraps? ? obj.of_type : nil }
 end

--- a/lib/graphql/introspection/possible_types_field.rb
+++ b/lib/graphql/introspection/possible_types_field.rb
@@ -1,6 +1,6 @@
 GraphQL::Introspection::PossibleTypesField = GraphQL::Field.define do
   type -> { types[!GraphQL::Introspection::TypeType] }
-  resolve -> (target, args, ctx) {
+  resolve ->(target, args, ctx) {
     if target.kind.resolves?
       ctx.schema.possible_types(target)
     else

--- a/lib/graphql/introspection/schema_field.rb
+++ b/lib/graphql/introspection/schema_field.rb
@@ -7,7 +7,7 @@ module GraphQL
           name("__schema")
           description("This GraphQL schema")
           type(!GraphQL::Introspection::SchemaType)
-          resolve -> (o, a, c) { wrapped_type }
+          resolve ->(o, a, c) { wrapped_type }
         end
       end
     end

--- a/lib/graphql/introspection/schema_type.rb
+++ b/lib/graphql/introspection/schema_type.rb
@@ -5,22 +5,22 @@ GraphQL::Introspection::SchemaType = GraphQL::ObjectType.define do
               "query, mutation, and subscription operations."
 
   field :types, !types[!GraphQL::Introspection::TypeType], "A list of all types supported by this server." do
-    resolve -> (obj, arg, ctx) { obj.types.values }
+    resolve ->(obj, arg, ctx) { obj.types.values }
   end
 
   field :queryType, !GraphQL::Introspection::TypeType, "The type that query operations will be rooted at." do
-    resolve -> (obj, arg, ctx) { obj.query }
+    resolve ->(obj, arg, ctx) { obj.query }
   end
 
   field :mutationType, GraphQL::Introspection::TypeType, "If this server supports mutation, the type that mutation operations will be rooted at." do
-    resolve -> (obj, arg, ctx) { obj.mutation }
+    resolve ->(obj, arg, ctx) { obj.mutation }
   end
 
   field :subscriptionType, GraphQL::Introspection::TypeType, "If this server support subscription, the type that subscription operations will be rooted at." do
-    resolve -> (obj, arg, ctx) { obj.subscription }
+    resolve ->(obj, arg, ctx) { obj.subscription }
   end
 
   field :directives, !types[!GraphQL::Introspection::DirectiveType], "A list of all directives supported by this server." do
-    resolve -> (obj, arg, ctx) { obj.directives.values }
+    resolve ->(obj, arg, ctx) { obj.directives.values }
   end
 end

--- a/lib/graphql/introspection/type_by_name_field.rb
+++ b/lib/graphql/introspection/type_by_name_field.rb
@@ -8,7 +8,7 @@ module GraphQL
           description("A type in the GraphQL system")
           type(GraphQL::Introspection::TypeType)
           argument :name, !types.String
-          resolve -> (o, args, c) { type_hash.fetch(args["name"], nil) }
+          resolve ->(o, args, c) { type_hash.fetch(args["name"], nil) }
         end
       end
     end

--- a/lib/graphql/introspection/type_type.rb
+++ b/lib/graphql/introspection/type_type.rb
@@ -12,7 +12,7 @@ GraphQL::Introspection::TypeType = GraphQL::ObjectType.define do
   field :description, types.String
   field :kind do
     type !GraphQL::Introspection::TypeKindEnum
-    resolve -> (target, a, c) { target.kind.name }
+    resolve ->(target, a, c) { target.kind.name }
   end
   field :fields,          field: GraphQL::Introspection::FieldsField
   field :ofType,          field: GraphQL::Introspection::OfTypeField

--- a/lib/graphql/introspection/typename_field.rb
+++ b/lib/graphql/introspection/typename_field.rb
@@ -7,7 +7,7 @@ module GraphQL
           name "__typename"
           description "The name of this type"
           type -> { !GraphQL::STRING_TYPE }
-          resolve -> (obj, a, c) { wrapped_type.name }
+          resolve ->(obj, a, c) { wrapped_type.name }
         end
       end
     end

--- a/lib/graphql/language/definition_slice.rb
+++ b/lib/graphql/language/definition_slice.rb
@@ -16,7 +16,7 @@ module GraphQL
       def find_definition_dependencies(definitions, name)
         names = Set.new([name])
         visitor = Visitor.new(definitions[name])
-        visitor[Nodes::FragmentSpread] << -> (node, parent) {
+        visitor[Nodes::FragmentSpread] << ->(node, parent) {
           if fragment = definitions[node.name]
             names.merge(find_definition_dependencies(definitions, fragment.name))
           end

--- a/lib/graphql/language/lexer.rb
+++ b/lib/graphql/language/lexer.rb
@@ -519,7 +519,7 @@ end
 
 # line 132 "lib/graphql/language/lexer.rl"
 
-        emit_token = -> (name) {
+        emit_token = ->(name) {
           emit(name, ts, te, meta)
         }
 
@@ -1008,7 +1008,7 @@ end
       }
 
       UTF_8 = /\\u[\dAa-f]{4}/i
-      UTF_8_REPLACE = -> (m) { [m[-4..-1].to_i(16)].pack('U'.freeze) }
+      UTF_8_REPLACE = ->(m) { [m[-4..-1].to_i(16)].pack('U'.freeze) }
 
       def self.emit_string(ts, te, meta)
         value = meta[:data][ts...te].pack("c*").force_encoding("UTF-8")

--- a/lib/graphql/language/lexer.rl
+++ b/lib/graphql/language/lexer.rl
@@ -130,7 +130,7 @@ module GraphQL
 
         %% write init;
 
-        emit_token = -> (name) {
+        emit_token = ->(name) {
           emit(name, ts, te, meta)
         }
 
@@ -163,7 +163,7 @@ module GraphQL
       }
 
       UTF_8 = /\\u[\dAa-f]{4}/i
-      UTF_8_REPLACE = -> (m) { [m[-4..-1].to_i(16)].pack('U'.freeze) }
+      UTF_8_REPLACE = ->(m) { [m[-4..-1].to_i(16)].pack('U'.freeze) }
 
       def self.emit_string(ts, te, meta)
         value = meta[:data][ts...te].pack("c*").force_encoding("UTF-8")

--- a/lib/graphql/language/visitor.rb
+++ b/lib/graphql/language/visitor.rb
@@ -6,9 +6,9 @@ module GraphQL
     #   total_field_count = 0
     #   visitor = GraphQL::Language::Visitor.new(document)
     #   # Whenever you find a field, increment the field count:
-    #   visitor[GraphQL::Language::Nodes::Field] << -> (node) { total_field_count += 1 }
+    #   visitor[GraphQL::Language::Nodes::Field] << ->(node) { total_field_count += 1 }
     #   # When we finish, print the field count:
-    #   visitor[GraphQL::Language::Nodes::Document].leave << -> (node) { p total_field_count }
+    #   visitor[GraphQL::Language::Nodes::Document].leave << ->(node) { p total_field_count }
     #   visitor.visit
     #   # => 6
     #
@@ -34,7 +34,7 @@ module GraphQL
       # @return [NodeVisitor]
       #
       # @example Run a hook whenever you enter a new Field
-      #   visitor[GraphQL::Language::Nodes::Field] << -> (node, parent) { p "Here's a field" }
+      #   visitor[GraphQL::Language::Nodes::Field] << ->(node, parent) { p "Here's a field" }
       def [](node_class)
         @visitors[node_class] ||= NodeVisitor.new
       end

--- a/lib/graphql/object_type.rb
+++ b/lib/graphql/object_type.rb
@@ -12,7 +12,7 @@ module GraphQL
   #     field :cast, CastType
   #     field :starring, types[PersonType] do
   #       argument :limit, types.Int
-  #       resolve -> (object, args, ctx) {
+  #       resolve ->(object, args, ctx) {
   #         stars = object.cast.stars
   #         args[:limit] && stars = stars.limit(args[:limit])
   #         stars

--- a/lib/graphql/query/serial_execution/field_resolution.rb
+++ b/lib/graphql/query/serial_execution/field_resolution.rb
@@ -75,7 +75,7 @@ module GraphQL
         # Execute the field's resolve method
         # @return [Proc] suitable to be the last step in a middleware chain
         def get_middleware_proc_from_field_resolve
-          -> (_parent_type, parent_object, field_definition, field_args, context, _next) {
+          ->(_parent_type, parent_object, field_definition, field_args, context, _next) {
             context.ast_node = irep_node.ast_node
             context.irep_node = irep_node
             value = field_definition.resolve(parent_object, field_args, context)

--- a/lib/graphql/relay/connection_type.rb
+++ b/lib/graphql/relay/connection_type.rb
@@ -11,7 +11,7 @@ module GraphQL
           name(connection_type_name)
           field :edges, types[edge_type] do
             description "A list of edges."
-            resolve -> (obj, args, ctx) {
+            resolve ->(obj, args, ctx) {
               obj.edge_nodes.map { |item| edge_class.new(item, obj) }
             }
           end

--- a/lib/graphql/relay/mutation.rb
+++ b/lib/graphql/relay/mutation.rb
@@ -19,7 +19,7 @@ module GraphQL
     #
     #     return_field :item, ItemType
     #
-    #     resolve -> (inputs, ctx) {
+    #     resolve ->(inputs, ctx) {
     #       item = Item.find_by_id(inputs[:id])
     #       item.update(name: inputs[:name])
     #       {item: item}

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -50,9 +50,9 @@ module GraphQL
       :max_depth, :max_complexity,
       :orphan_types, :resolve_type,
       :object_from_id, :id_from_object,
-      query_analyzer: -> (schema, analyzer) { schema.query_analyzers << analyzer },
-      middleware: -> (schema, middleware) { schema.middleware << middleware },
-      rescue_from: -> (schema, err_class, &block) { schema.rescue_from(err_class, &block)}
+      query_analyzer: ->(schema, analyzer) { schema.query_analyzers << analyzer },
+      middleware: ->(schema, middleware) { schema.middleware << middleware },
+      rescue_from: ->(schema, err_class, &block) { schema.rescue_from(err_class, &block)}
 
     lazy_defined_attr_accessor \
       :query, :mutation, :subscription,

--- a/lib/graphql/schema/loader.rb
+++ b/lib/graphql/schema/loader.rb
@@ -14,7 +14,7 @@ module GraphQL
         schema = introspection_result.fetch("data").fetch("__schema")
 
         types = {}
-        type_resolver = -> (type) { -> { resolve_type(types, type) } }
+        type_resolver = ->(type) { -> { resolve_type(types, type) } }
 
         schema.fetch("types").each do |type|
           next if type.fetch("name").start_with?("__")
@@ -31,7 +31,7 @@ module GraphQL
         Schema.define(**kargs)
       end
 
-      NullResolveType = -> (obj, ctx) {
+      NullResolveType = ->(obj, ctx) {
         raise(NotImplementedError, "This schema was loaded from string, so it can't resolve types for objects")
       }
 

--- a/lib/graphql/schema/validation.rb
+++ b/lib/graphql/schema/validation.rb
@@ -24,7 +24,7 @@ module GraphQL
         # @return [Proc] A proc which will validate the input by calling `property_name` and asserting it is an instance of one of `allowed_classes`
         def self.assert_property(property_name, *allowed_classes)
           allowed_classes_message = allowed_classes.map(&:name).join(" or ")
-          -> (obj) {
+          ->(obj) {
             property_value = obj.public_send(property_name)
             is_valid_value = allowed_classes.any? { |allowed_class| property_value.is_a?(allowed_class) }
             is_valid_value ? nil : "#{property_name} must return #{allowed_classes_message}, not #{property_value.class.name} (#{property_value.inspect})"
@@ -36,7 +36,7 @@ module GraphQL
         # @param to_class [Class] The class for values in the return value
         # @return [Proc] A proc to validate that validates the input by calling `property_name` and asserting that the return value is a Hash of `{from_class => to_class}` pairs
         def self.assert_property_mapping(property_name, from_class, to_class)
-          -> (obj) {
+          ->(obj) {
             property_value = obj.public_send(property_name)
             error_message = nil
             if !property_value.is_a?(Hash)
@@ -56,7 +56,7 @@ module GraphQL
         # @param list_member_class [Class] The class which each member of the returned array should be an instance of
         # @return [Proc] A proc to validate the input by calling `property_name` and asserting that the return is an Array of `list_member_class` instances
         def self.assert_property_list_of(property_name, list_member_class)
-          -> (obj) {
+          ->(obj) {
             property_value = obj.public_send(property_name)
             if !property_value.is_a?(Array)
               "#{property_name} must be an Array of #{list_member_class.name}, not a #{property_value.class.name} (#{property_value.inspect})"
@@ -72,7 +72,7 @@ module GraphQL
         end
 
         def self.assert_named_items_are_valid(item_name, get_items_proc)
-          -> (type) {
+          ->(type) {
             items = get_items_proc.call(type)
             error_message = nil
             items.each do |item|
@@ -87,18 +87,18 @@ module GraphQL
         end
 
 
-        FIELDS_ARE_VALID = Rules.assert_named_items_are_valid("field", -> (type) { type.all_fields })
+        FIELDS_ARE_VALID = Rules.assert_named_items_are_valid("field", ->(type) { type.all_fields })
 
-        HAS_ONE_OR_MORE_POSSIBLE_TYPES = -> (type) {
+        HAS_ONE_OR_MORE_POSSIBLE_TYPES = ->(type) {
           type.possible_types.length >= 1 ? nil : "must have at least one possible type"
         }
 
         NAME_IS_STRING = Rules.assert_property(:name, String)
         DESCRIPTION_IS_STRING_OR_NIL = Rules.assert_property(:description, String, NilClass)
         ARGUMENTS_ARE_STRING_TO_ARGUMENT = Rules.assert_property_mapping(:arguments, String, GraphQL::Argument)
-        ARGUMENTS_ARE_VALID =  Rules.assert_named_items_are_valid("argument", -> (type) { type.arguments.values })
+        ARGUMENTS_ARE_VALID =  Rules.assert_named_items_are_valid("argument", ->(type) { type.arguments.values })
 
-        DEFAULT_VALUE_IS_VALID_FOR_TYPE = -> (type) {
+        DEFAULT_VALUE_IS_VALID_FOR_TYPE = ->(type) {
           if !type.default_value.nil?
             coerced_value = begin
               type.type.coerce_result(type.default_value)
@@ -114,7 +114,7 @@ module GraphQL
           end
         }
 
-        TYPE_IS_VALID_INPUT_TYPE = -> (type) {
+        TYPE_IS_VALID_INPUT_TYPE = ->(type) {
           outer_type = type.type
           inner_type = outer_type.is_a?(GraphQL::BaseType) ? outer_type.unwrap : nil
 
@@ -126,7 +126,7 @@ module GraphQL
           end
         }
 
-        SCHEMA_CAN_RESOLVE_TYPES = -> (schema) {
+        SCHEMA_CAN_RESOLVE_TYPES = ->(schema) {
           if schema.types.values.any? { |type| type.kind.resolves? } && schema.resolve_type_proc.nil?
             "schema contains Interfaces or Unions, so you must define a `resolve_type (obj, ctx) -> { ... }` function"
           else
@@ -134,7 +134,7 @@ module GraphQL
           end
         }
 
-        SCHEMA_CAN_FETCH_IDS = -> (schema) {
+        SCHEMA_CAN_FETCH_IDS = ->(schema) {
           has_node_field = schema.query && schema.query.all_fields.any? { |f| f.metadata[:relay_node_field] }
           if has_node_field && schema.object_from_id_proc.nil?
             "schema contains `node(id:...)` field, so you must define a `object_from_id (id, ctx) -> { ... }` function"
@@ -143,7 +143,7 @@ module GraphQL
           end
         }
 
-        SCHEMA_CAN_GENERATE_IDS = -> (schema) {
+        SCHEMA_CAN_GENERATE_IDS = ->(schema) {
           has_id_field = schema.types.values.any? { |t| t.kind.fields? && t.all_fields.any? { |f| f.resolve_proc.is_a?(GraphQL::Relay::GlobalIdResolve) } }
           if has_id_field && schema.id_from_object_proc.nil?
             "schema contains `global_id_field`, so you must define a `id_from_object (obj, type, ctx) -> { ... }` function"

--- a/lib/graphql/static_validation/arguments_validator.rb
+++ b/lib/graphql/static_validation/arguments_validator.rb
@@ -6,7 +6,7 @@ module GraphQL
 
       def validate(context)
         visitor = context.visitor
-        visitor[GraphQL::Language::Nodes::Argument] << -> (node, parent) {
+        visitor[GraphQL::Language::Nodes::Argument] << ->(node, parent) {
           if parent.is_a?(GraphQL::Language::Nodes::InputObject)
             arg_defn = context.argument_definition
             if arg_defn.nil?

--- a/lib/graphql/static_validation/rules/directives_are_defined.rb
+++ b/lib/graphql/static_validation/rules/directives_are_defined.rb
@@ -5,7 +5,7 @@ module GraphQL
 
       def validate(context)
         directive_names = context.schema.directives.keys
-        context.visitor[GraphQL::Language::Nodes::Directive] << -> (node, parent) {
+        context.visitor[GraphQL::Language::Nodes::Directive] << ->(node, parent) {
           validate_directive(node, directive_names, context)
         }
       end

--- a/lib/graphql/static_validation/rules/directives_are_in_valid_locations.rb
+++ b/lib/graphql/static_validation/rules/directives_are_in_valid_locations.rb
@@ -7,7 +7,7 @@ module GraphQL
       def validate(context)
         directives = context.schema.directives
 
-        context.visitor[Nodes::Directive] << -> (node, parent) {
+        context.visitor[Nodes::Directive] << ->(node, parent) {
           validate_location(node, parent, directives, context)
         }
       end

--- a/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb
+++ b/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb
@@ -5,7 +5,7 @@ module GraphQL
 
       def validate(context)
         visitor = context.visitor
-        visitor[GraphQL::Language::Nodes::Field] << -> (node, parent) {
+        visitor[GraphQL::Language::Nodes::Field] << ->(node, parent) {
           return if context.skip_field?(node.name)
           parent_type = context.object_types[-2]
           parent_type = parent_type.unwrap

--- a/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb
+++ b/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb
@@ -6,7 +6,7 @@ module GraphQL
       include GraphQL::StaticValidation::Message::MessageHelper
 
       def validate(context)
-        context.visitor[GraphQL::Language::Nodes::Field] << -> (node, parent)  {
+        context.visitor[GraphQL::Language::Nodes::Field] << ->(node, parent)  {
           return if context.skip_field?(node.name)
           field_defn = context.field_definition
           validate_field_selections(node, field_defn, context)

--- a/lib/graphql/static_validation/rules/fields_will_merge.rb
+++ b/lib/graphql/static_validation/rules/fields_will_merge.rb
@@ -5,12 +5,12 @@ module GraphQL
         fragments = {}
         has_selections = []
         visitor = context.visitor
-        visitor[GraphQL::Language::Nodes::OperationDefinition] << -> (node, parent) {
+        visitor[GraphQL::Language::Nodes::OperationDefinition] << ->(node, parent) {
           if node.selections.any?
             has_selections << node
           end
         }
-        visitor[GraphQL::Language::Nodes::Document].leave << -> (node, parent) {
+        visitor[GraphQL::Language::Nodes::Document].leave << ->(node, parent) {
           has_selections.each { |node|
             field_map = gather_fields_by_name(node.selections, {}, [], context)
             find_conflicts(field_map, [], context)

--- a/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb
+++ b/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb
@@ -5,7 +5,7 @@ module GraphQL
 
       def validate(context)
 
-        context.visitor[GraphQL::Language::Nodes::InlineFragment] << -> (node, parent) {
+        context.visitor[GraphQL::Language::Nodes::InlineFragment] << ->(node, parent) {
           fragment_parent = context.object_types[-2]
           fragment_child = context.object_types.last
           if fragment_child
@@ -15,12 +15,12 @@ module GraphQL
 
         spreads_to_validate = []
 
-        context.visitor[GraphQL::Language::Nodes::FragmentSpread] << -> (node, parent) {
+        context.visitor[GraphQL::Language::Nodes::FragmentSpread] << ->(node, parent) {
           fragment_parent = context.object_types.last
           spreads_to_validate << FragmentSpread.new(node: node, parent_type: fragment_parent, path: context.path)
         }
 
-        context.visitor[GraphQL::Language::Nodes::Document].leave << -> (doc_node, parent) {
+        context.visitor[GraphQL::Language::Nodes::Document].leave << ->(doc_node, parent) {
           spreads_to_validate.each do |frag_spread|
             fragment_child_name = context.fragments[frag_spread.node.name].type
             fragment_child = context.schema.types.fetch(fragment_child_name, nil) # Might be non-existent type name

--- a/lib/graphql/static_validation/rules/fragment_types_exist.rb
+++ b/lib/graphql/static_validation/rules/fragment_types_exist.rb
@@ -10,7 +10,7 @@ module GraphQL
 
       def validate(context)
         FRAGMENTS_ON_TYPES.each do |node_class|
-          context.visitor[node_class] << -> (node, parent) { validate_type_exists(node, context) }
+          context.visitor[node_class] << ->(node, parent) { validate_type_exists(node, context) }
         end
       end
 

--- a/lib/graphql/static_validation/rules/fragments_are_finite.rb
+++ b/lib/graphql/static_validation/rules/fragments_are_finite.rb
@@ -4,7 +4,7 @@ module GraphQL
       include GraphQL::StaticValidation::Message::MessageHelper
 
       def validate(context)
-        context.visitor[GraphQL::Language::Nodes::FragmentDefinition] << -> (node, parent) {
+        context.visitor[GraphQL::Language::Nodes::FragmentDefinition] << ->(node, parent) {
           if has_nested_spread(node, [], context)
             context.errors << message("Fragment #{node.name} contains an infinite loop", node, context: context)
           end

--- a/lib/graphql/static_validation/rules/fragments_are_named.rb
+++ b/lib/graphql/static_validation/rules/fragments_are_named.rb
@@ -4,7 +4,7 @@ module GraphQL
       include GraphQL::StaticValidation::Message::MessageHelper
 
       def validate(context)
-        context.visitor[GraphQL::Language::Nodes::FragmentDefinition] << -> (node, parent) { validate_name_exists(node, context) }
+        context.visitor[GraphQL::Language::Nodes::FragmentDefinition] << ->(node, parent) { validate_name_exists(node, context) }
       end
 
       private

--- a/lib/graphql/static_validation/rules/fragments_are_on_composite_types.rb
+++ b/lib/graphql/static_validation/rules/fragments_are_on_composite_types.rb
@@ -10,7 +10,7 @@ module GraphQL
 
       def validate(context)
         HAS_TYPE_CONDITION.each do |node_class|
-          context.visitor[node_class] << -> (node, parent) {
+          context.visitor[node_class] << ->(node, parent) {
             validate_type_is_composite(node, context)
           }
         end

--- a/lib/graphql/static_validation/rules/fragments_are_used.rb
+++ b/lib/graphql/static_validation/rules/fragments_are_used.rb
@@ -8,19 +8,19 @@ module GraphQL
         used_fragments = []
         defined_fragments = []
 
-        v[GraphQL::Language::Nodes::Document] << -> (node, parent) {
+        v[GraphQL::Language::Nodes::Document] << ->(node, parent) {
           defined_fragments = node.definitions
             .select { |defn| defn.is_a?(GraphQL::Language::Nodes::FragmentDefinition) }
             .map { |node| FragmentInstance.new(node: node, path: context.path) }
         }
 
-        v[GraphQL::Language::Nodes::FragmentSpread] << -> (node, parent) {
+        v[GraphQL::Language::Nodes::FragmentSpread] << ->(node, parent) {
           used_fragments << FragmentInstance.new(node: node, path: context.path)
           if defined_fragments.none? { |defn| defn.name == node.name }
             GraphQL::Language::Visitor::SKIP
           end
         }
-        v[GraphQL::Language::Nodes::Document].leave << -> (node, parent) { add_errors(context, used_fragments, defined_fragments) }
+        v[GraphQL::Language::Nodes::Document].leave << ->(node, parent) { add_errors(context, used_fragments, defined_fragments) }
       end
 
       private

--- a/lib/graphql/static_validation/rules/mutation_root_exists.rb
+++ b/lib/graphql/static_validation/rules/mutation_root_exists.rb
@@ -8,7 +8,7 @@ module GraphQL
 
         visitor = context.visitor
 
-        visitor[GraphQL::Language::Nodes::OperationDefinition].enter << -> (ast_node, prev_ast_node) {
+        visitor[GraphQL::Language::Nodes::OperationDefinition].enter << ->(ast_node, prev_ast_node) {
           if ast_node.operation_type == 'mutation'
             context.errors << message('Schema is not configured for mutations', ast_node, context: context)
             return GraphQL::Language::Visitor::SKIP

--- a/lib/graphql/static_validation/rules/required_arguments_are_present.rb
+++ b/lib/graphql/static_validation/rules/required_arguments_are_present.rb
@@ -5,8 +5,8 @@ module GraphQL
 
       def validate(context)
         v = context.visitor
-        v[GraphQL::Language::Nodes::Field] << -> (node, parent) { validate_field(node, context) }
-        v[GraphQL::Language::Nodes::Directive] << -> (node, parent) { validate_directive(node, context) }
+        v[GraphQL::Language::Nodes::Field] << ->(node, parent) { validate_field(node, context) }
+        v[GraphQL::Language::Nodes::Directive] << ->(node, parent) { validate_directive(node, context) }
       end
 
       private

--- a/lib/graphql/static_validation/rules/subscription_root_exists.rb
+++ b/lib/graphql/static_validation/rules/subscription_root_exists.rb
@@ -8,7 +8,7 @@ module GraphQL
 
         visitor = context.visitor
 
-        visitor[GraphQL::Language::Nodes::OperationDefinition].enter << -> (ast_node, prev_ast_node) {
+        visitor[GraphQL::Language::Nodes::OperationDefinition].enter << ->(ast_node, prev_ast_node) {
           if ast_node.operation_type == 'subscription'
             context.errors << message('Schema is not configured for subscriptions', ast_node, context: context)
             return GraphQL::Language::Visitor::SKIP

--- a/lib/graphql/static_validation/rules/variable_default_values_are_correctly_typed.rb
+++ b/lib/graphql/static_validation/rules/variable_default_values_are_correctly_typed.rb
@@ -5,7 +5,7 @@ module GraphQL
 
       def validate(context)
         literal_validator = GraphQL::StaticValidation::LiteralValidator.new
-        context.visitor[GraphQL::Language::Nodes::VariableDefinition] << -> (node, parent) {
+        context.visitor[GraphQL::Language::Nodes::VariableDefinition] << ->(node, parent) {
           if !node.default_value.nil?
             validate_default_value(node, literal_validator, context)
           end

--- a/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb
+++ b/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb
@@ -7,11 +7,11 @@ module GraphQL
         # holds { name => ast_node } pairs
         declared_variables = {}
 
-        context.visitor[GraphQL::Language::Nodes::OperationDefinition] << -> (node, parent) {
+        context.visitor[GraphQL::Language::Nodes::OperationDefinition] << ->(node, parent) {
           declared_variables = node.variables.each_with_object({}) { |var, memo| memo[var.name] = var }
         }
 
-        context.visitor[GraphQL::Language::Nodes::Argument] << -> (node, parent) {
+        context.visitor[GraphQL::Language::Nodes::Argument] << ->(node, parent) {
           return if !node.value.is_a?(GraphQL::Language::Nodes::VariableIdentifier)
           if parent.is_a?(GraphQL::Language::Nodes::Field)
             arguments = context.field_definition.arguments

--- a/lib/graphql/static_validation/rules/variables_are_input_types.rb
+++ b/lib/graphql/static_validation/rules/variables_are_input_types.rb
@@ -4,7 +4,7 @@ module GraphQL
       include GraphQL::StaticValidation::Message::MessageHelper
 
       def validate(context)
-        context.visitor[GraphQL::Language::Nodes::VariableDefinition] << -> (node, parent) {
+        context.visitor[GraphQL::Language::Nodes::VariableDefinition] << ->(node, parent) {
           validate_is_input_type(node, context)
         }
       end

--- a/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb
+++ b/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb
@@ -35,19 +35,19 @@ module GraphQL
 
         # OperationDefinitions and FragmentDefinitions
         # both push themselves onto the context stack (and pop themselves off)
-        push_variable_context_stack = -> (node, parent) {
+        push_variable_context_stack = ->(node, parent) {
           # initialize the hash of vars for this context:
           variable_usages_for_context[node]
           variable_context_stack.push(node)
         }
 
-        pop_variable_context_stack = -> (node, parent) {
+        pop_variable_context_stack = ->(node, parent) {
           variable_context_stack.pop
         }
 
 
         context.visitor[GraphQL::Language::Nodes::OperationDefinition] << push_variable_context_stack
-        context.visitor[GraphQL::Language::Nodes::OperationDefinition] << -> (node, parent) {
+        context.visitor[GraphQL::Language::Nodes::OperationDefinition] << ->(node, parent) {
           # mark variables as defined:
           var_hash = variable_usages_for_context[node]
           node.variables.each { |var|
@@ -64,7 +64,7 @@ module GraphQL
         # For FragmentSpreads:
         #  - find the context on the stack
         #  - mark the context as containing this spread
-        context.visitor[GraphQL::Language::Nodes::FragmentSpread] << -> (node, parent) {
+        context.visitor[GraphQL::Language::Nodes::FragmentSpread] << ->(node, parent) {
           variable_context = variable_context_stack.last
           spreads_for_context[variable_context] << node.name
         }
@@ -72,7 +72,7 @@ module GraphQL
         # For VariableIdentifiers:
         #  - mark the variable as used
         #  - assign its AST node
-        context.visitor[GraphQL::Language::Nodes::VariableIdentifier] << -> (node, parent) {
+        context.visitor[GraphQL::Language::Nodes::VariableIdentifier] << ->(node, parent) {
           usage_context = variable_context_stack.last
           declared_variables = variable_usages_for_context[usage_context]
           usage = declared_variables[node.name]
@@ -82,7 +82,7 @@ module GraphQL
         }
 
 
-        context.visitor[GraphQL::Language::Nodes::Document].leave << -> (node, parent) {
+        context.visitor[GraphQL::Language::Nodes::Document].leave << ->(node, parent) {
           fragment_definitions = variable_usages_for_context.select { |key, value| key.is_a?(GraphQL::Language::Nodes::FragmentDefinition) }
           operation_definitions = variable_usages_for_context.select { |key, value| key.is_a?(GraphQL::Language::Nodes::OperationDefinition) }
 

--- a/lib/graphql/static_validation/type_stack.rb
+++ b/lib/graphql/static_validation/type_stack.rb
@@ -41,8 +41,8 @@ module GraphQL
         @directive_definitions = []
         @argument_definitions = []
         @path = []
-        visitor.enter << -> (node, parent) { PUSH_STRATEGIES[node.class].push(self, node) }
-        visitor.leave << -> (node, parent) { PUSH_STRATEGIES[node.class].pop(self, node) }
+        visitor.enter << ->(node, parent) { PUSH_STRATEGIES[node.class].push(self, node) }
+        visitor.leave << ->(node, parent) { PUSH_STRATEGIES[node.class].pop(self, node) }
       end
 
       private

--- a/lib/graphql/string_type.rb
+++ b/lib/graphql/string_type.rb
@@ -2,6 +2,6 @@ GraphQL::STRING_TYPE = GraphQL::ScalarType.define do
   name "String"
   description "Represents textual data as UTF-8 character sequences. This type is most often used by GraphQL to represent free-form human-readable text."
 
-  coerce_result -> (value) { value.to_s }
-  coerce_input -> (value) { value.is_a?(String) ? value : nil }
+  coerce_result ->(value) { value.to_s }
+  coerce_input ->(value) { value.is_a?(String) ? value : nil }
 end

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ QueryType = GraphQL::ObjectType.define do
   field :post do
     type PostType
     argument :id, !types.ID
-    resolve -> (obj, args, ctx) { Post.find(args["id"]) }
+    resolve ->(obj, args, ctx) { Post.find(args["id"]) }
   end
 end
 

--- a/spec/graphql/analysis/analyze_query_spec.rb
+++ b/spec/graphql/analysis/analyze_query_spec.rb
@@ -17,7 +17,7 @@ describe GraphQL::Analysis do
 
   describe ".analyze_query" do
     let(:node_counter) {
-      -> (memo, visit_type, irep_node) {
+      ->(memo, visit_type, irep_node) {
         memo ||= Hash.new { |h,k| h[k] = 0 }
         visit_type == :enter && memo[irep_node.ast_node.class] += 1
         memo
@@ -57,7 +57,7 @@ describe GraphQL::Analysis do
           }
         }
       |}
-      let(:variable_accessor) { -> (memo, visit_type, irep_node) { query.variables["cheeseId"] } }
+      let(:variable_accessor) { ->(memo, visit_type, irep_node) { query.variables["cheeseId"] } }
 
       before do
         @previous_query_analyzers = DummySchema.query_analyzers.dup
@@ -78,7 +78,7 @@ describe GraphQL::Analysis do
 
     describe "when processing fields" do
       let(:connection_counter) {
-        -> (memo, visit_type, irep_node) {
+        ->(memo, visit_type, irep_node) {
           memo ||= Hash.new { |h,k| h[k] = 0 }
           if visit_type == :enter
             if irep_node.ast_node.is_a?(GraphQL::Language::Nodes::Field)

--- a/spec/graphql/analysis/query_complexity_spec.rb
+++ b/spec/graphql/analysis/query_complexity_spec.rb
@@ -223,12 +223,12 @@ describe GraphQL::Analysis::QueryComplexity do
       single_complexity_type = GraphQL::ObjectType.define do
         name "SingleComplexity"
         field :value, types.Int, complexity: 0.1 do
-          resolve -> (obj, args, ctx) { obj }
+          resolve ->(obj, args, ctx) { obj }
         end
         field :complexity, single_complexity_type do
           argument :value, types.Int
-          complexity -> (ctx, args, child_complexity) { args[:value] + child_complexity }
-          resolve -> (obj, args, ctx) { args[:value] }
+          complexity ->(ctx, args, child_complexity) { args[:value] + child_complexity }
+          resolve ->(obj, args, ctx) { args[:value] }
         end
         interfaces [complexity_interface]
       end
@@ -236,7 +236,7 @@ describe GraphQL::Analysis::QueryComplexity do
       double_complexity_type = GraphQL::ObjectType.define do
         name "DoubleComplexity"
         field :value, types.Int, complexity: 4 do
-          resolve -> (obj, args, ctx) { obj }
+          resolve ->(obj, args, ctx) { obj }
         end
         interfaces [complexity_interface]
       end
@@ -245,13 +245,13 @@ describe GraphQL::Analysis::QueryComplexity do
         name "Query"
         field :complexity, single_complexity_type do
           argument :value, types.Int
-          complexity -> (ctx, args, child_complexity) { args[:value] + child_complexity }
-          resolve -> (obj, args, ctx) { args[:value] }
+          complexity ->(ctx, args, child_complexity) { args[:value] + child_complexity }
+          resolve ->(obj, args, ctx) { args[:value] }
         end
 
         field :innerComplexity, complexity_interface do
           argument :value, types.Int
-          resolve -> (obj, args, ctx) { args[:value] }
+          resolve ->(obj, args, ctx) { args[:value] }
         end
       end
 

--- a/spec/graphql/language/visitor_spec.rb
+++ b/spec/graphql/language/visitor_spec.rb
@@ -19,13 +19,13 @@ describe GraphQL::Language::Visitor do
 
   let(:visitor) do
     v = GraphQL::Language::Visitor.new(document)
-    v[GraphQL::Language::Nodes::Field] << -> (node, parent) { counts[:fields_entered] += 1 }
+    v[GraphQL::Language::Nodes::Field] << ->(node, parent) { counts[:fields_entered] += 1 }
     # two ways to set up enter hooks:
-    v[GraphQL::Language::Nodes::Argument] <<       -> (node, parent) { counts[:argument_names] << node.name }
-    v[GraphQL::Language::Nodes::Argument].enter << -> (node, parent) { counts[:arguments_entered] += 1}
-    v[GraphQL::Language::Nodes::Argument].leave << -> (node, parent) { counts[:arguments_left] += 1 }
+    v[GraphQL::Language::Nodes::Argument] <<       ->(node, parent) { counts[:argument_names] << node.name }
+    v[GraphQL::Language::Nodes::Argument].enter << ->(node, parent) { counts[:arguments_entered] += 1}
+    v[GraphQL::Language::Nodes::Argument].leave << ->(node, parent) { counts[:arguments_left] += 1 }
 
-    v[GraphQL::Language::Nodes::Document].leave << -> (node, parent) { counts[:finished] = true }
+    v[GraphQL::Language::Nodes::Document].leave << ->(node, parent) { counts[:finished] = true }
     v
   end
 
@@ -41,7 +41,7 @@ describe GraphQL::Language::Visitor do
 
   describe "Visitor::SKIP" do
     it "skips the rest of the node" do
-      visitor[GraphQL::Language::Nodes::Document] << -> (node, parent) { GraphQL::Language::Visitor::SKIP }
+      visitor[GraphQL::Language::Nodes::Document] << ->(node, parent) { GraphQL::Language::Visitor::SKIP }
       visitor.visit
       assert_equal(0, counts[:fields_entered])
     end

--- a/spec/graphql/query/arguments_spec.rb
+++ b/spec/graphql/query/arguments_spec.rb
@@ -84,7 +84,7 @@ describe GraphQL::Query::Arguments do
           argument :b, types.Int, default_value: 2
           argument :c, types.Int
           argument :d, test_input_type
-          resolve -> (obj, args, ctx) {
+          resolve ->(obj, args, ctx) {
             arg_values_array << args
             1
           }

--- a/spec/graphql/query/context_spec.rb
+++ b/spec/graphql/query/context_spec.rb
@@ -5,16 +5,16 @@ describe GraphQL::Query::Context do
     name "Query"
     field :context, types.String do
       argument :key, !types.String
-      resolve -> (target, args, ctx) { ctx[args[:key]] }
+      resolve ->(target, args, ctx) { ctx[args[:key]] }
     end
     field :contextAstNodeName, types.String do
-      resolve -> (target, args, ctx) { ctx.ast_node.class.name }
+      resolve ->(target, args, ctx) { ctx.ast_node.class.name }
     end
     field :contextIrepNodeName, types.String do
-      resolve -> (target, args, ctx) { ctx.irep_node.class.name }
+      resolve ->(target, args, ctx) { ctx.irep_node.class.name }
     end
     field :queryName, types.String do
-      resolve -> (target, args, ctx) { ctx.query.class.name }
+      resolve ->(target, args, ctx) { ctx.query.class.name }
     end
   }}
   let(:schema) { GraphQL::Schema.define(query: query_type, mutation: nil)}

--- a/spec/graphql/query/executor_spec.rb
+++ b/spec/graphql/query/executor_spec.rb
@@ -77,7 +77,7 @@ describe GraphQL::Query::Executor do
         name "Query"
         field :dairy do
           type DairyType
-          resolve -> (t, a, c) {
+          resolve ->(t, a, c) {
             raise if resolved
             resolved = true
             DAIRY

--- a/spec/graphql/query/serial_execution/value_resolution_spec.rb
+++ b/spec/graphql/query/serial_execution/value_resolution_spec.rb
@@ -46,7 +46,7 @@ describe GraphQL::Query::SerialExecution::ValueResolution do
     GraphQL::Schema.define do
       query(query_root)
       orphan_types [some_object]
-      resolve_type -> (obj, ctx) do
+      resolve_type ->(obj, ctx) do
         if obj.is_a?(OtherObject)
           other_object
         else

--- a/spec/graphql/relay/mutation_spec.rb
+++ b/spec/graphql/relay/mutation_spec.rb
@@ -72,7 +72,7 @@ describe GraphQL::Relay::Mutation do
       GraphQL::Relay::Mutation.define do
         name "CustomReturnTypeTest"
         return_type custom_type
-        resolve -> (input, ctx) {
+        resolve ->(input, ctx) {
           OpenStruct.new(name: "Custom Return Type Test")
         }
       end

--- a/spec/graphql/relay/node_spec.rb
+++ b/spec/graphql/relay/node_spec.rb
@@ -11,11 +11,11 @@ describe GraphQL::Relay::Node do
         @previous_id_from_object_proc = StarWarsSchema.id_from_object_proc
         @previous_object_from_id_proc = StarWarsSchema.object_from_id_proc
 
-        StarWarsSchema.id_from_object = -> (obj, type_name, ctx) {
+        StarWarsSchema.id_from_object = ->(obj, type_name, ctx) {
           "#{type_name}/#{obj.id}"
         }
 
-        StarWarsSchema.object_from_id = -> (global_id, ctx) {
+        StarWarsSchema.object_from_id = ->(global_id, ctx) {
           type_name, id = global_id.split("/")
           STAR_WARS_DATA[type_name][id]
         }

--- a/spec/graphql/schema/loader_spec.rb
+++ b/spec/graphql/schema/loader_spec.rb
@@ -22,8 +22,8 @@ describe GraphQL::Schema::Loader do
 
     big_int_type = GraphQL::ScalarType.define do
       name "BigInt"
-      coerce_input -> (value) { value =~ /\d+/ ? Integer(value) : nil }
-      coerce_result -> (value) { value.to_s }
+      coerce_input ->(value) { value =~ /\d+/ ? Integer(value) : nil }
+      coerce_result ->(value) { value.to_s }
     end
 
     variant_input_type = GraphQL::InputObjectType.define do

--- a/spec/graphql/schema/middleware_chain_spec.rb
+++ b/spec/graphql/schema/middleware_chain_spec.rb
@@ -1,9 +1,9 @@
 require "spec_helper"
 
 describe GraphQL::Schema::MiddlewareChain do
-  let(:step_1) { -> (step_values, next_step) { step_values << 1; next_step.call } }
-  let(:step_2) { -> (step_values, next_step) { step_values << 2; next_step.call } }
-  let(:step_3) { -> (step_values, next_step) { step_values << 3; :return_value } }
+  let(:step_1) { ->(step_values, next_step) { step_values << 1; next_step.call } }
+  let(:step_2) { ->(step_values, next_step) { step_values << 2; next_step.call } }
+  let(:step_3) { ->(step_values, next_step) { step_values << 3; :return_value } }
   let(:steps) { [step_1, step_2, step_3] }
   let(:step_values) { [] }
   let(:arguments) { [step_values] }
@@ -20,7 +20,7 @@ describe GraphQL::Schema::MiddlewareChain do
     end
 
     describe "when a step returns early" do
-      let(:early_return_step) { -> (step_values, next_step) { :early_return } }
+      let(:early_return_step) { ->(step_values, next_step) { :early_return } }
       it "doesn't continue the chain" do
         steps.insert(2, early_return_step)
         assert_equal(:early_return, middleware_chain.call)
@@ -30,8 +30,8 @@ describe GraphQL::Schema::MiddlewareChain do
 
     describe "when a step provides alternate arguments" do
       it "passes the new arguments to the next step" do
-        step_1 = -> (test_arg, next_step) { assert_equal(test_arg, 'HELLO'); next_step.call(['WORLD']) }
-        step_2 = -> (test_arg, next_step) { assert_equal(test_arg, 'WORLD'); test_arg }
+        step_1 = ->(test_arg, next_step) { assert_equal(test_arg, 'HELLO'); next_step.call(['WORLD']) }
+        step_2 = ->(test_arg, next_step) { assert_equal(test_arg, 'WORLD'); test_arg }
 
         chain = GraphQL::Schema::MiddlewareChain.new(steps: [step_1, step_2], arguments: ['HELLO'])
         result = chain.call

--- a/spec/graphql/schema/printer_spec.rb
+++ b/spec/graphql/schema/printer_spec.rb
@@ -59,7 +59,7 @@ describe GraphQL::Schema::Printer do
         type post_type
         argument :id, !types.ID
         argument :varied, variant_input_type, default_value: { id: "123", int: 234, float: 2.3, enum: :foo, sub: [{ string: "str" }] }
-        resolve -> (obj, args, ctx) { Post.find(args["id"]) }
+        resolve ->(obj, args, ctx) { Post.find(args["id"]) }
       end
     end
 

--- a/spec/graphql/schema/rescue_middleware_spec.rb
+++ b/spec/graphql/schema/rescue_middleware_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 class SpecExampleError < StandardError; end
 
 describe GraphQL::Schema::RescueMiddleware do
-  let(:error_middleware) { -> (next_middleware) { raise(error_class) } }
+  let(:error_middleware) { ->(next_middleware) { raise(error_class) } }
 
   let(:rescue_middleware) do
     middleware = GraphQL::Schema::RescueMiddleware.new

--- a/spec/graphql/schema/timeout_middleware_spec.rb
+++ b/spec/graphql/schema/timeout_middleware_spec.rb
@@ -5,7 +5,7 @@ describe GraphQL::Schema::TimeoutMiddleware do
   let(:timeout_middleware) {  GraphQL::Schema::TimeoutMiddleware.new(max_seconds: max_seconds) }
   let(:timeout_schema) {
 
-    sleep_for_seconds_resolve = -> (obj, args, ctx) {
+    sleep_for_seconds_resolve = ->(obj, args, ctx) {
       sleep(args[:seconds])
       args[:seconds]
     }
@@ -13,7 +13,7 @@ describe GraphQL::Schema::TimeoutMiddleware do
     nested_sleep_type = GraphQL::ObjectType.define do
       name "NestedSleep"
       field :seconds, types.Float do
-        resolve -> (obj, args, ctx) { obj }
+        resolve ->(obj, args, ctx) { obj }
       end
 
       field :nestedSleep, -> { nested_sleep_type } do

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -92,7 +92,7 @@ describe GraphQL::Schema do
         assert_raises(NotImplementedError) {
           GraphQL::Schema.define do
             query(query_type)
-            resolve_type -> (obj, ctx) { :whatever }
+            resolve_type ->(obj, ctx) { :whatever }
           end
         }
       end
@@ -118,7 +118,7 @@ describe GraphQL::Schema do
         assert_raises(NotImplementedError) {
           GraphQL::Schema.define do
             query(query_type)
-            resolve_type -> (obj, ctx) { :whatever }
+            resolve_type ->(obj, ctx) { :whatever }
           end
         }
       end

--- a/spec/graphql/static_validation/type_stack_spec.rb
+++ b/spec/graphql/static_validation/type_stack_spec.rb
@@ -7,7 +7,7 @@ class TypeCheckValidator
 
   def validate(context)
     self.class.checks.clear
-    context.visitor[GraphQL::Language::Nodes::Field] << -> (node, parent) {
+    context.visitor[GraphQL::Language::Nodes::Field] << ->(node, parent) {
       self.class.checks << context.object_types.map(&:name)
     }
   end


### PR DESCRIPTION
See http://ruby-journal.com/becareful-with-space-in-lambda-hash-rocket-syntax-between-ruby-1-dot-9-and-2-dot-0/ for more info.

Extracted from #306 which will be easier to maintain without that commit.

Note that this is also how http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/Lambda defines lambdas like this as well.