### PR TITLE
Ensure there are no spaces after lambda arrows throughout the code

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,3 +45,7 @@ Style/MethodName:
 
 Style/WordArray:
   EnforcedStyle: brackets
+
+# ->(...) { ... }
+Style/SpaceInLambdaLiteral:
+  Enabled: true # Default is "require_no_space"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 gemspec
+
+# Temporary point to the repo on GitHub to have access to new cop
+gem "rubocop", git: "https://github.com/bbatsov/rubocop.git", ref: "a94bef08e0559d0037b368037aa8cbac01e3fe94"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,3 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 gemspec
-
-# Temporary point to the repo on GitHub to have access to new cop
-gem "rubocop", git: "https://github.com/bbatsov/rubocop.git", ref: "a94bef08e0559d0037b368037aa8cbac01e3fe94"

--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "racc", "~> 1.4"
   s.add_development_dependency "rails"
   s.add_development_dependency "rake", "~> 11.0"
-  # s.add_development_dependency "rubocop", "~> 0.45"
+  s.add_development_dependency "rubocop", "~> 0.45"
   # following are required for relay helpers
   s.add_development_dependency "appraisal"
   s.add_development_dependency "sequel"

--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "racc", "~> 1.4"
   s.add_development_dependency "rails"
   s.add_development_dependency "rake", "~> 11.0"
-  s.add_development_dependency "rubocop", "~> 0.44"
+  # s.add_development_dependency "rubocop", "~> 0.45"
   # following are required for relay helpers
   s.add_development_dependency "appraisal"
   s.add_development_dependency "sequel"

--- a/lib/graphql/define/assign_mutation_function.rb
+++ b/lib/graphql/define/assign_mutation_function.rb
@@ -15,7 +15,7 @@ module GraphQL
 
         target.arguments = function.arguments
         target.description = function.description
-        target.resolve = -> (o, a, c) {
+        target.resolve = ->(o, a, c) {
           res = function.call(o, a, c)
           ResultProxy.new(res, a[:clientMutationId])
         }

--- a/lib/graphql/introspection/schema_type.rb
+++ b/lib/graphql/introspection/schema_type.rb
@@ -6,7 +6,7 @@ GraphQL::Introspection::SchemaType = GraphQL::ObjectType.define do
               "query, mutation, and subscription operations."
 
   field :types, !types[!GraphQL::Introspection::TypeType], "A list of all types supported by this server." do
-    resolve -> (obj, arg, ctx) { ctx.warden.types }
+    resolve ->(obj, arg, ctx) { ctx.warden.types }
   end
 
   field :queryType, !GraphQL::Introspection::TypeType, "The type that query operations will be rooted at." do

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -60,7 +60,7 @@ module GraphQL
       :default_mask,
       :cursor_encoder,
       directives: ->(schema, directives) { schema.directives = directives.reduce({}) { |m, d| m[d.name] = d; m  }},
-      instrument: -> (schema, type, instrumenter) { schema.instrumenters[type] << instrumenter },
+      instrument: ->(schema, type, instrumenter) { schema.instrumenters[type] << instrumenter },
       query_analyzer: ->(schema, analyzer) { schema.query_analyzers << analyzer },
       middleware: ->(schema, middleware) { schema.middleware << middleware },
       lazy_resolve: ->(schema, lazy_class, lazy_value_method) { schema.lazy_methods.set(lazy_class, lazy_value_method) },

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -19,7 +19,7 @@ module GraphQL
           types = {}
           types.merge!(GraphQL::Schema::BUILT_IN_TYPES)
           directives = {}
-          type_resolver = -> (type) { -> { resolve_type(types, type) } }
+          type_resolver = ->(type) { -> { resolve_type(types, type) } }
 
           document.definitions.each do |definition|
             case definition
@@ -81,7 +81,7 @@ module GraphQL
           end
         end
 
-        NullResolveType = -> (obj, ctx) {
+        NullResolveType = ->(obj, ctx) {
           raise(NotImplementedError, "Generated Schema cannot use Interface or Union types for execution.")
         }
 

--- a/lib/graphql/static_validation/definition_dependencies.rb
+++ b/lib/graphql/static_validation/definition_dependencies.rb
@@ -42,26 +42,26 @@ module GraphQL
 
       def mount(context)
         visitor = context.visitor
-        visitor[GraphQL::Language::Nodes::OperationDefinition] << -> (node, prev_node) {
+        visitor[GraphQL::Language::Nodes::OperationDefinition] << ->(node, prev_node) {
           @current_parent = @definitions[node.name] = NodeWithPath.new(node, context.path)
         }
 
-        visitor[GraphQL::Language::Nodes::OperationDefinition].leave << -> (node, prev_node) {
+        visitor[GraphQL::Language::Nodes::OperationDefinition].leave << ->(node, prev_node) {
           @current_parent = nil
         }
 
-        visitor[GraphQL::Language::Nodes::FragmentDefinition] << -> (node, prev_node) {
+        visitor[GraphQL::Language::Nodes::FragmentDefinition] << ->(node, prev_node) {
           @current_parent = @definitions[node.name] = NodeWithPath.new(node, context.path)
         }
 
-        visitor[GraphQL::Language::Nodes::FragmentDefinition].leave << -> (node, prev_node) {
+        visitor[GraphQL::Language::Nodes::FragmentDefinition].leave << ->(node, prev_node) {
           if @immediate_dependencies[@current_parent].none?
             @independent_fragments << @current_parent
           end
           @current_parent = nil
         }
 
-        visitor[GraphQL::Language::Nodes::FragmentSpread] << -> (node, prev_node) {
+        visitor[GraphQL::Language::Nodes::FragmentSpread] << ->(node, prev_node) {
           # Track both sides of the dependency
           @dependent_definitions[node.name] << @current_parent
           @immediate_dependencies[@current_parent] << NodeWithPath.new(node, context.path)

--- a/lib/graphql/static_validation/rules/operation_names_are_valid.rb
+++ b/lib/graphql/static_validation/rules/operation_names_are_valid.rb
@@ -7,11 +7,11 @@ module GraphQL
       def validate(context)
         op_names = Hash.new { |h, k| h[k] = [] }
 
-        context.visitor[GraphQL::Language::Nodes::OperationDefinition].enter << -> (node, _parent) {
+        context.visitor[GraphQL::Language::Nodes::OperationDefinition].enter << ->(node, _parent) {
           op_names[node.name] << node
         }
 
-        context.visitor[GraphQL::Language::Nodes::Document].leave << -> (node, _parent) {
+        context.visitor[GraphQL::Language::Nodes::Document].leave << ->(node, _parent) {
           op_count = op_names.values.inject(0) { |m, v| m += v.size }
 
           op_names.each do |name, nodes|

--- a/lib/graphql/static_validation/validation_context.rb
+++ b/lib/graphql/static_validation/validation_context.rb
@@ -40,7 +40,7 @@ module GraphQL
         definition_dependencies = DefinitionDependencies.mount(self)
         @on_dependency_resolve_handlers = []
         @each_irep_node_handlers = []
-        visitor[GraphQL::Language::Nodes::Document].leave << -> (_n, _p) {
+        visitor[GraphQL::Language::Nodes::Document].leave << ->(_n, _p) {
           @dependencies = definition_dependencies.dependency_map { |defn, spreads, frag|
             @on_dependency_resolve_handlers.each { |h| h.call(defn, spreads, frag) }
           }

--- a/spec/graphql/field_spec.rb
+++ b/spec/graphql/field_spec.rb
@@ -126,7 +126,7 @@ describe GraphQL::Field do
       int_field = GraphQL::Field.define do
         type types.Int
         argument :value, types.Int
-        resolve -> (obj, args, ctx) { args[:value] }
+        resolve ->(obj, args, ctx) { args[:value] }
       end
 
       query_type = GraphQL::ObjectType.define do

--- a/spec/graphql/schema/printer_spec.rb
+++ b/spec/graphql/schema/printer_spec.rb
@@ -499,7 +499,7 @@ input Varied {
 }
 SCHEMA
 
-    only_filter = -> (member, ctx) {
+    only_filter = ->(member, ctx) {
       case member
       when GraphQL::ScalarType
         true
@@ -583,7 +583,7 @@ type Subscription {
 }
 SCHEMA
 
-    except_filter = -> (member, ctx) {
+    except_filter = ->(member, ctx) {
       ctx[:names].include?(member.name) || (member.respond_to?(:deprecation_reason) && member.deprecation_reason)
     }
 

--- a/spec/graphql/schema/warden_spec.rb
+++ b/spec/graphql/schema/warden_spec.rb
@@ -107,7 +107,7 @@ module MaskHelpers
     query QueryType
     mutation MutationType
     subscription MutationType
-    resolve_type -> (obj, ctx) { PhonemeType }
+    resolve_type ->(obj, ctx) { PhonemeType }
   end
 
   module Data
@@ -208,7 +208,7 @@ describe GraphQL::Schema::Warden do
 
   describe "hiding fields" do
     let(:mask) {
-      -> (member, ctx) { member.metadata[:hidden_field] || member.metadata[:hidden_type] }
+      ->(member, ctx) { member.metadata[:hidden_field] || member.metadata[:hidden_type] }
     }
 
     it "causes validation errors" do
@@ -254,7 +254,7 @@ describe GraphQL::Schema::Warden do
 
   describe "hiding types" do
     let(:whitelist) {
-      -> (member, ctx) { !member.metadata[:hidden_type] }
+      ->(member, ctx) { !member.metadata[:hidden_type] }
     }
 
     it "hides types from introspection" do
@@ -340,7 +340,7 @@ describe GraphQL::Schema::Warden do
 
     describe "hiding an abstract type" do
       let(:mask) {
-        -> (member, ctx) { member.metadata[:hidden_abstract_type] }
+        ->(member, ctx) { member.metadata[:hidden_abstract_type] }
       }
 
       it "isn't present in a type's interfaces" do
@@ -362,7 +362,7 @@ describe GraphQL::Schema::Warden do
 
   describe "hiding arguments" do
     let(:mask) {
-      -> (member, ctx) { member.metadata[:hidden_argument] || member.metadata[:hidden_input_type] }
+      ->(member, ctx) { member.metadata[:hidden_argument] || member.metadata[:hidden_input_type] }
     }
 
     it "isn't present in introspection" do
@@ -398,7 +398,7 @@ describe GraphQL::Schema::Warden do
 
   describe "hidding input type arguments" do
     let(:mask) {
-      -> (member, ctx) { member.metadata[:hidden_input_field] }
+      ->(member, ctx) { member.metadata[:hidden_input_field] }
     }
 
     it "isn't present in introspection" do
@@ -447,7 +447,7 @@ describe GraphQL::Schema::Warden do
 
   describe "hidding input types" do
     let(:mask) {
-      -> (member, ctx) { member.metadata[:hidden_input_object_type] }
+      ->(member, ctx) { member.metadata[:hidden_input_object_type] }
     }
 
     it "isn't present in introspection" do
@@ -492,7 +492,7 @@ describe GraphQL::Schema::Warden do
 
   describe "hiding enum values" do
     let(:mask) {
-      -> (member, ctx) { member.metadata[:hidden_enum_value] }
+      ->(member, ctx) { member.metadata[:hidden_enum_value] }
     }
 
     it "isn't present in introspection" do
@@ -570,7 +570,7 @@ describe GraphQL::Schema::Warden do
 
   describe "default_mask" do
     let(:default_mask) {
-      -> (member, ctx) { member.metadata[:hidden_enum_value] }
+      ->(member, ctx) { member.metadata[:hidden_enum_value] }
     }
     let(:schema) {
       MaskHelpers::Schema.redefine(default_mask: default_mask)
@@ -584,7 +584,7 @@ describe GraphQL::Schema::Warden do
     }
 
     it "is additive with query filters" do
-      query_except = -> (member, ctx) { member.metadata[:hidden_input_object_type] }
+      query_except = ->(member, ctx) { member.metadata[:hidden_input_object_type] }
       res = schema.execute(query_str, except: query_except)
       assert_equal nil, res["data"]["input"]
       enum_values = res["data"]["enum"]["enumValues"].map { |v| v["name"] }

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -236,7 +236,7 @@ type Query {
         name "Query"
         field :int, types.Int do
           argument :value, types.Int
-          resolve -> (obj, args, ctx) { args[:value] == 13 ? raise("13 is unlucky") : args[:value] }
+          resolve ->(obj, args, ctx) { args[:value] == 13 ? raise("13 is unlucky") : args[:value] }
         end
       end
     }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ Minitest.backtrace_filter = Minitest::BacktraceFilter.new
 
 
 # This is for convenient access to metadata in test definitions
-assign_metadata_key = -> (target, key, value) { target.metadata[key] = value }
+assign_metadata_key = ->(target, key, value) { target.metadata[key] = value }
 GraphQL::BaseType.accepts_definitions(metadata: assign_metadata_key)
 GraphQL::Field.accepts_definitions(metadata: assign_metadata_key)
 GraphQL::Argument.accepts_definitions(metadata: assign_metadata_key)


### PR DESCRIPTION
This cop was added to RuboCop by https://github.com/bbatsov/rubocop/pull/3656.

This PR ensures #313 will be consistently enforced. It was discussed in #306, #326 and #320.

_**Caveat:** ~~I'm jumping the gun a bit here because that PR wasn't merged yet~~, nor RuboCop's next version was release, but at least my PR will be ready as soon as these happen. I'll be rebasing this PR accordingly.
**Edit:** PR was merged, no new release yet._
