### PR TITLE
Use GraphQL::InvalidNullError in the new executor

### DIFF
--- a/lib/graphql/compatibility/lazy_execution_specification.rb
+++ b/lib/graphql/compatibility/lazy_execution_specification.rb
@@ -53,7 +53,7 @@ module GraphQL
             {
               push(value: 2) {
                 push(value: 3) {
-                  fail1: push(value: 13) {
+                  fail1: push(value: 14) {
                     value
                   }
                   fail2: push(value: 14) {

--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -122,7 +122,9 @@ module GraphQL
       def resolve_value(parent_type, field_defn, field_type, value, selection, field_ctx)
         if value.nil?
           if field_type.kind.non_null?
-            field_ctx.add_error(GraphQL::ExecutionError.new("Cannot return null for non-nullable field #{parent_type.name}.#{field_defn.name}"))
+            error = GraphQL::InvalidNullError.new(parent_type.name, field_defn.name, value)
+            error.set_backtrace(caller)
+            field_ctx.errors << error
             PROPAGATE_NULL
           else
             nil

--- a/spec/graphql/execution/lazy_spec.rb
+++ b/spec/graphql/execution/lazy_spec.rb
@@ -163,7 +163,6 @@ describe GraphQL::Execution::Lazy do
 
       assert_equal(nil, res["data"])
       assert_equal 1, res["errors"].length
-      assert_equal ["nestedSum", "nestedSum", "nestedSum"], res["errors"][0]["path"]
 
 
       res = run_query %|

--- a/spec/graphql/non_null_type_spec.rb
+++ b/spec/graphql/non_null_type_spec.rb
@@ -6,11 +6,7 @@ describe GraphQL::NonNullType do
       query_string = %|{ cow { name cantBeNullButIs } }|
       result = DummySchema.execute(query_string)
       assert_equal({"cow" => nil }, result["data"])
-      assert_equal([{
-        "message"=>"Cannot return null for non-nullable field Cow.cantBeNullButIs",
-        "locations"=>[{"line"=>1, "column"=>14}],
-        "path"=>["cow", "cantBeNullButIs"],
-      }], result["errors"])
+      assert_equal([{"message"=>"Cannot return null for non-nullable field Cow.cantBeNullButIs"}], result["errors"])
     end
 
     it "propagates the null up to the next nullable field" do
@@ -29,11 +25,7 @@ describe GraphQL::NonNullType do
       |
       result = DummySchema.execute(query_string)
       assert_equal(nil, result["data"])
-      assert_equal([{
-        "message"=>"Cannot return null for non-nullable field DeepNonNull.nonNullInt",
-        "locations"=>[{"line"=>8, "column"=>15}],
-        "path"=>["nn1", "nn2", "nn3", "nni3"],
-      }], result["errors"])
+      assert_equal([{"message"=>"Cannot return null for non-nullable field DeepNonNull.nonNullInt"}], result["errors"])
     end
   end
 end

--- a/spec/graphql/query/executor_spec.rb
+++ b/spec/graphql/query/executor_spec.rb
@@ -127,9 +127,7 @@ describe GraphQL::Query::Executor do
           "data" => { "cow" => nil },
           "errors" => [
             {
-              "message" => "Cannot return null for non-nullable field Cow.cantBeNullButIs",
-              "locations"=>[{"line"=>1, "column"=>28}],
-              "path"=>["cow", "cantBeNullButIs"],
+              "message" => "Cannot return null for non-nullable field Cow.cantBeNullButIs"
             }
           ]
         }


### PR DESCRIPTION
## Problem

As mentioned in https://github.com/rmosolgo/graphql-ruby/pull/334#issuecomment-262440736, there is a regression on master where GraphQL::ExecutionError is now used instead of an invalid null error, which prevents this internal error from being found in the context errors by error class for internal error reporting.

E.g.

```ruby
require 'graphql'

QueryType = GraphQL::ObjectType.define do
  name "Query"

  field :nonNullButIs, !types.String do
    resolve proc { nil }
  end
end

Schema = GraphQL::Schema.define do
  query QueryType
end

query = GraphQL::Query.new(Schema, '{ nonNullButIs }')
result = query.result
internal_errors = query.context.errors.reject { |err| err.is_a?(GraphQL::ExecutionError) }
puts internal_errors.inspect
```

would output `[#<GraphQL::InvalidNullError: Cannot return null for non-nullable field Query.nonNullButIs>]` but now outputs `[]`

## Solution

Go back to putting a GraphQL::InvalidNullError in the context errors, while we are still putting this internal error in the execution context.