### PR TITLE
refactor(TypeError) rename to RuntimeTypeError to avoid conflicts

### DIFF
--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -76,7 +76,7 @@ require "graphql/schema/printer"
 # Order does not matter for these:
 
 require "graphql/analysis_error"
-require "graphql/type_error"
+require "graphql/runtime_type_error"
 require "graphql/invalid_null_error"
 require "graphql/unresolved_type_error"
 require "graphql/query"

--- a/lib/graphql/invalid_null_error.rb
+++ b/lib/graphql/invalid_null_error.rb
@@ -2,7 +2,7 @@
 module GraphQL
   # Raised automatically when a field's resolve function returns `nil`
   # for a non-null field.
-  class InvalidNullError < GraphQL::TypeError
+  class InvalidNullError < GraphQL::RuntimeTypeError
     # @return [GraphQL::BaseType] The owner of {#field}
     attr_reader :parent_type
 

--- a/lib/graphql/runtime_type_error.rb
+++ b/lib/graphql/runtime_type_error.rb
@@ -1,0 +1,4 @@
+module GraphQL
+  class RuntimeTypeError < GraphQL::Error
+  end
+end

--- a/lib/graphql/type_error.rb
+++ b/lib/graphql/type_error.rb
@@ -1,4 +1,0 @@
-module GraphQL
-  class TypeError < GraphQL::Error
-  end
-end

--- a/lib/graphql/unresolved_type_error.rb
+++ b/lib/graphql/unresolved_type_error.rb
@@ -2,7 +2,7 @@
 module GraphQL
   # Error raised when the value provided for a field
   # can't be resolved to one of the possible types for the field.
-  class UnresolvedTypeError < GraphQL::TypeError
+  class UnresolvedTypeError < GraphQL::RuntimeTypeError
     # @return [Object] The runtime value which couldn't be successfully resolved with `resolve_type`
     attr_reader :value
 


### PR DESCRIPTION
The previous name breaks existing "rescue TypeError" clauses inside the GraphQL namespace, boo hiss.
