### PR TITLE
Uphold spec for reserved `__` naming

### DIFF
--- a/spec/graphql/schema/validation_spec.rb
+++ b/spec/graphql/schema/validation_spec.rb
@@ -13,6 +13,13 @@ describe GraphQL::Schema::Validation do
       end
     }
 
+    let(:invalid_name_field) {
+      GraphQL::Field.define do
+        name "__Something"
+        type GraphQL::STRING_TYPE
+      end
+    }
+
     let(:untyped_field) {
       GraphQL::Field.define do
         name "Untyped"
@@ -44,6 +51,10 @@ describe GraphQL::Schema::Validation do
       assert_error_includes unnamed_field, "must return String, not NilClass"
     end
 
+    it "cannot use reserved name" do
+      assert_error_includes invalid_name_field, 'Name "__Something" must not begin with "__", which is reserved by GraphQL introspection.'
+    end
+
     it "requires a BaseType for type" do
       assert_error_includes untyped_field, "must return GraphQL::BaseType, not Symbol"
     end
@@ -64,14 +75,25 @@ describe GraphQL::Schema::Validation do
       end
     }
 
+    let(:invalid_name_type) {
+      GraphQL::BaseType.define do
+        name '__Something'
+      end
+    }
+
     let(:wrongly_described_type) {
       GraphQL::BaseType.define do
         name "WronglyDescribed"
         description 12345
       end
     }
+
     it "requires a String name" do
       assert_error_includes unnamed_type, "must return String, not Symbol"
+    end
+
+    it "cannot use reserved name" do
+      assert_error_includes invalid_name_type, 'Name "__Something" must not begin with "__", which is reserved by GraphQL introspection.'
     end
 
     it "requires String-or-nil description" do
@@ -86,6 +108,7 @@ describe GraphQL::Schema::Validation do
         interfaces(55)
       end
     }
+
     let(:invalid_interface_member_object) {
       GraphQL::ObjectType.define do
         name "InvalidInterfaceMember"
@@ -208,6 +231,13 @@ describe GraphQL::Schema::Validation do
       end
     }
 
+    let(:invalid_name_argument) {
+      GraphQL::Argument.define do
+        name "__Something"
+        type GraphQL::INT_TYPE
+      end
+    }
+
     let(:null_default_value) {
       GraphQL::Argument.define do
         name "NullDefault"
@@ -222,6 +252,10 @@ describe GraphQL::Schema::Validation do
 
     it "does not allow default values for non-null argument" do
       assert_error_includes invalid_default_argument_for_non_null_argument, 'Variable InvalidDefault of type "Int!" is required and will not use the default value. Perhaps you meant to use type "Int".'
+    end
+
+    it "cannot use reserved name" do
+      assert_error_includes invalid_name_argument, 'Name "__Something" must not begin with "__", which is reserved by GraphQL introspection.'
     end
 
     it "allows null default value for nullable argument" do


### PR DESCRIPTION
Ref: https://github.com/graphql/graphql-js/pull/600

> GraphQL type system authors must not define any types, fields, arguments, or any other type system artifact with two leading underscores.

Spec: http://facebook.github.io/graphql/#sec-Naming-conventions

---

This PR enforces type, argument, and field names cannot begin with `__`.

:eyes: @rmosolgo 