### PR TITLE
Context tree

### DIFF
--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -55,7 +55,7 @@ module GraphQL
         field_ctx = query_ctx.spawn(
           parent_type: parent_type,
           field: field,
-          path: query_ctx.path + [irep_node.name],
+          key: irep_node.name,
           irep_node: irep_node,
           irep_nodes: irep_nodes,
         )
@@ -149,7 +149,7 @@ module GraphQL
             wrapped_type = field_type.of_type
             result = value.each_with_index.map do |inner_value, index|
               inner_ctx = field_ctx.spawn(
-                path: field_ctx.path + [index],
+                key: index,
                 irep_node: field_ctx.irep_node,
                 irep_nodes: irep_nodes,
                 parent_type: parent_type,

--- a/lib/graphql/query/serial_execution/field_resolution.rb
+++ b/lib/graphql/query/serial_execution/field_resolution.rb
@@ -12,7 +12,7 @@ module GraphQL
           @query = query_ctx.query
           @field = @query.get_field(parent_type, irep_node.definition_name)
           @field_ctx = query_ctx.spawn(
-            path: query_ctx.path + [irep_node.name],
+            key: irep_node.name,
             irep_node: irep_node,
             parent_type: parent_type,
             field: field,

--- a/lib/graphql/query/serial_execution/value_resolution.rb
+++ b/lib/graphql/query/serial_execution/value_resolution.rb
@@ -19,7 +19,7 @@ module GraphQL
               wrapped_type = field_type.of_type
               result = value.each_with_index.map do |inner_value, index|
                 inner_ctx = query_ctx.spawn(
-                  path: query_ctx.path + [index],
+                  key: index,
                   irep_node: query_ctx.irep_node,
                   parent_type: wrapped_type,
                   field: field_defn,


### PR DESCRIPTION
In a recent change, we started making a separate, immutable context object for each resolution. This makes things keep working even when they happen "out of bounds" of normal resolution. 

I wondered if there'd be any gain of _lazily_ assigning `path` instead of eagerly doing it. It looks like not. 


## Before 

```
Measure Mode: wall_time
Thread ID: 70248447613400
Fiber ID: 70248448605740
Total: 0.236249
Sort by: self_time

 %self      total      self      wait     child     calls  name
  6.37      0.036     0.015     0.000     0.021     6457  *Class#new
  4.49      0.011     0.011     0.000     0.000    12118  *GraphQL::Define::InstanceDefinable#ensure_defined
  3.75      0.009     0.009     0.000     0.000     8873   Kernel#hash
  2.73      0.006     0.006     0.000     0.000     5245   Array#first
  2.63      0.032     0.006     0.000     0.026     3496  *GraphQL::Schema::MiddlewareChain#call
  2.54      0.013     0.006     0.000     0.007     3856   #<Module:0x007fc7fc00e300>#type
  2.17      0.005     0.005     0.000     0.000     6233   <Module::GraphQL::Query::NullExcept>#call
  2.06      0.005     0.005     0.000     0.000    25361   Module#===
  1.85      0.004     0.004     0.000     0.000     4252   Kernel#class
  1.66      0.009     0.004     0.000     0.005     6233   GraphQL::Schema::Warden#visible?
  1.53      0.015     0.004     0.000     0.011     1959   GraphQL::Query::Context::FieldResolutionContext#spawn
  1.52      0.007     0.004     0.000     0.004     1812   Kernel#dup
```

## After 

```
Measure Mode: wall_time
Thread ID: 70340508391880
Fiber ID: 70340508740460
Total: 0.236074
Sort by: self_time

 %self      total      self      wait     child     calls  name
  7.54      0.037     0.018     0.000     0.019     6457  *Class#new
  5.59      0.013     0.013     0.000     0.000    12121  *GraphQL::Define::InstanceDefinable#ensure_defined
  3.41      0.008     0.008     0.000     0.000     8873   Kernel#hash
  3.15      0.034     0.007     0.000     0.026     3496  *GraphQL::Schema::MiddlewareChain#call
  2.67      0.006     0.006     0.000     0.000     5245   Array#first
  2.58      0.014     0.006     0.000     0.007     3856   #<Module:0x007ff2da883158>#type
  2.11      0.005     0.005     0.000     0.000     6233   <Module::GraphQL::Query::NullExcept>#call
  2.10      0.005     0.005     0.000     0.000    25361   Module#===
  1.99      0.015     0.005     0.000     0.011     1959   GraphQL::Query::Context::FieldResolutionContext#spawn
  1.79      0.004     0.004     0.000     0.000     4252   Kernel#class
  1.62      0.009     0.004     0.000     0.005     6233   GraphQL::Schema::Warden#visible?
  1.60      0.004     0.004     0.000     0.000     1960   GraphQL::Query::Context::FieldResolutionContext#initialize
  1.49      0.011     0.004     0.000     0.008     1864   GraphQL::Schema#get_field
```