### PR TITLE
Resolve connection class by most specific class type

### DIFF
--- a/lib/graphql/relay/base_connection.rb
+++ b/lib/graphql/relay/base_connection.rb
@@ -30,13 +30,14 @@ module GraphQL
         def connection_for_nodes(nodes)
           # Check for class _names_ because classes can be redefined in Rails development
           ancestor_names = nodes.class.ancestors.map(&:name)
-          implementation = CONNECTION_IMPLEMENTATIONS.find do |nodes_class_name, connection_class|
-            ancestor_names.include? nodes_class_name
+          implementation_class_name = ancestor_names.find do |ancestor_class_name|
+            CONNECTION_IMPLEMENTATIONS.include? ancestor_class_name
           end
-          if implementation.nil?
+
+          if implementation_class_name.nil?
             raise("No connection implementation to wrap #{nodes.class} (#{nodes})")
           else
-            implementation[1]
+            CONNECTION_IMPLEMENTATIONS[implementation_class_name]
           end
         end
 

--- a/spec/graphql/relay/base_connection_spec.rb
+++ b/spec/graphql/relay/base_connection_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe GraphQL::Relay::BaseConnection do
+
+  describe ".connection_for_nodes" do
+
+    it "resolves most specific connection type" do
+      class SpecialArray < Array; end
+      class SpecialArrayConnection < GraphQL::Relay::BaseConnection; end
+      GraphQL::Relay::BaseConnection.register_connection_implementation(SpecialArray, SpecialArrayConnection)
+
+      nodes = SpecialArray.new
+
+      GraphQL::Relay::BaseConnection.connection_for_nodes(nodes)
+        .must_equal SpecialArrayConnection
+    end
+
+  end
+end


### PR DESCRIPTION
This PR updates the way GraphQL::Relay::BaseConnection.connection_for_nodes resolves Connection class implementations from collection types.

The current algorithm is depth-first, so custom Nodes collection classes which inherit from Array will resolve to ArrayConnection even if there is a more specific subclass of BaseConnection registered.

With this PR, it changes to breadth-first to search all registered CONNECTION_IMPLEMENTATIONS for ancestors of the nodes class, starting with the most specific.