### PR TITLE
`input_fields` did not ensure_define

### DIFF
--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -30,9 +30,8 @@ module GraphQL
     )
 
     attr_accessor :mutation, :arguments
-    alias :input_fields :arguments
-
     ensure_defined(:mutation, :arguments)
+    alias :input_fields :arguments
 
     # @!attribute mutation
     #   @return [GraphQL::Relay::Mutation, nil] The mutation this field was derived from, if it was derived from a mutation

--- a/spec/graphql/input_object_type_spec.rb
+++ b/spec/graphql/input_object_type_spec.rb
@@ -10,6 +10,18 @@ describe GraphQL::InputObjectType do
     assert(DairyProductInputType.input_fields["fatContent"])
   end
 
+  describe "on a type unused by the schema" do
+    it "has input fields" do
+      UnreachedInputType = GraphQL::InputObjectType.define do
+        name 'UnreachedInputType'
+        description 'An input object type not directly used in the schema.'
+
+        input_field :field, types.String
+      end
+      assert(UnreachedInputType.input_fields['field'])
+    end
+  end
+
   describe "input validation" do
     it "Accepts anything that yields key-value pairs to #all?" do
       values_obj = MinimumInputObject.new({"source" => "COW", "fatContent" => 0.4})

--- a/spec/graphql/relay/mutation_spec.rb
+++ b/spec/graphql/relay/mutation_spec.rb
@@ -77,6 +77,23 @@ describe GraphQL::Relay::Mutation do
     assert_equal IntroduceShipMutation, IntroduceShipMutation.result_class.mutation
   end
 
+  describe "aliased methods" do
+    describe "on an unreached mutation" do
+      it 'still ensures definitions' do
+        UnreachedMutation = GraphQL::Relay::Mutation.define do
+          name 'UnreachedMutation'
+          description 'A mutation type not directly used in the schema.'
+
+          input_field :input, types.String
+          return_field :return, types.String
+        end
+
+        assert UnreachedMutation.input_fields['input']
+        assert UnreachedMutation.return_fields['return']
+      end
+    end
+  end
+
   describe "providing a return type" do
     let(:custom_return_type) {
       GraphQL::ObjectType.define do


### PR DESCRIPTION
Based on the original order of execution, `input_fields` was still aliased to the un-`ensure_defined` version of `arguments`.