### PR TITLE
Returning a GraphQL::ExecutionError in a mutation with return_fields …

### DIFF
--- a/lib/graphql/relay/mutation.rb
+++ b/lib/graphql/relay/mutation.rb
@@ -148,6 +148,7 @@ module GraphQL
         attr_reader :client_mutation_id
         def initialize(client_mutation_id:, result:)
           @client_mutation_id = client_mutation_id
+          raise result if result.is_a? GraphQL::ExecutionError
           result.each do |key, value|
             self.public_send("#{key}=", value)
           end

--- a/spec/graphql/relay/mutation_spec.rb
+++ b/spec/graphql/relay/mutation_spec.rb
@@ -160,4 +160,22 @@ describe GraphQL::Relay::Mutation do
       assert_equal "String", input.arguments['stringDefault'].default_value
     end
   end
+  
+  describe "handling errors" do
+    it "supports returning an error in resolve" do
+      result = star_wars_query(query_string, "clientMutationId" => "5678", "shipName" => "Millennium Falcon")
+
+      expected = { "data" => {
+          "introduceShip" => nil
+        } , "errors" => [
+          { "message" => "Sorry, Millennium Falcon ship is reserved",
+              "locations" => [ { "line" => 3 , "column" => 7}],
+              "path" => ["introduceShip"]
+            }
+        ]
+      }
+      
+      assert_equal(expected, result)
+    end
+  end
 end

--- a/spec/support/star_wars_schema.rb
+++ b/spec/support/star_wars_schema.rb
@@ -157,6 +157,7 @@ IntroduceShipMutation = GraphQL::Relay::Mutation.define do
   # Here's the mutation operation:
   resolve ->(root_obj, inputs, ctx) {
     faction_id = inputs["factionId"]
+    return GraphQL::ExecutionError.new("Sorry, Millennium Falcon ship is reserved") if inputs["shipName"] == 'Millennium Falcon'
     ship = STAR_WARS_DATA.create_ship(inputs["shipName"], faction_id)
     faction = STAR_WARS_DATA["Faction"][faction_id]
     connection_class = GraphQL::Relay::BaseConnection.connection_for_nodes(faction.ships)


### PR DESCRIPTION
…works as expected.