### PR TITLE
Raise a PropagateNull exceptions to keep compatibility with graphql-batch

### DIFF
--- a/lib/graphql/invalid_null_error.rb
+++ b/lib/graphql/invalid_null_error.rb
@@ -24,9 +24,9 @@ module GraphQL
       { "message" => message }
     end
 
-    # @return [Boolean] Whether the null in question was caused by another error
+    # @deprecated always false
     def parent_error?
-      @value.is_a?(GraphQL::ExecutionError)
+      false
     end
   end
 end

--- a/lib/graphql/query/executor.rb
+++ b/lib/graphql/query/executor.rb
@@ -2,6 +2,8 @@
 module GraphQL
   class Query
     class Executor
+      class PropagateNull < StandardError; end
+
       # @return [GraphQL::Query] the query being executed
       attr_reader :query
 
@@ -31,7 +33,11 @@ module GraphQL
         execution_strategy = execution_strategy_class.new
 
         query.context.execution_strategy = execution_strategy
-        data_result = execution_strategy.execute(operation, root_type, query)
+        data_result = begin
+          execution_strategy.execute(operation, root_type, query)
+        rescue PropagateNull
+          nil
+        end
         result = { "data" => data_result }
         error_result = query.context.errors.map(&:to_h)
 

--- a/lib/graphql/query/serial_execution/field_resolution.rb
+++ b/lib/graphql/query/serial_execution/field_resolution.rb
@@ -53,14 +53,22 @@ module GraphQL
             end
           end
 
-          GraphQL::Query::SerialExecution::ValueResolution.resolve(
-            parent_type,
-            field,
-            field.type,
-            raw_value,
-            @selection,
-            @field_ctx,
-          )
+          begin
+            GraphQL::Query::SerialExecution::ValueResolution.resolve(
+              parent_type,
+              field,
+              field.type,
+              raw_value,
+              @selection,
+              @field_ctx,
+            )
+          rescue GraphQL::Query::Executor::PropagateNull
+            if field.type.kind.non_null?
+              raise
+            else
+              nil
+            end
+          end
         end
 
         # Get the result of:

--- a/lib/graphql/query/serial_execution/operation_resolution.rb
+++ b/lib/graphql/query/serial_execution/operation_resolution.rb
@@ -12,9 +12,6 @@ module GraphQL
           )
 
           result
-        rescue GraphQL::InvalidNullError => err
-          err.parent_error? || query.context.errors.push(err)
-          nil
         end
       end
     end

--- a/lib/graphql/query/serial_execution/selection_resolution.rb
+++ b/lib/graphql/query/serial_execution/selection_resolution.rb
@@ -7,19 +7,12 @@ module GraphQL
           selection_result = {}
 
           selection.each_selection(type: current_type) do |name, subselection|
-            field_result = query_ctx.execution_strategy.field_resolution.new(
+            selection_result.merge!(query_ctx.execution_strategy.field_resolution.new(
               subselection,
               current_type,
               target,
               query_ctx
-            ).result
-
-            if field_result.values[0] == GraphQL::Execution::Execute::PROPAGATE_NULL
-              selection_result = nil
-              break
-            else
-              selection_result.merge!(field_result)
-            end
+            ).result)
           end
 
           selection_result


### PR DESCRIPTION
## Problem

As originally mentioned in https://github.com/rmosolgo/graphql-ruby/pull/416#issuecomment-263365631

> I ran the graphql-batch tests and found that this PR caused a regression as seen from this graphql-batch test failure:
> 
> ```
>   1) Failure:
> GraphQL::GraphQLTest#test_non_null_field_promise_raises [/Users/dylansmith/src/graphql-batch/test/graphql_test.rb:116]:
> --- expected
> +++ actual
> @@ -1 +1 @@
> -{"data"=>nil, "errors"=>[{"message"=>"Error", "locations"=>[{"line"=>1, "column"=>3}], "path"=>["nonNullButPromiseRaises"]}]}
> +{"data"=>{"nonNullButPromiseRaises"=>:__graphql_propagate_null__}, "errors"=>[{"message"=>"Error", "locations"=>[{"line"=>1, "column"=>3}], "path"=>["nonNullButPromiseRaises"]}]}
> ```

The bug came from the serial execution engine refactor to use a PROPAGATE_NULL value rather than an exception, since now it expects that it can check that value in selection resolution.  As I mentioned in https://github.com/rmosolgo/graphql-ruby/pull/416#pullrequestreview-10430255 that doesn't work because graphql-batch lazily resolves fields, so the value may be a promise that will resolve to PROPAGATE_NULL.

## Solution

Switch back to using exceptions to propagate null values on non-null types, except using an internal GraphQL::Query::Executor::PropagateNull exception to make it clearer that it has distinct behaviour from the GraphQL::InvalidNullError type error.

The graphql-batch tests pass when run against this branch.