### PR TITLE
Enable Frozen String Literals

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,9 @@ Style/ClassAndModuleChildren:
 Style/EmptyLineBetweenDefs:
   AllowAdjacentOneLineDefs: true
 
+Style/FrozenStringLiteralComment:
+  Enabled: true
+
 Style/IndentationWidth:
   Width: 2
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 source "https://rubygems.org"
 gemspec

--- a/Guardfile
+++ b/Guardfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 guard :bundler do
   watch("Gemfile")
   # Uncomment next line if your Gemfile contains the `gemspec' command.

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "bundler/setup"
 Bundler::GemHelper.install_tasks
 

--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 $LOAD_PATH.push File.expand_path("../lib", __FILE__)
 
 require "graphql/version"

--- a/guides/_plugins/api_doc.rb
+++ b/guides/_plugins/api_doc.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQLSite
   module APIDoc
     API_DOC_ROOT = "http://www.rubydoc.info/gems/graphql/"

--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "json"
 require "set"
 require "singleton"

--- a/lib/graphql/analysis.rb
+++ b/lib/graphql/analysis.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "graphql/analysis/max_query_complexity"
 require "graphql/analysis/max_query_depth"
 require "graphql/analysis/query_complexity"

--- a/lib/graphql/analysis/analyze_query.rb
+++ b/lib/graphql/analysis/analyze_query.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Analysis
     module_function

--- a/lib/graphql/analysis/field_usage.rb
+++ b/lib/graphql/analysis/field_usage.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Analysis
     # A query reducer for tracking both field usage and deprecated field usage.

--- a/lib/graphql/analysis/max_query_complexity.rb
+++ b/lib/graphql/analysis/max_query_complexity.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "./query_complexity"
 module GraphQL
   module Analysis

--- a/lib/graphql/analysis/max_query_depth.rb
+++ b/lib/graphql/analysis/max_query_depth.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "./query_depth"
 module GraphQL
   module Analysis

--- a/lib/graphql/analysis/query_complexity.rb
+++ b/lib/graphql/analysis/query_complexity.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Analysis
     # Calculate the complexity of a query, using {Field#complexity} values.

--- a/lib/graphql/analysis/query_depth.rb
+++ b/lib/graphql/analysis/query_depth.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Analysis
     # A query reducer for measuring the depth of a given query.

--- a/lib/graphql/analysis/reducer_state.rb
+++ b/lib/graphql/analysis/reducer_state.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Analysis
     class ReducerState

--- a/lib/graphql/analysis_error.rb
+++ b/lib/graphql/analysis_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class AnalysisError < GraphQL::ExecutionError
   end

--- a/lib/graphql/argument.rb
+++ b/lib/graphql/argument.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   # Used for defined arguments ({Field}, {InputObjectType})
   #

--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   # The parent for all type classes.
   class BaseType

--- a/lib/graphql/boolean_type.rb
+++ b/lib/graphql/boolean_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 GraphQL::BOOLEAN_TYPE = GraphQL::ScalarType.define do
   name "Boolean"
   description "Represents `true` or `false` values."

--- a/lib/graphql/compatibility.rb
+++ b/lib/graphql/compatibility.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "graphql/compatibility/execution_specification"
 require "graphql/compatibility/lazy_execution_specification"
 require "graphql/compatibility/query_parser_specification"

--- a/lib/graphql/compatibility/execution_specification.rb
+++ b/lib/graphql/compatibility/execution_specification.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "graphql/compatibility/execution_specification/counter_schema"
 require "graphql/compatibility/execution_specification/specification_schema"
 

--- a/lib/graphql/compatibility/execution_specification/counter_schema.rb
+++ b/lib/graphql/compatibility/execution_specification/counter_schema.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Compatibility
     module ExecutionSpecification

--- a/lib/graphql/compatibility/execution_specification/specification_schema.rb
+++ b/lib/graphql/compatibility/execution_specification/specification_schema.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Compatibility
     module ExecutionSpecification

--- a/lib/graphql/compatibility/lazy_execution_specification.rb
+++ b/lib/graphql/compatibility/lazy_execution_specification.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "graphql/compatibility/lazy_execution_specification/lazy_schema"
 
 module GraphQL

--- a/lib/graphql/compatibility/lazy_execution_specification/lazy_schema.rb
+++ b/lib/graphql/compatibility/lazy_execution_specification/lazy_schema.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Compatibility
     module LazyExecutionSpecification

--- a/lib/graphql/compatibility/query_parser_specification.rb
+++ b/lib/graphql/compatibility/query_parser_specification.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "graphql/compatibility/query_parser_specification/query_assertions"
 require "graphql/compatibility/query_parser_specification/parse_error_specification"
 

--- a/lib/graphql/compatibility/query_parser_specification/parse_error_specification.rb
+++ b/lib/graphql/compatibility/query_parser_specification/parse_error_specification.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Compatibility
     module QueryParserSpecification

--- a/lib/graphql/compatibility/query_parser_specification/query_assertions.rb
+++ b/lib/graphql/compatibility/query_parser_specification/query_assertions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Compatibility
     module QueryParserSpecification

--- a/lib/graphql/compatibility/schema_parser_specification.rb
+++ b/lib/graphql/compatibility/schema_parser_specification.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Compatibility
     # This asserts that a given parse function turns a string into

--- a/lib/graphql/define.rb
+++ b/lib/graphql/define.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "graphql/define/assign_argument"
 require "graphql/define/assign_connection"
 require "graphql/define/assign_enum_value"

--- a/lib/graphql/define/assign_argument.rb
+++ b/lib/graphql/define/assign_argument.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Define
     # Turn argument configs into a {GraphQL::Argument}.

--- a/lib/graphql/define/assign_connection.rb
+++ b/lib/graphql/define/assign_connection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Define
     module AssignConnection

--- a/lib/graphql/define/assign_enum_value.rb
+++ b/lib/graphql/define/assign_enum_value.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Define
     # Turn enum value configs into a {GraphQL::EnumType::EnumValue} and register it with the {GraphQL::EnumType}

--- a/lib/graphql/define/assign_global_id_field.rb
+++ b/lib/graphql/define/assign_global_id_field.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Define
     module AssignGlobalIdField

--- a/lib/graphql/define/assign_object_field.rb
+++ b/lib/graphql/define/assign_object_field.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Define
     # Turn field configs into a {GraphQL::Field} and attach it to a {GraphQL::ObjectType} or {GraphQL::InterfaceType}

--- a/lib/graphql/define/defined_object_proxy.rb
+++ b/lib/graphql/define/defined_object_proxy.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Define
     class DefinedObjectProxy

--- a/lib/graphql/define/instance_definable.rb
+++ b/lib/graphql/define/instance_definable.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Define
     # This module provides the `.define { ... }` API for

--- a/lib/graphql/define/non_null_with_bang.rb
+++ b/lib/graphql/define/non_null_with_bang.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Define
     # Wrap the object in NonNullType in response to `!`

--- a/lib/graphql/define/type_definer.rb
+++ b/lib/graphql/define/type_definer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Define
     # Some conveniences for definining return & argument types.

--- a/lib/graphql/directive.rb
+++ b/lib/graphql/directive.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   # Directives are server-defined hooks for modifying execution.
   #

--- a/lib/graphql/directive/deprecated_directive.rb
+++ b/lib/graphql/directive/deprecated_directive.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 GraphQL::Directive::DeprecatedDirective = GraphQL::Directive.define do
   name "deprecated"
   description "Marks an element of a GraphQL schema as no longer supported."

--- a/lib/graphql/directive/include_directive.rb
+++ b/lib/graphql/directive/include_directive.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 GraphQL::Directive::IncludeDirective = GraphQL::Directive.define do
   name "include"
   description "Directs the executor to include this field or fragment only when the `if` argument is true."

--- a/lib/graphql/directive/skip_directive.rb
+++ b/lib/graphql/directive/skip_directive.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 GraphQL::Directive::SkipDirective = GraphQL::Directive.define do
   name "skip"
   description "Directs the executor to skip this field or fragment when the `if` argument is true."

--- a/lib/graphql/enum_type.rb
+++ b/lib/graphql/enum_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   # Represents a collection of related values.
   # By convention, enum names are `SCREAMING_CASE_NAMES`,

--- a/lib/graphql/execution.rb
+++ b/lib/graphql/execution.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "graphql/execution/directive_checks"
 require "graphql/execution/execute"
 require "graphql/execution/field_result"

--- a/lib/graphql/execution/directive_checks.rb
+++ b/lib/graphql/execution/directive_checks.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Execution
     # Boolean checks for how an AST node's directives should

--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Execution
     # A valid execution strategy

--- a/lib/graphql/execution/field_result.rb
+++ b/lib/graphql/execution/field_result.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Execution
     # This is one key-value pair in a GraphQL response.

--- a/lib/graphql/execution/lazy.rb
+++ b/lib/graphql/execution/lazy.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "graphql/execution/lazy/lazy_method_map"
 require "graphql/execution/lazy/resolve"
 module GraphQL

--- a/lib/graphql/execution/lazy/lazy_method_map.rb
+++ b/lib/graphql/execution/lazy/lazy_method_map.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Execution
     class Lazy

--- a/lib/graphql/execution/lazy/resolve.rb
+++ b/lib/graphql/execution/lazy/resolve.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Execution
     class Lazy

--- a/lib/graphql/execution/selection_result.rb
+++ b/lib/graphql/execution/selection_result.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Execution
     # A set of key-value pairs suitable for a GraphQL response.

--- a/lib/graphql/execution/typecast.rb
+++ b/lib/graphql/execution/typecast.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Execution
     # GraphQL object `{value, current_type}` can be cast to `potential_type` when:

--- a/lib/graphql/execution_error.rb
+++ b/lib/graphql/execution_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   # If a field's resolve function returns a {ExecutionError},
   # the error will be inserted into the response's `"errors"` key

--- a/lib/graphql/field.rb
+++ b/lib/graphql/field.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "graphql/field/resolve"
 
 module GraphQL

--- a/lib/graphql/field/resolve.rb
+++ b/lib/graphql/field/resolve.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Field
     # Create resolve procs ahead of time based on a {GraphQL::Field}'s `name`, `property`, and `hash_key` configuration.

--- a/lib/graphql/float_type.rb
+++ b/lib/graphql/float_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 GraphQL::FLOAT_TYPE = GraphQL::ScalarType.define do
   name "Float"
   description "Represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point)."

--- a/lib/graphql/id_type.rb
+++ b/lib/graphql/id_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 GraphQL::ID_TYPE = GraphQL::ScalarType.define do
   name "ID"
   description "Represents a unique identifier that is Base64 obfuscated. It is often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"VXNlci0xMA==\"`) or integer (such as `4`) input value will be accepted as an ID."

--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   # {InputObjectType}s are key-value inputs for fields.
   #

--- a/lib/graphql/int_type.rb
+++ b/lib/graphql/int_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 GraphQL::INT_TYPE = GraphQL::ScalarType.define do
   name "Int"
   description "Represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."

--- a/lib/graphql/interface_type.rb
+++ b/lib/graphql/interface_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   # An Interface contains a collection of types which implement some of the same fields.
   #

--- a/lib/graphql/internal_representation.rb
+++ b/lib/graphql/internal_representation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "graphql/internal_representation/node"
 require "graphql/internal_representation/rewrite"
 require "graphql/internal_representation/selection"

--- a/lib/graphql/internal_representation/node.rb
+++ b/lib/graphql/internal_representation/node.rb
@@ -115,7 +115,7 @@ module GraphQL
 
       def inspect(indent = 0)
         own_indent = " " * indent
-        self_inspect = "#{own_indent}<Node #{name} #{skipped? ? "(skipped)" : ""}(#{definition_name} -> #{return_type})>"
+        self_inspect = "#{own_indent}<Node #{name} #{skipped? ? "(skipped)" : ""}(#{definition_name} -> #{return_type})>".dup
         if typed_children.any?
           self_inspect << " {"
           typed_children.each do |type_defn, children|

--- a/lib/graphql/internal_representation/node.rb
+++ b/lib/graphql/internal_representation/node.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "set"
 
 module GraphQL

--- a/lib/graphql/internal_representation/rewrite.rb
+++ b/lib/graphql/internal_representation/rewrite.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module InternalRepresentation
     # Convert an AST into a tree of {InternalRepresentation::Node}s

--- a/lib/graphql/internal_representation/selection.rb
+++ b/lib/graphql/internal_representation/selection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module InternalRepresentation
     # A selection is a single field on an object.

--- a/lib/graphql/introspection.rb
+++ b/lib/graphql/introspection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Introspection
   end

--- a/lib/graphql/introspection/arguments_field.rb
+++ b/lib/graphql/introspection/arguments_field.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 GraphQL::Introspection::ArgumentsField = GraphQL::Field.define do
   type !GraphQL::ListType.new(of_type: !GraphQL::Introspection::InputValueType)
   resolve ->(obj, args, ctx) {

--- a/lib/graphql/introspection/directive_location_enum.rb
+++ b/lib/graphql/introspection/directive_location_enum.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 GraphQL::Introspection::DirectiveLocationEnum = GraphQL::EnumType.define do
   name "__DirectiveLocation"
   description "A Directive can be adjacent to many parts of the GraphQL language, a "\

--- a/lib/graphql/introspection/directive_type.rb
+++ b/lib/graphql/introspection/directive_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 GraphQL::Introspection::DirectiveType = GraphQL::ObjectType.define do
   name "__Directive"
   description "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document."\

--- a/lib/graphql/introspection/enum_value_type.rb
+++ b/lib/graphql/introspection/enum_value_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 GraphQL::Introspection::EnumValueType = GraphQL::ObjectType.define do
   name "__EnumValue"
   description "One possible value for a given Enum. Enum values are unique values, not a "\

--- a/lib/graphql/introspection/enum_values_field.rb
+++ b/lib/graphql/introspection/enum_values_field.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 GraphQL::Introspection::EnumValuesField = GraphQL::Field.define do
   type types[!GraphQL::Introspection::EnumValueType]
   argument :includeDeprecated, types.Boolean, default_value: false

--- a/lib/graphql/introspection/field_type.rb
+++ b/lib/graphql/introspection/field_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 GraphQL::Introspection::FieldType = GraphQL::ObjectType.define do
   name "__Field"
   description "Object and Interface types are described by a list of Fields, each of which has "\

--- a/lib/graphql/introspection/fields_field.rb
+++ b/lib/graphql/introspection/fields_field.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 GraphQL::Introspection::FieldsField = GraphQL::Field.define do
   type -> { types[!GraphQL::Introspection::FieldType] }
   argument :includeDeprecated, GraphQL::BOOLEAN_TYPE, default_value: false

--- a/lib/graphql/introspection/input_fields_field.rb
+++ b/lib/graphql/introspection/input_fields_field.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 GraphQL::Introspection::InputFieldsField = GraphQL::Field.define do
   name "inputFields"
   type types[!GraphQL::Introspection::InputValueType]

--- a/lib/graphql/introspection/input_value_type.rb
+++ b/lib/graphql/introspection/input_value_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 GraphQL::Introspection::InputValueType = GraphQL::ObjectType.define do
   name "__InputValue"
   description "Arguments provided to Fields or Directives and the input fields of an "\

--- a/lib/graphql/introspection/interfaces_field.rb
+++ b/lib/graphql/introspection/interfaces_field.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 GraphQL::Introspection::InterfacesField = GraphQL::Field.define do
   type -> { types[!GraphQL::Introspection::TypeType] }
   resolve ->(target, a, ctx) {

--- a/lib/graphql/introspection/introspection_query.rb
+++ b/lib/graphql/introspection/introspection_query.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # The introspection query to end all introspection queries, copied from
 # https://github.com/graphql/graphql-js/blob/master/src/utilities/introspectionQuery.js
 GraphQL::Introspection::INTROSPECTION_QUERY = "

--- a/lib/graphql/introspection/of_type_field.rb
+++ b/lib/graphql/introspection/of_type_field.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 GraphQL::Introspection::OfTypeField = GraphQL::Field.define do
   name "ofType"
   type -> { GraphQL::Introspection::TypeType }

--- a/lib/graphql/introspection/possible_types_field.rb
+++ b/lib/graphql/introspection/possible_types_field.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 GraphQL::Introspection::PossibleTypesField = GraphQL::Field.define do
   type -> { types[!GraphQL::Introspection::TypeType] }
   resolve ->(target, args, ctx) {

--- a/lib/graphql/introspection/schema_field.rb
+++ b/lib/graphql/introspection/schema_field.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Introspection
     # A wrapper to implement `__schema`

--- a/lib/graphql/introspection/schema_type.rb
+++ b/lib/graphql/introspection/schema_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 GraphQL::Introspection::SchemaType = GraphQL::ObjectType.define do
   name "__Schema"
   description "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all "\

--- a/lib/graphql/introspection/type_by_name_field.rb
+++ b/lib/graphql/introspection/type_by_name_field.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Introspection
     # A wrapper to create `__type(name: )` dynamically.

--- a/lib/graphql/introspection/type_kind_enum.rb
+++ b/lib/graphql/introspection/type_kind_enum.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 GraphQL::Introspection::TypeKindEnum = GraphQL::EnumType.define do
   name "__TypeKind"
   description "An enum describing what kind of type a given `__Type` is."

--- a/lib/graphql/introspection/type_type.rb
+++ b/lib/graphql/introspection/type_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 GraphQL::Introspection::TypeType = GraphQL::ObjectType.define do
   name "__Type"
   description "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in "\

--- a/lib/graphql/introspection/typename_field.rb
+++ b/lib/graphql/introspection/typename_field.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Introspection
     # A wrapper to create `__typename`.

--- a/lib/graphql/invalid_null_error.rb
+++ b/lib/graphql/invalid_null_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   # Raised automatically when a field's resolve function returns `nil`
   # for a non-null field.

--- a/lib/graphql/language.rb
+++ b/lib/graphql/language.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "graphql/language/definition_slice"
 require "graphql/language/generation"
 require "graphql/language/lexer"

--- a/lib/graphql/language/comments.rb
+++ b/lib/graphql/language/comments.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Language
     module Comments

--- a/lib/graphql/language/comments.rb
+++ b/lib/graphql/language/comments.rb
@@ -7,7 +7,7 @@ module GraphQL
       def commentize(description, indent: '')
         lines = description.split("\n")
 
-        comment = ''
+        comment = ''.dup
 
         lines.each do |line|
           if line == ''

--- a/lib/graphql/language/definition_slice.rb
+++ b/lib/graphql/language/definition_slice.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Language
     module DefinitionSlice

--- a/lib/graphql/language/generation.rb
+++ b/lib/graphql/language/generation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Language
     # Exposes {.generate}, which turns AST nodes back into query strings.

--- a/lib/graphql/language/generation.rb
+++ b/lib/graphql/language/generation.rb
@@ -20,17 +20,17 @@ module GraphQL
         when Nodes::Document
           node.definitions.map { |d| generate(d) }.join("\n\n")
         when Nodes::Argument
-          "#{node.name}: #{generate(node.value)}"
+          "#{node.name}: #{generate(node.value)}".dup
         when Nodes::Directive
-          out = "@#{node.name}"
+          out = "@#{node.name}".dup
           out << "(#{node.arguments.map { |a| generate(a) }.join(", ")})" if node.arguments.any?
           out
         when Nodes::Enum
-          "#{node.name}"
+          "#{node.name}".dup
         when Nodes::NullValue
-          "null"
+          "null".dup
         when Nodes::Field
-          out = "#{indent}"
+          out = "#{indent}".dup
           out << "#{node.alias}: " if node.alias
           out << "#{node.name}"
           out << "(#{node.arguments.map { |a| generate(a) }.join(", ")})" if node.arguments.any?
@@ -38,7 +38,7 @@ module GraphQL
           out << generate_selections(node.selections, indent: indent)
           out
         when Nodes::FragmentDefinition
-          out = "#{indent}fragment #{node.name}"
+          out = "#{indent}fragment #{node.name}".dup
           if node.type
             out << " on #{generate(node.type)}"
           end
@@ -46,11 +46,11 @@ module GraphQL
           out << generate_selections(node.selections, indent: indent)
           out
         when Nodes::FragmentSpread
-          out = "#{indent}...#{node.name}"
+          out = "#{indent}...#{node.name}".dup
           out << generate_directives(node.directives)
           out
         when Nodes::InlineFragment
-          out = "#{indent}..."
+          out = "#{indent}...".dup
           if node.type
             out << " on #{generate(node.type)}"
           end
@@ -60,24 +60,24 @@ module GraphQL
         when Nodes::InputObject
           generate(node.to_h)
         when Nodes::ListType
-          "[#{generate(node.of_type)}]"
+          "[#{generate(node.of_type)}]".dup
         when Nodes::NonNullType
-          "#{generate(node.of_type)}!"
+          "#{generate(node.of_type)}!".dup
         when Nodes::OperationDefinition
-          out = "#{indent}#{node.operation_type}"
+          out = "#{indent}#{node.operation_type}".dup
           out << " #{node.name}" if node.name
           out << "(#{node.variables.map { |v| generate(v) }.join(", ")})" if node.variables.any?
           out << generate_directives(node.directives)
           out << generate_selections(node.selections, indent: indent)
           out
         when Nodes::TypeName
-          "#{node.name}"
+          "#{node.name}".dup
         when Nodes::VariableDefinition
-          out = "$#{node.name}: #{generate(node.type)}"
+          out = "$#{node.name}: #{generate(node.type)}".dup
           out << " = #{generate(node.default_value)}" unless node.default_value.nil?
           out
         when Nodes::VariableIdentifier
-          "$#{node.name}"
+          "$#{node.name}".dup
         when Nodes::SchemaDefinition
           if (node.query.nil? || node.query == 'Query') &&
              (node.mutation.nil? || node.mutation == 'Mutation') &&
@@ -85,7 +85,7 @@ module GraphQL
             return
           end
 
-          out = "schema {\n"
+          out = "schema {\n".dup
           out << "  query: #{node.query}\n" if node.query
           out << "  mutation: #{node.mutation}\n" if node.mutation
           out << "  subscription: #{node.subscription}\n" if node.subscription
@@ -101,7 +101,7 @@ module GraphQL
           out << " implements " << node.interfaces.map(&:name).join(", ") unless node.interfaces.empty?
           out << generate_field_definitions(node.fields)
         when Nodes::InputValueDefinition
-          out = "#{node.name}: #{generate(node.type)}"
+          out = "#{node.name}: #{generate(node.type)}".dup
           out << " = #{generate(node.default_value)}" unless node.default_value.nil?
           out << generate_directives(node.directives)
         when Nodes::FieldDefinition
@@ -130,7 +130,7 @@ module GraphQL
           end
           out << "}"
         when Nodes::EnumValueDefinition
-          out = "  #{node.name}"
+          out = "  #{node.name}".dup
           out << generate_directives(node.directives)
           out << "\n"
         when Nodes::InputObjectTypeDefinition
@@ -153,9 +153,9 @@ module GraphQL
         when FalseClass, Float, Integer, NilClass, String, TrueClass
           JSON.generate(node, quirks_mode: true)
         when Array
-          "[#{node.map { |v| generate(v) }.join(", ")}]"
+          "[#{node.map { |v| generate(v) }.join(", ")}]".dup
         when Hash
-          "{#{node.map { |k, v| "#{k}: #{generate(v)}" }.join(", ")}}"
+          "{#{node.map { |k, v| "#{k}: #{generate(v)}" }.join(", ")}}".dup
         else
           raise TypeError
         end
@@ -173,7 +173,7 @@ module GraphQL
 
       def generate_selections(selections, indent: "")
         if selections.any?
-          out = " {\n"
+          out = " {\n".dup
           selections.each do |selection|
             out << generate(selection, indent: indent + "  ") << "\n"
           end
@@ -184,14 +184,14 @@ module GraphQL
       end
 
       def generate_description(node, indent: '', first_in_block: true)
-        return '' unless node.description
+        return ''.dup unless node.description
 
-        description = indent != '' && !first_in_block ? "\n" : ""
+        description = indent != '' && !first_in_block ? "\n".dup : "".dup
         description << GraphQL::Language::Comments.commentize(node.description, indent: indent)
       end
 
       def generate_field_definitions(fields)
-        out = " {\n"
+        out = " {\n".dup
         fields.each.with_index do |field, i|
           out << generate_description(field, indent: '  ', first_in_block: i == 0)
           out << "  #{generate(field)}\n"

--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Language
     module Nodes

--- a/lib/graphql/language/token.rb
+++ b/lib/graphql/language/token.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Language
     # Emitted by the lexer and passed to the parser.

--- a/lib/graphql/language/visitor.rb
+++ b/lib/graphql/language/visitor.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Language
     # Depth-first traversal through the tree, calling hooks at each stop.

--- a/lib/graphql/list_type.rb
+++ b/lib/graphql/list_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   # A list type modifies another type.
   #

--- a/lib/graphql/non_null_type.rb
+++ b/lib/graphql/non_null_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   # A non-null type modifies another type.
   #

--- a/lib/graphql/object_type.rb
+++ b/lib/graphql/object_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   # This type exposes fields on an object.
   #

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "graphql/query/arguments"
 require "graphql/query/context"
 require "graphql/query/executor"

--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Query
     # Read-only access to values, normalizing all keys to strings

--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Query
     # Expose some query-specific info to field resolve functions.

--- a/lib/graphql/query/executor.rb
+++ b/lib/graphql/query/executor.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Query
     class Executor

--- a/lib/graphql/query/input_validation_result.rb
+++ b/lib/graphql/query/input_validation_result.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Query
     class InputValidationResult

--- a/lib/graphql/query/literal_input.rb
+++ b/lib/graphql/query/literal_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Query
     # Turn query string values into something useful for query execution

--- a/lib/graphql/query/serial_execution.rb
+++ b/lib/graphql/query/serial_execution.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "graphql/query/serial_execution/value_resolution"
 require "graphql/query/serial_execution/field_resolution"
 require "graphql/query/serial_execution/operation_resolution"

--- a/lib/graphql/query/serial_execution/field_resolution.rb
+++ b/lib/graphql/query/serial_execution/field_resolution.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Query
     class SerialExecution

--- a/lib/graphql/query/serial_execution/operation_resolution.rb
+++ b/lib/graphql/query/serial_execution/operation_resolution.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Query
     class SerialExecution

--- a/lib/graphql/query/serial_execution/selection_resolution.rb
+++ b/lib/graphql/query/serial_execution/selection_resolution.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Query
     class SerialExecution

--- a/lib/graphql/query/serial_execution/value_resolution.rb
+++ b/lib/graphql/query/serial_execution/value_resolution.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Query
     class SerialExecution

--- a/lib/graphql/query/variable_validation_error.rb
+++ b/lib/graphql/query/variable_validation_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Query
     class VariableValidationError < GraphQL::ExecutionError

--- a/lib/graphql/query/variables.rb
+++ b/lib/graphql/query/variables.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Query
     # Read-only access to query variables, applying default values if needed.

--- a/lib/graphql/relay.rb
+++ b/lib/graphql/relay.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'base64'
 
 require 'graphql/relay/page_info'

--- a/lib/graphql/relay/array_connection.rb
+++ b/lib/graphql/relay/array_connection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Relay
     class ArrayConnection < BaseConnection

--- a/lib/graphql/relay/base_connection.rb
+++ b/lib/graphql/relay/base_connection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Relay
     # Subclasses must implement:

--- a/lib/graphql/relay/connection_field.rb
+++ b/lib/graphql/relay/connection_field.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Relay
     # Provided a GraphQL field which returns a collection of nodes,

--- a/lib/graphql/relay/connection_resolve.rb
+++ b/lib/graphql/relay/connection_resolve.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Relay
     class ConnectionResolve

--- a/lib/graphql/relay/connection_type.rb
+++ b/lib/graphql/relay/connection_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Relay
     module ConnectionType

--- a/lib/graphql/relay/edge.rb
+++ b/lib/graphql/relay/edge.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Relay
     # Mostly an internal concern.

--- a/lib/graphql/relay/edge_type.rb
+++ b/lib/graphql/relay/edge_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Relay
     module EdgeType

--- a/lib/graphql/relay/global_id_resolve.rb
+++ b/lib/graphql/relay/global_id_resolve.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Relay
     class GlobalIdResolve

--- a/lib/graphql/relay/mutation.rb
+++ b/lib/graphql/relay/mutation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Relay
     # Define a Relay mutation:

--- a/lib/graphql/relay/node.rb
+++ b/lib/graphql/relay/node.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Relay
     # Helpers for working with Relay-specific Node objects.

--- a/lib/graphql/relay/page_info.rb
+++ b/lib/graphql/relay/page_info.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Relay
     # Wrap a Connection and expose its page info

--- a/lib/graphql/relay/relation_connection.rb
+++ b/lib/graphql/relay/relation_connection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Relay
     # A connection implementation to expose SQL collection objects.

--- a/lib/graphql/scalar_type.rb
+++ b/lib/graphql/scalar_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   # # GraphQL::ScalarType
   #

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "graphql/schema/catchall_middleware"
 require "graphql/schema/default_type_error"
 require "graphql/schema/invalid_type_error"

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Schema
     module BuildFromDefinition

--- a/lib/graphql/schema/catchall_middleware.rb
+++ b/lib/graphql/schema/catchall_middleware.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Schema
     # In early GraphQL versions, errors would be "automatically"

--- a/lib/graphql/schema/default_type_error.rb
+++ b/lib/graphql/schema/default_type_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Schema
     module DefaultTypeError

--- a/lib/graphql/schema/instrumented_field_map.rb
+++ b/lib/graphql/schema/instrumented_field_map.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Schema
     # A two-level map with fields as the last values.

--- a/lib/graphql/schema/invalid_type_error.rb
+++ b/lib/graphql/schema/invalid_type_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Schema
     class InvalidTypeError < GraphQL::Error

--- a/lib/graphql/schema/loader.rb
+++ b/lib/graphql/schema/loader.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Schema
     # You can use the result of {GraphQL::Introspection::INTROSPECTION_QUERY}

--- a/lib/graphql/schema/middleware_chain.rb
+++ b/lib/graphql/schema/middleware_chain.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Schema
     # Given {steps} and {arguments}, call steps in order, passing `(*arguments, next_step)`.

--- a/lib/graphql/schema/possible_types.rb
+++ b/lib/graphql/schema/possible_types.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Schema
     # Find the members of a union or interface within a given schema.

--- a/lib/graphql/schema/printer.rb
+++ b/lib/graphql/schema/printer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Schema
     # Used to convert your {GraphQL::Schema} to a GraphQL schema string

--- a/lib/graphql/schema/printer.rb
+++ b/lib/graphql/schema/printer.rb
@@ -96,7 +96,7 @@ module GraphQL
           def print_description(definition, indentation='', first_in_block=true)
             return '' unless definition.description
 
-            description = indentation != '' && !first_in_block ? "\n" : ""
+            description = indentation != '' && !first_in_block ? "\n".dup : "".dup
             description << GraphQL::Language::Comments.commentize(definition.description, indent: indentation)
           end
         end
@@ -112,7 +112,7 @@ module GraphQL
               return "(#{field_arguments.map{ |arg| print_input_value(arg) }.join(", ")})"
             end
 
-            out = "(\n"
+            out = "(\n".dup
             out << field_arguments.map.with_index{ |arg, i|
               "#{print_description(arg, "  #{indentation}", i == 0)}  #{indentation}"\
               "#{print_input_value(arg)}"

--- a/lib/graphql/schema/reduce_types.rb
+++ b/lib/graphql/schema/reduce_types.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Schema
     module ReduceTypes

--- a/lib/graphql/schema/rescue_middleware.rb
+++ b/lib/graphql/schema/rescue_middleware.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Schema
     # - Store a table of errors & handlers

--- a/lib/graphql/schema/timeout_middleware.rb
+++ b/lib/graphql/schema/timeout_middleware.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "delegate"
 
 module GraphQL

--- a/lib/graphql/schema/type_expression.rb
+++ b/lib/graphql/schema/type_expression.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Schema
     module TypeExpression

--- a/lib/graphql/schema/type_map.rb
+++ b/lib/graphql/schema/type_map.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Schema
     # Stores `{ name => type }` pairs for a given schema.

--- a/lib/graphql/schema/unique_within_type.rb
+++ b/lib/graphql/schema/unique_within_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Schema
     module UniqueWithinType

--- a/lib/graphql/schema/validation.rb
+++ b/lib/graphql/schema/validation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Schema
     # This module provides a function for validating GraphQL types.

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Schema
     # Restrict access to a {GraphQL::Schema} with a user-defined mask.

--- a/lib/graphql/static_validation.rb
+++ b/lib/graphql/static_validation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "graphql/static_validation/message"
 require "graphql/static_validation/arguments_validator"
 require "graphql/static_validation/type_stack"

--- a/lib/graphql/static_validation/all_rules.rb
+++ b/lib/graphql/static_validation/all_rules.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     # Default rules for {GraphQL::StaticValidation::Validator}

--- a/lib/graphql/static_validation/arguments_validator.rb
+++ b/lib/graphql/static_validation/arguments_validator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     # Implement validate_node

--- a/lib/graphql/static_validation/literal_validator.rb
+++ b/lib/graphql/static_validation/literal_validator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     # Test whether `ast_value` is a valid input for `type`

--- a/lib/graphql/static_validation/message.rb
+++ b/lib/graphql/static_validation/message.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     # Generates GraphQL-compliant validation message.

--- a/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb
+++ b/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     class ArgumentLiteralsAreCompatible < GraphQL::StaticValidation::ArgumentsValidator

--- a/lib/graphql/static_validation/rules/arguments_are_defined.rb
+++ b/lib/graphql/static_validation/rules/arguments_are_defined.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     class ArgumentsAreDefined < GraphQL::StaticValidation::ArgumentsValidator

--- a/lib/graphql/static_validation/rules/directives_are_defined.rb
+++ b/lib/graphql/static_validation/rules/directives_are_defined.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     class DirectivesAreDefined

--- a/lib/graphql/static_validation/rules/directives_are_in_valid_locations.rb
+++ b/lib/graphql/static_validation/rules/directives_are_in_valid_locations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     class DirectivesAreInValidLocations

--- a/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb
+++ b/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     class FieldsAreDefinedOnType

--- a/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb
+++ b/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     # Scalars _can't_ have selections

--- a/lib/graphql/static_validation/rules/fields_will_merge.rb
+++ b/lib/graphql/static_validation/rules/fields_will_merge.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     class FieldsWillMerge

--- a/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb
+++ b/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     class FragmentSpreadsArePossible

--- a/lib/graphql/static_validation/rules/fragment_types_exist.rb
+++ b/lib/graphql/static_validation/rules/fragment_types_exist.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     class FragmentTypesExist

--- a/lib/graphql/static_validation/rules/fragments_are_finite.rb
+++ b/lib/graphql/static_validation/rules/fragments_are_finite.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     class FragmentsAreFinite

--- a/lib/graphql/static_validation/rules/fragments_are_named.rb
+++ b/lib/graphql/static_validation/rules/fragments_are_named.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     class FragmentsAreNamed

--- a/lib/graphql/static_validation/rules/fragments_are_on_composite_types.rb
+++ b/lib/graphql/static_validation/rules/fragments_are_on_composite_types.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     class FragmentsAreOnCompositeTypes

--- a/lib/graphql/static_validation/rules/fragments_are_used.rb
+++ b/lib/graphql/static_validation/rules/fragments_are_used.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     class FragmentsAreUsed

--- a/lib/graphql/static_validation/rules/mutation_root_exists.rb
+++ b/lib/graphql/static_validation/rules/mutation_root_exists.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     class MutationRootExists

--- a/lib/graphql/static_validation/rules/required_arguments_are_present.rb
+++ b/lib/graphql/static_validation/rules/required_arguments_are_present.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     class RequiredArgumentsArePresent

--- a/lib/graphql/static_validation/rules/subscription_root_exists.rb
+++ b/lib/graphql/static_validation/rules/subscription_root_exists.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     class SubscriptionRootExists

--- a/lib/graphql/static_validation/rules/unique_directives_per_location.rb
+++ b/lib/graphql/static_validation/rules/unique_directives_per_location.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     class UniqueDirectivesPerLocation

--- a/lib/graphql/static_validation/rules/variable_default_values_are_correctly_typed.rb
+++ b/lib/graphql/static_validation/rules/variable_default_values_are_correctly_typed.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     class VariableDefaultValuesAreCorrectlyTyped

--- a/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb
+++ b/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     class VariableUsagesAreAllowed

--- a/lib/graphql/static_validation/rules/variables_are_input_types.rb
+++ b/lib/graphql/static_validation/rules/variables_are_input_types.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     class VariablesAreInputTypes

--- a/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb
+++ b/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     # The problem is

--- a/lib/graphql/static_validation/type_stack.rb
+++ b/lib/graphql/static_validation/type_stack.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     # - Ride along with `GraphQL::Language::Visitor`

--- a/lib/graphql/static_validation/validation_context.rb
+++ b/lib/graphql/static_validation/validation_context.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     # The validation context gets passed to each validator.

--- a/lib/graphql/static_validation/validator.rb
+++ b/lib/graphql/static_validation/validator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     # Initialized with a {GraphQL::Schema}, then it can validate {GraphQL::Language::Nodes::Documents}s based on that schema.

--- a/lib/graphql/string_type.rb
+++ b/lib/graphql/string_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 GraphQL::STRING_TYPE = GraphQL::ScalarType.define do
   name "String"
   description "Represents textual data as UTF-8 character sequences. This type is most often used by GraphQL to represent free-form human-readable text."

--- a/lib/graphql/type_kinds.rb
+++ b/lib/graphql/type_kinds.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   # Type kinds are the basic categories which a type may belong to (`Object`, `Scalar`, `Union`...)
   module TypeKinds

--- a/lib/graphql/union_type.rb
+++ b/lib/graphql/union_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   # A Union is is a collection of object types which may appear in the same place.
   #

--- a/lib/graphql/unresolved_type_error.rb
+++ b/lib/graphql/unresolved_type_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   # Error raised when the value provided for a field can't be resolved to one of the possible types
   # for the field.

--- a/lib/graphql/version.rb
+++ b/lib/graphql/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   VERSION = "1.2.5"
 end

--- a/spec/graphql/analysis/analyze_query_spec.rb
+++ b/spec/graphql/analysis/analyze_query_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Analysis do

--- a/spec/graphql/analysis/field_usage_spec.rb
+++ b/spec/graphql/analysis/field_usage_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Analysis::FieldUsage do

--- a/spec/graphql/analysis/max_query_complexity_spec.rb
+++ b/spec/graphql/analysis/max_query_complexity_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Analysis::MaxQueryComplexity do

--- a/spec/graphql/analysis/max_query_depth_spec.rb
+++ b/spec/graphql/analysis/max_query_depth_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Analysis::MaxQueryDepth do

--- a/spec/graphql/analysis/query_complexity_spec.rb
+++ b/spec/graphql/analysis/query_complexity_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Analysis::QueryComplexity do

--- a/spec/graphql/analysis/query_depth_spec.rb
+++ b/spec/graphql/analysis/query_depth_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Analysis::QueryDepth do

--- a/spec/graphql/argument_spec.rb
+++ b/spec/graphql/argument_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Argument do

--- a/spec/graphql/base_type_spec.rb
+++ b/spec/graphql/base_type_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::BaseType do

--- a/spec/graphql/boolean_type_spec.rb
+++ b/spec/graphql/boolean_type_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::BOOLEAN_TYPE do

--- a/spec/graphql/compatibility/execution_specification_spec.rb
+++ b/spec/graphql/compatibility/execution_specification_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 SerialExecutionSuite = GraphQL::Compatibility::ExecutionSpecification.build_suite(GraphQL::Query::SerialExecution)

--- a/spec/graphql/compatibility/lazy_execution_specification_spec.rb
+++ b/spec/graphql/compatibility/lazy_execution_specification_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 LazySpecSuite = GraphQL::Compatibility::LazyExecutionSpecification.build_suite(GraphQL::Execution::Execute)

--- a/spec/graphql/compatibility/query_parser_specification_spec.rb
+++ b/spec/graphql/compatibility/query_parser_specification_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 BuiltInQueryParserSuite = GraphQL::Compatibility::QueryParserSpecification.build_suite do |query_string|

--- a/spec/graphql/compatibility/schema_parser_specification_spec.rb
+++ b/spec/graphql/compatibility/schema_parser_specification_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 BuiltInSchemaParserSuite = GraphQL::Compatibility::SchemaParserSpecification.build_suite do |query_string|

--- a/spec/graphql/define/assign_argument_spec.rb
+++ b/spec/graphql/define/assign_argument_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Define::AssignArgument do

--- a/spec/graphql/define/instance_definable_spec.rb
+++ b/spec/graphql/define/instance_definable_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "date"
 require "spec_helper"
 

--- a/spec/graphql/directive_spec.rb
+++ b/spec/graphql/directive_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Directive do

--- a/spec/graphql/enum_type_spec.rb
+++ b/spec/graphql/enum_type_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::EnumType do

--- a/spec/graphql/execution/execute_spec.rb
+++ b/spec/graphql/execution/execute_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 ExecuteSuite = GraphQL::Compatibility::ExecutionSpecification.build_suite(GraphQL::Execution::Execute)

--- a/spec/graphql/execution/lazy_spec.rb
+++ b/spec/graphql/execution/lazy_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Execution::Lazy do

--- a/spec/graphql/execution/typecast_spec.rb
+++ b/spec/graphql/execution/typecast_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Execution::Typecast do

--- a/spec/graphql/execution_error_spec.rb
+++ b/spec/graphql/execution_error_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::ExecutionError do

--- a/spec/graphql/field_spec.rb
+++ b/spec/graphql/field_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Field do

--- a/spec/graphql/float_type_spec.rb
+++ b/spec/graphql/float_type_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::FLOAT_TYPE do

--- a/spec/graphql/id_type_spec.rb
+++ b/spec/graphql/id_type_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::ID_TYPE do

--- a/spec/graphql/input_object_type_spec.rb
+++ b/spec/graphql/input_object_type_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::InputObjectType do

--- a/spec/graphql/int_type_spec.rb
+++ b/spec/graphql/int_type_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::INT_TYPE do

--- a/spec/graphql/interface_type_spec.rb
+++ b/spec/graphql/interface_type_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::InterfaceType do

--- a/spec/graphql/internal_representation/rewrite_spec.rb
+++ b/spec/graphql/internal_representation/rewrite_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::InternalRepresentation::Rewrite do

--- a/spec/graphql/introspection/directive_type_spec.rb
+++ b/spec/graphql/introspection/directive_type_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Introspection::DirectiveType do

--- a/spec/graphql/introspection/input_value_type_spec.rb
+++ b/spec/graphql/introspection/input_value_type_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 

--- a/spec/graphql/introspection/introspection_query_spec.rb
+++ b/spec/graphql/introspection/introspection_query_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe "GraphQL::Introspection::INTROSPECTION_QUERY" do

--- a/spec/graphql/introspection/schema_type_spec.rb
+++ b/spec/graphql/introspection/schema_type_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Introspection::SchemaType do

--- a/spec/graphql/introspection/type_type_spec.rb
+++ b/spec/graphql/introspection/type_type_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Introspection::TypeType do

--- a/spec/graphql/language/definition_slice_spec.rb
+++ b/spec/graphql/language/definition_slice_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Language::DefinitionSlice do

--- a/spec/graphql/language/equality_spec.rb
+++ b/spec/graphql/language/equality_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Language::Nodes::AbstractNode do

--- a/spec/graphql/language/generation_spec.rb
+++ b/spec/graphql/language/generation_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Language::Generation do

--- a/spec/graphql/language/lexer_spec.rb
+++ b/spec/graphql/language/lexer_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Language::Lexer do

--- a/spec/graphql/language/nodes_spec.rb
+++ b/spec/graphql/language/nodes_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Language::Nodes::AbstractNode do

--- a/spec/graphql/language/parser_spec.rb
+++ b/spec/graphql/language/parser_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Language::Parser do

--- a/spec/graphql/language/visitor_spec.rb
+++ b/spec/graphql/language/visitor_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Language::Visitor do

--- a/spec/graphql/list_type_spec.rb
+++ b/spec/graphql/list_type_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::ListType do

--- a/spec/graphql/non_null_type_spec.rb
+++ b/spec/graphql/non_null_type_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::NonNullType do

--- a/spec/graphql/object_type_spec.rb
+++ b/spec/graphql/object_type_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::ObjectType do

--- a/spec/graphql/query/arguments_spec.rb
+++ b/spec/graphql/query/arguments_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Query::Arguments do

--- a/spec/graphql/query/context_spec.rb
+++ b/spec/graphql/query/context_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Query::Context do

--- a/spec/graphql/query/executor_spec.rb
+++ b/spec/graphql/query/executor_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Query::Executor do

--- a/spec/graphql/query/serial_execution/value_resolution_spec.rb
+++ b/spec/graphql/query/serial_execution/value_resolution_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Query::SerialExecution::ValueResolution do

--- a/spec/graphql/query/variables_spec.rb
+++ b/spec/graphql/query/variables_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Query::Variables do

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Query do

--- a/spec/graphql/relay/array_connection_spec.rb
+++ b/spec/graphql/relay/array_connection_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe GraphQL::Relay::ArrayConnection do

--- a/spec/graphql/relay/base_connection_spec.rb
+++ b/spec/graphql/relay/base_connection_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe GraphQL::Relay::BaseConnection do

--- a/spec/graphql/relay/connection_field_spec.rb
+++ b/spec/graphql/relay/connection_field_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Relay::ConnectionField do

--- a/spec/graphql/relay/connection_type_spec.rb
+++ b/spec/graphql/relay/connection_type_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Relay::ConnectionType do

--- a/spec/graphql/relay/mutation_spec.rb
+++ b/spec/graphql/relay/mutation_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe GraphQL::Relay::Mutation do

--- a/spec/graphql/relay/node_spec.rb
+++ b/spec/graphql/relay/node_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Relay::Node do

--- a/spec/graphql/relay/page_info_spec.rb
+++ b/spec/graphql/relay/page_info_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Relay::PageInfo do

--- a/spec/graphql/relay/relation_connection_spec.rb
+++ b/spec/graphql/relay/relation_connection_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe GraphQL::Relay::RelationConnection do

--- a/spec/graphql/scalar_type_spec.rb
+++ b/spec/graphql/scalar_type_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::ScalarType do

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Schema::BuildFromDefinition do

--- a/spec/graphql/schema/catchall_middleware_spec.rb
+++ b/spec/graphql/schema/catchall_middleware_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Schema::CatchallMiddleware do

--- a/spec/graphql/schema/loader_spec.rb
+++ b/spec/graphql/schema/loader_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Schema::Loader do

--- a/spec/graphql/schema/middleware_chain_spec.rb
+++ b/spec/graphql/schema/middleware_chain_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Schema::MiddlewareChain do

--- a/spec/graphql/schema/printer_spec.rb
+++ b/spec/graphql/schema/printer_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Schema::Printer do

--- a/spec/graphql/schema/reduce_types_spec.rb
+++ b/spec/graphql/schema/reduce_types_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Schema::ReduceTypes do

--- a/spec/graphql/schema/rescue_middleware_spec.rb
+++ b/spec/graphql/schema/rescue_middleware_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 class SpecExampleError < StandardError; end

--- a/spec/graphql/schema/timeout_middleware_spec.rb
+++ b/spec/graphql/schema/timeout_middleware_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Schema::TimeoutMiddleware do

--- a/spec/graphql/schema/type_expression_spec.rb
+++ b/spec/graphql/schema/type_expression_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Schema::TypeExpression do

--- a/spec/graphql/schema/unique_within_type_spec.rb
+++ b/spec/graphql/schema/unique_within_type_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Schema::UniqueWithinType do

--- a/spec/graphql/schema/validation_spec.rb
+++ b/spec/graphql/schema/validation_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Schema::Validation do

--- a/spec/graphql/schema/warden_spec.rb
+++ b/spec/graphql/schema/warden_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 module MaskHelpers

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Schema do

--- a/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
+++ b/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do

--- a/spec/graphql/static_validation/rules/arguments_are_defined_spec.rb
+++ b/spec/graphql/static_validation/rules/arguments_are_defined_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::StaticValidation::ArgumentsAreDefined do

--- a/spec/graphql/static_validation/rules/directives_are_defined_spec.rb
+++ b/spec/graphql/static_validation/rules/directives_are_defined_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::StaticValidation::DirectivesAreDefined do

--- a/spec/graphql/static_validation/rules/directives_are_in_valid_locations_spec.rb
+++ b/spec/graphql/static_validation/rules/directives_are_in_valid_locations_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::StaticValidation::DirectivesAreInValidLocations do

--- a/spec/graphql/static_validation/rules/fields_are_defined_on_type_spec.rb
+++ b/spec/graphql/static_validation/rules/fields_are_defined_on_type_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::StaticValidation::FieldsAreDefinedOnType do

--- a/spec/graphql/static_validation/rules/fields_have_appropriate_selections_spec.rb
+++ b/spec/graphql/static_validation/rules/fields_have_appropriate_selections_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::StaticValidation::FieldsHaveAppropriateSelections do

--- a/spec/graphql/static_validation/rules/fields_will_merge_spec.rb
+++ b/spec/graphql/static_validation/rules/fields_will_merge_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::StaticValidation::FieldsWillMerge do

--- a/spec/graphql/static_validation/rules/fragment_spreads_are_possible_spec.rb
+++ b/spec/graphql/static_validation/rules/fragment_spreads_are_possible_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::StaticValidation::FragmentSpreadsArePossible do

--- a/spec/graphql/static_validation/rules/fragment_types_exist_spec.rb
+++ b/spec/graphql/static_validation/rules/fragment_types_exist_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::StaticValidation::FragmentTypesExist do

--- a/spec/graphql/static_validation/rules/fragments_are_finite_spec.rb
+++ b/spec/graphql/static_validation/rules/fragments_are_finite_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::StaticValidation::FragmentsAreFinite do

--- a/spec/graphql/static_validation/rules/fragments_are_named_spec.rb
+++ b/spec/graphql/static_validation/rules/fragments_are_named_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::StaticValidation::FragmentTypesExist do

--- a/spec/graphql/static_validation/rules/fragments_are_on_composite_types_spec.rb
+++ b/spec/graphql/static_validation/rules/fragments_are_on_composite_types_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::StaticValidation::FragmentsAreOnCompositeTypes do

--- a/spec/graphql/static_validation/rules/fragments_are_used_spec.rb
+++ b/spec/graphql/static_validation/rules/fragments_are_used_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::StaticValidation::FragmentsAreUsed do

--- a/spec/graphql/static_validation/rules/mutation_root_exists_spec.rb
+++ b/spec/graphql/static_validation/rules/mutation_root_exists_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::StaticValidation::MutationRootExists do

--- a/spec/graphql/static_validation/rules/required_arguments_are_present_spec.rb
+++ b/spec/graphql/static_validation/rules/required_arguments_are_present_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::StaticValidation::RequiredArgumentsArePresent do

--- a/spec/graphql/static_validation/rules/subscription_root_exists_spec.rb
+++ b/spec/graphql/static_validation/rules/subscription_root_exists_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::StaticValidation::SubscriptionRootExists do

--- a/spec/graphql/static_validation/rules/unique_directives_per_location_spec.rb
+++ b/spec/graphql/static_validation/rules/unique_directives_per_location_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::StaticValidation::UniqueDirectivesPerLocation do

--- a/spec/graphql/static_validation/rules/variable_default_values_are_correctly_typed_spec.rb
+++ b/spec/graphql/static_validation/rules/variable_default_values_are_correctly_typed_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::StaticValidation::VariableDefaultValuesAreCorrectlyTyped do

--- a/spec/graphql/static_validation/rules/variable_usages_are_allowed_spec.rb
+++ b/spec/graphql/static_validation/rules/variable_usages_are_allowed_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::StaticValidation::VariableUsagesAreAllowed do

--- a/spec/graphql/static_validation/rules/variables_are_input_types_spec.rb
+++ b/spec/graphql/static_validation/rules/variables_are_input_types_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::StaticValidation::VariablesAreInputTypes do

--- a/spec/graphql/static_validation/rules/variables_are_used_and_defined_spec.rb
+++ b/spec/graphql/static_validation/rules/variables_are_used_and_defined_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::StaticValidation::VariablesAreUsedAndDefined do

--- a/spec/graphql/static_validation/type_stack_spec.rb
+++ b/spec/graphql/static_validation/type_stack_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 class TypeCheckValidator

--- a/spec/graphql/static_validation/validator_spec.rb
+++ b/spec/graphql/static_validation/validator_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::StaticValidation::Validator do

--- a/spec/graphql/string_type_spec.rb
+++ b/spec/graphql/string_type_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::STRING_TYPE do

--- a/spec/graphql/union_type_spec.rb
+++ b/spec/graphql/union_type_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::UnionType do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "codeclimate-test-reporter"
 CodeClimate::TestReporter.start
 require "sqlite3"

--- a/spec/support/dairy_app.rb
+++ b/spec/support/dairy_app.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "./dairy_data"
 
 class NoSuchDairyError < StandardError; end

--- a/spec/support/dairy_data.rb
+++ b/spec/support/dairy_data.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'ostruct'
 
 Cheese = Struct.new(:id, :flavor, :origin, :fat_content, :source)

--- a/spec/support/minimum_input_object.rb
+++ b/spec/support/minimum_input_object.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # This is the minimum required interface for an input object
 class MinimumInputObject
   include Enumerable

--- a/spec/support/star_wars_data.rb
+++ b/spec/support/star_wars_data.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'ostruct'
 
 names = [

--- a/spec/support/star_wars_schema.rb
+++ b/spec/support/star_wars_schema.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Adapted from graphql-relay-js
 # https://github.com/graphql/graphql-relay-js/blob/master/src/__tests__/starWarsSchema.js
 

--- a/spec/support/static_validation_helpers.rb
+++ b/spec/support/static_validation_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # This module assumes you have `let(:query_string)` in your spec.
 # It provides `errors` which are the validation errors for that string,
 # as validated against `DummySchema`.


### PR DESCRIPTION
> Matz said "All String literals are immutable (frozen) on Ruby 3".

The plan is for literal strings to be frozen by default in Ruby 3.0. For now, Ruby 2.3 lets developers opt in on a per file basis to transition to this new world.

This PR adds the `# frozen_string_literal: true` pragma to all files as well as enables the RuboCop linter to require its presence.

A few changes needed to be made to `.dup` string literals that were being used as String buffers to build up larger strings.

##

To: @rmosolgo 
CC: @charliesome 