### PR TITLE
Use JSON's generate+quirks_mode to allow dumping scalar values

### DIFF
--- a/lib/graphql/enum_type.rb
+++ b/lib/graphql/enum_type.rb
@@ -91,7 +91,7 @@ module GraphQL
       result = GraphQL::Query::InputValidationResult.new
 
       if !@values_by_name.key?(value_name)
-        result.add_problem("Expected #{JSON.dump(value_name)} to be one of: #{@values_by_name.keys.join(', ')}")
+        result.add_problem("Expected #{JSON.generate(value_name, quirks_mode: true)} to be one of: #{@values_by_name.keys.join(', ')}")
       end
 
       result

--- a/lib/graphql/introspection/input_value_type.rb
+++ b/lib/graphql/introspection/input_value_type.rb
@@ -9,7 +9,7 @@ GraphQL::Introspection::InputValueType = GraphQL::ObjectType.define do
   field :defaultValue, types.String, "A GraphQL-formatted string representing the default value for this input value." do
     resolve -> (obj, args, ctx) {
       value = obj.default_value
-      value.nil? ? nil : JSON.dump(obj.type.coerce_result(value))
+      value.nil? ? nil : JSON.generate(obj.type.coerce_result(value), quirks_mode: true)
     }
   end
 end

--- a/lib/graphql/scalar_type.rb
+++ b/lib/graphql/scalar_type.rb
@@ -44,7 +44,7 @@ module GraphQL
     def validate_non_null_input(value)
       result = Query::InputValidationResult.new
       if coerce_non_null_input(value).nil?
-        result.add_problem("Could not coerce value #{JSON.dump(value)} to #{name}")
+        result.add_problem("Could not coerce value #{JSON.generate(value, quirks_mode: true)} to #{name}")
       end
       result
     end


### PR DESCRIPTION
From https://github.com/rmosolgo/graphql-ruby/pull/306#issuecomment-254020617:

> One more thing, I'd like to get the `JSON`-related changes in `master`. Recently, someone else reported a bug for that, where another JSON implementation was 💥-ing.

Exported from #306. This was failing on Ruby 1.9.3 as well.