### PR TITLE
Allow feature detection on DefinedObjectProxy

### DIFF
--- a/lib/graphql/define/defined_object_proxy.rb
+++ b/lib/graphql/define/defined_object_proxy.rb
@@ -20,6 +20,11 @@ module GraphQL
         end
       end
 
+      def respond_to_missing?(name, include_private = false)
+        return true if @dictionary[name]
+        super
+      end
+
       def to_s
         inspect
       end


### PR DESCRIPTION
## Problem

I would like to run the graphql-batch tests against both graphql-ruby master and the latest release, however, the version hasn't been bumped on graphql-ruby master and I wasn't able to get this feature detection to work.

```ruby
has_lazy_resolve = nil
GraphQL::Schema.define do
  has_lazy_resolve = respond_to?(:lazy_resolve)
end
```

The problem was that inside the `GraphQL::Schema.define` block `self` is a DefinedObjectProxy object that defines `method_missing` to support methods like `lazy_resolve` but it doesn't implement `respond_to_missing?` to support `respond_to?`

## Solution

Add a `respond_to_missing?` method to DefinedObjectProxy to return true for proxied methods