### PR TITLE
In-house batching 

### DIFF
--- a/lib/graphql/define.rb
+++ b/lib/graphql/define.rb
@@ -1,4 +1,5 @@
 require "graphql/define/assign_argument"
+require "graphql/define/assign_batch_resolve"
 require "graphql/define/assign_connection"
 require "graphql/define/assign_enum_value"
 require "graphql/define/assign_global_id_field"

--- a/lib/graphql/define/assign_batch_resolve.rb
+++ b/lib/graphql/define/assign_batch_resolve.rb
@@ -1,0 +1,10 @@
+module GraphQL
+  module Define
+    module AssignBatchResolve
+      def self.call(field_defn, loader, *loader_args, resolve_func)
+        field_defn.batch_loader = GraphQL::Execution::Batch::BatchLoader.new(loader, loader_args)
+        field_defn.resolve = resolve_func
+      end
+    end
+  end
+end

--- a/lib/graphql/execution.rb
+++ b/lib/graphql/execution.rb
@@ -1,2 +1,4 @@
+require "graphql/execution/batch"
 require "graphql/execution/directive_checks"
+require "graphql/execution/frame"
 require "graphql/execution/typecast"

--- a/lib/graphql/execution/batch.rb
+++ b/lib/graphql/execution/batch.rb
@@ -1,0 +1,63 @@
+module GraphQL
+  module Execution
+    module Batch
+      def self.resolve(item_arg, func)
+        BatchResolve.new(item_arg, func )
+      end
+
+      class BatchLoader
+        attr_reader :func, :args
+        def initialize(func, args)
+          @func = func
+          @args = args
+        end
+      end
+
+      class BatchResolve
+        attr_reader :item_arg, :func
+        def initialize(item_arg, func)
+          @item_arg = item_arg
+          @func = func
+        end
+      end
+
+      class Accumulator
+        def initialize
+          @storage = init_storage
+        end
+
+        def register(loader, group_args, path, batch_resolve)
+          key = [loader, group_args]
+          callback = [path, batch_resolve.func]
+          @storage[key][batch_resolve.item_arg] << callback
+        end
+
+        def any?
+          @storage.any?
+        end
+
+        def resolve_all(&block)
+          batches = @storage
+          @storage = init_storage
+          batches.each do |(loader, group_args), item_arg_callbacks|
+            item_args = item_arg_callbacks.keys
+            loader.call(*group_args, item_args) { |item_arg, result|
+              callbacks = item_arg_callbacks[item_arg]
+              callbacks.each do |(path, func)|
+                next_result = func.nil? ? result : func.call(result)
+                yield(path, next_result)
+              end
+            }
+          end
+        end
+
+        private
+
+        def init_storage
+          # { [loader, group_args] => { item_arg => [callback, ...] } }
+          Hash.new { |h, k| h[k] = Hash.new { |h2, k2| h2[k2] = [] } }
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/execution/frame.rb
+++ b/lib/graphql/execution/frame.rb
@@ -1,0 +1,48 @@
+module GraphQL
+  module Execution
+    # This is the info for resolving a single field
+    class Frame
+      extend Forwardable
+      attr_reader :query, :type, :irep_node
+
+      def initialize(query:, irep_node:, type: )
+        @query = query
+        @type = type
+        @irep_node = irep_node
+      end
+
+      def field
+        @field ||= query.get_field(type, irep_node.definition_name)
+      end
+
+      def ast_node
+        irep_node.ast_node
+      end
+
+      def path
+        irep_node.path
+      end
+
+      def context
+        @context ||= query.context
+      end
+
+      def add_error(err)
+        if err.is_a?(GraphQL::ExecutionError)
+          err.ast_node = ast_node
+          err.path = path
+        end
+        context.errors << err
+        nil
+      end
+
+      def spawn(**kwargs)
+        next_kwargs = {query: @query, irep_node: @irep_node, type: @type}
+        next_kwargs.merge!(kwargs)
+        self.class.new(next_kwargs)
+      end
+
+      def_delegators :context, :[], :[]=
+    end
+  end
+end

--- a/lib/graphql/field.rb
+++ b/lib/graphql/field.rb
@@ -123,13 +123,15 @@ module GraphQL
     accepts_definitions :name, :description, :deprecation_reason,
       :resolve, :type, :arguments,
       :property, :hash_key, :complexity, :mutation,
-      argument: GraphQL::Define::AssignArgument
+      argument: GraphQL::Define::AssignArgument,
+      batch_resolve: GraphQL::Define::AssignBatchResolve
 
 
-    attr_accessor :name, :deprecation_reason, :description, :property, :hash_key, :mutation, :arguments, :complexity
+
+    attr_accessor :name, :deprecation_reason, :description, :property, :hash_key, :mutation, :arguments, :complexity, :batch_loader
     ensure_defined(
       :name, :deprecation_reason, :description, :property, :hash_key, :mutation, :arguments, :complexity,
-      :resolve, :resolve=, :type, :type=, :name=, :property=, :hash_key=
+      :resolve, :resolve=, :type, :type=, :name=, :property=, :hash_key=, :batch_loader
     )
 
     # @!attribute [r] resolve_proc

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -25,7 +25,7 @@ module GraphQL
       end
     end
 
-    attr_reader :schema, :document, :context, :fragments, :operations, :root_value, :max_depth, :query_string, :warden
+    attr_reader :schema, :document, :context, :fragments, :operations, :root_value, :max_depth, :query_string, :warden, :accumulator
 
     # Prepare query `query_string` on `schema`
     # @param schema [GraphQL::Schema]
@@ -42,6 +42,7 @@ module GraphQL
 
       @schema = schema
       @warden = GraphQL::Schema::Warden.new(schema, except)
+      @accumulator = GraphQL::Execution::Batch::Accumulator.new
       @max_depth = max_depth || schema.max_depth
       @max_complexity = max_complexity || schema.max_complexity
       @query_analyzers = schema.query_analyzers.dup
@@ -165,6 +166,10 @@ module GraphQL
       end
 
       @valid
+    end
+
+    def get_field(parent_type, name)
+      @warden.get_field(parent_type, name)
     end
 
     private

--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -60,6 +60,10 @@ module GraphQL
 
         nil
       end
+
+      def batch(item_arg, &func)
+        GraphQL::Execution::Batch.resolve(item_arg, func)
+      end
     end
   end
 end

--- a/lib/graphql/query/serial_execution/operation_resolution.rb
+++ b/lib/graphql/query/serial_execution/operation_resolution.rb
@@ -1,20 +1,12 @@
 module GraphQL
   class Query
     class SerialExecution
-      class OperationResolution
-        attr_reader :target, :execution_context, :irep_node
-
-        def initialize(irep_node, target, execution_context)
-          @target = target
-          @irep_node = irep_node
-          @execution_context = execution_context
-        end
-
-        def result
+      module OperationResolution
+        def self.resolve(frame, root_type, execution_context)
           execution_context.strategy.selection_resolution.resolve(
             execution_context.query.root_value,
-            target,
-            irep_node,
+            root_type,
+            frame,
             execution_context
           )
         rescue GraphQL::InvalidNullError => err

--- a/spec/graphql/execution/batch_spec.rb
+++ b/spec/graphql/execution/batch_spec.rb
@@ -1,0 +1,166 @@
+require "spec_helper"
+
+describe GraphQL::Execution::Batch do
+  LOADS = []
+
+  module MultiplyLoader
+    def self.call(factor, ints)
+      LOADS << ints
+      ints.each do |int|
+        if int == 99
+          yield(int, GraphQL::ExecutionError.new("99 is forbidden"))
+        else
+          yield(int, int * factor)
+        end
+      end
+    end
+  end
+
+  BatchQueryType = GraphQL::ObjectType.define do
+    name "Query"
+    field :int, types.Int do
+      argument :value, types.Int
+      batch_resolve MultiplyLoader, 1, -> (_obj, args, ctx) {
+        # It's ok to not pass a block
+        ctx.batch(args[:value])
+      }
+    end
+
+    field :batchInt, BatchIntType do
+      argument :value, types.Int
+      batch_resolve MultiplyLoader, 2, -> (_obj, args, ctx) {
+        ctx.batch(args[:value]) { |v| OpenStruct.new(val: v, query: :q) }
+      }
+    end
+
+    field :self, BatchQueryType, resolve: ->(o, a, c) { :q }
+    field :selfs, types[BatchQueryType] do
+      argument :count, types.Int
+      resolve ->(o, args, c) { args[:count].times.map { :q } }
+    end
+  end
+
+  BatchIntType = GraphQL::ObjectType.define do
+    name "BatchInt"
+    field :val, types.Int
+    field :query, BatchQueryType
+  end
+
+  BatchSchema = GraphQL::Schema.define do
+    query(BatchQueryType)
+  end
+
+  before do
+    LOADS.clear
+  end
+
+  describe "batch resolving" do
+    it "makes one load with all values" do
+      res = BatchSchema.execute(%|
+        {
+          one: int(value: 1)
+          two: int(value: 2)
+          self {
+            three: int(value: 3)
+            three2: int(value: 3)
+          }
+        }
+      |)
+
+      assert_equal [[1,2,3]], LOADS, "It called the loader once"
+      expected_data = {
+        "one" => 1,
+        "two" => 2,
+        "self" => {
+          "three" => 3,
+          "three2" => 3
+        }
+      }
+      assert_equal expected_data, res["data"], "The loader modified values"
+    end
+  end
+
+  describe "nested batch fields" do
+    it "makes multiple batches" do
+      res = BatchSchema.execute(%|
+        {
+          one: int(value: 1),
+          two: int(value: 2),
+          six: batchInt(value: 6) {
+            val
+            query {
+              three: int(value: 3)
+              four: int(value: 4)
+            }
+          }
+          seven: batchInt(value: 7) {
+            val
+            query {
+              five: int(value: 5)
+            }
+          }
+        }
+      |)
+
+      assert_equal [[1,2], [6,7], [3,4,5]], LOADS
+
+      expected_data = {
+        "one" => 1,
+        "two" => 2,
+        "six" => {
+          "val" => 12,
+          "query" => {
+            "three" => 3,
+            "four" => 4,
+          }
+        },
+        "seven" => {
+          "val" => 14,
+          "query" => {
+            "five" => 5,
+          }
+        }
+      }
+      assert_equal expected_data, res["data"]
+    end
+  end
+
+
+  describe "yielding errors in batches" do
+    it "treats it like a returned error" do
+      res = BatchSchema.execute(%|
+        {
+          one: int(value: 1)
+          two: batchInt(value: 2) {
+            val
+            query {
+              err: int(value: 99)
+            }
+          }
+        }
+      |)
+
+      expected_data = {
+        "one"=>1,
+        "two"=>{
+          "val"=>4,
+          "query"=>{
+            "err"=>nil
+          }
+        }
+      }
+
+      expected_errors = [
+        {
+          "message"=>"99 is forbidden",
+          "locations"=>[{"line"=>7, "column"=>15}],
+          "path"=>["two", "query", "err"]
+        }
+      ]
+      assert_equal expected_data, res["data"]
+      assert_equal expected_errors, res["errors"]
+    end
+
+    it "propagates invalid nulls"
+  end
+end


### PR DESCRIPTION
For reasons (#274), the gem should have built-in support for batched resolution: one pass to gather needs, then resolve those needs together, then dole out the results to the fields that asked for them. This is what graphql-batch does so well, but moving it to core library code will make things a bit easier to maintain. 

## Todo 

- [ ] Add query-level batching
- [ ] Implement null propagation
- [ ] Support nested loaders 
- [ ] Check graphql-batch tests for any cases I've missed 