### PR TITLE
Move ensure defined

### DIFF
--- a/lib/graphql/argument.rb
+++ b/lib/graphql/argument.rb
@@ -17,24 +17,22 @@ module GraphQL
   class Argument
     include GraphQL::Define::InstanceDefinable
     accepts_definitions :name, :type, :description, :default_value
-    lazy_defined_attr_accessor :type, :description, :default_value, :name
+    attr_accessor :type, :description, :default_value, :name
+
+    ensure_defined(:name, :description, :default_value, :type=, :type)
 
     # @!attribute name
     #   @return [String] The name of this argument on its {GraphQL::Field} or {GraphQL::InputObjectType}
 
     # @param new_input_type [GraphQL::BaseType, Proc] Assign a new input type for this argument (if it's a proc, it will be called after schema initialization)
     def type=(new_input_type)
-      ensure_defined
       @clean_type = nil
       @dirty_type = new_input_type
     end
 
     # @return [GraphQL::BaseType] the input type for this argument
     def type
-      @clean_type ||= begin
-        ensure_defined
-        GraphQL::BaseType.resolve_related_type(@dirty_type)
-      end
+      @clean_type ||= GraphQL::BaseType.resolve_related_type(@dirty_type)
     end
   end
 end

--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -8,7 +8,8 @@ module GraphQL
         global_id_field: GraphQL::Define::AssignGlobalIdField,
       }
 
-    lazy_defined_attr_accessor :name, :description
+    attr_accessor :name, :description
+    ensure_defined(:name, :description)
 
     # @!attribute name
     #   @return [String] the name of this type, must be unique within a Schema

--- a/lib/graphql/define/instance_definable.rb
+++ b/lib/graphql/define/instance_definable.rb
@@ -174,23 +174,6 @@ module GraphQL
           @own_dictionary = own_dictionary.merge(new_assignments)
         end
 
-        # Define a reader and writer for each of `attr_names` which
-        # ensures that the definition block was called before accessing it.
-        def lazy_defined_attr_accessor(*attr_names)
-          attr_names.each do |attr_name|
-            ivar_name = :"@#{attr_name}"
-            define_method(attr_name) do
-              ensure_defined
-              instance_variable_get(ivar_name)
-            end
-
-            define_method("#{attr_name}=") do |new_value|
-              ensure_defined
-              instance_variable_set(ivar_name, new_value)
-            end
-          end
-        end
-
         def ensure_defined(*method_names)
           ensure_defined_module = Module.new
           ensure_defined_module.module_eval {

--- a/lib/graphql/directive.rb
+++ b/lib/graphql/directive.rb
@@ -9,7 +9,8 @@ module GraphQL
     include GraphQL::Define::InstanceDefinable
     accepts_definitions :locations, :name, :description, :arguments, argument: GraphQL::Define::AssignArgument
 
-    lazy_defined_attr_accessor :locations, :arguments, :name, :description
+    attr_accessor :locations, :arguments, :name, :description
+    ensure_defined(:locations, :arguments, :name, :description)
 
     LOCATIONS = [
       QUERY =                  :QUERY,

--- a/lib/graphql/field.rb
+++ b/lib/graphql/field.rb
@@ -126,7 +126,11 @@ module GraphQL
       argument: GraphQL::Define::AssignArgument
 
 
-    lazy_defined_attr_accessor :name, :deprecation_reason, :description, :property, :hash_key, :mutation, :arguments, :complexity
+    attr_accessor :name, :deprecation_reason, :description, :property, :hash_key, :mutation, :arguments, :complexity
+    ensure_defined(
+      :name, :deprecation_reason, :description, :property, :hash_key, :mutation, :arguments, :complexity,
+      :resolve, :resolve=, :type, :type=, :name=, :property=, :hash_key=
+    )
 
     # @!attribute [r] resolve_proc
     #   @return [<#call(obj, args,ctx)>] A proc-like object which can be called to return the field's value
@@ -158,7 +162,6 @@ module GraphQL
     # @param arguments [Hash] Arguments declared in the query
     # @param context [GraphQL::Query::Context]
     def resolve(object, arguments, context)
-      ensure_defined
       resolve_proc.call(object, arguments, context)
     end
 
@@ -166,22 +169,17 @@ module GraphQL
     # a new resolve proc will be build based on its {#name}, {#property} or {#hash_key}.
     # @param new_resolve_proc [<#call(obj, args, ctx)>, nil]
     def resolve=(new_resolve_proc)
-      ensure_defined
       @resolve_proc = new_resolve_proc || build_default_resolver
     end
 
     def type=(new_return_type)
-      ensure_defined
       @clean_type = nil
       @dirty_type = new_return_type
     end
 
     # Get the return type for this field.
     def type
-      @clean_type ||= begin
-        ensure_defined
-        GraphQL::BaseType.resolve_related_type(@dirty_type)
-      end
+      @clean_type ||= GraphQL::BaseType.resolve_related_type(@dirty_type)
     end
 
     # You can only set a field's name _once_ -- this to prevent
@@ -189,7 +187,6 @@ module GraphQL
     #
     # This is important because {#name} may be used by {#resolve}.
     def name=(new_name)
-      ensure_defined
       if @name.nil?
         @name = new_name
       elsif @name != new_name
@@ -199,14 +196,12 @@ module GraphQL
 
     # @param new_property [Symbol] A method to call to resolve this field. Overrides the existing resolve proc.
     def property=(new_property)
-      ensure_defined
       @property = new_property
       self.resolve = nil # reset resolve proc
     end
 
     # @param new_hash_key [Symbol] A key to access with `#[key]` to resolve this field. Overrides the existing resolve proc.
     def hash_key=(new_hash_key)
-      ensure_defined
       @hash_key = new_hash_key
       self.resolve = nil # reset resolve proc
     end

--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -29,8 +29,10 @@ module GraphQL
       argument: GraphQL::Define::AssignArgument
     )
 
-    lazy_defined_attr_accessor :mutation, :arguments
+    attr_accessor :mutation, :arguments
     alias :input_fields :arguments
+
+    ensure_defined(:mutation, :arguments)
 
     # @!attribute mutation
     #   @return [GraphQL::Relay::Mutation, nil] The mutation this field was derived from, if it was derived from a mutation

--- a/lib/graphql/interface_type.rb
+++ b/lib/graphql/interface_type.rb
@@ -24,7 +24,8 @@ module GraphQL
   class InterfaceType < GraphQL::BaseType
     accepts_definitions :fields, field: GraphQL::Define::AssignObjectField
 
-    lazy_defined_attr_accessor :fields
+    attr_accessor :fields
+    ensure_defined :fields
 
     def initialize
       @fields = {}

--- a/lib/graphql/object_type.rb
+++ b/lib/graphql/object_type.rb
@@ -23,7 +23,8 @@ module GraphQL
   class ObjectType < GraphQL::BaseType
     accepts_definitions :interfaces, :fields, :mutation, field: GraphQL::Define::AssignObjectField
 
-    lazy_defined_attr_accessor :fields, :mutation
+    attr_accessor :fields, :mutation
+    ensure_defined(:fields, :mutation, :interfaces)
 
     # @!attribute fields
     #   @return [Hash<String => GraphQL::Field>] Map String fieldnames to their {GraphQL::Field} implementations
@@ -45,7 +46,6 @@ module GraphQL
 
     def interfaces
       @clean_interfaces ||= begin
-        ensure_defined
         if @dirty_interfaces.respond_to?(:map)
           @dirty_interfaces.map { |i_type| GraphQL::BaseType.resolve_related_type(i_type) }
         else

--- a/lib/graphql/relay/mutation.rb
+++ b/lib/graphql/relay/mutation.rb
@@ -55,9 +55,9 @@ module GraphQL
         input_field: GraphQL::Define::AssignArgument,
         return_field: GraphQL::Define::AssignObjectField,
       )
-      lazy_defined_attr_accessor :name, :description
-      lazy_defined_attr_accessor :fields, :arguments, :return_type
+      attr_accessor :name, :description, :fields, :arguments, :return_type
 
+      ensure_defined(:name, :description, :fields, :arguments, :return_type, :resolve=, :field, :result_class, :input_type)
       # For backwards compat, but do we need this separate API?
       alias :return_fields :fields
       alias :input_fields :arguments
@@ -75,13 +75,11 @@ module GraphQL
       end
 
       def resolve=(new_resolve_proc)
-        ensure_defined
         @resolve_proc = MutationResolve.new(self, new_resolve_proc, wrap_result: has_generated_return_type?)
       end
 
       def field
         @field ||= begin
-          ensure_defined
           relay_mutation = self
           field_resolve_proc = @resolve_proc
           GraphQL::Field.define do
@@ -95,7 +93,6 @@ module GraphQL
       end
 
       def return_type
-        ensure_defined
         @return_type ||= begin
           @has_generated_return_type = true
           relay_mutation = self
@@ -113,7 +110,6 @@ module GraphQL
 
       def input_type
         @input_type ||= begin
-          ensure_defined
           relay_mutation = self
           GraphQL::InputObjectType.define do
             name("#{relay_mutation.name}Input")
@@ -129,7 +125,6 @@ module GraphQL
 
       def result_class
         @result_class ||= begin
-          ensure_defined
           Result.define_subclass(self)
         end
       end

--- a/lib/graphql/scalar_type.rb
+++ b/lib/graphql/scalar_type.rb
@@ -35,6 +35,7 @@ module GraphQL
   #
   class ScalarType < GraphQL::BaseType
     accepts_definitions :coerce, :coerce_input, :coerce_result
+    ensure_defined :coerce_non_null_input, :coerce_result
 
     def coerce=(proc)
       self.coerce_input = proc
@@ -50,7 +51,6 @@ module GraphQL
     end
 
     def coerce_non_null_input(value)
-      ensure_defined
       @coerce_input_proc.call(value)
     end
 
@@ -61,7 +61,6 @@ module GraphQL
     end
 
     def coerce_result(value)
-      ensure_defined
       @coerce_result_proc ? @coerce_result_proc.call(value) : value
     end
 

--- a/lib/graphql/union_type.rb
+++ b/lib/graphql/union_type.rb
@@ -24,6 +24,7 @@ module GraphQL
   #
   class UnionType < GraphQL::BaseType
     accepts_definitions :possible_types, :resolve_type
+    ensure_defined :possible_types
 
     def kind
       GraphQL::TypeKinds::UNION
@@ -40,8 +41,6 @@ module GraphQL
 
     def possible_types
       @clean_possible_types ||= begin
-        ensure_defined
-
         if @dirty_possible_types.respond_to?(:map)
           @dirty_possible_types.map { |type| GraphQL::BaseType.resolve_related_type(type) }
         else

--- a/spec/graphql/define/instance_definable_spec.rb
+++ b/spec/graphql/define/instance_definable_spec.rb
@@ -11,11 +11,13 @@ module Garden
 
   class Vegetable
     include GraphQL::Define::InstanceDefinable
-    lazy_defined_attr_accessor :name, :start_planting_on, :end_planting_on
+    attr_accessor :name, :start_planting_on, :end_planting_on
+    ensure_defined(:name, :start_planting_on, :end_planting_on)
     accepts_definitions :name, plant_between: DefinePlantBetween, color: GraphQL::Define.assign_metadata_key(:color)
 
     # definition added later:
-    lazy_defined_attr_accessor :height
+    attr_accessor :height
+    ensure_defined(:height)
   end
 end
 


### PR DESCRIPTION
This is a slightly tamer approach to reduce the overhead of lazy definitions. It also opens the door to the more bonkers approach in #344 . 

It seems to result in a modest improvement over master, looks like because it uses built-in `attr_accessor` rather than `instance_variable_get`: 

- Master: 

<details>

```
Measure Mode: wall_time
Thread ID: 70159054412240
Fiber ID: 70159063195160
Total: 0.161769
Sort by: self_time

 %self      total      self      wait     child     calls  name
  8.34      0.014     0.013     0.000     0.000    12614  *GraphQL::Define::InstanceDefinable#ensure_defined
  5.73      0.009     0.009     0.000     0.000     7844   Kernel#instance_variable_get
  4.32      0.053     0.007     0.000     0.046     3985  *Class#new
  4.06      0.051     0.007     0.000     0.044     1748   GraphQL::Query::SerialExecution::FieldResolution#get_raw_value
  2.99      0.027     0.005     0.000     0.022     3496  *GraphQL::Schema::MiddlewareChain#call
  2.58      0.004     0.004     0.000     0.000     6209   <Module::GraphQL::Query::NullExcept>#call
  2.45      0.010     0.004     0.000     0.006     2971   GraphQL::BaseType#name
  2.29      0.004     0.004     0.000     0.000     4451   Kernel#hash
  2.27      0.038     0.004     0.000     0.034     1748   GraphQL::Query::SerialExecution::FieldResolution#initialize
  2.17      0.004     0.004     0.000     0.000     3854   GraphQL::Field#type
```
</details>

- This branch: 

<details>

```
Measure Mode: wall_time
Thread ID: 70149453650360
Fiber ID: 70149457883260
Total: 0.159599
Sort by: self_time

 %self      total      self      wait     child     calls  name
  6.13      0.010     0.010     0.000     0.000    12914  *GraphQL::Define::InstanceDefinable#ensure_defined
  4.45      0.054     0.007     0.000     0.046     3985  *Class#new
  3.65      0.045     0.006     0.000     0.039     1748   GraphQL::Query::SerialExecution::FieldResolution#get_raw_value
  3.29      0.011     0.005     0.000     0.006     3854   #<Module:0x007f99e30cee80>#type
  3.12      0.005     0.005     0.000     0.000     6209   <Module::GraphQL::Query::NullExcept>#call
  3.09      0.028     0.005     0.000     0.023     3496  *GraphQL::Schema::MiddlewareChain#call
  2.35      0.038     0.004     0.000     0.034     1748   GraphQL::Query::SerialExecution::FieldResolution#initialize
  2.33      0.006     0.004     0.000     0.002     2971   #<Module:0x007f99e303d548>#name
  2.30      0.004     0.004     0.000     0.000     4451   Kernel#hash
  2.21      0.009     0.004     0.000     0.005     6209   GraphQL::Schema::Warden#visible?

```
</details>