### PR TITLE
Update mutation resolve() signature

### DIFF
--- a/guides/relay/mutations.md
+++ b/guides/relay/mutations.md
@@ -68,7 +68,7 @@ AddCommentMutation = GraphQL::Relay::Mutation.define do
   return_field :comment, CommentType
 
   # The resolve proc is where you alter the system state.
-  resolve ->(inputs, ctx) {
+  resolve ->(object, inputs, ctx) {
     post = Post.find(inputs[:postId])
     comment = post.comments.create!(author_id: inputs[:authorId], content: inputs[:content])
 


### PR DESCRIPTION
Two arg signatures are deprecated; this little bit in the docs just was missed in all the updates lately, looks like.