### PR TITLE
feat(Execution::Lazy) support lazy connection values

### DIFF
--- a/lib/graphql/compatibility/lazy_execution_specification.rb
+++ b/lib/graphql/compatibility/lazy_execution_specification.rb
@@ -108,6 +108,34 @@ module GraphQL
             ]
             assert_equal expected_pushes, pushes
           end
+
+          def test_it_resolves_lazy_connections
+            pushes = []
+            query_str = %|
+            {
+              pushes(values: [1,2,3]) {
+                edges {
+                  node {
+                    value
+                    push(value: 4) {
+                      value
+                    }
+                  }
+                }
+              }
+            }
+            |
+            res = self.class.lazy_schema.execute(query_str, context: {pushes: pushes})
+
+            expected_edges = [
+              {"node"=>{"value"=>1, "push"=>{"value"=>4}}},
+              {"node"=>{"value"=>2, "push"=>{"value"=>4}}},
+              {"node"=>{"value"=>3, "push"=>{"value"=>4}}},
+            ]
+            assert_equal expected_edges, res["data"]["pushes"]["edges"]
+            assert_equal [[1, 2, 3], [4, 4, 4]], pushes
+
+          end
         end
       end
     end

--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -76,7 +76,11 @@ module GraphQL
 
         lazy_method_name = query.lazy_method(raw_value)
         result = if lazy_method_name
-          GraphQL::Execution::Lazy.new { raw_value.public_send(lazy_method_name) }.then { |inner_value|
+          GraphQL::Execution::Lazy.new(raw_value, lazy_method_name).then { |inner_value|
+            continue_resolve_field(selection, parent_type, field, inner_value, field_ctx)
+          }
+        elsif raw_value.is_a?(GraphQL::Execution::Lazy)
+          raw_value.then { |inner_value|
             continue_resolve_field(selection, parent_type, field, inner_value, field_ctx)
           }
         else

--- a/lib/graphql/execution/lazy.rb
+++ b/lib/graphql/execution/lazy.rb
@@ -18,9 +18,16 @@ module GraphQL
       end
 
       # Create a {Lazy} which will get its inner value by calling the block
+      # @param target [Object]
+      # @param method_name [Symbol]
       # @param get_value_func [Proc] a block to get the inner value (later)
-      def initialize(&get_value_func)
-        @get_value_func = get_value_func
+      def initialize(target = nil, method_name = nil, &get_value_func)
+        if block_given?
+          @get_value_func = get_value_func
+        else
+          @target = target
+          @method_name = method_name
+        end
         @resolved = false
       end
 
@@ -28,7 +35,11 @@ module GraphQL
       def value
         if !@resolved
           @resolved = true
-          @value = @get_value_func.call
+          if @get_value_func
+            @value = @get_value_func.call
+          else
+            @value = @target.public_send(@method_name)
+          end
         end
         @value
       rescue GraphQL::ExecutionError => err


### PR DESCRIPTION
The forthcoming `lazy_resolve` feature should play nice with connections: if you provide a connection resolve function and it's a registered lazy object, we'll treat it lazily, then continue with a connection object wrapping the lazily-resolved nodes.

Fixes #420 