### PR TITLE
Fix links to other guides in website

### DIFF
--- a/guides/introduction.md
+++ b/guides/introduction.md
@@ -166,5 +166,5 @@ result_hash = Schema.execute(query_string)
 
 Read more in some other guides:
 
-- [Defining Your Schema](http://www.rubydoc.info/github/rmosolgo/graphql-ruby/file/guides/defining_your_schema.md)
-- [Executing Queries](http://www.rubydoc.info/github/rmosolgo/graphql-ruby/file/guides/executing_queries.md)
+- [Defining Your Schema](https://rmosolgo.github.io/graphql-ruby/defining_your_schema)
+- [Executing Queries](https://rmosolgo.github.io/graphql-ruby/executing_queries)


### PR DESCRIPTION
Prior to this change, guides on the website were redirecting to the Rubydoc pages.

This also brings the advantage of not leaving the HTTPS world.

Of course, note that with this change, the links in the Rubydoc pages now redirect to the website...
I'll let you decide if this is an issue to you or not. Maybe you're perfectly aware and fine with that, I don't have an opinion, just giving you the option 😅.