### PR TITLE
Improve API for returning value and error

### DIFF
--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -54,8 +54,8 @@ module GraphQL
           raise TypeError, "expected error to be a ExecutionError, but was #{error.class}"
         end
 
-        error.ast_node = irep_node.ast_node
-        error.path = irep_node.path
+        error.ast_node = irep_node.ast_node unless error.ast_node
+        error.path = irep_node.path unless error.path
         errors << error
 
         nil

--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -45,6 +45,21 @@ module GraphQL
       def []=(key, value)
         @values[key] = value
       end
+
+      # Add error to current field resolution.
+      # @param error [GraphQL::ExecutionError] an execution error
+      # @return [void]
+      def add_error(error)
+        unless error.is_a?(ExecutionError)
+          raise TypeError, "expected error to be a ExecutionError, but was #{error.class}"
+        end
+
+        error.ast_node = irep_node.ast_node
+        error.path = irep_node.path
+        errors << error
+
+        nil
+      end
     end
   end
 end

--- a/lib/graphql/query/serial_execution/field_resolution.rb
+++ b/lib/graphql/query/serial_execution/field_resolution.rb
@@ -24,17 +24,18 @@ module GraphQL
         # After getting the value from the field's resolve method,
         # continue by "finishing" the value, eg. executing sub-fields or coercing values
         def get_finished_value(raw_value)
-          execution_context.query.context.irep_node = irep_node
-
           case raw_value
           when GraphQL::ExecutionError
-            execution_context.query.context.add_error(raw_value)
+            raw_value.ast_node = irep_node.ast_node
+            raw_value.path = irep_node.path
+            execution_context.add_error(raw_value)
           when Array
             list_errors = raw_value.each_with_index.select { |value, _| value.is_a?(GraphQL::ExecutionError) }
             if list_errors.any?
               list_errors.each do |error, index|
+                error.ast_node = irep_node.ast_node
                 error.path = irep_node.path + [index]
-                execution_context.query.context.add_error(error)
+                execution_context.add_error(error)
               end
             end
           end

--- a/lib/graphql/query/serial_execution/field_resolution.rb
+++ b/lib/graphql/query/serial_execution/field_resolution.rb
@@ -24,18 +24,17 @@ module GraphQL
         # After getting the value from the field's resolve method,
         # continue by "finishing" the value, eg. executing sub-fields or coercing values
         def get_finished_value(raw_value)
+          execution_context.query.context.irep_node = irep_node
+
           case raw_value
           when GraphQL::ExecutionError
-            raw_value.ast_node = irep_node.ast_node
-            raw_value.path = irep_node.path
-            execution_context.add_error(raw_value)
+            execution_context.query.context.add_error(raw_value)
           when Array
             list_errors = raw_value.each_with_index.select { |value, _| value.is_a?(GraphQL::ExecutionError) }
             if list_errors.any?
               list_errors.each do |error, index|
-                error.ast_node = irep_node.ast_node
                 error.path = irep_node.path + [index]
-                execution_context.add_error(error)
+                execution_context.query.context.add_error(error)
               end
             end
           end

--- a/spec/graphql/execution_error_spec.rb
+++ b/spec/graphql/execution_error_spec.rb
@@ -44,6 +44,7 @@ describe GraphQL::ExecutionError do
         }
       }
       executionError
+      valueWithExecutionError
     }
 
     fragment similarCheeseFields on Cheese {
@@ -90,6 +91,7 @@ describe GraphQL::ExecutionError do
               ]
             },
             "executionError" => nil,
+            "valueWithExecutionError" => 0
           },
           "errors"=>[
             {
@@ -126,6 +128,11 @@ describe GraphQL::ExecutionError do
               "message"=>"There was an execution error",
               "locations"=>[{"line"=>41, "column"=>7}],
               "path"=>["executionError"]
+            },
+            {
+              "message"=>"Could not fetch latest value",
+              "locations"=>[{"line"=>42, "column"=>7}],
+              "path"=>["valueWithExecutionError"]
             },
           ]
         }

--- a/spec/graphql/introspection/schema_type_spec.rb
+++ b/spec/graphql/introspection/schema_type_spec.rb
@@ -32,6 +32,7 @@ describe GraphQL::Introspection::SchemaType do
             {"name"=>"milk"},
             {"name"=>"root"},
             {"name"=>"searchDairy"},
+            {"name"=>"valueWithExecutionError"},
           ]
         },
         "mutationType"=> {

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -297,6 +297,14 @@ DairyAppQueryType = GraphQL::ObjectType.define do
     resolve ->(t, a, c) { raise(GraphQL::ExecutionError, "There was an execution error") }
   end
 
+  field :valueWithExecutionError do
+    type !GraphQL::INT_TYPE
+    resolve ->(t, a, c) {
+      c.add_error(GraphQL::ExecutionError.new("Could not fetch latest value"))
+      return 0
+    }
+  end
+
   # To test possibly-null fields
   field :maybeNull, MaybeNullType do
     resolve ->(t, a, c) { OpenStruct.new(cheese: nil) }


### PR DESCRIPTION
Returning an `ExecutionError` from a resolver automatically annotates the error object with the current ast node and path. Super handy.

However, this only works with nullable fields. If you want to return a sensible value on a non-nullable field you must annotate the ast node and path by hand.

This adds `Context#add_error` to automatically annotate resolver errors.

``` ruby
resolve -> (repo, args, ctx) {
  ctx.add_error GraphQL::ExecutionError.new("Repository stars could not be fetched")
  # just return a zero star count to clients
  return 0
}
```

An alternative API might be allowing another special error type that would hold a value and error.

``` ruby
resolve -> (repo, args, ctx) {
  return GraphQL::ExecutionErrorWithValue.new(value: 0, error: "Repository stars could not be fetched")
}
```

<hr>

To: @rmosolgo 
CC: @mcolyer 