### PR TITLE
Optimizations

### DIFF
--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -55,7 +55,7 @@ module GraphQL
         field_ctx = query_ctx.spawn(
           parent_type: parent_type,
           field: field,
-          path: query_ctx.path + [irep_node.name],
+          key: irep_node.name,
           irep_node: irep_node,
           irep_nodes: irep_nodes,
         )
@@ -149,7 +149,7 @@ module GraphQL
             wrapped_type = field_type.of_type
             result = value.each_with_index.map do |inner_value, index|
               inner_ctx = field_ctx.spawn(
-                path: field_ctx.path + [index],
+                key: index,
                 irep_node: field_ctx.irep_node,
                 irep_nodes: irep_nodes,
                 parent_type: parent_type,

--- a/lib/graphql/execution/lazy/lazy_method_map.rb
+++ b/lib/graphql/execution/lazy/lazy_method_map.rb
@@ -6,7 +6,14 @@ module GraphQL
       # The result of this lookup is cached for future resolutions.
       class LazyMethodMap
         def initialize
-          @storage = {}
+          @storage = Hash.new do |h, value_class|
+            registered_superclass = h.each_key.find { |lazy_class| value_class < lazy_class }
+            if registered_superclass.nil?
+              h[value_class] = nil
+            else
+              h[value_class] = h[registered_superclass]
+            end
+          end
         end
 
         # @param lazy_class [Class] A class which represents a lazy value (subclasses may also be used)
@@ -18,13 +25,7 @@ module GraphQL
         # @param value [Object] an object which may have a `lazy_value_method` registered for its class or superclasses
         # @return [Symbol, nil] The `lazy_value_method` for this object, or nil
         def get(value)
-          if @storage.key?(value.class)
-            @storage[value.class]
-          else
-            value_class = value.class
-            registered_superclass = @storage.each_key.find { |lazy_class| value_class < lazy_class }
-            @storage[value_class] = @storage[registered_superclass]
-          end
+          @storage[value.class]
         end
       end
     end

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -183,7 +183,8 @@ module GraphQL
     end
 
     def get_field(type, name)
-      @warden.get_field(type, name)
+      @fields ||= Hash.new { |h, k| h[k] = Hash.new { |h2, k2| h2[k2] = @warden.get_field(k, k2) } }
+      @fields[type][name]
     end
 
     def possible_types(type)

--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -59,10 +59,10 @@ module GraphQL
         @values[key] = value
       end
 
-      def spawn(path:, irep_node:, parent_type:, field:, irep_nodes:)
+      def spawn(key:, irep_node:, parent_type:, field:, irep_nodes:)
         FieldResolutionContext.new(
           context: self,
-          path: path,
+          path: path + [key],
           irep_node: irep_node,
           parent_type: parent_type,
           field: field,
@@ -103,6 +103,17 @@ module GraphQL
           error.path ||= path
           errors << error
           nil
+        end
+
+        def spawn(key:, irep_node:, parent_type:, field:, irep_nodes:)
+          FieldResolutionContext.new(
+            context: @context,
+            path: path + [key],
+            irep_node: irep_node,
+            parent_type: parent_type,
+            field: field,
+            irep_nodes: irep_nodes,
+          )
         end
       end
     end

--- a/lib/graphql/query/serial_execution/field_resolution.rb
+++ b/lib/graphql/query/serial_execution/field_resolution.rb
@@ -12,7 +12,7 @@ module GraphQL
           @query = query_ctx.query
           @field = @query.get_field(parent_type, irep_node.definition_name)
           @field_ctx = query_ctx.spawn(
-            path: query_ctx.path + [irep_node.name],
+            key: irep_node.name,
             irep_node: irep_node,
             parent_type: parent_type,
             field: field,

--- a/lib/graphql/query/serial_execution/value_resolution.rb
+++ b/lib/graphql/query/serial_execution/value_resolution.rb
@@ -19,7 +19,7 @@ module GraphQL
               wrapped_type = field_type.of_type
               result = value.each_with_index.map do |inner_value, index|
                 inner_ctx = query_ctx.spawn(
-                  path: query_ctx.path + [index],
+                  key: index,
                   irep_node: query_ctx.irep_node,
                   parent_type: wrapped_type,
                   field: field_defn,


### PR DESCRIPTION
Trying to find some low hanging fruit while checking out ruby-prof output. (I'll come for `ensure_defined` soon...)

## Before 

```
Measure Mode: wall_time
Thread ID: 70265958824400
Fiber ID: 70265955160600
Total: 0.232596
Sort by: self_time

 %self      total      self      wait     child     calls  name
  6.59      0.034     0.015     0.000     0.018     6457  *Class#new
  4.33      0.010     0.010     0.000     0.000    12118  *GraphQL::Define::InstanceDefinable#ensure_defined
  3.48      0.008     0.008     0.000     0.000     8873   Kernel#hash
  2.78      0.032     0.006     0.000     0.025     3496  *GraphQL::Schema::MiddlewareChain#call
  2.67      0.006     0.006     0.000     0.000     5245   Array#first
  2.52      0.012     0.006     0.000     0.006     3856   #<Module:0x007fd0231882b0>#type
  2.12      0.005     0.005     0.000     0.000    25361   Module#===
  2.07      0.005     0.005     0.000     0.000     6233   <Module::GraphQL::Query::NullExcept>#call
  1.80      0.004     0.004     0.000     0.000     4252   Kernel#class
  1.72      0.011     0.004     0.000     0.007     1864   GraphQL::Schema#get_field
  1.67      0.009     0.004     0.000     0.005     6233   GraphQL::Schema::Warden#visible?
  1.49      0.015     0.003     0.000     0.012     1959   GraphQL::Query::Context::FieldResolutionContext#spawn
  1.43      0.007     0.003     0.000     0.004     1748   GraphQL::Query#arguments_for
  1.40      0.003     0.003     0.000     0.000     1960   GraphQL::Query::Context::FieldResolutionContext#initialize
  1.40      0.003     0.003     0.000     0.000     4184   GraphQL::Query::Context::FieldResolutionContext#query
  1.31      0.003     0.003     0.000     0.000     1864   GraphQL::Schema::InstrumentedFieldMap#get
  1.30      0.005     0.003     0.000     0.002     2180   #<Module:0x007fd02289bd28>#name
  1.29      0.012     0.003     0.000     0.009     1748   GraphQL::Execution::Lazy::LazyMethodMap#get
```

## After 

```
Measure Mode: wall_time
Thread ID: 70277623192040
Fiber ID: 70277623042200
Total: 0.193297
Sort by: self_time

 %self      total      self      wait     child     calls  name
  7.53      0.033     0.015     0.000     0.018     6465  *Class#new
  4.46      0.009     0.009     0.000     0.000     8880   Kernel#hash
  3.71      0.007     0.007     0.000     0.000     8688  *GraphQL::Define::InstanceDefinable#ensure_defined
  3.51      0.033     0.007     0.000     0.026     3496  *GraphQL::Schema::MiddlewareChain#call
  3.33      0.006     0.006     0.000     0.000     5245   Array#first
  2.34      0.005     0.005     0.000     0.000    25361   Module#===
  1.75      0.011     0.003     0.000     0.008     1959   GraphQL::Query::Context::FieldResolutionContext#spawn
  1.71      0.003     0.003     0.000     0.000     1960   GraphQL::Query::Context::FieldResolutionContext#initialize
  1.67      0.003     0.003     0.000     0.000     4184   GraphQL::Query::Context::FieldResolutionContext#query
  1.62      0.007     0.003     0.000     0.003     2141   #<Module:0x007fd59306fe80>#type
  1.53      0.005     0.003     0.000     0.002     1048   Kernel#public_send
  1.47      0.007     0.003     0.000     0.004     1748   GraphQL::Query#arguments_for
  1.37      0.005     0.003     0.000     0.003     1748   GraphQL::Query#get_field
  1.26      0.002     0.002     0.000     0.000     2504   Kernel#class
  1.21      0.006     0.002     0.000     0.003     1812   Kernel#dup
  1.19      0.014     0.002     0.000     0.012     1748   GraphQL::Field#resolve
  1.18      0.002     0.002     0.000     0.000     6596   Kernel#is_a?
  1.15      0.002     0.002     0.000     0.000     2803   <Module::GraphQL::Query::NullExcept>#call
  1.12      0.006     0.002     0.000     0.004     1748   GraphQL::Execution::Lazy::LazyMethodMap#get
```