### PR TITLE
Expose Schema#from_definition directly in schema.rb

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -46,8 +46,6 @@ module GraphQL
   #   end
   #
   class Schema
-    include BuildFromDefinition
-
     include GraphQL::Define::InstanceDefinable
     accepts_definitions \
       :query, :mutation, :subscription,
@@ -269,6 +267,16 @@ module GraphQL
     def self.from_introspection(introspection_result)
       GraphQL::Schema::Loader.load(introspection_result)
     end
+
+    # Create schema from an IDL schema.
+    # @param definition_string String A schema definition string
+    # @return [GraphQL::Schema] the schema described by `document`
+    def self.from_definition(definition_string)
+      GraphQL::Schema::BuildFromDefinition.from_definition(definition_string)
+    end
+
+    # Error that is raised when [#Schema#from_definition] is passed an invalid schema definition string.
+    class InvalidDocumentError < Error; end;
 
     private
 

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -1,16 +1,7 @@
 module GraphQL
   class Schema
     module BuildFromDefinition
-      def self.included(base)
-        base.extend(ClassMethods)
-      end
-
-      class InvalidDocumentError < Error; end;
-
-      module ClassMethods
-        # Create schema from an IDL schema.
-        # @param definition_string String A schema definition string
-        # @return [GraphQL::Schema] the schema described by `document`
+      class << self
         def from_definition(definition_string)
           document = GraphQL::parse(definition_string)
           Builder.build(document)


### PR DESCRIPTION
As per https://github.com/rmosolgo/graphql-ruby/pull/384#discussion_r86922870, this will make it a bit more obvious to the reader what is being exposed in `Schema` as well as where `BuildFromDefinition` is used.

:eyes: @rmosolgo 

