### PR TITLE
Add Rubocop to CI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,11 +5,6 @@ AllCops:
   - 'lib/graphql/language/lexer.rb'
   - 'lib/graphql/language/parser.rb'
 
-# value = do_something
-# if value # ...
-Lint/AssignmentInCondition:
-  AllowSafeAssignment: false
-
 # def ...
 # end
 Lint/DefEndAlignment:
@@ -20,10 +15,6 @@ Lint/DefEndAlignment:
 # end
 Lint/EndAlignment:
   AlignWith: variable
-
-Metrics/ClassLength:
-  CountComments: false
-  Max: 120
 
 Metrics/ParameterLists:
   Max: 6
@@ -47,23 +38,5 @@ Style/LeadingCommentSpace:
 Style/MethodName:
   EnforcedStyle: snake_case
 
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-
 Style/WordArray:
   EnforcedStyle: brackets
-
-Style/StringLiterals:
-  Enabled: false
-
-Metrics/ClassLength:
-  Enabled: false
-
-Metrics/ModuleLength:
-  Enabled: false
-
-Metrics/MethodLength:
-  Enabled: false
-
-Lint/AssignmentInCondition:
-  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,9 +32,6 @@ Metrics/ParameterLists:
 Style/ClassAndModuleChildren:
   EnforcedStyle: nested
 
-Style/DeprecatedHashMethods:
-  Enabled: true
-
 Style/EmptyLineBetweenDefs:
   AllowAdjacentOneLineDefs: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,3 +52,18 @@ Style/StringLiterals:
 
 Style/WordArray:
   EnforcedStyle: brackets
+
+Style/StringLiterals:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false
+
+Lint/AssignmentInCondition:
+  Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,11 @@ Rake::TestTask.new do |t|
 end
 
 require 'rubocop/rake_task'
-RuboCop::RakeTask.new(:rubocop)
+RuboCop::RakeTask.new(:rubocop) do |t|
+  t.patterns = Rake::FileList['lib/**/{*}.rb', 'spec/**/*.rb']
+    .exclude("lib/graphql/language/parser.rb")
+    .exclude("lib/graphql/language/lexer.rb")
+end
 
 task(default: [:test, :rubocop])
 

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,10 @@ Rake::TestTask.new do |t|
   t.warning = false
 end
 
-task(default: :test)
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new(:rubocop)
+
+task(default: [:test, :rubocop])
 
 def load_gem_and_dummy
   $:.push File.expand_path("../lib", __FILE__)
@@ -25,8 +28,6 @@ task :console do
   ARGV.clear
   IRB.start
 end
-
-
 
 desc "Use Racc & Ragel to regenerate parser.rb & lexer.rb from configuration files"
 task :build_parser do
@@ -78,11 +79,11 @@ namespace :site do
 
     # Proceed to purge all files in case we removed a file in this release.
     puts "Cleaning gh-pages directory..."
-    purge_exclude = %w[
-      gh-pages/.
-      gh-pages/..
-      gh-pages/.git
-      gh-pages/.gitignore
+    purge_exclude = [
+      'gh-pages/.',
+      'gh-pages/..',
+      'gh-pages/.git',
+      'gh-pages/.gitignore',
     ]
     FileList["gh-pages/{*,.*}"].exclude(*purge_exclude).each do |path|
       sh "rm -rf #{path}"

--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest-reporters", "~>1.0"
   s.add_development_dependency "racc", "~> 1.4"
   s.add_development_dependency "rake", "~> 11.0"
+  s.add_development_dependency "rubocop", "~> 0.44"
   # following are required for relay helpers
   s.add_development_dependency "activerecord"
   s.add_development_dependency "appraisal"

--- a/lib/graphql/schema/timeout_middleware.rb
+++ b/lib/graphql/schema/timeout_middleware.rb
@@ -50,18 +50,18 @@ module GraphQL
         end
         err
       end
-    end
 
-    # This error is raised when a query exceeds `max_seconds`.
-    # Since it's a child of {GraphQL::ExecutionError},
-    # its message will be added to the response's `errors` key.
-    #
-    # To raise an error that will stop query resolution, use a custom block
-    # to take this error and raise a new one which _doesn't_ descend from {GraphQL::ExecutionError},
-    # such as `RuntimeError`.
-    class GraphQL::Schema::TimeoutMiddleware::TimeoutError < GraphQL::ExecutionError
-      def initialize(parent_type, field_defn)
-        super("Timeout on #{parent_type.name}.#{field_defn.name}")
+      # This error is raised when a query exceeds `max_seconds`.
+      # Since it's a child of {GraphQL::ExecutionError},
+      # its message will be added to the response's `errors` key.
+      #
+      # To raise an error that will stop query resolution, use a custom block
+      # to take this error and raise a new one which _doesn't_ descend from {GraphQL::ExecutionError},
+      # such as `RuntimeError`.
+      class TimeoutError < GraphQL::ExecutionError
+        def initialize(parent_type, field_defn)
+          super("Timeout on #{parent_type.name}.#{field_defn.name}")
+        end
       end
     end
   end

--- a/lib/graphql/static_validation/rules/fields_will_merge.rb
+++ b/lib/graphql/static_validation/rules/fields_will_merge.rb
@@ -92,6 +92,7 @@ module GraphQL
             JSON.dump(arg)
           end
         end
+
         # Turn AST tree into a hash
         # can't look up args, the names just have to match
         def reduce_list(args)

--- a/spec/graphql/introspection/introspection_query_spec.rb
+++ b/spec/graphql/introspection/introspection_query_spec.rb
@@ -9,18 +9,18 @@ describe "GraphQL::Introspection::INTROSPECTION_QUERY" do
   end
 
   it "handles deeply nested (<= 7) schemas" do
-     query_type =  GraphQL::ObjectType.define do
-        name "DeepQuery"
-        field :foo do
-          type !GraphQL::ListType.new(
-            of_type: !GraphQL::ListType.new(
-              of_type: !GraphQL::ListType.new(
-                of_type: GraphQL::FLOAT_TYPE
-              )
-            )
-          )
-        end
-     end
+    query_type =  GraphQL::ObjectType.define do
+      name "DeepQuery"
+       field :foo do
+         type !GraphQL::ListType.new(
+           of_type: !GraphQL::ListType.new(
+             of_type: !GraphQL::ListType.new(
+               of_type: GraphQL::FLOAT_TYPE
+             )
+           )
+         )
+       end
+    end
 
      deep_schema = GraphQL::Schema.define do
        query query_type
@@ -31,20 +31,20 @@ describe "GraphQL::Introspection::INTROSPECTION_QUERY" do
   end
 
   it "doesn't handle too deeply nested (< 8) schemas" do
-     query_type =  GraphQL::ObjectType.define do
-        name "DeepQuery"
-        field :foo do
-          type !GraphQL::ListType.new(
-            of_type: !GraphQL::ListType.new(
-              of_type: !GraphQL::ListType.new(
-                of_type: !GraphQL::ListType.new(
-                  of_type: GraphQL::FLOAT_TYPE
-                )
-              )
-            )
-          )
-        end
-     end
+    query_type =  GraphQL::ObjectType.define do
+      name "DeepQuery"
+       field :foo do
+         type !GraphQL::ListType.new(
+           of_type: !GraphQL::ListType.new(
+             of_type: !GraphQL::ListType.new(
+               of_type: !GraphQL::ListType.new(
+                 of_type: GraphQL::FLOAT_TYPE
+               )
+             )
+           )
+         )
+       end
+    end
 
      deep_schema = GraphQL::Schema.define do
        query query_type


### PR DESCRIPTION
We currently have `.rubocop.yml` but it is not enforced by CI. This means we will end up having code violations in `master` unless every person thinks about running `rubocop` locally, which isn't realistic.

This PR will make CI fail when Rubocop finds bad code.

I also made a few adjustments to our `.robucop.yml` file. We can discuss each change in the diff.

I also ran `rubocop` and corrected offenses in the codebase.

:eyes: @rmosolgo @astorije 