### PR TITLE
feat(Query) run after_query hooks even if an error occurs

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -254,6 +254,7 @@ module GraphQL
       def call
         @instrumenters.each { |i| i.before_query(@query) }
         result = get_result
+      ensure
         @instrumenters.each { |i| i.after_query(@query) }
         result
       end


### PR DESCRIPTION
With this change, `after_query` hooks are _always_ run, even if the query raises a Runtime error