### PR TITLE
Fix nested typed fields

### DIFF
--- a/lib/graphql/analysis/analyze_query.rb
+++ b/lib/graphql/analysis/analyze_query.rb
@@ -32,8 +32,10 @@ module GraphQL
     def reduce_node(irep_node, reducer_states)
       visit_analyzers(:enter, irep_node, reducer_states)
 
-      irep_node.children.each do |name, child_irep_node|
-        reduce_node(child_irep_node, reducer_states)
+      irep_node.typed_children.each do |type_defn, children|
+        children.each do |name, child_irep_node|
+          reduce_node(child_irep_node, reducer_states)
+        end
       end
 
       visit_analyzers(:leave, irep_node, reducer_states)

--- a/lib/graphql/analysis/field_usage.rb
+++ b/lib/graphql/analysis/field_usage.rb
@@ -26,10 +26,10 @@ module GraphQL
 
       def call(memo, visit_type, irep_node)
         if irep_node.ast_node.is_a?(GraphQL::Language::Nodes::Field) && visit_type == :leave
-          irep_node.definitions.each do |type_defn, field_defn|
-            field = "#{type_defn.name}.#{field_defn.name}"
-            memo[:used_fields] << field
-            memo[:used_deprecated_fields] << field if field_defn.deprecation_reason
+          field = "#{irep_node.owner_type.name}.#{irep_node.definition.name}"
+          memo[:used_fields] << field
+          if irep_node.definition.deprecation_reason
+            memo[:used_deprecated_fields] << field
           end
         end
 

--- a/lib/graphql/internal_representation/node.rb
+++ b/lib/graphql/internal_representation/node.rb
@@ -3,13 +3,14 @@ require "set"
 module GraphQL
   module InternalRepresentation
     class Node
-      def initialize(parent:, ast_node: nil, return_type: nil, name: nil, definition_name: nil, definitions: {}, spreads: [], directives: Set.new, included: true, typed_children: Hash.new {|h, k| h[k] = {} })
+      def initialize(parent:, ast_node: nil, return_type: nil, owner_type: nil, name: nil, definition_name: nil, definition: nil, spreads: [], directives: Set.new, included: true, typed_children: Hash.new {|h, k| h[k] = {} })
         @ast_node = ast_node
         @return_type = return_type
+        @owner_type = owner_type
         @name = name
         @definition_name = definition_name
+        @definition = definition
         @parent = parent
-        @definitions = definitions
         @spreads = spreads
         @directives = directives
         @included = included
@@ -30,24 +31,8 @@ module GraphQL
       # @return [String] the name for this node's definition ({#name} may be a field's alias, this is always the name)
       attr_reader :definition_name
 
-      # A cache of type-field pairs for executing & analyzing this node
-      #
-      # @example On-type from previous return value
-      # {
-      #   person(id: 1) {
-      #     firstName # => defined type is person
-      #   }
-      # }
-      # @example On-type from explicit type condition
-      # {
-      #   node(id: $nodeId) {
-      #     ... on Nameable {
-      #       firstName # => defined type is Nameable
-      #     }
-      #   }
-      # }
-      # @return [Hash<GraphQL::BaseType => GraphQL::Field>] definitions to use for each possible type
-      attr_reader :definitions
+      # @return [GraphQL::Field, GraphQL::Directive] the static definition for this field (it might be an interface field definition even though an object field definition will be used at runtime)
+      attr_reader :definition
 
       # @return [String] the name to use for the result in the response hash
       attr_reader :name
@@ -58,15 +43,8 @@ module GraphQL
       # @return [GraphQL::BaseType]
       attr_reader :return_type
 
-      # @deprecated Use {#typed_children} instead
-      # @return [Hash{String => Node}]
-      def children
-        if typed_children.size > 1
-          raise("This node has children of different types, use #typed_children")
-        else
-          typed_children.values.first || {}
-        end
-      end
+      # @return [GraphQL::BaseType]
+      attr_reader :owner_type
 
       # @return [Boolean] false if every field for this node included `@skip(if: true)`
       attr_accessor :included
@@ -105,7 +83,7 @@ module GraphQL
 
       def inspect(indent = 0)
         own_indent = " " * indent
-        self_inspect = "#{own_indent}<Node #{name} #{skipped? ? "(skipped)" : ""}(#{definition_name}: {#{definitions.keys.join("|")}} -> #{return_type})>"
+        self_inspect = "#{own_indent}<Node #{name} #{skipped? ? "(skipped)" : ""}(#{definition_name} -> #{return_type})>"
         if typed_children.any?
           self_inspect << " {"
           typed_children.each do |type_defn, children|

--- a/lib/graphql/internal_representation/node.rb
+++ b/lib/graphql/internal_representation/node.rb
@@ -3,19 +3,21 @@ require "set"
 module GraphQL
   module InternalRepresentation
     class Node
-      def initialize(parent:, ast_node: nil, return_type: nil, name: nil, definition_name: nil, definitions: {}, children: {}, spreads: [], directives: Set.new, included: true)
-        # Make sure these are kept in sync with #dup
+      def initialize(parent:, ast_node: nil, return_type: nil, name: nil, definition_name: nil, definitions: {}, spreads: [], directives: Set.new, included: true, typed_children: Hash.new {|h, k| h[k] = {} })
         @ast_node = ast_node
         @return_type = return_type
         @name = name
         @definition_name = definition_name
         @parent = parent
         @definitions = definitions
-        @children = children
         @spreads = spreads
         @directives = directives
         @included = included
+        @typed_children = typed_children
       end
+
+      # @return [Hash{GraphQL::BaseType => Hash{String => Node}] Children for each type condition
+      attr_reader :typed_children
 
       # Note: by the time this gets out of the Rewrite phase, this will be empty -- it's emptied out when fragments are merged back in
       # @return [Array<GraphQL::InternalRepresentation::Node>] Fragment names that were spread in this node
@@ -56,8 +58,15 @@ module GraphQL
       # @return [GraphQL::BaseType]
       attr_reader :return_type
 
-      # @return [Array<GraphQL::Query::Node>]
-      attr_reader :children
+      # @deprecated Use {#typed_children} instead
+      # @return [Hash{String => Node}]
+      def children
+        if typed_children.size > 1
+          raise("This node has children of different types, use #typed_children")
+        else
+          typed_children.values.first || {}
+        end
+      end
 
       # @return [Boolean] false if every field for this node included `@skip(if: true)`
       attr_accessor :included
@@ -97,8 +106,12 @@ module GraphQL
       def inspect(indent = 0)
         own_indent = " " * indent
         self_inspect = "#{own_indent}<Node #{name} #{skipped? ? "(skipped)" : ""}(#{definition_name}: {#{definitions.keys.join("|")}} -> #{return_type})>"
-        if children.any?
-          self_inspect << " {\n#{children.values.map { |n| n.inspect(indent + 2)}.join("\n")}\n#{own_indent}}"
+        if typed_children.any?
+          self_inspect << " {"
+          typed_children.each do |type_defn, children|
+            self_inspect << "\n#{own_indent}  #{type_defn} => (#{children.keys.join(",")})"
+          end
+          self_inspect << "\n#{own_indent}}"
         end
         self_inspect
       end

--- a/lib/graphql/internal_representation/rewrite.rb
+++ b/lib/graphql/internal_representation/rewrite.rb
@@ -57,6 +57,8 @@ module GraphQL
             owner_type: owner_type,
             included: false, # may be set to true on leaving the node
           )
+          parent_node.children[node_name] ||= node
+          node.definitions[owner_type] = context.field_definition
           @nodes.push(node)
           @parent_directives.push([])
         }
@@ -73,6 +75,7 @@ module GraphQL
               definition_name: ast_node.name,
               ast_node: ast_node,
               definition: context.directive_definition,
+              definitions: {context.directive_definition => context.directive_definition},
               # This isn't used, the directive may have many parents in the case of inline fragment
               parent: nil,
             )

--- a/lib/graphql/internal_representation/rewrite.rb
+++ b/lib/graphql/internal_representation/rewrite.rb
@@ -45,10 +45,11 @@ module GraphQL
         visitor[Nodes::Field].enter << ->(ast_node, prev_ast_node) {
           parent_node = @nodes.last
           node_name = ast_node.alias || ast_node.name
+          owner_type = context.parent_type_definition.unwrap
           # This node might not be novel, eg inside an inline fragment
           # but it could contain new type information, which is captured below.
           # (StaticValidation ensures that merging fields is fair game)
-          node = parent_node.children[node_name] ||= begin
+          node = parent_node.typed_children[owner_type][node_name] ||= begin
             Node.new(
               return_type: context.type_definition && context.type_definition.unwrap,
               ast_node: ast_node,
@@ -58,8 +59,7 @@ module GraphQL
               included: false, # may be set to true on leaving the node
             )
           end
-          object_type = context.parent_type_definition.unwrap
-          node.definitions[object_type] = context.field_definition
+          node.definitions[owner_type] = context.field_definition
           @nodes.push(node)
           @parent_directives.push([])
         }
@@ -176,8 +176,10 @@ module GraphQL
       # Merge the children from `fragment_node` into `parent_node`.
       # This is an implementation of "fragment inlining"
       def deep_merge(parent_node, fragment_node, included)
-        fragment_node.children.each do |name, child_node|
-          deep_merge_child(parent_node, name, child_node, included)
+        fragment_node.typed_children.each do |type_defn, children|
+          children.each do |name, child_node|
+            deep_merge_child(parent_node, type_defn, name, child_node, included)
+          end
         end
       end
 
@@ -186,29 +188,29 @@ module GraphQL
       # - If the spread was included, first-level children should be included if _either_ node was included
       # - If the spread was _not_ included, first-level children should be included if _a pre-existing_ node was included
       #   (A copied node should be excluded)
-      def deep_merge_child(parent_node, name, node, extra_included)
-        child_node = parent_node.children[name]
+      def deep_merge_child(parent_node, type_defn, name, node, extra_included)
+        child_node = parent_node.typed_children[type_defn][name]
         previously_included = child_node.nil? ? false : child_node.included?
         next_included = extra_included ? (previously_included || node.included?) : previously_included
 
         if child_node.nil?
-          child_node = parent_node.children[name] = node.dup
+          child_node = parent_node.typed_children[type_defn][name] = node.dup
         end
 
         child_node.definitions.merge!(node.definitions)
 
         child_node.included = next_included
 
-
-
-        node.children.each do |merge_child_name, merge_child_node|
-          deep_merge_child(child_node, merge_child_name, merge_child_node, node.included)
+        node.typed_children.each do |type_defn, children|
+          children.each do |merge_child_name, merge_child_node|
+            deep_merge_child(child_node, type_defn, merge_child_name, merge_child_node, node.included)
+          end
         end
       end
 
       # return true if node or _any_ children have a fragment spread
       def any_fragment_spreads?(node)
-        node.spreads.any? || node.children.any? { |name, node| any_fragment_spreads?(node) }
+        node.spreads.any? || node.typed_children.any? { |type_defn, children| children.any? { |name, node| any_fragment_spreads?(node) } }
       end
 
       # pop off own directives,

--- a/lib/graphql/query/serial_execution/execution_context.rb
+++ b/lib/graphql/query/serial_execution/execution_context.rb
@@ -20,8 +20,7 @@ module GraphQL
         end
 
         def get_field(type, irep_node)
-          # fall back for dynamic fields (eg __typename)
-          irep_node.definitions[type] || @warden.get_field(type, irep_node.definition_name) || raise("No field found on #{type.name} for '#{irep_node.definition_name}' (#{irep_node.ast_node.name})")
+          @warden.get_field(type, irep_node.definition_name) || raise("No field found on #{type.name} for '#{irep_node.definition_name}' (#{irep_node.ast_node.name})")
         end
 
         def possible_types(type)

--- a/lib/graphql/query/serial_execution/selection_resolution.rb
+++ b/lib/graphql/query/serial_execution/selection_resolution.rb
@@ -3,15 +3,36 @@ module GraphQL
     class SerialExecution
       module SelectionResolution
         def self.resolve(target, current_type, irep_node, execution_context)
-          irep_node.children.each_with_object({}) do |(name, irep_node), memo|
-            if irep_node.included? && irep_node.definitions.any? { |potential_type, field_defn| GraphQL::Execution::Typecast.compatible?(current_type, potential_type, execution_context.query.context) }
-              field_result = execution_context.strategy.field_resolution.new(
-                irep_node,
-                current_type,
-                target,
-                execution_context
-              ).result
-              memo.merge!(field_result)
+          selection_result = {}
+          irep_node.typed_children.each do |type_defn, typed_children|
+            type_child_result = {}
+            compat = GraphQL::Execution::Typecast.compatible?(current_type, type_defn, execution_context.query.context)
+            if compat
+              typed_children.each do |name, irep_node|
+                applies = irep_node.included? && irep_node.definitions.any? { |potential_type, field_defn| GraphQL::Execution::Typecast.compatible?(current_type, potential_type, execution_context.query.context) }
+                if applies
+                  field_result = execution_context.strategy.field_resolution.new(
+                    irep_node,
+                    current_type,
+                    target,
+                    execution_context
+                  ).result
+                  type_child_result.merge!(field_result)
+                end
+              end
+            end
+            deeply_merge(selection_result, type_child_result)
+          end
+          selection_result
+        end
+
+        def self.deeply_merge(complete_result, typed_result)
+          typed_result.each do |key, value|
+            if value.is_a?(Hash)
+              (complete_result[key] ||= {}).merge!(value)
+            else
+              # TODO: we can avoid running this twice
+              complete_result[key] = value
             end
           end
         end

--- a/lib/graphql/query/serial_execution/selection_resolution.rb
+++ b/lib/graphql/query/serial_execution/selection_resolution.rb
@@ -5,34 +5,52 @@ module GraphQL
         def self.resolve(target, current_type, irep_node, execution_context)
           selection_result = {}
           irep_node.typed_children.each do |type_defn, typed_children|
-            type_child_result = {}
-            compat = GraphQL::Execution::Typecast.compatible?(current_type, type_defn, execution_context.query.context)
-            if compat
+            if GraphQL::Execution::Typecast.compatible?(current_type, type_defn, execution_context.query.context)
               typed_children.each do |name, irep_node|
-                applies = irep_node.included? && irep_node.definitions.any? { |potential_type, field_defn| GraphQL::Execution::Typecast.compatible?(current_type, potential_type, execution_context.query.context) }
-                if applies
-                  field_result = execution_context.strategy.field_resolution.new(
-                    irep_node,
-                    current_type,
-                    target,
-                    execution_context
-                  ).result
-                  type_child_result.merge!(field_result)
+                if irep_node.included?
+                  previous_result = selection_result.fetch(irep_node.name, :__graphql_not_resolved__)
+                  case previous_result
+                  when :__graphql_not_resolved__
+                    # There's no value for this yet, so we can assign it directly
+                    field_result = execution_context.strategy.field_resolution.new(
+                      irep_node,
+                      current_type,
+                      target,
+                      execution_context
+                    ).result
+                    selection_result.merge!(field_result)
+                  when Hash
+                    # This field was also requested on a different type, so we need
+                    # to deeply merge _this_ branch with the other branch
+                    field_result = execution_context.strategy.field_resolution.new(
+                      irep_node,
+                      current_type,
+                      target,
+                      execution_context
+                    ).result
+                    deeply_merge(selection_result, field_result)
+                  else
+                    # This value has already been resolved in another type branch
+                  end
                 end
               end
             end
-            deeply_merge(selection_result, type_child_result)
           end
           selection_result
         end
 
-        def self.deeply_merge(complete_result, typed_result)
-          typed_result.each do |key, value|
-            if value.is_a?(Hash)
-              (complete_result[key] ||= {}).merge!(value)
+        # Modify `complete_result` by recursively merging `type_branch_result`
+        # @return [void]
+        def self.deeply_merge(complete_result, type_branch_result)
+          type_branch_result.each do |key, branch_value|
+            prev_value = complete_result[key]
+            case prev_value
+            when nil
+              complete_result[key] = branch_value
+            when Hash
+              deeply_merge(prev_value, branch_value)
             else
-              # TODO: we can avoid running this twice
-              complete_result[key] = value
+              # Sad, this was not needed.
             end
           end
         end

--- a/readme.md
+++ b/readme.md
@@ -68,3 +68,4 @@ See "Getting Started" on the [website](https://rmosolgo.github.io/graphql-ruby/)
   - Renaming fragments from local names to unique names
 - Document encrypted & versioned cursors
 - Make it faster
+- Is it possible to merge typed branches before resolving them? It's hard because even the branches will have branches.

--- a/spec/graphql/analysis/analyze_query_spec.rb
+++ b/spec/graphql/analysis/analyze_query_spec.rb
@@ -82,14 +82,12 @@ describe GraphQL::Analysis do
           memo ||= Hash.new { |h,k| h[k] = 0 }
           if visit_type == :enter
             if irep_node.ast_node.is_a?(GraphQL::Language::Nodes::Field)
-              irep_node.definitions.each do |type_defn, field_defn|
-                if field_defn.resolve_proc.is_a?(GraphQL::Relay::ConnectionResolve)
-                  memo[:connection] ||= 0
-                  memo[:connection] += 1
-                else
-                  memo[:field] ||= 0
-                  memo[:field] += 1
-                end
+              if irep_node.definition.resolve_proc.is_a?(GraphQL::Relay::ConnectionResolve)
+                memo[:connection] ||= 0
+                memo[:connection] += 1
+              else
+                memo[:field] ||= 0
+                memo[:field] += 1
               end
             end
           end

--- a/spec/graphql/introspection/type_type_spec.rb
+++ b/spec/graphql/introspection/type_type_spec.rb
@@ -18,6 +18,7 @@ describe GraphQL::Introspection::TypeType do
     {"name"=>"id",          "isDeprecated" => false, "type" => { "kind" => "NON_NULL", "name" => nil, "ofType" => { "name" => "Int"}}},
     {"name"=>"nullableCheese", "isDeprecated"=>false, "type"=>{ "kind" => "OBJECT",  "name" => "Cheese", "ofType"=>nil}},
     {"name"=>"origin",      "isDeprecated" => false, "type" => { "kind" => "NON_NULL", "name" => nil, "ofType" => { "name" => "String"}}},
+    {"name"=>"selfAsEdible", "isDeprecated"=>false, "type"=>{"kind"=>"INTERFACE", "name"=>"Edible", "ofType"=>nil}},
     {"name"=>"similarCheese", "isDeprecated"=>false, "type"=>{ "kind" => "OBJECT", "name"=>"Cheese", "ofType"=>nil}},
     {"name"=>"source",      "isDeprecated" => false, "type" => { "kind" => "NON_NULL", "name" => nil, "ofType" => { "name" => "DairyAnimal"}}},
   ]}
@@ -49,6 +50,7 @@ describe GraphQL::Introspection::TypeType do
           {"type"=>{"kind"=>"LIST","name"=>nil, "ofType"=>{"name"=>"String"}}},
           {"type"=>{"kind"=>"NON_NULL","name"=>nil, "ofType"=>{"name"=>"ID"}}},
           {"type"=>{"kind"=>"NON_NULL","name"=>nil, "ofType"=>{"name"=>"String"}}},
+          {"type"=>{"kind"=>"INTERFACE", "name"=>"Edible", "ofType"=>nil}},
           {"type"=>{"kind"=>"ENUM","name"=>"DairyAnimal", "ofType"=>nil}},
         ]
       },

--- a/spec/graphql/schema/reduce_types_spec.rb
+++ b/spec/graphql/schema/reduce_types_spec.rb
@@ -10,9 +10,9 @@ describe GraphQL::Schema::ReduceTypes do
       "Cheese" => CheeseType,
       "Float" => GraphQL::FLOAT_TYPE,
       "String" => GraphQL::STRING_TYPE,
+      "Edible" => EdibleInterface,
       "DairyAnimal" => DairyAnimalEnum,
       "Int" => GraphQL::INT_TYPE,
-      "Edible" => EdibleInterface,
       "AnimalProduct" => AnimalProductInterface,
       "LocalProduct" => LocalProductInterface,
     }

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -16,6 +16,7 @@ EdibleInterface = GraphQL::InterfaceType.define do
   description "Something you can eat, yum"
   field :fatContent, !types.Float, "Percentage which is fat"
   field :origin, !types.String, "Place the edible comes from"
+  field :selfAsEdible, EdibleInterface, resolve: ->(o, a, c) { o }
 end
 
 AnimalProductInterface = GraphQL::InterfaceType.define do


### PR DESCRIPTION
Fixes #370 

That was a doozy! 

Sadly this is a breaking change to `InternalRepresentation::Node`, but I don't see a way around it. 

The old structure kept _shallow_ typed branches in the form of `definitions[type] # => field_defn`. But the problem was that `children` wasn't branched by type, so when we deeply merged children, we lost information about which type condition that branch applied to. 

Now, `children` is replaced by `typed_children`, whose keys are GraphQL types and values are `{ string => node }` hashes (what `children` was previously). 

There's still an issue: when _executing_ divergent branches, it's possible that we'll do redundant work. For example, this would result in double work: 

```graphql
{
  thing {
    ... on InterfaceA {
      inner1 { inner2 }
    }
 
    ... on InterfaceB {
      inner1 { inner2 }
   }
}
```

We see that `inner1` is not a scalar, so we go execute it, but we get nothing new. 

Somehow this needs to _keep_ type condition info as you merge nested selections, so that we only traverse it once.
