### PR TITLE
Query cleanup

### DIFF
--- a/lib/graphql/query/serial_execution/value_resolution.rb
+++ b/lib/graphql/query/serial_execution/value_resolution.rb
@@ -19,8 +19,11 @@ module GraphQL
           end
 
           def result
-            return nil if value.nil? || value.is_a?(GraphQL::ExecutionError)
-            non_null_result
+            if value.nil? || value.is_a?(GraphQL::ExecutionError)
+              nil
+            else
+              non_null_result
+            end
           end
 
           def non_null_result

--- a/lib/graphql/static_validation/validator.rb
+++ b/lib/graphql/static_validation/validator.rb
@@ -33,7 +33,7 @@ module GraphQL
         context.visitor.visit
 
         {
-          errors: context.errors.map(&:to_h),
+          errors: context.errors,
           # If there were errors, the irep is garbage
           irep: context.errors.none? ? rewrite.operations : nil,
         }

--- a/spec/graphql/static_validation/validator_spec.rb
+++ b/spec/graphql/static_validation/validator_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe GraphQL::StaticValidation::Validator do
   let(:validator) { GraphQL::StaticValidation::Validator.new(schema: DummySchema) }
   let(:query) { GraphQL::Query.new(DummySchema, query_string) }
-  let(:errors) { validator.validate(query)[:errors] }
+  let(:errors) { validator.validate(query)[:errors].map(&:to_h) }
 
 
   describe "validation order" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@ require "benchmark"
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/reporters"
-Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
+Minitest::Reporters.use! Minitest::Reporters::DefaultReporter.new(color: true)
 
 Minitest::Spec.make_my_diffs_pretty!
 

--- a/spec/support/static_validation_helpers.rb
+++ b/spec/support/static_validation_helpers.rb
@@ -14,7 +14,7 @@ module StaticValidationHelpers
     target_schema = schema
     validator = GraphQL::StaticValidation::Validator.new(schema: target_schema)
     query = GraphQL::Query.new(target_schema, query_string)
-    validator.validate(query)[:errors]
+    validator.validate(query)[:errors].map(&:to_h)
   end
 
   def error_messages


### PR DESCRIPTION
- Remove `validate: false` option (it hasn't worked since introducing `InternalRepresentation` since the rewrite follows along with validation, so obviously nobody is `validate: false`-ing 😬 )
- Some parts of query initialization used to raise errors (which were rescued by Query). Now those errors are caught earlier on. 
- Validation & analysis errors used to be exposed from `Query` as hashes, now they're exposed as Error objects (which respond to `#to_h`)