### PR TITLE
nameless LIST and NON_NULL

### DIFF
--- a/lib/graphql/list_type.rb
+++ b/lib/graphql/list_type.rb
@@ -25,9 +25,8 @@ module GraphQL
   #
   class ListType < GraphQL::BaseType
     include GraphQL::BaseType::ModifiesAnotherType
-    attr_reader :of_type, :name
+    attr_reader :of_type
     def initialize(of_type:)
-      @name = "List"
       @of_type = of_type
     end
 

--- a/lib/graphql/non_null_type.rb
+++ b/lib/graphql/non_null_type.rb
@@ -35,10 +35,6 @@ module GraphQL
       @of_type = of_type
     end
 
-    def name
-      "Non-Null"
-    end
-
     def valid_input?(value)
       validate_input(value).valid?
     end

--- a/spec/graphql/introspection/directive_type_spec.rb
+++ b/spec/graphql/introspection/directive_type_spec.rb
@@ -6,7 +6,7 @@ describe GraphQL::Introspection::DirectiveType do
       __schema {
         directives {
           name,
-          args { name, type { name, ofType { name } } },
+          args { name, type { kind, name, ofType { name } } },
           locations
           # Deprecated fields:
           onField
@@ -25,7 +25,7 @@ describe GraphQL::Introspection::DirectiveType do
           {
             "name" => "include",
             "args" => [
-              {"name"=>"if", "type"=>{"name"=>"Non-Null", "ofType"=>{"name"=>"Boolean"}}}
+              {"name"=>"if", "type"=>{"kind"=>"NON_NULL", "name"=>nil, "ofType"=>{"name"=>"Boolean"}}}
             ],
             "locations"=>["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
             "onField" => true,
@@ -35,7 +35,7 @@ describe GraphQL::Introspection::DirectiveType do
           {
             "name" => "skip",
             "args" => [
-              {"name"=>"if", "type"=>{"name"=>"Non-Null", "ofType"=>{"name"=>"Boolean"}}}
+              {"name"=>"if", "type"=>{"kind"=>"NON_NULL", "name"=>nil, "ofType"=>{"name"=>"Boolean"}}}
             ],
             "locations"=>["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
             "onField" => true,
@@ -45,7 +45,7 @@ describe GraphQL::Introspection::DirectiveType do
           {
             "name" => "deprecated",
             "args" => [
-              {"name"=>"reason", "type"=>{"name"=>"String", "ofType"=>nil}}
+              {"name"=>"reason", "type"=>{"kind"=>"SCALAR", "name"=>"String", "ofType"=>nil}}
             ],
             "locations"=>["FIELD_DEFINITION", "ENUM_VALUE"],
             "onField" => false,

--- a/spec/graphql/introspection/input_value_type_spec.rb
+++ b/spec/graphql/introspection/input_value_type_spec.rb
@@ -10,7 +10,7 @@ describe GraphQL::Introspection::InputValueType do
          kind,
          inputFields {
            name,
-           type { name },
+           type { kind, name },
            defaultValue
            description
          }
@@ -26,13 +26,13 @@ describe GraphQL::Introspection::InputValueType do
           "description"=>"Properties for finding a dairy product",
           "kind"=>"INPUT_OBJECT",
           "inputFields"=>[
-            {"name"=>"source", "type"=>{ "name" => "Non-Null"}, "defaultValue"=>nil,
+            {"name"=>"source", "type"=>{"kind"=>"NON_NULL", "name" => nil}, "defaultValue"=>nil,
              "description" => "Where it came from"},
-            {"name"=>"originDairy", "type"=>{ "name" => "String"}, "defaultValue"=>"\"Sugar Hollow Dairy\"",
+            {"name"=>"originDairy", "type"=>{"kind"=>"SCALAR", "name" => "String"}, "defaultValue"=>"\"Sugar Hollow Dairy\"",
              "description" => "Dairy which produced it"},
-            {"name"=>"fatContent", "type"=>{ "name" => "Float"}, "defaultValue"=>"0.3",
+            {"name"=>"fatContent", "type"=>{"kind"=>"SCALAR",  "name" => "Float"}, "defaultValue"=>"0.3",
              "description" => "How much fat it has"},
-            {"name"=>"organic", "type"=>{ "name" => "Boolean"}, "defaultValue"=>"false",
+            {"name"=>"organic", "type"=>{"kind"=>"SCALAR",  "name" => "Boolean"}, "defaultValue"=>"false",
              "description" => nil}
           ]
         }

--- a/spec/graphql/static_validation/type_stack_spec.rb
+++ b/spec/graphql/static_validation/type_stack_spec.rb
@@ -8,7 +8,7 @@ class TypeCheckValidator
   def validate(context)
     self.class.checks.clear
     context.visitor[GraphQL::Language::Nodes::Field] << ->(node, parent) {
-      self.class.checks << context.object_types.map(&:name)
+      self.class.checks << context.object_types.map {|t| t.name || t.kind.name }
     }
   end
 end
@@ -29,8 +29,8 @@ describe GraphQL::StaticValidation::TypeStack do
     validator.validate(query)
     expected = [
       ["Query", "Cheese"],
-      ["Query", "Cheese", "Non-Null"],
-      ["Edible", "Non-Null"]
+      ["Query", "Cheese", "NON_NULL"],
+      ["Edible", "NON_NULL"]
     ]
     assert_equal(expected, TypeCheckValidator.checks)
   end


### PR DESCRIPTION
Fixes #352.

This modifies both `ListType#name` and `NonNullType#name` to return `nil`, so that introspection responses correctly return `null` names for these types as per the GraphQL spec. This is a breaking change, both because it modifies the introspection responses, and because downstream code may be relying on the `name` method on types always returning a string.