### PR TITLE
Instrumentation

### DIFF
--- a/guides/schema/instrumentation.md
+++ b/guides/schema/instrumentation.md
@@ -1,0 +1,64 @@
+---
+title: Schema — Instrumentation
+---
+
+Instrumentation provides hooks for inserting custom code around field resolution and query execution.
+
+## Field Instrumentation
+
+Field instrumentation can be attached during schema definition:
+
+```ruby
+MySchema = GraphQL::Schema.define do
+  instrument(:field, MyFieldInstrumentation.new)
+end
+```
+
+The instrumenter is an object which responds to `#instrument(type, field)`. `#instrument` should return a `GraphQL::Field` instance which will be used during query execution. `#instrument` is called with each type-field pair for _all_ Object types and Interface types in your schema.
+
+Here's an example field instrumenter:
+
+```ruby
+class MyFieldInstrumentation
+  # If a field was flagged to be timed,
+  # wrap its resolve proc with a timer.
+  def instrument(type, field)
+    if field.metadata[:timed]
+      old_resolve_proc = field.resolve_proc
+      new_resolve_proc = ->(obj, args, ctx) {
+        Rails.logger.info("#{type.name}.#{field.name} START: #{Time.now.to_i}")
+        old_resolve_proc.call(obj, args, ctx)
+        Rails.logger.info("#{type.name}.#{field.name} END: #{Time.now.to_i}")
+      }
+    end
+  end
+end
+```
+
+It can be attached as shown above. This implementation will _modify_ the underlying `GraphQL::Field` instance... be warned!
+
+## Query Instrumetation
+
+
+Query instrumentation can be attached during schema definition:
+
+```ruby
+MySchema = GraphQL::Schema.define do
+  instrument(:query, MyQueryInstrumentation.new)
+end
+```
+
+The instrumenter must implement `#before_query(query)` and `#after_query(query)`. The return value of these methods are not used. They receive the `GraphQL::Query` instance.
+
+```ruby
+class MyQueryInstrumentation
+  # Log the time of the query
+  def before_query(query)
+    Rails.logger.info("Query begin: #{Time.now.to_i}")
+  end
+
+  def after_query(query)
+    Rails.logger.info("Query end: #{Time.now.to_i}")
+  end
+end
+```

--- a/guides/schema/instrumentation.md
+++ b/guides/schema/instrumentation.md
@@ -30,6 +30,11 @@ class MyFieldInstrumentation
         old_resolve_proc.call(obj, args, ctx)
         Rails.logger.info("#{type.name}.#{field.name} END: #{Time.now.to_i}")
       }
+
+      # Return a copy of `field`, with a new resolve proc
+      field.redefine do
+        resolve(new_resolve_proc)
+      end
     end
   end
 end
@@ -37,7 +42,7 @@ end
 
 It can be attached as shown above. This implementation will _modify_ the underlying `GraphQL::Field` instance... be warned!
 
-## Query Instrumetation
+## Query Instrumentation
 
 
 Query instrumentation can be attached during schema definition:

--- a/guides/schema/instrumentation.md
+++ b/guides/schema/instrumentation.md
@@ -10,7 +10,7 @@ Field instrumentation can be attached during schema definition:
 
 ```ruby
 MySchema = GraphQL::Schema.define do
-  instrument(:field, MyFieldInstrumentation.new)
+  instrument(:field, FieldTimerInstrumentation.new)
 end
 ```
 
@@ -19,7 +19,7 @@ The instrumenter is an object which responds to `#instrument(type, field)`. `#in
 Here's an example field instrumenter:
 
 ```ruby
-class MyFieldInstrumentation
+class FieldTimerInstrumentation
   # If a field was flagged to be timed,
   # wrap its resolve proc with a timer.
   def instrument(type, field)
@@ -40,7 +40,7 @@ class MyFieldInstrumentation
 end
 ```
 
-It can be attached as shown above. This implementation will _modify_ the underlying `GraphQL::Field` instance... be warned!
+It can be attached as shown above. You can use `redefine { ... }` to make a shallow copy of the  {{ "GraphQL::Field" | api_doc }} and extend its definition.
 
 ## Query Instrumentation
 
@@ -49,14 +49,16 @@ Query instrumentation can be attached during schema definition:
 
 ```ruby
 MySchema = GraphQL::Schema.define do
-  instrument(:query, MyQueryInstrumentation.new)
+  instrument(:query, QueryTimerInstrumentation)
 end
 ```
 
-The instrumenter must implement `#before_query(query)` and `#after_query(query)`. The return value of these methods are not used. They receive the `GraphQL::Query` instance.
+The instrumenter must implement `#before_query(query)` and `#after_query(query)`. The return values of these methods are not used. They receive the {{ "GraphQL::Query" | api_doc }} instance.
 
 ```ruby
-class MyQueryInstrumentation
+module MyQueryInstrumentation
+  module_function
+
   # Log the time of the query
   def before_query(query)
     Rails.logger.info("Query begin: #{Time.now.to_i}")

--- a/lib/graphql/query/variables.rb
+++ b/lib/graphql/query/variables.rb
@@ -2,6 +2,8 @@ module GraphQL
   class Query
     # Read-only access to query variables, applying default values if needed.
     class Variables
+      extend Forwardable
+
       # @return [Array<GraphQL::Query::VariableValidationError>]  Any errors encountered when parsing the provided variables and literal values
       attr_reader :errors
 
@@ -19,6 +21,8 @@ module GraphQL
       def [](key)
         @storage.fetch(key)
       end
+
+      def_delegators :@storage, :length
 
       private
 

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -110,7 +110,9 @@ module GraphQL
 
     def define(**kwargs, &block)
       super
-      types
+      all_types = orphan_types + [query, mutation, subscription, GraphQL::Introspection::SchemaType]
+      @types = GraphQL::Schema::ReduceTypes.reduce(all_types.compact)
+
       @instrumented_field_map = InstrumentedFieldMap.new(self)
       field_instrumenters = @instrumenters[:field]
       types.each do |type_name, type|
@@ -134,13 +136,7 @@ module GraphQL
 
     # @see [GraphQL::Schema::Warden] Restricted access to members of a schema
     # @return [GraphQL::Schema::TypeMap] `{ name => type }` pairs of types in this schema
-    def types
-      @types ||= begin
-        ensure_defined
-        all_types = orphan_types + [query, mutation, subscription, GraphQL::Introspection::SchemaType]
-        GraphQL::Schema::ReduceTypes.reduce(all_types.compact)
-      end
-    end
+    attr_reader :types
 
     # Execute a query on itself.
     # See {Query#initialize} for arguments.

--- a/lib/graphql/schema/instrumented_field_map.rb
+++ b/lib/graphql/schema/instrumented_field_map.rb
@@ -1,0 +1,23 @@
+module GraphQL
+  class Schema
+    # A two-level map with fields as the last values.
+    # The first level is type names, which point to a second map.
+    # The second level is field names, which point to fields.
+    #
+    # The catch is, the fields in this map _may_ have been modified by being instrumented.
+    class InstrumentedFieldMap
+      def initialize(schema)
+        @storage = Hash.new { |h, k| h[k] = {} }
+      end
+
+      def set(type_name, field_name, field)
+        @storage[type_name][field_name] = field
+      end
+
+      def get(type_name, field_name)
+        type = @storage[type_name]
+        type && type[field_name]
+      end
+    end
+  end
+end

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -190,18 +190,39 @@ type Query {
       end
 
       def instrument(type_defn, field_defn)
-        prev_proc = field_defn.resolve_proc
-        new_resolve_proc = ->(obj, args, ctx) {
-          inner_value = prev_proc.call(obj, args, ctx)
-          inner_value * @multiplier
-        }
+        if type_defn.name == "Query" && field_defn.name == "int"
+          prev_proc = field_defn.resolve_proc
+          new_resolve_proc = ->(obj, args, ctx) {
+            inner_value = prev_proc.call(obj, args, ctx)
+            inner_value * @multiplier
+          }
 
-        field_defn.redefine do
-          resolve(new_resolve_proc)
+          field_defn.redefine do
+            resolve(new_resolve_proc)
+          end
+        else
+          field_defn
         end
       end
     end
 
+    class VariableCountInstrumenter
+      attr_reader :counts
+      def initialize
+        @counts = []
+      end
+
+      def before_query(query)
+        @counts << query.variables.length
+      end
+
+      def after_query(query)
+      end
+    end
+
+    let(:variable_counter) {
+      VariableCountInstrumenter.new
+    }
     let(:query_type) {
       GraphQL::ObjectType.define do
         name "Query"
@@ -217,12 +238,19 @@ type Query {
       GraphQL::Schema.define do
         query(spec.query_type)
         instrument(:field, MultiplyInstrumenter.new(3))
+        instrument(:query, spec.variable_counter)
       end
     }
 
     it "can modify field definitions" do
       res = schema.execute(" { int(value: 2) } ")
       assert_equal 6, res["data"]["int"]
+    end
+
+    it "can wrap query execution" do
+      schema.execute("query getInt($val: Int = 5){ int(value: $val) } ")
+      schema.execute("query getInt($val: Int = 5, $val2: Int = 3){ int(value: $val) int2: int(value: $val2) } ")
+      assert_equal [1, 2], variable_counter.counts
     end
   end
 end


### PR DESCRIPTION
A hot take on #186 
- Apply field instrumentation at build time 
- Apply query instrumentation at runtime 
- _Very_ specific implementation of instrumentation hooks 

Buyer beware: if you _modify_ the passed-in type or field, it will be changed _everywhere_ it's used (since it's the same object). I want to provide a shallow-copy API for these objects so that wrapping them is easier. 

If there just _happened_ to be any [widely used extensions](https://github.com/Shopify/graphql-batch) to this gem, they could accept instrumentation of their own: 

``` ruby
MySchema = GraphQL::Schema.define do 
  instrument(:batch, MyBatchInstrumentation) 
end 
```

And fetch it out & apply it as they see fit: 

``` ruby
MySchema.instrumenters[:batch] # => array of instrumenters (empty if `instrument` was not called)
```

**Todo** 
- [x] Benchmark: what's the overhead if you don't use it? 
- [x] Shallow-copy API for schema members 
