### PR TITLE
feat(Field#lazy_resove) add hook for instrumenting lazy methods

### DIFF
--- a/guides/schema/instrumentation.md
+++ b/guides/schema/instrumentation.md
@@ -45,8 +45,9 @@ end
 
 It can be attached as shown above. You can use `redefine { ... }` to make a shallow copy of the  {{ "GraphQL::Field" | api_doc }} and extend its definition.
 
-## Query Instrumentation
+{{ "GraphQL::Field#lazy_resolve_proc" | api_doc }} can also be instrumented. This is called for objects registered with [lazy execution]({{ site.baseurl }}/schema/lazy_execution).
 
+## Query Instrumentation
 
 Query instrumentation can be attached during schema definition:
 

--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -77,10 +77,11 @@ module GraphQL
 
         lazy_method_name = query.lazy_method(raw_value)
         result = if lazy_method_name
-          GraphQL::Execution::Lazy.new(raw_value, lazy_method_name).then { |inner_value|
+          field.prepare_lazy(raw_value, arguments, field_ctx).then { |inner_value|
             continue_resolve_field(selection, parent_type, field, inner_value, field_ctx)
           }
         elsif raw_value.is_a?(GraphQL::Execution::Lazy)
+          # It came from a connection resolve, assume it was already instrumented
           raw_value.then { |inner_value|
             continue_resolve_field(selection, parent_type, field, inner_value, field_ctx)
           }

--- a/lib/graphql/relay/connection_resolve.rb
+++ b/lib/graphql/relay/connection_resolve.rb
@@ -12,10 +12,9 @@ module GraphQL
         nodes = @underlying_resolve.call(obj, args, ctx)
         lazy_method = ctx.query.lazy_method(nodes)
         if lazy_method
-          GraphQL::Execution::Lazy.new do
-            resolved_nodes = nodes.public_send(lazy_method)
+          @field.prepare_lazy(nodes, args, ctx).then { |resolved_nodes|
             build_connection(resolved_nodes, args, obj, ctx)
-          end
+          }
         else
           build_connection(nodes, args, obj, ctx)
         end


### PR DESCRIPTION
Now, you can "hook in" to `lazy_resolve` similar to `resolve`. You get access to the same things: type, field, runtime object (eg, Promise), arguments, and field context. 

I think you could use the runtime object to group `lazy_resolves` by _actual_ database operation. For example, I think `Promise#source` will point to the `Loader` instance. 