### PR TITLE
refactor(SerialExecution) make fewer objects

### DIFF
--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -6,7 +6,9 @@ module GraphQL
       attr_accessor :execution_strategy
 
       # @return [GraphQL::Language::Nodes::Field] The AST node for the currently-executing field
-      attr_accessor :ast_node
+      def ast_node
+        irep_node.ast_node
+      end
 
       # @return [GraphQL::InternalRepresentation::Node] The internal representation for this query node
       attr_accessor :irep_node

--- a/lib/graphql/query/serial_execution/field_resolution.rb
+++ b/lib/graphql/query/serial_execution/field_resolution.rb
@@ -40,10 +40,15 @@ module GraphQL
             end
           end
 
-          strategy_class = GraphQL::Query::SerialExecution::ValueResolution.get_strategy_for_kind(field.type.kind)
-          result_strategy = strategy_class.new(raw_value, field.type, target, parent_type, irep_node, execution_context)
           begin
-            result_strategy.result
+            GraphQL::Query::SerialExecution::ValueResolution.resolve(
+              parent_type,
+              field,
+              field.type,
+              raw_value,
+              irep_node,
+              execution_context,
+            )
           rescue GraphQL::InvalidNullError => err
             if field.type.kind.non_null?
               raise(err)
@@ -63,7 +68,6 @@ module GraphQL
           middlewares = execution_context.query.schema.middleware
           query_context = execution_context.query.context
           # setup
-          query_context.ast_node = @irep_node.ast_node
           query_context.irep_node = @irep_node
 
           resolve_arguments = [parent_type, target, field, arguments, query_context]
@@ -84,7 +88,6 @@ module GraphQL
             end
         ensure
           # teardown
-          query_context.ast_node = nil
           query_context.irep_node = nil
           resolve_value
         end

--- a/lib/graphql/query/serial_execution/operation_resolution.rb
+++ b/lib/graphql/query/serial_execution/operation_resolution.rb
@@ -11,12 +11,12 @@ module GraphQL
         end
 
         def result
-          execution_context.strategy.selection_resolution.new(
+          execution_context.strategy.selection_resolution.resolve(
             execution_context.query.root_value,
             target,
             irep_node,
             execution_context
-          ).result
+          )
         rescue GraphQL::InvalidNullError => err
           err.parent_error? || execution_context.add_error(err)
           nil

--- a/lib/graphql/query/serial_execution/selection_resolution.rb
+++ b/lib/graphql/query/serial_execution/selection_resolution.rb
@@ -1,36 +1,19 @@
 module GraphQL
   class Query
     class SerialExecution
-      class SelectionResolution
-        attr_reader :target, :type, :irep_node, :execution_context
-
-        def initialize(target, type, irep_node, execution_context)
-          @target = target
-          @type = type
-          @irep_node = irep_node
-          @execution_context = execution_context
-        end
-
-        def result
+      module SelectionResolution
+        def self.resolve(target, current_type, irep_node, execution_context)
           irep_node.children.each_with_object({}) do |(name, irep_node), memo|
-            if irep_node.included? && applies_to_type?(irep_node, type)
+            if irep_node.included? && irep_node.definitions.any? { |potential_type, field_defn| GraphQL::Execution::Typecast.compatible?(current_type, potential_type, execution_context.query.context) }
               field_result = execution_context.strategy.field_resolution.new(
                 irep_node,
-                type,
+                current_type,
                 target,
                 execution_context
               ).result
               memo.merge!(field_result)
             end
           end
-        end
-
-        private
-
-        def applies_to_type?(irep_node, current_type)
-          irep_node.definitions.any? { |potential_type, field_defn|
-            GraphQL::Execution::Typecast.compatible?(current_type, potential_type, execution_context.query.context)
-          }
         end
       end
     end

--- a/lib/graphql/query/serial_execution/value_resolution.rb
+++ b/lib/graphql/query/serial_execution/value_resolution.rb
@@ -2,119 +2,72 @@ module GraphQL
   class Query
     class SerialExecution
       module ValueResolution
-        def self.get_strategy_for_kind(kind)
-          TYPE_KIND_STRATEGIES[kind] || raise("No value resolution strategy for #{kind}!")
-        end
-
-        class BaseResolution
-          attr_reader :value, :field_type, :target, :parent_type,
-            :irep_node, :execution_context
-          def initialize(value, field_type, target, parent_type, irep_node, execution_context)
-            @value = value
-            @field_type = field_type
-            @target = target
-            @parent_type = parent_type
-            @irep_node = irep_node
-            @execution_context = execution_context
-          end
-
-          def result
-            if value.nil? || value.is_a?(GraphQL::ExecutionError)
+        def self.resolve(parent_type, field_defn, field_type, value, irep_node, execution_context)
+          if value.nil? || value.is_a?(GraphQL::ExecutionError)
+            if field_type.kind.non_null?
+              raise GraphQL::InvalidNullError.new(parent_type.name, field_defn.name, value)
+            else
               nil
-            else
-              non_null_result
             end
-          end
-
-          def non_null_result
-            raise NotImplementedError, "Should return a value based on initialization params"
-          end
-
-          def get_strategy_for_kind(*args)
-            GraphQL::Query::SerialExecution::ValueResolution.get_strategy_for_kind(*args)
-          end
-        end
-
-        class ScalarResolution < BaseResolution
-          # Apply the scalar's defined `coerce_result` method to the value
-          def non_null_result
-            field_type.coerce_result(value)
-          end
-        end
-
-        class EnumResolution < BaseResolution
-          # Pick an enum value, but make sure it's allowed
-          def non_null_result
-            field_type.coerce_result(value, execution_context.query.warden)
-          end
-        end
-
-        class ListResolution < BaseResolution
-          # For each item in the list,
-          # Resolve it with the "wrapped" type of this list
-          def non_null_result
-            wrapped_type = field_type.of_type
-            strategy_class = get_strategy_for_kind(wrapped_type.kind)
-            result = value.each_with_index.map do |item, index|
-              irep_node.index = index
-              inner_strategy = strategy_class.new(item, wrapped_type, target, parent_type, irep_node, execution_context)
-              inner_strategy.result
-            end
-            irep_node.index = nil
-            result
-          end
-        end
-
-        class HasPossibleTypeResolution < BaseResolution
-          def non_null_result
-            resolved_type = execution_context.schema.resolve_type(value, execution_context.query.context)
-            possible_types = execution_context.possible_types(field_type)
-
-            if !possible_types.include?(resolved_type)
-              raise GraphQL::UnresolvedTypeError.new(irep_node.definition_name, field_type, parent_type, resolved_type, possible_types)
-            end
-
-            strategy_class = get_strategy_for_kind(resolved_type.kind)
-            inner_strategy = strategy_class.new(value, resolved_type, target, parent_type, irep_node, execution_context)
-            inner_strategy.result
-          end
-        end
-
-        class ObjectResolution < BaseResolution
-          # Resolve the selections on this object
-          def non_null_result
-            execution_context.strategy.selection_resolution.new(
-              value,
-              field_type,
-              irep_node,
-              execution_context
-            ).result
-          end
-        end
-
-        class NonNullResolution < BaseResolution
-          # Get the "wrapped" type and resolve the value according to that type
-          def result
-            if value.nil? || value.is_a?(GraphQL::ExecutionError)
-              raise GraphQL::InvalidNullError.new(parent_type.name, irep_node.definition_name, value)
-            else
+          else
+            case field_type.kind
+            when GraphQL::TypeKinds::SCALAR
+              field_type.coerce_result(value)
+            when GraphQL::TypeKinds::ENUM
+              field_type.coerce_result(value, execution_context.query.warden)
+            when GraphQL::TypeKinds::LIST
               wrapped_type = field_type.of_type
-              strategy_class = get_strategy_for_kind(wrapped_type.kind)
-              inner_strategy = strategy_class.new(value, wrapped_type, target, parent_type, irep_node, execution_context)
-              inner_strategy.result
+              result = value.each_with_index.map do |inner_value, index|
+                irep_node.index = index
+                resolve(
+                  parent_type,
+                  field_defn,
+                  wrapped_type,
+                  inner_value,
+                  irep_node,
+                  execution_context,
+                )
+              end
+              irep_node.index = nil
+              result
+            when GraphQL::TypeKinds::NON_NULL
+              wrapped_type = field_type.of_type
+              resolve(
+                parent_type,
+                field_defn,
+                wrapped_type,
+                value,
+                irep_node,
+                execution_context,
+              )
+            when GraphQL::TypeKinds::OBJECT
+              execution_context.strategy.selection_resolution.resolve(
+                value,
+                field_type,
+                irep_node,
+                execution_context
+              )
+            when GraphQL::TypeKinds::UNION, GraphQL::TypeKinds::INTERFACE
+              resolved_type = execution_context.schema.resolve_type(value, execution_context.query.context)
+              possible_types = execution_context.possible_types(field_type)
+
+              if !possible_types.include?(resolved_type)
+                raise GraphQL::UnresolvedTypeError.new(irep_node.definition_name, field_type, parent_type, resolved_type, possible_types)
+              else
+                resolve(
+                  parent_type,
+                  field_defn,
+                  resolved_type,
+                  value,
+                  irep_node,
+                  execution_context,
+                )
+              end
+            else
+              raise("Unknown type kind: #{field_type.kind}")
             end
           end
         end
-
-        TYPE_KIND_STRATEGIES = {
-          GraphQL::TypeKinds::SCALAR =>     ScalarResolution,
-          GraphQL::TypeKinds::LIST =>       ListResolution,
-          GraphQL::TypeKinds::OBJECT =>     ObjectResolution,
-          GraphQL::TypeKinds::ENUM =>       EnumResolution,
-          GraphQL::TypeKinds::NON_NULL =>   NonNullResolution,
-          GraphQL::TypeKinds::INTERFACE =>  HasPossibleTypeResolution,
-          GraphQL::TypeKinds::UNION =>      HasPossibleTypeResolution,
-        }
       end
     end
   end


### PR DESCRIPTION
Some of these objects don't need to be objects at all, but being a pure function will do. I didn't touch `FieldResolution` because I think graphql-batch depends on it!

You can see a bit less `Class#new` in the profile 

- Before: 

  ```
Measure Mode: wall_time
Thread ID: 70200716433880
Fiber ID: 70200724772180
Total: 0.166652
Sort by: self_time

 %self      total      self      wait     child     calls  name
  7.83      0.013     0.013     0.000     0.000    11461  *GraphQL::Define::InstanceDefinable#ensure_defined
  6.97      0.037     0.012     0.000     0.026     7067  *Class#new
  6.32      0.011     0.011     0.000     0.000     8520   Kernel#instance_variable_get
  4.37      0.007     0.007     0.000     0.000     8721   Kernel#hash
  3.93      0.052     0.007     0.000     0.045     1700   GraphQL::Query::SerialExecution::FieldResolution#get_raw_value
  ```

- After:

  ```
Measure Mode: wall_time
Thread ID: 70366898936280
Fiber ID: 70366898773200
Total: 0.140283
Sort by: self_time

 %self      total      self      wait     child     calls  name
  8.72      0.012     0.012     0.000     0.000    11461  *GraphQL::Define::InstanceDefinable#ensure_defined
  6.64      0.009     0.009     0.000     0.000     8520   Kernel#instance_variable_get
  4.81      0.027     0.007     0.000     0.020     3813  *Class#new
  4.38      0.047     0.006     0.000     0.041     1700   GraphQL::Query::SerialExecution::FieldResolution#get_raw_value
  3.70      0.013     0.005     0.000     0.007     3662   GraphQL::BaseType#name
  3.39      0.005     0.005     0.000     0.000     5939   Kernel#hash
  ```
