### PR TITLE
Add validation rule for unique directives per location

### DIFF
--- a/lib/graphql/static_validation/all_rules.rb
+++ b/lib/graphql/static_validation/all_rules.rb
@@ -8,6 +8,7 @@ module GraphQL
     ALL_RULES = [
       GraphQL::StaticValidation::DirectivesAreDefined,
       GraphQL::StaticValidation::DirectivesAreInValidLocations,
+      GraphQL::StaticValidation::UniqueDirectivesPerLocation,
       GraphQL::StaticValidation::FragmentsAreFinite,
       GraphQL::StaticValidation::FragmentsAreNamed,
       GraphQL::StaticValidation::FragmentsAreUsed,

--- a/lib/graphql/static_validation/message.rb
+++ b/lib/graphql/static_validation/message.rb
@@ -1,23 +1,22 @@
 module GraphQL
   module StaticValidation
     # Generates GraphQL-compliant validation message.
-    # Only supports one "location", too bad :(
     class Message
       # Convenience for validators
       module MessageHelper
         # Error `message` is located at `node`
-        def message(message, node, context: nil, path: nil)
+        def message(message, nodes, context: nil, path: nil)
           path ||= context.path
-          GraphQL::StaticValidation::Message.new(message, line: node.line, col: node.col, path: path)
+          nodes = Array(nodes)
+          GraphQL::StaticValidation::Message.new(message, nodes: nodes, path: path)
         end
       end
 
-      attr_reader :message, :line, :col, :path
+      attr_reader :message, :path
 
-      def initialize(message, line: nil, col: nil, path: [])
+      def initialize(message, path: [], nodes: [])
         @message = message
-        @line = line
-        @col = col
+        @nodes = nodes
         @path = path
       end
 
@@ -33,7 +32,7 @@ module GraphQL
       private
 
       def locations
-        @line.nil? && @col.nil? ? [] : [{"line" => @line, "column" => @col}]
+        @nodes.map{|node| {"line" => node.line, "column" => node.col}}
       end
     end
   end

--- a/lib/graphql/static_validation/rules/unique_directives_per_location.rb
+++ b/lib/graphql/static_validation/rules/unique_directives_per_location.rb
@@ -1,0 +1,38 @@
+module GraphQL
+  module StaticValidation
+    class UniqueDirectivesPerLocation
+      include GraphQL::StaticValidation::Message::MessageHelper
+
+      def validate(context)
+        nodes_with_directives = GraphQL::Language::Nodes.constants
+          .map{|c| GraphQL::Language::Nodes.const_get(c)}
+          .select{|c| c.is_a?(Class) && c.instance_methods.include?(:directives)}
+
+        nodes_with_directives.each do |node_class|
+          context.visitor[node_class] << ->(node, _) {
+            validate_directives(node, context) unless node.directives.empty?
+          }
+        end
+      end
+
+      private
+
+      def validate_directives(node, context)
+        used_directives = {}
+
+        node.directives.each do |ast_directive|
+          directive_name = ast_directive.name
+          if used_directives[directive_name]
+            context.errors << message(
+              "The directive \"#{directive_name}\" can only be used once at this location.",
+              [used_directives[directive_name], ast_directive],
+              context: context
+            )
+          else
+            used_directives[directive_name] = ast_directive
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/static_validation/rules/unique_directives_per_location.rb
+++ b/lib/graphql/static_validation/rules/unique_directives_per_location.rb
@@ -3,12 +3,12 @@ module GraphQL
     class UniqueDirectivesPerLocation
       include GraphQL::StaticValidation::Message::MessageHelper
 
-      def validate(context)
-        nodes_with_directives = GraphQL::Language::Nodes.constants
-          .map{|c| GraphQL::Language::Nodes.const_get(c)}
-          .select{|c| c.is_a?(Class) && c.instance_methods.include?(:directives)}
+      NODES_WITH_DIRECTIVES = GraphQL::Language::Nodes.constants
+        .map{|c| GraphQL::Language::Nodes.const_get(c)}
+        .select{|c| c.is_a?(Class) && c.instance_methods.include?(:directives)}
 
-        nodes_with_directives.each do |node_class|
+      def validate(context)
+        NODES_WITH_DIRECTIVES.each do |node_class|
           context.visitor[node_class] << ->(node, _) {
             validate_directives(node, context) unless node.directives.empty?
           }

--- a/spec/graphql/static_validation/rules/unique_directives_per_location_spec.rb
+++ b/spec/graphql/static_validation/rules/unique_directives_per_location_spec.rb
@@ -1,0 +1,180 @@
+require "spec_helper"
+
+describe GraphQL::StaticValidation::UniqueDirectivesPerLocation do
+  include StaticValidationHelpers
+
+  let(:schema) { GraphQL::Schema.from_definition("
+    type Query {
+      type: Type
+    }
+
+    type Type {
+      field: String
+    }
+
+    directive @A on FIELD
+    directive @B on FIELD
+  ") }
+
+  describe "query with no directives" do
+    let(:query_string) {"
+      {
+        type {
+          field
+        }
+      }
+    "}
+
+    it "passes rule" do
+      assert_equal [], errors
+    end
+  end
+
+  describe "query with unique directives in different locations" do
+    let(:query_string) {"
+      {
+        type @A {
+          field @B
+        }
+      }
+    "}
+
+    it "passes rule" do
+      assert_equal [], errors
+    end
+  end
+
+  describe "query with unique directives in same locations" do
+    let(:query_string) {"
+      {
+        type @A @B {
+          field @A @B
+        }
+      }
+    "}
+
+    it "passes rule" do
+      assert_equal [], errors
+    end
+  end
+
+  describe "query with same directives in different locations" do
+    let(:query_string) {"
+      {
+        type @A {
+          field @A
+        }
+      }
+    "}
+
+    it "passes rule" do
+      assert_equal [], errors
+    end
+  end
+
+  describe "query with same directives in similar locations" do
+    let(:query_string) {"
+      {
+        type {
+          field @A
+          field @A
+        }
+      }
+    "}
+
+    it "passes rule" do
+      assert_equal [], errors
+    end
+  end
+
+  describe "query with duplicate directives in one location" do
+    let(:query_string) {"
+      {
+        type {
+          field @A @A
+        }
+      }
+    "}
+
+    it "fails rule" do
+      assert_includes errors, {
+        "message" => 'The directive "A" can only be used once at this location.',
+        "locations" => [{ "line" => 4, "column" => 17 }, { "line" => 4, "column" => 20 }],
+        "fields" => ["query", "type", "field"],
+      }
+    end
+  end
+
+
+  describe "query with many duplicate directives in one location" do
+    let(:query_string) {"
+      {
+        type {
+          field @A @A @A
+        }
+      }
+    "}
+
+    it "fails rule" do
+      assert_includes errors, {
+        "message" => 'The directive "A" can only be used once at this location.',
+        "locations" => [{ "line" => 4, "column" => 17 }, { "line" => 4, "column" => 20 }],
+        "fields" => ["query", "type", "field"],
+      }
+
+      assert_includes errors, {
+        "message" => 'The directive "A" can only be used once at this location.',
+        "locations" => [{ "line" => 4, "column" => 17 }, { "line" => 4, "column" => 23 }],
+        "fields" => ["query", "type", "field"],
+      }
+    end
+  end
+
+  describe "query with different duplicate directives in one location" do
+    let(:query_string) {"
+      {
+        type {
+          field @A @B @A @B
+        }
+      }
+    "}
+
+    it "fails rule" do
+      assert_includes errors, {
+        "message" => 'The directive "A" can only be used once at this location.',
+        "locations" => [{ "line" => 4, "column" => 17 }, { "line" => 4, "column" => 23 }],
+        "fields" => ["query", "type", "field"],
+      }
+
+      assert_includes errors, {
+        "message" => 'The directive "B" can only be used once at this location.',
+        "locations" => [{ "line" => 4, "column" => 20 }, { "line" => 4, "column" => 26 }],
+        "fields" => ["query", "type", "field"],
+      }
+    end
+  end
+
+  describe "query with duplicate directives in many locations" do
+    let(:query_string) {"
+      {
+        type @A @A {
+          field @A @A
+        }
+      }
+    "}
+
+    it "fails rule" do
+      assert_includes errors, {
+        "message" => 'The directive "A" can only be used once at this location.',
+        "locations" => [{ "line" => 3, "column" => 14 }, { "line" => 3, "column" => 17 }],
+        "fields" => ["query", "type"],
+      }
+
+      assert_includes errors, {
+        "message" => 'The directive "A" can only be used once at this location.',
+        "locations" => [{ "line" => 4, "column" => 17 }, { "line" => 4, "column" => 20 }],
+        "fields" => ["query", "type", "field"],
+      }
+    end
+  end
+end


### PR DESCRIPTION
This implements facebook/graphql#229, in order to adhere with the October 2016 edition of the spec.

ref. implementation: graphql/graphql-js#552

:eyes: @rmosolgo 