### PR TITLE
Parse implemented interfaces and union members as TypeName instead of String

### DIFF
--- a/lib/graphql/language/generation.rb
+++ b/lib/graphql/language/generation.rb
@@ -83,7 +83,7 @@ module GraphQL
         when Nodes::ObjectTypeDefinition
           out = "type #{node.name}"
           out << generate_directives(node.directives)
-          out << " implements " << node.interfaces.join(", ") unless node.interfaces.empty?
+          out << " implements " << node.interfaces.map(&:name).join(", ") unless node.interfaces.empty?
           out << generate_field_definitions(node.fields)
         when Nodes::InputValueDefinition
           out = "#{node.name}: #{generate(node.type)}"

--- a/lib/graphql/language/generation.rb
+++ b/lib/graphql/language/generation.rb
@@ -103,7 +103,7 @@ module GraphQL
         when Nodes::UnionTypeDefinition
           out = "union #{node.name}"
           out << generate_directives(node.directives)
-          out << " = " + node.types.join(" | ")
+          out << " = " + node.types.map(&:name).join(" | ")
         when Nodes::EnumTypeDefinition
           out = "enum #{node.name}#{generate_directives(node.directives)} {\n"
           node.values.each do |value|

--- a/lib/graphql/language/parser.rb
+++ b/lib/graphql/language/parser.rb
@@ -1466,14 +1466,14 @@ module_eval(<<'.,.,', 'parser.y', 307)
 
 module_eval(<<'.,.,', 'parser.y', 311)
   def _reduce_126(val, _values, result)
-     return [val[0].to_s]
+     return [make_node(:TypeName, name: val[0])]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 312)
   def _reduce_127(val, _values, result)
-     val[0] << val[2].to_s 
+     val[0] << make_node(:TypeName, name: val[2]) 
     result
   end
 .,.,

--- a/lib/graphql/language/parser.rb
+++ b/lib/graphql/language/parser.rb
@@ -1046,14 +1046,14 @@ module_eval(<<'.,.,', 'parser.y', 103)
 
 module_eval(<<'.,.,', 'parser.y', 146)
   def _reduce_58(val, _values, result)
-     return [val[0].to_s]
+     return [make_node(:TypeName, name: val[0])] 
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 147)
   def _reduce_59(val, _values, result)
-     val[0] << val[1].to_s 
+     val[0] << make_node(:TypeName, name: val[1]) 
     result
   end
 .,.,

--- a/lib/graphql/language/parser.y
+++ b/lib/graphql/language/parser.y
@@ -144,8 +144,8 @@ rule
     | schema_keyword
 
   name_list:
-      name             { return [val[0].to_s]}
-    | name_list name   { val[0] << val[1].to_s }
+      name             { return [make_node(:TypeName, name: val[0])] }
+    | name_list name   { val[0] << make_node(:TypeName, name: val[1]) }
 
   enum_value_definition:
     enum_name directives_list_opt { return make_node(:EnumValueDefinition, name: val[0], directives: val[1]) }

--- a/lib/graphql/language/parser.y
+++ b/lib/graphql/language/parser.y
@@ -309,8 +309,8 @@ rule
       }
 
   union_members:
-      name                    { return [val[0].to_s]}
-    | union_members PIPE name { val[0] << val[2].to_s }
+      name                    { return [make_node(:TypeName, name: val[0])]}
+    | union_members PIPE name { val[0] << make_node(:TypeName, name: val[2]) }
 
   union_type_definition:
       UNION name directives_list_opt EQUALS union_members {

--- a/lib/graphql/language/parser_tests.rb
+++ b/lib/graphql/language/parser_tests.rb
@@ -319,7 +319,7 @@ module GraphQL
                 type = document.definitions.first
                 assert_equal GraphQL::Language::Nodes::ObjectTypeDefinition, type.class
                 assert_equal 'Comment', type.name
-                assert_equal ['Node'], type.interfaces
+                assert_equal ['Node'], type.interfaces.map(&:name)
                 assert_equal ['id'], type.fields.map(&:name)
                 assert_equal [], type.fields[0].arguments
                 assert_equal 'ID', type.fields[0].type.of_type.name
@@ -335,7 +335,7 @@ module GraphQL
                 type = document.definitions.first
                 assert_equal GraphQL::Language::Nodes::ObjectTypeDefinition, type.class
                 assert_equal 'Comment', type.name
-                assert_equal ['Node'], type.interfaces
+                assert_equal ['Node'], type.interfaces.map(&:name)
                 assert_equal ['id'], type.fields.map(&:name)
                 assert_equal [], type.fields[0].arguments
                 assert_equal 'ID', type.fields[0].type.of_type.name


### PR DESCRIPTION
While working on an utility method to convert an `AST` to `Schema` (like [graphql-js' `buildASTSchema.js`](https://github.com/graphql/graphql-js/blob/345400987c67bc67f57d1d07f637bc9acbfd1016/src/utilities/buildASTSchema.js)), I noticed two spots where we parse referenced types as a string instead of a `TypeName` node:

1. We parse an object type definition's interfaces as strings. In graphql-js [they are parsed as a `NAMED_TYPE` node](https://github.com/graphql/graphql-js/blob/345400987c67bc67f57d1d07f637bc9acbfd1016/src/language/parser.js#L816-L825).

2. We parse union members as strings. In graphql-js [they are parsed as a `NAMED_TYPE` node](https://github.com/graphql/graphql-js/blob/345400987c67bc67f57d1d07f637bc9acbfd1016/src/language/parser.js#L929-L935).

On the surface this might not seem problematic, but [it causes code like this](https://github.com/rmosolgo/graphql-ruby/blob/28998fec1a02f79ab2de7be88e67ca17fc2cb490/lib/graphql/schema/type_expression.rb) to break as `ast_node` would be a string instead of a `TypeName` node.

This is a breaking change for anyone relying on `GraphQL::Language::Nodes`.

:eyes: @rmosolgo 