### PR TITLE
feat(Schema#type_error) use TypeError to pass info to type_error hook

### DIFF
--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -24,7 +24,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency "guard-minitest", "~> 2.4"
   s.add_development_dependency "guard-rake"
   s.add_development_dependency "listen", "~> 3.0.0"
-  s.add_development_dependency "minitest", "~> 5"
+  # Remove this limit when minitest-reports is compatible
+  # https://github.com/kern/minitest-reporters/pull/220
+  s.add_development_dependency "minitest", "~> 5.9.0"
   s.add_development_dependency "minitest-focus", "~> 1.1"
   s.add_development_dependency "minitest-reporters", "~>1.0"
   s.add_development_dependency "racc", "~> 1.4"

--- a/guides/schema/configuration_options.md
+++ b/guides/schema/configuration_options.md
@@ -80,22 +80,17 @@ You can specify behavior in these cases by defining a {{ "Schema#type_error" | a
 
 ```ruby
 MySchema = GraphQL::Schema.define do
-  type_error ->(value, field, parent_type, query_ctx) {
+  type_error ->(type_error, query_ctx) {
     # Handle a failed runtime type coercion
   }
 end
 ```
 
-It is called with four parameters:
-
-- `value` is the runtime value which was unexpected
-- `field` is the {{ "GraphQL::Field" | api_doc }} whose `resolve` function returned `value`
-- `parent_type` is the type that `field` belongs to
-- `query_ctx` is the same `ctx` which was provided to the resolve function
+It is called with an instance of {{ "GraphQL::UnresolvedTypeError" | api_doc }} or {{ "GraphQL::InvalidNullError" | api_doc }} and the query context (a {{ "GraphQL::Query::Context" |  api_doc }}).
 
 If you don't specify a hook, you get the default behavior:
 
-- Unexpected nulls add an error the response's `"errors"` key
+- Unexpected `nil`s add an error the response's `"errors"` key
 - Unresolved Union / Interface types raise {{ "GraphQL::UnresolvedTypeError" | api_doc }}
 
 An object that fails type resolution is treated as `nil`.

--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -76,6 +76,7 @@ require "graphql/schema/printer"
 # Order does not matter for these:
 
 require "graphql/analysis_error"
+require "graphql/type_error"
 require "graphql/invalid_null_error"
 require "graphql/unresolved_type_error"
 require "graphql/query"

--- a/lib/graphql/compatibility/execution_specification.rb
+++ b/lib/graphql/compatibility/execution_specification.rb
@@ -191,7 +191,7 @@ module GraphQL
               }
             }|
 
-            assert_raises(GraphQL::UnresolvedTypeError) {
+            err = assert_raises(GraphQL::UnresolvedTypeError) {
               execute_query(query_string, except: no_org)
             }
 
@@ -204,6 +204,11 @@ module GraphQL
 
             assert_equal nil, res["data"]
             assert_equal 1, res["errors"].length
+            assert_equal "SNCC", err.value.name
+            assert_equal GraphQL::Relay::Node.interface, err.field.type
+            assert_equal 1, err.possible_types.length
+            assert_equal "Organization", err.resolved_type.name
+            assert_equal "Query", err.parent_type.name
 
             query_string = %|
             {

--- a/lib/graphql/compatibility/execution_specification/specification_schema.rb
+++ b/lib/graphql/compatibility/execution_specification/specification_schema.rb
@@ -171,9 +171,9 @@ module GraphQL
               end
             }
 
-            type_error ->(val, field, type, ctx) {
-              ctx[:type_errors] && (ctx[:type_errors] << val)
-              ctx[:gobble] || GraphQL::Schema::DefaultTypeError.call(val, field, type, ctx)
+            type_error ->(err, ctx) {
+              ctx[:type_errors] && (ctx[:type_errors] << err.value)
+              ctx[:gobble] || GraphQL::Schema::DefaultTypeError.call(err, ctx)
             }
             middleware(TestMiddleware)
           end

--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -127,7 +127,8 @@ module GraphQL
       def resolve_value(parent_type, field_defn, field_type, value, selection, field_ctx)
         if value.nil?
           if field_type.kind.non_null?
-            field_ctx.schema.type_error(value, field_defn, parent_type, field_ctx)
+            type_error = GraphQL::InvalidNullError.new(parent_type, field_defn, value)
+            field_ctx.schema.type_error(type_error, field_ctx)
             PROPAGATE_NULL
           else
             nil
@@ -188,7 +189,8 @@ module GraphQL
             possible_types = query.possible_types(field_type)
 
             if !possible_types.include?(resolved_type)
-              field_ctx.schema.type_error(value, field_defn, parent_type, field_ctx)
+              type_error = GraphQL::UnresolvedTypeError.new(value, field_defn, parent_type, resolved_type, possible_types)
+              field_ctx.schema.type_error(type_error, field_ctx)
               PROPAGATE_NULL
             else
               resolve_value(

--- a/lib/graphql/invalid_null_error.rb
+++ b/lib/graphql/invalid_null_error.rb
@@ -2,12 +2,21 @@
 module GraphQL
   # Raised automatically when a field's resolve function returns `nil`
   # for a non-null field.
-  class InvalidNullError < GraphQL::Error
-    def initialize(parent_type_name, field_name, value)
-      @parent_type_name = parent_type_name
-      @field_name = field_name
+  class InvalidNullError < GraphQL::TypeError
+    # @return [GraphQL::BaseType] The owner of {#field}
+    attr_reader :parent_type
+
+    # @return [GraphQL::Field] The field which failed to return a value
+    attr_reader :field
+
+    # @return [nil, GraphQL::ExecutionError] The invalid value for this field
+    attr_reader :value
+
+    def initialize(parent_type, field, value)
+      @parent_type = parent_type
+      @field = field
       @value = value
-      super("Cannot return null for non-nullable field #{@parent_type_name}.#{@field_name}")
+      super("Cannot return null for non-nullable field #{@parent_type.name}.#{@field.name}")
     end
 
     # @return [Hash] An entry for the response's "errors" key

--- a/lib/graphql/non_null_type.rb
+++ b/lib/graphql/non_null_type.rb
@@ -12,7 +12,7 @@ module GraphQL
   #   # or
   #   field :items, ItemType.to_non_null_type
   #
-  # (If the application fails to return a value, {InvalidNullError} will be raised.)
+  # (If the application fails to return a value, {InvalidNullError} will be passed to {Schema#type_error}.)
   #
   # For input types, it says that the incoming value _must_ be provided by the query.
   #

--- a/lib/graphql/query/serial_execution/value_resolution.rb
+++ b/lib/graphql/query/serial_execution/value_resolution.rb
@@ -7,8 +7,10 @@ module GraphQL
           case value
           when GraphQL::ExecutionError, NilClass
             if field_type.kind.non_null?
-              type_error = GraphQL::InvalidNullError.new(parent_type, field_defn, value)
-              query_ctx.schema.type_error(type_error, query_ctx)
+              if value.nil?
+                type_error = GraphQL::InvalidNullError.new(parent_type, field_defn, value)
+                query_ctx.schema.type_error(type_error, query_ctx)
+              end
               GraphQL::Execution::Execute::PROPAGATE_NULL
             else
               nil

--- a/lib/graphql/query/serial_execution/value_resolution.rb
+++ b/lib/graphql/query/serial_execution/value_resolution.rb
@@ -7,7 +7,8 @@ module GraphQL
           case value
           when GraphQL::ExecutionError, NilClass
             if field_type.kind.non_null?
-              query_ctx.schema.type_error(value, field_defn, parent_type, query_ctx)
+              type_error = GraphQL::InvalidNullError.new(parent_type, field_defn, value)
+              query_ctx.schema.type_error(type_error, query_ctx)
               GraphQL::Execution::Execute::PROPAGATE_NULL
             else
               nil
@@ -69,7 +70,8 @@ module GraphQL
               possible_types = query.possible_types(field_type)
 
               if !possible_types.include?(resolved_type)
-                query.schema.type_error(value, field_defn, parent_type, query_ctx)
+                type_error = GraphQL::UnresolvedTypeError.new(value, field_defn, parent_type, resolved_type, possible_types)
+                query.schema.type_error(type_error, query_ctx)
                 nil
               else
                 resolve(

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -254,35 +254,25 @@ module GraphQL
     # When we encounter a type error during query execution, we call this hook.
     #
     # You can use this hook to write a log entry,
-    # add an error to the response (with `ctx.add_error`)
+    # add a {GraphQL::ExecutionError} to the response (with `ctx.add_error`)
     # or raise an exception and halt query execution.
     #
     # @example A `nil` is encountered by a non-null field
-    #   type_error ->(value, field, parent_type, parent_value) {
-    #     value           # => nil
-    #     field           # => #<GraphQL::Field name="count" ... >
-    #     field.type      # => #<GraphQL::NonNullType ... />
-    #     field.type.to_s # => Int!
-    #     parent_type     # => #<GraphQL::ObjectType ... />
-    #     parent_value    # => #<YourObject ... />
+    #   type_error ->(err, query_ctx) {
+    #     err.is_a?(GraphQL::InvalidNullError) # => true
     #   }
     #
     # @example An object doesn't resolve to one of a {UnionType}'s members
-    #   type_error ->(value, field, parent_type, query_ctx) {
-    #     value           # => nil
-    #     field           # => #<GraphQL::Field name="count" ... >
-    #     field.type      # => #<GraphQL::NonNullType ... />
-    #     field.type.to_s # => Int!
-    #     parent_type     # => #<GraphQL::ObjectType ... />
-    #     query_ctx.path  # => ["viewer", "teams", "count"]
+    #   type_error ->(err, query_ctx) {
+    #     err.is_a?(GraphQL::UnresolvedTypeError) # => true
     #   }
     #
     # @see {DefaultTypeError} is the default behavior.
-    # @param value [Object] This value was encountered, but couldn't be processed.
-    # @param expected_type [GraphQL::BaseType] Tried to treat `value` as this type, but we couldn't
+    # @param err [GraphQL::TypeError] The error encountered during execution
+    # @param ctx [GraphQL::Query::Context] The context for the field where the error occurred
     # @return void
-    def type_error(value, field, parent_type, parent_value)
-      @type_error_proc.call(value, field, parent_type, parent_value)
+    def type_error(err, ctx)
+      @type_error_proc.call(err, ctx)
     end
 
     # @param new_proc [#call] A new callable for handling type errors during execution

--- a/lib/graphql/schema/default_type_error.rb
+++ b/lib/graphql/schema/default_type_error.rb
@@ -2,17 +2,14 @@
 module GraphQL
   class Schema
     module DefaultTypeError
-      def self.call(value, field, parent_type, query_ctx)
-        if field.type.kind.non_null?
-          if value.nil?
-            query_ctx.errors << GraphQL::InvalidNullError.new(parent_type.name, field.name, value)
-          else
-            # it was caused by GraphQL::ExecutionError
+      def self.call(type_error, ctx)
+        case type_error
+        when GraphQL::InvalidNullError
+          if !type_error.parent_error?
+            ctx.errors << type_error
           end
-        else
-          resolved_type = query_ctx.query.resolve_type(value)
-          possible_types = query_ctx.query.possible_types(field.type.unwrap)
-          raise GraphQL::UnresolvedTypeError.new(field.name, field.type, parent_type, resolved_type, possible_types)
+        when GraphQL::UnresolvedTypeError
+          raise type_error
         end
       end
     end

--- a/lib/graphql/schema/default_type_error.rb
+++ b/lib/graphql/schema/default_type_error.rb
@@ -5,9 +5,7 @@ module GraphQL
       def self.call(type_error, ctx)
         case type_error
         when GraphQL::InvalidNullError
-          if !type_error.parent_error?
-            ctx.errors << type_error
-          end
+          ctx.errors << type_error
         when GraphQL::UnresolvedTypeError
           raise type_error
         end

--- a/lib/graphql/type_error.rb
+++ b/lib/graphql/type_error.rb
@@ -1,0 +1,4 @@
+module GraphQL
+  class TypeError < GraphQL::Error
+  end
+end

--- a/lib/graphql/unresolved_type_error.rb
+++ b/lib/graphql/unresolved_type_error.rb
@@ -1,10 +1,30 @@
 # frozen_string_literal: true
 module GraphQL
-  # Error raised when the value provided for a field can't be resolved to one of the possible types
-  # for the field.
-  class UnresolvedTypeError < GraphQL::Error
-    def initialize(field_name, field_type, parent_type, received_type, possible_types)
-      message = %|The value from "#{field_name}" on "#{parent_type}" could not be resolved to "#{field_type}". (Received: #{received_type.inspect}, Expected: [#{possible_types.map(&:inspect).join(", ")}])|
+  # Error raised when the value provided for a field
+  # can't be resolved to one of the possible types for the field.
+  class UnresolvedTypeError < GraphQL::TypeError
+    # @return [Object] The runtime value which couldn't be successfully resolved with `resolve_type`
+    attr_reader :value
+
+    # @return [GraphQL::Field] The field whose value couldn't be resolved (`field.type` is type which couldn't be resolved)
+    attr_reader :field
+
+    # @return [GraphQL::BaseType] The owner of `field`
+    attr_reader :parent_type
+
+    # @return [Object] The return of {Schema#resolve_type} for `value`
+    attr_reader :resolved_type
+
+    # @return [Array<GraphQL::BaseType>] The allowed options for resolving `value` to `field.type`
+    attr_reader :possible_types
+
+    def initialize(value, field, parent_type, resolved_type, possible_types)
+      @value = value
+      @field = field
+      @parent_type = parent_type
+      @resolved_type = resolved_type
+      @possible_types = possible_types
+      message = %|The value from "#{field.name}" on "#{parent_type}" could not be resolved to "#{field.type}". (Received: #{resolved_type.inspect}, Expected: [#{possible_types.map(&:inspect).join(", ")}])|
       super(message)
     end
   end


### PR DESCRIPTION
Pass a `TypeError` instance to `Schema#type_error` instead of a long list of marginally useful arguments 😬  Includes assertions about those error objects' APIs.

cc @dylanahsmith thanks for this suggestion!