### PR TITLE
convert enum type values to names for error messages

### DIFF
--- a/lib/graphql/enum_type.rb
+++ b/lib/graphql/enum_type.rb
@@ -149,6 +149,10 @@ module GraphQL
       accepts_definitions(*ATTRIBUTES)
       attr_accessor(*ATTRIBUTES)
       ensure_defined(*ATTRIBUTES)
+
+      def to_s
+        name
+      end
     end
 
     class UnresolvedValueError < GraphQL::Error

--- a/spec/graphql/enum_type_spec.rb
+++ b/spec/graphql/enum_type_spec.rb
@@ -75,6 +75,10 @@ describe GraphQL::EnumType do
 
     it "returns an invalid result" do
       assert(!result.valid?)
+      assert_equal(
+        result.problems.first['explanation'],
+        "Expected \"bad enum\" to be one of: COW, DONKEY, GOAT, REINDEER, SHEEP, YAK"
+      )
     end
   end
 


### PR DESCRIPTION
In error messages for `EnumType#validate_non_null_input`, display the enum value names instead of the default ruby object representation.