### PR TITLE
feat(Query::Arguments) preserve underlying definitions with argument values

### DIFF
--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -11,7 +11,8 @@ module GraphQL
         @argument_values = values.inject({}) do |memo, (inner_key, inner_value)|
           string_key = inner_key.to_s
           arg_defn = argument_definitions[string_key]
-          memo[string_key] = wrap_value(inner_value, arg_defn.type)
+          arg_value = wrap_value(inner_value, arg_defn.type)
+          memo[string_key] = ArgumentValue.new(string_key, arg_value, arg_defn)
           memo
         end
       end
@@ -19,7 +20,7 @@ module GraphQL
       # @param key [String, Symbol] name or index of value to access
       # @return [Object] the argument at that key
       def [](key)
-        @argument_values[key.to_s]
+        @argument_values[key.to_s].value
       end
 
       # @param key [String, Symbol] name of value to access
@@ -36,7 +37,25 @@ module GraphQL
 
       def_delegators :string_key_values, :keys, :values, :each
 
+      # Access each key, value and type for the arguments in this set.
+      # @yield [argument_value] The {ArgumentValue} for each argument
+      # @yieldparam argument_value [ArgumentValue]
+      def each_value
+        @argument_values.each_value do |argument_value|
+          yield(argument_value)
+        end
+      end
+
       private
+
+      class ArgumentValue
+        attr_reader :key, :value, :definition
+        def initialize(key, value, definition)
+          @key = key
+          @value = value
+          @definition = definition
+        end
+      end
 
       def wrap_value(value, arg_defn_type)
         case value

--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -20,7 +20,7 @@ module GraphQL
       # @param key [String, Symbol] name or index of value to access
       # @return [Object] the argument at that key
       def [](key)
-        @argument_values[key.to_s].value
+        @argument_values.fetch(key.to_s, NULL_ARGUMENT_VALUE).value
       end
 
       # @param key [String, Symbol] name of value to access
@@ -56,6 +56,8 @@ module GraphQL
           @definition = definition
         end
       end
+
+      NULL_ARGUMENT_VALUE = ArgumentValue.new(nil, nil, nil)
 
       def wrap_value(value, arg_defn_type)
         case value

--- a/spec/graphql/query/arguments_spec.rb
+++ b/spec/graphql/query/arguments_spec.rb
@@ -45,6 +45,37 @@ describe GraphQL::Query::Arguments do
     assert_equal({ a: 1, b: 2, c: { d: 3, e: 4 } }, arguments.to_h)
   end
 
+  it "yields key, value, and arg_defnition" do
+    type_info = []
+    arguments.each_value do |arg_value|
+      value = arg_value.value.is_a?(GraphQL::Query::Arguments) ? arg_value.value.to_h : arg_value.value
+      type_info << [arg_value.key, value, arg_value.definition.type.unwrap.name]
+    end
+    expected_type_info =[
+      ["a", 1, "Int"],
+      ["b", 2, "Int"],
+      ["c", { d: 3, e: 4 }, "TestInput1"],
+    ]
+    assert_equal expected_type_info, type_info
+  end
+
+  it "can be copied to a new Arguments instance" do
+    transformed_args = {}
+    types = {}
+    arguments.each_value do |arg_value|
+      transformed_args[arg_value.key.upcase] = arg_value.value
+      types[arg_value.key.upcase] = arg_value.definition
+    end
+
+    new_arguments = GraphQL::Query::Arguments.new(transformed_args, argument_definitions: types)
+    expected_hash = {
+      "A" => 1,
+      "B" => 2,
+      "C" => { d: 3 , e: 4 },
+    }
+    assert_equal expected_hash, new_arguments.to_h
+  end
+
   describe "nested hashes" do
     let(:input_type) {
       test_input_type = GraphQL::InputObjectType.define do

--- a/spec/graphql/query/arguments_spec.rb
+++ b/spec/graphql/query/arguments_spec.rb
@@ -95,6 +95,19 @@ describe GraphQL::Query::Arguments do
     end
   end
 
+  describe "#[]" do
+    it "returns the value at that key" do
+      assert_equal 1, arguments["a"]
+      assert_equal 1, arguments[:a]
+      assert arguments["c"].is_a?(GraphQL::Query::Arguments)
+    end
+
+    it "returns nil for missing keys" do
+      assert_equal nil, arguments["z"]
+      assert_equal nil, arguments[7]
+    end
+  end
+
   describe "#key?" do
     let(:arg_values) { [] }
     let(:schema) {


### PR DESCRIPTION
Fixes #325 

Introduce `ArgumentValue` as the backing object for `Query::Arguments`