### PR TITLE
Add missing requires for OpenStruct objects

### DIFF
--- a/spec/support/dairy_data.rb
+++ b/spec/support/dairy_data.rb
@@ -1,3 +1,5 @@
+require 'ostruct'
+
 Cheese = Struct.new(:id, :flavor, :origin, :fat_content, :source)
 CHEESES = {
   1 => Cheese.new(1, "Brie", "France", 0.19, 1),

--- a/spec/support/star_wars_data.rb
+++ b/spec/support/star_wars_data.rb
@@ -1,3 +1,4 @@
+require 'ostruct'
 
 names = [
   'X-Wing',


### PR DESCRIPTION
Std-lib doc shows the needed `require` statement, not sure why the builds pass without it:
http://ruby-doc.org/stdlib/libdoc/ostruct/rdoc/OpenStruct.html

It was failing during the Ruby 1.9.3 experiments.
Extracted from #306. 