### PR TITLE
[documentation] fix the logic in the Instrumenter::field setup exampl…

### DIFF
--- a/guides/schema/instrumentation.md
+++ b/guides/schema/instrumentation.md
@@ -27,14 +27,17 @@ class FieldTimerInstrumentation
       old_resolve_proc = field.resolve_proc
       new_resolve_proc = ->(obj, args, ctx) {
         Rails.logger.info("#{type.name}.#{field.name} START: #{Time.now.to_i}")
-        old_resolve_proc.call(obj, args, ctx)
+        resolved = old_resolve_proc.call(obj, args, ctx)
         Rails.logger.info("#{type.name}.#{field.name} END: #{Time.now.to_i}")
+        resolved
       }
 
       # Return a copy of `field`, with a new resolve proc
       field.redefine do
         resolve(new_resolve_proc)
       end
+    else
+      field
     end
   end
 end


### PR DESCRIPTION
…e to return the intended value

Overview:
- it seems valid to return a previous resolver value in the :field instrumentation example - without it we have an error;
- minor comment change: previous comment mentioned `return` and `copy` which may not be correct because there is no need to return `the field` in `#instrument` and the field is not a copy, but the same reference.