### PR TITLE
Fix indentation when printing args that have comments

### DIFF
--- a/lib/graphql/schema/printer.rb
+++ b/lib/graphql/schema/printer.rb
@@ -116,7 +116,7 @@ module GraphQL
               "#{print_description(arg, "  #{indentation}", i == 0)}  #{indentation}"\
               "#{print_input_value(arg)}"
             }.join("\n")
-            out << "\n)"
+            out << "\n#{indentation})"
           end
 
           def print_input_value(arg)

--- a/spec/graphql/schema/printer_spec.rb
+++ b/spec/graphql/schema/printer_spec.rb
@@ -83,7 +83,7 @@ describe GraphQL::Schema::Printer do
 
       field :post do
         type post_type
-        argument :id, !types.ID
+        argument :id, !types.ID, 'Post ID'
         argument :varied, variant_input_type, default_value: { id: "123", int: 234, float: 2.3, enum: :foo, sub: [{ string: "str" }] }
         resolve ->(obj, args, ctx) { Post.find(args["id"]) }
       end
@@ -440,7 +440,11 @@ type Post {
 
 # The query root of this schema
 type Query {
-  post(id: ID!, varied: Varied = {id: \"123\", int: 234, float: 2.3, enum: FOO, sub: [{string: \"str\"}]}): Post
+  post(
+    # Post ID
+    id: ID!
+    varied: Varied = {id: \"123\", int: 234, float: 2.3, enum: FOO, sub: [{string: \"str\"}]}
+  ): Post
 }
 
 # Test


### PR DESCRIPTION
There was a small indentation bug in `Schema::Printer` when printing arguments that have comments.

Here's an example that displays the bug:

**Currently**

```graphql
type Query {
  post(
    # Post ID
    id: ID!
    varied: Varied = {id: \"123\", int: 234, float: 2.3, enum: FOO, sub: [{string: \"str\"}]}
): Post
}
```

**With this PR**

```graphql
type Query {
  post(
    # Post ID
    id: ID!
    varied: Varied = {id: \"123\", int: 234, float: 2.3, enum: FOO, sub: [{string: \"str\"}]}
  ): Post
}
```

:eyes: @rmosolgo 