### PR TITLE
Add strategy alias for execution_strategy in FieldResolutionContext

### DIFF
--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -73,6 +73,7 @@ module GraphQL
         end
 
         def_delegators :@context, :[], :[]=, :spawn, :query, :schema, :warden, :errors, :execution_strategy
+        alias_method :strategy, :execution_strategy
 
         # @return [GraphQL::Language::Nodes::Field] The AST node for the currently-executing field
         def ast_node


### PR DESCRIPTION
https://github.com/rmosolgo/graphql-ruby/pull/379 changed the API of FieldResolution which broken graphql-batch https://github.com/Shopify/graphql-batch/pull/32 for version 1.2.0 of the graphql gem.  Now I'm not sure what the best way to get access to the execution strategy from a FieldResolution object.

I found that adding an strategy alias in FieldResolutionContext would allow https://github.com/rmosolgo/graphql-ruby/pull/379 to work with older and newer versions of the graphql gem.