### PR TITLE
Use dot-notation for OpenStructs as [] is not available in Ruby 1.9.3

### DIFF
--- a/spec/graphql/relay/mutation_spec.rb
+++ b/spec/graphql/relay/mutation_spec.rb
@@ -22,7 +22,7 @@ describe GraphQL::Relay::Mutation do
 
   after do
     STAR_WARS_DATA["Ship"].delete("9")
-    STAR_WARS_DATA["Faction"]["1"]["ships"].delete("9")
+    STAR_WARS_DATA["Faction"]["1"].ships.delete("9")
   end
 
   it "returns the result & clientMutationId" do

--- a/spec/support/star_wars_data.rb
+++ b/spec/support/star_wars_data.rb
@@ -73,6 +73,6 @@ def STAR_WARS_DATA.create_ship(name, faction_id)
   new_id = (self["Ship"].keys.map(&:to_i).max + 1).to_s
   new_ship = OpenStruct.new(id: new_id, name: name)
   self["Ship"][new_id] = new_ship
-  self["Faction"][faction_id]["ships"] << new_id
+  self["Faction"][faction_id].ships << new_id
   new_ship
 end


### PR DESCRIPTION
This is also how doc (http://ruby-doc.org/stdlib-2.1.0/libdoc/ostruct/rdoc/OpenStruct.html) uses getters in most example.

This will make maintaining the Ruby 1.9.3 branch easier. Any strong opinion on this?
Extracted from #306.