### PR TITLE
Non-nullable arguments cannot have default values

### DIFF
--- a/lib/graphql/schema/validation.rb
+++ b/lib/graphql/schema/validation.rb
@@ -99,6 +99,10 @@ module GraphQL
         ARGUMENTS_ARE_VALID =  Rules.assert_named_items_are_valid("argument", ->(type) { type.arguments.values })
 
         DEFAULT_VALUE_IS_VALID_FOR_TYPE = ->(type) {
+          if !type.default_value.nil? && type.type.is_a?(NonNullType)
+            return %Q(Variable #{type.name} of type "#{type.type}" is required and will not use the default value. Perhaps you meant to use type "#{type.type.of_type}".)
+          end
+
           if !type.default_value.nil?
             coerced_value = begin
               type.type.coerce_result(type.default_value)

--- a/spec/graphql/introspection/input_value_type_spec.rb
+++ b/spec/graphql/introspection/input_value_type_spec.rb
@@ -58,7 +58,7 @@ describe GraphQL::Introspection::InputValueType do
 
   it "converts default values to GraphQL values" do
     field = cheese_type['data']['__type']['fields'].detect { |f| f['name'] == 'similarCheese' }
-    arg = field['args'].detect { |a| a['name'] == 'source' }
+    arg = field['args'].detect { |a| a['name'] == 'nullableSource' }
 
     assert_equal('["COW"]', arg['defaultValue'])
   end

--- a/spec/graphql/schema/validation_spec.rb
+++ b/spec/graphql/schema/validation_spec.rb
@@ -200,16 +200,20 @@ describe GraphQL::Schema::Validation do
       end
     }
 
-    let(:invalid_default_argument) {
+    let(:invalid_default_argument_for_non_null_field) {
       GraphQL::Argument.define do
         name "InvalidDefault"
-        type GraphQL::INT_TYPE
-        default_value "abc"
+        type !GraphQL::INT_TYPE
+        default_value 1
       end
     }
 
     it "requires the type is a Base type" do
       assert_error_includes untyped_argument, "must be a valid input type (Scalar or InputObject), not Symbol"
+    end
+
+    it "does not allow default values for non-null fields" do
+      assert_error_includes invalid_default_argument_for_non_null_field, 'Variable InvalidDefault of type "Int!" is required and will not use the default value. Perhaps you meant to use type "Int".'
     end
   end
 end

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -59,7 +59,8 @@ CheeseType = GraphQL::ObjectType.define do
   field :similarCheese, CheeseType, "Cheeses like this one", property: :this_should_be_overriden  do
     # metadata test
     joins [:cheeses, :milks]
-    argument :source, !types[!DairyAnimalEnum], default_value: [1]
+    argument :source, !types[!DairyAnimalEnum]
+    argument :nullableSource, types[!DairyAnimalEnum], default_value: [1]
     resolve ->(t, a, c) {
       # get the strings out:
       sources = a["source"]


### PR DESCRIPTION
While working on schema comparisons I realized we currently allow non-nullable types to have default values.

According to [`graphql-js`](https://github.com/graphql/graphql-js/blob/89f3f1a319bb913616f2910e8a806170155ffaf0/src/validation/rules/DefaultValuesOfCorrectType.js#L19) this is not valid.

This PR adds the same validation to `graphql-ruby`.

I'm not sure if this will change in the future due to facebook/graphql#83 but in the meantime it's probably best that we have this.

:eyes: @rmosolgo /cc @theorygeek 