### PR TITLE
Add instrumenters after schema.define 

### DIFF
--- a/lib/graphql/define/assign_object_field.rb
+++ b/lib/graphql/define/assign_object_field.rb
@@ -16,13 +16,13 @@ module GraphQL
         # Figure out how to find or initialize the field instance:
         if type_or_field.is_a?(GraphQL::Field)
           field = type_or_field
-          field.name ||= name_s
+          field = field.redefine(name: name_s)
         elsif block_given?
           field = GraphQL::Field.define(kwargs, &block)
         elsif field.nil?
           field = GraphQL::Field.define(kwargs)
         elsif field.is_a?(GraphQL::Field)
-          field.name ||= name_s
+          field = field.redefine(name: name_s)
         else
           raise("Couldn't find a field argument, received: #{field || type_or_field}")
         end

--- a/lib/graphql/field.rb
+++ b/lib/graphql/field.rb
@@ -123,13 +123,19 @@ module GraphQL
     accepts_definitions :name, :description, :deprecation_reason,
       :resolve, :type, :arguments,
       :property, :hash_key, :complexity, :mutation,
+      :relay_node_field,
       argument: GraphQL::Define::AssignArgument
 
 
     attr_accessor :name, :deprecation_reason, :description, :property, :hash_key, :mutation, :arguments, :complexity
+
+    # @return [Boolean] True if this is the Relay find-by-id field
+    attr_accessor :relay_node_field
+
     ensure_defined(
-      :name, :deprecation_reason, :description, :property, :hash_key, :mutation, :arguments, :complexity,
-      :resolve, :resolve=, :type, :type=, :name=, :property=, :hash_key=
+      :name, :deprecation_reason, :description, :description=, :property, :hash_key, :mutation, :arguments, :complexity,
+      :resolve, :resolve=, :type, :type=, :name=, :property=, :hash_key=,
+      :relay_node_field,
     )
 
     # @!attribute [r] resolve_proc
@@ -152,6 +158,7 @@ module GraphQL
       @complexity = 1
       @arguments = {}
       @resolve_proc = build_default_resolver
+      @relay_node_field = false
     end
 
     # Get a value for this field

--- a/lib/graphql/relay/node.rb
+++ b/lib/graphql/relay/node.rb
@@ -7,17 +7,13 @@ module GraphQL
         # We have to define it fresh each time because
         # its name will be modified and its description
         # _may_ be modified.
-        node_field = GraphQL::Field.define do
+        GraphQL::Field.define do
           type(GraphQL::Relay::Node.interface)
           description("Fetches an object given its ID.")
           argument(:id, !types.ID, "ID of the object.")
           resolve(GraphQL::Relay::Node::FindNode)
+          relay_node_field(true)
         end
-
-        # This is used to identify generated fields in the schema
-        node_field.metadata[:relay_node_field] = true
-
-        node_field
       end
 
       # @return [GraphQL::InterfaceType] The interface which all Relay types must implement

--- a/lib/graphql/schema/validation.rb
+++ b/lib/graphql/schema/validation.rb
@@ -139,7 +139,7 @@ module GraphQL
         }
 
         SCHEMA_CAN_FETCH_IDS = ->(schema) {
-          has_node_field = schema.query && schema.query.all_fields.any? { |f| f.metadata[:relay_node_field] }
+          has_node_field = schema.query && schema.query.all_fields.any?(&:relay_node_field)
           if has_node_field && schema.object_from_id_proc.nil?
             "schema contains `node(id:...)` field, so you must define a `object_from_id (id, ctx) -> { ... }` function"
           else

--- a/spec/graphql/define/instance_definable_spec.rb
+++ b/spec/graphql/define/instance_definable_spec.rb
@@ -18,6 +18,10 @@ module Garden
     # definition added later:
     attr_accessor :height
     ensure_defined(:height)
+
+    def color
+      metadata[:color]
+    end
   end
 end
 
@@ -84,14 +88,23 @@ describe GraphQL::Define::InstanceDefinable do
         name "Renamed Red Arugula"
       end
 
-      assert_equal :green, arugula.metadata[:color]
+      assert_equal :green, arugula.color
       assert_equal "Arugula", arugula.name
 
-      assert_equal :red, red_arugula.metadata[:color]
+      assert_equal :red, red_arugula.color
       assert_equal "Arugula", red_arugula.name
 
-      assert_equal :red, renamed_red_arugula.metadata[:color]
+      assert_equal :red, renamed_red_arugula.color
       assert_equal "Renamed Red Arugula", renamed_red_arugula.name
+    end
+
+    it "can be chained several times" do
+      arugula_1 = Garden::Vegetable.define(name: "Arugula") { color :green }
+      arugula_2 = arugula_1.redefine { color :red }
+      arugula_3 = arugula_2.redefine { plant_between(1..3) }
+      assert_equal ["Arugula", :green], [arugula_1.name, arugula_1.color]
+      assert_equal ["Arugula", :red], [arugula_2.name, arugula_2.color]
+      assert_equal ["Arugula", :red], [arugula_3.name, arugula_3.color]
     end
   end
 

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -252,5 +252,14 @@ type Query {
       schema.execute("query getInt($val: Int = 5, $val2: Int = 3){ int(value: $val) int2: int(value: $val2) } ")
       assert_equal [1, 2], variable_counter.counts
     end
+
+    it "can be applied after the fact" do
+      res = schema.execute("query { int(value: 2) } ")
+      assert_equal 6, res["data"]["int"]
+
+      schema.instrument(:field, MultiplyInstrumenter.new(4))
+      res = schema.execute("query { int(value: 2) } ")
+      assert_equal 24, res["data"]["int"]
+    end
   end
 end


### PR DESCRIPTION
This allows you to call `#instrument` _after_ `.define`, eg 

```ruby 
MySchema = Schema.define do 
  # ... 
end 

MySchema.instrument(:field, SomeInstrumenter)
```

It points out some issues with this approach: if an attribute wasn't assigned via `.define`, it's not copied by `redefine`. I found some bugs in the gem. I'll keep an eye out for others: if they pop up, I'll either find another way to support this API or investigate `#dup` as an implementation of `#redefine`.

cc @tmeasday


