### PR TITLE
Query accessors

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -92,14 +92,33 @@ module GraphQL
           @mutation = @selected_operation.operation_type == "mutation"
         end
       end
+      @result = nil
+      @executed = false
     end
 
     # Get the result for this query, executing it once
+    # @return [Hash] A GraphQL response, with `"data"` and/or `"errors"` keys
     def result
-      @result ||= begin
+      if @executed
+        @result
+      else
+        @executed = true
         instrumenters = @schema.instrumenters[:query]
-        execution_call = ExecutionCall.new(self, instrumenters)
-        execution_call.call
+        begin
+          instrumenters.each { |i| i.before_query(self) }
+          @result = if !valid?
+            all_errors = validation_errors + analysis_errors
+            if all_errors.any?
+              { "errors" => all_errors.map(&:to_h) }
+            else
+              nil
+            end
+          else
+            Executor.new(self).result
+          end
+        ensure
+          instrumenters.each { |i| i.after_query(self) }
+        end
       end
     end
 
@@ -239,38 +258,6 @@ module GraphQL
         nil
       else
         operations[operation_name]
-      end
-    end
-
-    class ExecutionCall
-      def initialize(query, instrumenters)
-        @query = query
-        @instrumenters = instrumenters
-      end
-
-      # Check if the query is valid, and if it is,
-      # execute it, calling instrumenters along the way
-      # @return [Hash] The GraphQL response
-      def call
-        @instrumenters.each { |i| i.before_query(@query) }
-        get_result
-      ensure
-        @instrumenters.each { |i| i.after_query(@query) }
-      end
-
-      private
-
-      def get_result
-        if !@query.valid?
-          all_errors = @query.validation_errors + @query.analysis_errors
-          if all_errors.any?
-            { "errors" => all_errors.map(&:to_h) }
-          else
-            nil
-          end
-        else
-          Executor.new(@query).result
-        end
       end
     end
   end

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -25,7 +25,7 @@ module GraphQL
       end
     end
 
-    attr_reader :schema, :document, :context, :fragments, :operations, :root_value, :max_depth, :query_string, :warden
+    attr_reader :schema, :document, :context, :fragments, :operations, :root_value, :max_depth, :query_string, :warden, :provided_variables
 
     # Prepare query `query_string` on `schema`
     # @param schema [GraphQL::Schema]

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -377,4 +377,10 @@ describe GraphQL::Query do
       end
     end
   end
+
+  describe "#provided_variables" do
+    it "returns the originally-provided object" do
+      assert_equal({"cheeseId" => 2}, query.provided_variables)
+    end
+  end
 end

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -122,6 +122,24 @@ describe GraphQL::Query do
         assert_equal(expected, result)
       end
     end
+
+    describe "after_query hooks" do
+      module Instrumenter
+        ERROR_LOG = []
+        def self.before_query(q); end;
+        def self.after_query(q); ERROR_LOG << q.result["errors"]; end;
+      end
+
+      let(:schema) {
+        DummySchema.redefine {
+          instrument(:query, Instrumenter)
+        }
+      }
+      it "can access #result" do
+        result
+        assert_equal [nil], Instrumenter::ERROR_LOG
+      end
+    end
   end
 
   it "fails to execute a query containing a type definition" do


### PR DESCRIPTION
Make queries a bit more useful in instrumentation: 

- Expose `provided_variables`
- Allow calling `result` from inside `after_query`
