### PR TITLE
Allow passing arrays as literals for scalar types

### DIFF
--- a/lib/graphql/static_validation/literal_validator.rb
+++ b/lib/graphql/static_validation/literal_validator.rb
@@ -12,7 +12,7 @@ module GraphQL
         elsif type.kind.list?
           item_type = type.of_type
           ensure_array(ast_value).all? { |val| validate(val, item_type) }
-        elsif type.kind.scalar? && !ast_value.is_a?(GraphQL::Language::Nodes::AbstractNode) && !ast_value.is_a?(Array)
+        elsif type.kind.scalar? && !ast_value.is_a?(GraphQL::Language::Nodes::AbstractNode)
           type.valid_input?(ast_value, @warden)
         elsif type.kind.enum? && ast_value.is_a?(GraphQL::Language::Nodes::Enum)
           type.valid_input?(ast_value.name, @warden)


### PR DESCRIPTION
From my understanding, the GraphQL spec doesn't dictate that arrays cannot be
used as literals for scalar types, therefore I'm removing this check.

I hit this while defining a scalar to represent two-dimensional coordinates
using an array with two values.
