### PR TITLE
test(Connection) assert that connection helper doesn't modify passed-in field

### DIFF
--- a/lib/graphql/relay/connection_field.rb
+++ b/lib/graphql/relay/connection_field.rb
@@ -27,7 +27,7 @@ module GraphQL
       # Turn A GraphQL::Field into a connection by:
       # - Merging in the default arguments
       # - Transforming its resolve function to return a connection object
-      # @param [GraphQL::Field] A field which returns nodes to be wrapped as a connection
+      # @param underlying_field [GraphQL::Field] A field which returns nodes to be wrapped as a connection
       # @param max_page_size [Integer] The maximum number of nodes which may be requested (if a larger page is requested, it is limited to this number)
       # @return [GraphQL::Field] The same field, modified to resolve to a connection object
       def self.create(underlying_field, max_page_size: nil)

--- a/spec/graphql/relay/connection_field_spec.rb
+++ b/spec/graphql/relay/connection_field_spec.rb
@@ -9,4 +9,26 @@ describe GraphQL::Relay::ConnectionField do
 
     assert_equal ["tests"], test_type.fields.keys
   end
+
+  it "leaves the original field untouched" do
+    test_type = nil
+
+    test_field = GraphQL::Field.define do
+      type(test_type.connection_type)
+      property(:something)
+    end
+
+    test_type = GraphQL::ObjectType.define do
+      name "Test"
+      connection :tests, test_field
+    end
+
+    conn_field = test_type.fields["tests"]
+
+    assert_equal 0, test_field.arguments.length
+    assert_equal 4, conn_field.arguments.length
+
+    assert_instance_of GraphQL::Field::Resolve::MethodResolve, test_field.resolve_proc
+    assert_instance_of GraphQL::Relay::ConnectionResolve, conn_field.resolve_proc
+  end
 end


### PR DESCRIPTION
This isn't really a fix, just a test that this doesn't mess with the Field instance anymore (it's shallow-copied by the `field` helper)