### PR TITLE
fix(Arguments) wrap based on type, not value

### DIFF
--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -60,14 +60,15 @@ module GraphQL
       NULL_ARGUMENT_VALUE = ArgumentValue.new(nil, nil, nil)
 
       def wrap_value(value, arg_defn_type)
-        case value
-        when Array
+        case arg_defn_type
+        when GraphQL::ListType
           value.map { |item| wrap_value(item, arg_defn_type.of_type) }
-        when Hash
-          if arg_defn_type.unwrap.kind.input_object?
+        when GraphQL::NonNullType
+          wrap_value(value, arg_defn_type.of_type)
+        when GraphQL::InputObjectType
+          if value.is_a?(Hash)
             self.class.new(value, argument_definitions: arg_defn_type.arguments)
           else
-            # It may be a custom scalar that coerces to a Hash
             value
           end
         else

--- a/spec/graphql/query/arguments_spec.rb
+++ b/spec/graphql/query/arguments_spec.rb
@@ -90,8 +90,8 @@ describe GraphQL::Query::Arguments do
         {a: 1, b: {a: 2}, c: {a: 3}},
         argument_definitions: input_type.arguments
       )
-      assert args["b"].is_a?(GraphQL::Query::Arguments)
-      assert args["c"].is_a?(Hash)
+      assert_instance_of GraphQL::Query::Arguments, args["b"]
+      assert_instance_of Hash, args["c"]
     end
   end
 


### PR DESCRIPTION
Oops, the old code assumed that any array was of `List` type, but in fact, an enum value could be an array! (Fixes #397) 