### PR TITLE
Execution "path" from fragment fields is wrong

### DIFF
--- a/spec/graphql/execution_error_spec.rb
+++ b/spec/graphql/execution_error_spec.rb
@@ -185,4 +185,63 @@ describe GraphQL::ExecutionError do
       assert_equal(expected_result, result)
     end
   end
+
+  describe "fragment query when returned from a field" do
+    let(:query_string) {%|
+    query MilkQuery {
+      dairy {
+        ...Dairy
+      }
+    }
+
+    fragment Dairy on Dairy {
+      milks {
+        source
+        executionError
+        allDairy {
+          __typename
+          ...Milk
+        }
+      }
+    }
+
+    fragment Milk on Milk {
+      origin
+      executionError
+    }
+    |}
+    it "the error is inserted into the errors key and the rest of the query is fulfilled" do
+      expected_result = {
+        "data"=>{
+            "dairy" => {
+              "milks" => [
+                {
+                  "source" => "COW",
+                  "executionError" => nil,
+                  "allDairy" => [
+                    { "__typename" => "Cheese" },
+                    { "__typename" => "Cheese" },
+                    { "__typename" => "Cheese" },
+                    { "__typename" => "Milk", "origin" => "Antiquity", "executionError" => nil }
+                  ]
+                }
+              ]
+            }
+          },
+          "errors"=>[
+            {
+              "message"=>"There was an execution error",
+              "locations"=>[{"line"=>6, "column"=>11}],
+              "path"=>["dairy", "milks", 0, "executionError"]
+            },
+            {
+              "message"=>"There was an execution error",
+              "locations"=>[{"line"=>11, "column"=>15}],
+              "path"=>["dairy", "milks", 0, "allDairy", 3, "executionError"]
+            }
+          ]
+        }
+      assert_equal(expected_result, result)
+    end
+  end
 end


### PR DESCRIPTION
Heh, I keep finding more problems with the implementation of error `"path"`. Basically my fault, I wrote this thing.

The latest is that resolving fields within a fragment context have an incomplete path. They only walk up to the root of the fragment definition rather than the full query stack.

I'm thinking that using `irep_node` is probably the wrong path for recording this path stack. And I'm feeling a little stuck about where to track this stack best.

<hr>

To: @rmosolgo 
CC: @mcolyer 