### PR TITLE
fix(Lexer) replace backslash-u-escaped unicode

### DIFF
--- a/lib/graphql/compatibility/query_parser_specification.rb
+++ b/lib/graphql/compatibility/query_parser_specification.rb
@@ -57,7 +57,7 @@ module GraphQL
                   int: 3,
                   float: 4.7e-24,
                   bool: false,
-                  string: "☀︎🏆\\n \\" \u00b6 /",
+                  string: "☀︎🏆 \\b \\f \\n \\r \\t \\" \u00b6 \\u00b6 / \\/",
                   enum: ENUM_NAME,
                   array: [7, 8, 9]
                   object: {a: [1,2,3], b: {c: "4"}}
@@ -71,7 +71,7 @@ module GraphQL
             assert_equal 3, inputs[0].value, "Integers"
             assert_equal 0.47e-23, inputs[1].value, "Floats"
             assert_equal false, inputs[2].value, "Booleans"
-            assert_equal %|☀︎🏆\n " ¶ /|, inputs[3].value, "Strings"
+            assert_equal %|☀︎🏆 \b \f \n \r \t " ¶ ¶ / /|, inputs[3].value, "Strings"
             assert_instance_of GraphQL::Language::Nodes::Enum, inputs[4].value
             assert_equal "ENUM_NAME", inputs[4].value.name, "Enums"
             assert_equal [7,8,9], inputs[5].value, "Lists"

--- a/lib/graphql/language/lexer.rl
+++ b/lib/graphql/language/lexer.rl
@@ -109,6 +109,7 @@ module GraphQL
       # To avoid allocating more strings, this modifies the string passed into it
       def self.replace_escaped_characters_in_place(raw_string)
         raw_string.gsub!(ESCAPES, ESCAPES_REPLACE)
+        raw_string.gsub!(UTF_8, &UTF_8_REPLACE)
         nil
       end
 
@@ -176,6 +177,9 @@ module GraphQL
         "\\r" => "\r",
         "\\t" => "\t",
       }
+
+      UTF_8 = /\\u[\dAa-f]{4}/i
+      UTF_8_REPLACE = ->(m) { [m[-4..-1].to_i(16)].pack('U'.freeze) }
 
       def self.emit_string(ts, te, meta)
         value = meta[:data][ts...te].pack("c*").force_encoding("UTF-8")


### PR DESCRIPTION
Oops, I just removed this in #366, But I think I shouldn't have. Here are some specs for this behavior in other parsers: 

https://github.com/graphql/graphql-js/blob/master/src/language/__tests__/lexer-test.js#L166-L173
https://github.com/graphql/libgraphqlparser/blob/master/test/ParserTests.cpp#L134-L137

So I think the old way was right. But `graphql-libgraphqlparser` doesn't pass this test, and that's what made me second-guess it in the first place. So I'll look into that.