### PR TITLE
Omit schema definition from IDL when type names match convention

### DIFF
--- a/lib/graphql/language/generation.rb
+++ b/lib/graphql/language/generation.rb
@@ -72,6 +72,12 @@ module GraphQL
         when Nodes::VariableIdentifier
           "$#{node.name}"
         when Nodes::SchemaDefinition
+          if (node.query.nil? || node.query == 'Query') &&
+             (node.mutation.nil? || node.mutation == 'Mutation') &&
+             (node.subscription.nil? || node.subscription == 'Subscription')
+            return
+          end
+
           out = "schema {\n"
           out << "  query: #{node.query}\n" if node.query
           out << "  mutation: #{node.mutation}\n" if node.mutation

--- a/spec/graphql/language/generation_spec.rb
+++ b/spec/graphql/language/generation_spec.rb
@@ -41,74 +41,136 @@ describe GraphQL::Language::Generation do
     end
 
     describe "schema" do
-      # From: https://github.com/graphql/graphql-js/blob/a725499b155285c2e33647a93393c82689b20b0f/src/language/__tests__/schema-kitchen-sink.graphql
-      let(:query_string) {<<-schema
-        schema {
-          query: QueryType
-          mutation: MutationType
+      describe "schema with convention names for root types" do
+        let(:query_string) {<<-schema
+          schema {
+            query: Query
+            mutation: Mutation
+            subscription: Subscription
+          }
+        schema
         }
 
-        type Foo implements Bar {
-          one: Type
-          two(argument: InputType!): Type
-          three(argument: InputType, other: String): Int
-          four(argument: String = "string"): String
-          five(argument: [String] = ["string", "string"]): String
-          six(argument: InputType = {key: "value"}): Type
-        }
-
-        type AnnotatedObject @onObject(arg: "value") {
-          annotatedField(arg: Type = "default" @onArg): Type @onField
-        }
-
-        interface Bar {
-          one: Type
-          four(argument: String = "string"): String
-        }
-
-        interface AnnotatedInterface @onInterface {
-          annotatedField(arg: Type @onArg): Type @onField
-        }
-
-        union Feed = Story | Article | Advert
-
-        union AnnotatedUnion @onUnion = A | B
-
-        scalar CustomScalar
-
-        scalar AnnotatedScalar @onScalar
-
-        enum Site {
-          DESKTOP
-          MOBILE
-        }
-
-        enum AnnotatedEnum @onEnum {
-          ANNOTATED_VALUE @onEnumValue
-          OTHER_VALUE
-        }
-
-        input InputType {
-          key: String!
-          answer: Int = 42
-        }
-
-        input AnnotatedInput @onInputObjectType {
-          annotatedField: Type @onField
-        }
-
-        directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
-
-        directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
-      schema
-      }
-
-      it "generate" do
-        assert_equal query_string.gsub(/^        /, "").strip, document.to_query_string
+        it 'omits schema definition' do
+          refute document.to_query_string =~ /schema/
+        end
       end
 
-      it "doesn't mutate the document" do
-        assert_equal document.to_query_string, document.to_query_string
+      describe "schema with custom query root name" do
+        let(:query_string) {<<-schema
+          schema {
+            query: MyQuery
+            mutation: Mutation
+            subscription: Subscription
+          }
+        schema
+        }
+
+        it 'includes schema definition' do
+          assert_equal query_string.gsub(/^          /, "").strip, document.to_query_string
+        end
+      end
+
+      describe "schema with custom mutation root name" do
+        let(:query_string) {<<-schema
+          schema {
+            query: Query
+            mutation: MyMutation
+            subscription: Subscription
+          }
+        schema
+        }
+
+        it 'includes schema definition' do
+          assert_equal query_string.gsub(/^          /, "").strip, document.to_query_string
+        end
+      end
+
+      describe "schema with custom subscription root name" do
+        let(:query_string) {<<-schema
+          schema {
+            query: Query
+            mutation: Mutation
+            subscription: MySubscription
+          }
+        schema
+        }
+
+        it 'includes schema definition' do
+          assert_equal query_string.gsub(/^          /, "").strip, document.to_query_string
+        end
+      end
+
+      describe "full featured schema" do
+        # From: https://github.com/graphql/graphql-js/blob/a725499b155285c2e33647a93393c82689b20b0f/src/language/__tests__/schema-kitchen-sink.graphql
+        let(:query_string) {<<-schema
+          schema {
+            query: QueryType
+            mutation: MutationType
+          }
+
+          type Foo implements Bar {
+            one: Type
+            two(argument: InputType!): Type
+            three(argument: InputType, other: String): Int
+            four(argument: String = "string"): String
+            five(argument: [String] = ["string", "string"]): String
+            six(argument: InputType = {key: "value"}): Type
+          }
+
+          type AnnotatedObject @onObject(arg: "value") {
+            annotatedField(arg: Type = "default" @onArg): Type @onField
+          }
+
+          interface Bar {
+            one: Type
+            four(argument: String = "string"): String
+          }
+
+          interface AnnotatedInterface @onInterface {
+            annotatedField(arg: Type @onArg): Type @onField
+          }
+
+          union Feed = Story | Article | Advert
+
+          union AnnotatedUnion @onUnion = A | B
+
+          scalar CustomScalar
+
+          scalar AnnotatedScalar @onScalar
+
+          enum Site {
+            DESKTOP
+            MOBILE
+          }
+
+          enum AnnotatedEnum @onEnum {
+            ANNOTATED_VALUE @onEnumValue
+            OTHER_VALUE
+          }
+
+          input InputType {
+            key: String!
+            answer: Int = 42
+          }
+
+          input AnnotatedInput @onInputObjectType {
+            annotatedField: Type @onField
+          }
+
+          directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+          directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+        schema
+        }
+
+        it "generate" do
+          assert_equal query_string.gsub(/^          /, "").strip, document.to_query_string
+        end
+
+        it "doesn't mutate the document" do
+          assert_equal document.to_query_string, document.to_query_string
+        end
       end
     end
   end

--- a/spec/graphql/schema/printer_spec.rb
+++ b/spec/graphql/schema/printer_spec.rb
@@ -72,7 +72,7 @@ describe GraphQL::Schema::Printer do
 
       return_field :post, post_type
 
-      resolve -> (_, _, _) { }
+      resolve ->(_, _, _) { }
     end
 
     mutation_root = GraphQL::ObjectType.define do
@@ -87,7 +87,7 @@ describe GraphQL::Schema::Printer do
       field :post do
         type post_type
         argument :id, !types.ID
-        resolve -> (obj, args, ctx) { }
+        resolve ->(_, _, _) { }
       end
     end
 


### PR DESCRIPTION
As per graphql/graphql-js#470, schema definition should be omitted from IDL when root types match convention names: `Query`, `Mutation`, `Subscription`.

The diff might be easier to look at with `&w=1` in query params as I indented a big chunk in `generation_spec.rb`.

:eyes: @rmosolgo 