### PR TITLE
Type error hook

### DIFF
--- a/guides/schema/configuration_options.md
+++ b/guides/schema/configuration_options.md
@@ -98,6 +98,8 @@ If you don't specify a hook, you get the default behavior:
 - Unexpected nulls add an error the response's `"errors"` key
 - Unresolved Union / Interface types raise {{ "GraphQL::UnresolvedTypeError" | api_doc }}
 
+An object that fails type resolution is treated as `nil`.
+
 ## Security Options
 
 These options can prevent execution of malicious queries.

--- a/guides/schema/configuration_options.md
+++ b/guides/schema/configuration_options.md
@@ -7,6 +7,7 @@ Many things can be added to a GraphQL schema. They fall into a few categories:
 - Data entry points: `query`, `mutation`, `subscription`
 - Manually adding types: `orphan_types`
 - Execution functions: `resolve_type`, `id_from_object`, `object_from_id`
+- Type error handling: `type_error`
 - Security options: `max_depth`, `max_complexity`
 - Middleware: `middleware`
 - Query analyzers: `query_analyzer`
@@ -67,6 +68,35 @@ end
 ```
 
 See ["Object Identification"]({{ site.baseurl }}/relay/object_identification) for more information about Relay IDs.
+
+## Type Error Handling
+
+In some cases, runtime data can cause GraphQL execution to reach an invalid state:
+
+- A `resolve` function returned `nil` for a non-null type
+- A `resolve` function's value couldn't be resolved to a valid Union or Interface member ({{ "Schema#resolve_type" | api_doc }} returned an unexpected value)
+
+You can specify behavior in these cases by defining a {{ "Schema#type_error" | api_doc }} hook:
+
+```ruby
+MySchema = GraphQL::Schema.define do
+  type_error ->(value, field, parent_type, query_ctx) {
+    # Handle a failed runtime type coercion
+  }
+end
+```
+
+It is called with four parameters:
+
+- `value` is the runtime value which was unexpected
+- `field` is the {{ "GraphQL::Field" | api_doc }} whose `resolve` function returned `value`
+- `parent_type` is the type that `field` belongs to
+- `query_ctx` is the same `ctx` which was provided to the resolve function
+
+If you don't specify a hook, you get the default behavior:
+
+- Unexpected nulls add an error the response's `"errors"` key
+- Unresolved Union / Interface types raise {{ "GraphQL::UnresolvedTypeError" | api_doc }}
 
 ## Security Options
 

--- a/lib/graphql/compatibility/execution_specification/specification_schema.rb
+++ b/lib/graphql/compatibility/execution_specification/specification_schema.rb
@@ -135,6 +135,13 @@ module GraphQL
               }
             end
 
+            field :requiredNode, node_union_type.to_non_null_type do
+              argument :id, !types.ID
+              resolve ->(obj, args, ctx) {
+                obj[args[:id]]
+              }
+            end
+
             field :organization, !organization_type do
               argument :id, !types.ID
               resolve ->(obj, args, ctx) {
@@ -165,9 +172,8 @@ module GraphQL
 
             type_error ->(val, field, type, ctx) {
               ctx[:type_errors] && (ctx[:type_errors] << val)
-              GraphQL::Schema::DefaultTypeError.call(val, field, type, ctx)
+              ctx[:gobble] || GraphQL::Schema::DefaultTypeError.call(val, field, type, ctx)
             }
-
             middleware(TestMiddleware)
           end
         end

--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -122,9 +122,7 @@ module GraphQL
       def resolve_value(parent_type, field_defn, field_type, value, selection, field_ctx)
         if value.nil?
           if field_type.kind.non_null?
-            error = GraphQL::InvalidNullError.new(parent_type.name, field_defn.name, value)
-            error.set_backtrace(caller)
-            field_ctx.errors << error
+            field_ctx.schema.type_error(value, field_defn, parent_type, field_ctx)
             PROPAGATE_NULL
           else
             nil
@@ -185,7 +183,7 @@ module GraphQL
             possible_types = query.possible_types(field_type)
 
             if !possible_types.include?(resolved_type)
-              raise GraphQL::UnresolvedTypeError.new(selection.definition_name, field_type, parent_type, resolved_type, possible_types)
+              field_ctx.schema.type_error(value, field_defn, parent_type, field_ctx)
             else
               resolve_value(
                 parent_type,

--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -162,7 +162,7 @@ module GraphQL
             result
           when GraphQL::TypeKinds::NON_NULL
             wrapped_type = field_type.of_type
-            resolve_value(
+            inner_value = resolve_value(
               parent_type,
               field_defn,
               wrapped_type,
@@ -170,6 +170,11 @@ module GraphQL
               selection,
               field_ctx,
             )
+            if inner_value.nil?
+              PROPAGATE_NULL
+            else
+              inner_value
+            end
           when GraphQL::TypeKinds::OBJECT
             resolve_selection(
               value,
@@ -184,6 +189,7 @@ module GraphQL
 
             if !possible_types.include?(resolved_type)
               field_ctx.schema.type_error(value, field_defn, parent_type, field_ctx)
+              PROPAGATE_NULL
             else
               resolve_value(
                 parent_type,

--- a/lib/graphql/query/serial_execution/field_resolution.rb
+++ b/lib/graphql/query/serial_execution/field_resolution.rb
@@ -52,23 +52,14 @@ module GraphQL
             end
           end
 
-          begin
-            GraphQL::Query::SerialExecution::ValueResolution.resolve(
-              parent_type,
-              field,
-              field.type,
-              raw_value,
-              @selection,
-              @field_ctx,
-            )
-          rescue GraphQL::InvalidNullError => err
-            if field.type.kind.non_null?
-              raise(err)
-            else
-              err.parent_error? || @query.context.errors.push(err)
-              nil
-            end
-          end
+          GraphQL::Query::SerialExecution::ValueResolution.resolve(
+            parent_type,
+            field,
+            field.type,
+            raw_value,
+            @selection,
+            @field_ctx,
+          )
         end
 
         # Get the result of:

--- a/lib/graphql/query/serial_execution/selection_resolution.rb
+++ b/lib/graphql/query/serial_execution/selection_resolution.rb
@@ -13,7 +13,7 @@ module GraphQL
               query_ctx
             ).result
 
-            if field_result.values.any? { |v| v == GraphQL::Execution::Execute::PROPAGATE_NULL }
+            if field_result.values[0] == GraphQL::Execution::Execute::PROPAGATE_NULL
               selection_result = nil
               break
             else

--- a/lib/graphql/query/serial_execution/selection_resolution.rb
+++ b/lib/graphql/query/serial_execution/selection_resolution.rb
@@ -6,12 +6,19 @@ module GraphQL
           selection_result = {}
 
           selection.each_selection(type: current_type) do |name, subselection|
-            selection_result.merge!(query_ctx.execution_strategy.field_resolution.new(
+            field_result = query_ctx.execution_strategy.field_resolution.new(
               subselection,
               current_type,
               target,
               query_ctx
-            ).result)
+            ).result
+
+            if field_result.values.any? { |v| v == GraphQL::Execution::Execute::PROPAGATE_NULL }
+              selection_result = nil
+              break
+            else
+              selection_result.merge!(field_result)
+            end
           end
 
           selection_result

--- a/lib/graphql/query/serial_execution/value_resolution.rb
+++ b/lib/graphql/query/serial_execution/value_resolution.rb
@@ -42,7 +42,7 @@ module GraphQL
               result
             when GraphQL::TypeKinds::NON_NULL
               wrapped_type = field_type.of_type
-              resolve(
+              required_value = resolve(
                 parent_type,
                 field_defn,
                 wrapped_type,
@@ -50,6 +50,11 @@ module GraphQL
                 selection,
                 query_ctx,
               )
+              if required_value.nil?
+                GraphQL::Execution::Execute::PROPAGATE_NULL
+              else
+                required_value
+              end
             when GraphQL::TypeKinds::OBJECT
               query_ctx.execution_strategy.selection_resolution.resolve(
                 value,
@@ -64,6 +69,7 @@ module GraphQL
 
               if !possible_types.include?(resolved_type)
                 query.schema.type_error(value, field_defn, parent_type, query_ctx)
+                nil
               else
                 resolve(
                   parent_type,

--- a/lib/graphql/schema/default_type_error.rb
+++ b/lib/graphql/schema/default_type_error.rb
@@ -1,0 +1,19 @@
+module GraphQL
+  class Schema
+    module DefaultTypeError
+      def self.call(value, field, parent_type, query_ctx)
+        if field.type.kind.non_null?
+          if value.nil?
+            query_ctx.errors << GraphQL::InvalidNullError.new(parent_type.name, field.name, value)
+          else
+            # it was caused by GraphQL::ExecutionError
+          end
+        else
+          resolved_type = query_ctx.query.resolve_type(value)
+          possible_types = query_ctx.query.possible_types(field.type.unwrap)
+          raise GraphQL::UnresolvedTypeError.new(field.name, field.type, parent_type, resolved_type, possible_types)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
There are a few judgment calls made by library internals that could be customized by users: 

- What to do when we get `nil` for a non-null type (currently, the library adds an error to the errors key) 
- What to do when a union/interface object can't be resolved to a member type (currently, the library :boom:s) 

This PR adds a hook for those two cases, with the default implementation being the current behavior. 

In the future, this hook could be expanded to handle more cases, like scalar coercion. 