### PR TITLE
Removes unused `skip?` method

### DIFF
--- a/lib/graphql/execution/directive_checks.rb
+++ b/lib/graphql/execution/directive_checks.rb
@@ -8,12 +8,6 @@ module GraphQL
 
       module_function
 
-      # This covers `@include(if:)` & `@skip(if:)`
-      # @return [Boolean] Should this node be skipped altogether?
-      def skip?(ast_node, query)
-        !include?(ast_node, query)
-      end
-
       # @return [Boolean] Should this node be included in the query?
       def include?(directive_irep_nodes, query)
         directive_irep_nodes.each do |directive_irep_node|


### PR DESCRIPTION
The last usage I could find of `skip?` was in 3b773899a4855194c595892a34a6abfe6c3d81c3. Now only the `include?` directive check is being used to determine if a field/spread node  should be skipped or included (see [rewriter.rb](https://github.com/rmosolgo/graphql-ruby/blob/2e59be6482ce94a6124ce27766ad4a7910e6c589/lib/graphql/internal_representation/rewrite.rb)). 


