### PR TITLE
Fix validations for dynamic fields

### DIFF
--- a/lib/graphql/static_validation/arguments_validator.rb
+++ b/lib/graphql/static_validation/arguments_validator.rb
@@ -17,8 +17,6 @@ module GraphQL
                 return
               end
             end
-          elsif context.skip_field?(parent.name)
-            return
           elsif parent.is_a?(GraphQL::Language::Nodes::Directive)
             parent_defn = context.schema.directives[parent.name]
           else

--- a/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb
+++ b/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb
@@ -6,7 +6,6 @@ module GraphQL
       def validate(context)
         visitor = context.visitor
         visitor[GraphQL::Language::Nodes::Field] << ->(node, parent) {
-          return if context.skip_field?(node.name)
           parent_type = context.object_types[-2]
           parent_type = parent_type.unwrap
           validate_field(context, node, parent_type, parent)
@@ -16,7 +15,7 @@ module GraphQL
       private
 
       def validate_field(context, ast_field, parent_type, parent)
-        if parent_type.kind.union?
+        if parent_type.kind.union? && ast_field.name != '__typename'
           context.errors << message("Selections can't be made directly on unions (see selections on #{parent_type.name})", parent, context: context)
           return GraphQL::Language::Visitor::SKIP
         end

--- a/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb
+++ b/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb
@@ -7,7 +7,6 @@ module GraphQL
 
       def validate(context)
         context.visitor[GraphQL::Language::Nodes::Field] << ->(node, parent)  {
-          return if context.skip_field?(node.name)
           field_defn = context.field_definition
           validate_field_selections(node, field_defn, context)
         }

--- a/lib/graphql/static_validation/rules/required_arguments_are_present.rb
+++ b/lib/graphql/static_validation/rules/required_arguments_are_present.rb
@@ -17,7 +17,6 @@ module GraphQL
       end
 
       def validate_field(ast_field, context)
-        return if context.skip_field?(ast_field.name)
         defn = context.field_definition
         assert_required_args(ast_field, defn, context)
       end

--- a/lib/graphql/static_validation/validation_context.rb
+++ b/lib/graphql/static_validation/validation_context.rb
@@ -74,12 +74,6 @@ module GraphQL
         @literal_validator ||= LiteralValidator.new(warden: @warden)
         @literal_validator.validate(ast_value, type)
       end
-
-      # Don't try to validate dynamic fields
-      # since they aren't defined by the type system
-      def skip_field?(field_name)
-        GraphQL::Schema::DYNAMIC_FIELDS.include?(field_name)
-      end
     end
   end
 end

--- a/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
+++ b/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
@@ -187,4 +187,20 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
       end
     end
   end
+
+  describe "dynamic fields" do
+    let(:query_string) {"
+      query {
+        __type(name: 1) { name }
+      }
+    "}
+
+    it "finds invalid argument types" do
+      assert_includes(errors, {
+        "message"=>"Argument 'name' on Field '__type' has an invalid value. Expected type 'String!'.",
+        "locations"=>[{"line"=>3, "column"=>9}],
+        "fields"=>["query", "__type", "name"],
+      })
+    end
+  end
 end

--- a/spec/graphql/static_validation/rules/arguments_are_defined_spec.rb
+++ b/spec/graphql/static_validation/rules/arguments_are_defined_spec.rb
@@ -49,4 +49,20 @@ describe GraphQL::StaticValidation::ArgumentsAreDefined do
     }
     assert_includes(errors, directive_error)
   end
+
+  describe "dynamic fields" do
+    let(:query_string) {"
+      query {
+        __type(somethingInvalid: 1) { name }
+      }
+    "}
+
+    it "finds undefined arguments" do
+      assert_includes(errors, {
+        "message"=>"Field '__type' doesn't accept argument 'somethingInvalid'",
+        "locations"=>[{"line"=>3, "column"=>9}],
+        "fields"=>["query", "__type", "somethingInvalid"],
+      })
+    end
+  end
 end

--- a/spec/graphql/static_validation/rules/required_arguments_are_present_spec.rb
+++ b/spec/graphql/static_validation/rules/required_arguments_are_present_spec.rb
@@ -39,4 +39,25 @@ describe GraphQL::StaticValidation::RequiredArgumentsArePresent do
     }
     assert_includes(errors, directive_error)
   end
+
+  describe "dynamic fields" do
+    let(:query_string) {"
+      query {
+        __type { name }
+      }
+    "}
+
+    it "finds undefined required arguments" do
+      expected_errors = [
+        {
+          "message"=>"Field '__type' is missing required arguments: name",
+          "locations"=>[
+            {"line"=>3, "column"=>9}
+          ],
+          "fields"=>["query", "__type"],
+        }
+      ]
+      assert_equal(expected_errors, errors)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #387

Validation of dynamic fields (i.e. `__schema`, `_type`, and `__typename`) seem broken (see tests for examples) because we were early returning for them.

I believe we can treat these fields as any other field since [`Schema.get_field`](https://github.com/rmosolgo/graphql-ruby/blob/1246912b777b5e82665349c592f85f8885c376b0/lib/graphql/schema.rb#L150) is aware of these special fields.

Also added a bit more test coverage around validating these dynamic fields.

:eyes: @rmosolgo 