### PR TITLE
Fixed typo in testing guide

### DIFF
--- a/guides/testing.md
+++ b/guides/testing.md
@@ -183,9 +183,9 @@ describe MySchema do
 
     context "when there's a current user" do
       # override `context`
-      let(:context) {
+      let(:context) {{
         current_user: User.new(name: "ABC")
-      }
+      }}
 
       it "shows the user's name" do
         user_name = result["data"]["viewer"]["name"]


### PR DESCRIPTION
There should be double curly braces, like in the docs:

http://www.rubydoc.info/github/rmosolgo/graphql-ruby/file/guides/testing.md