### PR TITLE
Encoders

### DIFF
--- a/guides/relay/connections.md
+++ b/guides/relay/connections.md
@@ -6,7 +6,7 @@ Relay expresses [one-to-many relationships with _connections_](https://facebook.
 
 `graphql-ruby` includes built-in connection support for `Array`, `ActiveRecord::Relation`s, and `Sequel::Dataset`s. You can define custom connection classes to expose other collections with GraphQL.
 
-### Connection fields
+## Connection fields
 
 To define a connection field, use the `connection` helper. For a return type, get a type's `.connection_type`.  The `resolve` proc should return a collection (eg, `Array` or `ActiveRecord::Relation`) _without_ pagination. (The connection will paginate the collection).
 
@@ -55,7 +55,7 @@ You can limit the number of results with `max_page_size:`:
 connection :featured_comments, CommentType.connection_type, max_page_size: 50
 ```
 
-### Connection types
+## Connection types
 
 You can customize a connection type with `.define_connection`:
 
@@ -188,7 +188,7 @@ TeamMembershipsConnectionType = TeamType.define_connection(
 end
 ```
 
-### Connection objects
+## Connection objects
 
 Maybe you need to make a connection object yourself (for example, to return a connection type from a mutation). You can create a connection object like this:
 
@@ -272,3 +272,30 @@ field = GraphQL::Field.new
 # ... define the field
 connection_field = GraphQL::Relay::ConnectionField.create(field)
 ```
+
+## Cursors
+
+By default, cursors are encoded in base64 to make them opaque to a human client. You can specify a custom encoder with `Schema#cursor_encoder`. The value should be an object which responds to `.encode(plain_text)` and `.decode(encoded_text)`.
+
+For example, to use URL-safe base-64 encoding:
+
+```ruby
+module URLSafeBase64Encoder
+  def self.encode(txt)
+    Base64.urlsafe_encode64(txt)
+  end
+
+  def self.decode(txt)
+    Base64.urlsafe_decode64(txt)
+  end
+end
+
+MySchema = GraphQL::Schema.define do
+  # ...
+  cursor_encoder(URLSafeBase64Encoder)
+end
+```
+
+Now, all connections will use URL-safe base-64 encoding.
+
+From a connection instance, the `cursor_encoders` methods available via {{ "GraphQL::Relay::BaseConnection#encode" | api_doc }} and {{ "GraphQL::Relay::BaseConnection#decode" | api_doc }}

--- a/guides/relay/connections.md
+++ b/guides/relay/connections.md
@@ -275,17 +275,17 @@ connection_field = GraphQL::Relay::ConnectionField.create(field)
 
 ## Cursors
 
-By default, cursors are encoded in base64 to make them opaque to a human client. You can specify a custom encoder with `Schema#cursor_encoder`. The value should be an object which responds to `.encode(plain_text)` and `.decode(encoded_text)`.
+By default, cursors are encoded in base64 to make them opaque to a human client. You can specify a custom encoder with `Schema#cursor_encoder`. The value should be an object which responds to `.encode(plain_text, nonce:)` and `.decode(encoded_text, nonce:)`.
 
 For example, to use URL-safe base-64 encoding:
 
 ```ruby
 module URLSafeBase64Encoder
-  def self.encode(txt)
+  def self.encode(txt, nonce: false)
     Base64.urlsafe_encode64(txt)
   end
 
-  def self.decode(txt)
+  def self.decode(txt, nonce: false)
     Base64.urlsafe_decode64(txt)
   end
 end

--- a/guides/relay/connections.md
+++ b/guides/relay/connections.md
@@ -275,7 +275,7 @@ connection_field = GraphQL::Relay::ConnectionField.create(field)
 
 ## Cursors
 
-By default, cursors are encoded in base64 to make them opaque to a human client. You can specify a custom encoder with `Schema#cursor_encoder`. The value should be an object which responds to `.encode(plain_text, nonce:)` and `.decode(encoded_text, nonce:)`.
+By default, cursors are encoded in base64 to make them opaque to a human client. You can specify a custom encoder with `Schema#cursor_encoder`. The value should be an object which responds to `.encode(plain_text, nonce:)` and `.decode(encoded_text, nonce: false)`.
 
 For example, to use URL-safe base-64 encoding:
 

--- a/lib/graphql/relay/array_connection.rb
+++ b/lib/graphql/relay/array_connection.rb
@@ -4,7 +4,7 @@ module GraphQL
     class ArrayConnection < BaseConnection
       def cursor_from_node(item)
         idx = starting_offset + sliced_nodes.find_index(item) + 1
-        Base64.strict_encode64(idx.to_s)
+        encode(idx.to_s)
       end
 
       def has_next_page
@@ -36,7 +36,7 @@ module GraphQL
       end
 
       def index_from_cursor(cursor)
-        Base64.decode64(cursor).to_i
+        decode(cursor).to_i
       end
 
       def starting_offset

--- a/lib/graphql/relay/base_connection.rb
+++ b/lib/graphql/relay/base_connection.rb
@@ -55,12 +55,22 @@ module GraphQL
       # @param field [Object] The underlying field
       # @param max_page_size [Int] The maximum number of results to return
       # @param parent [Object] The object which this collection belongs to
-      def initialize(nodes, arguments, field: nil, max_page_size: nil, parent: nil)
+      def initialize(nodes, arguments, field: nil, max_page_size: nil, parent: nil, context: nil)
         @nodes = nodes
         @arguments = arguments
         @max_page_size = max_page_size
         @field = field
         @parent = parent
+        @context = context
+        @encoder = context ? @context.schema.cursor_encoder : GraphQL::Schema::Base64Encoder
+      end
+
+      def encode(plaintext)
+        @encoder.encode(plaintext)
+      end
+
+      def decode(ciphertext)
+        @encoder.decode(ciphertext)
       end
 
       # Provide easy access to provided arguments:

--- a/lib/graphql/relay/base_connection.rb
+++ b/lib/graphql/relay/base_connection.rb
@@ -12,7 +12,6 @@ module GraphQL
     #   - {#max_page_size} (the specified maximum page size that can be returned from a connection)
     #
     class BaseConnection
-      extend Forwardable
       # Just to encode data in the cursor, use something that won't conflict
       CURSOR_SEPARATOR = "---"
 
@@ -67,8 +66,13 @@ module GraphQL
         @encoder = context ? @context.schema.cursor_encoder : GraphQL::Schema::Base64Encoder
       end
 
+      def encode(data)
+        @encoder.encode(data, nonce: true)
+      end
 
-      def_delegators :@encoder, :encode, :decode
+      def decode(data)
+        @encoder.decode(data, nonce: true)
+      end
 
       # Provide easy access to provided arguments:
       METHODS_FROM_ARGUMENTS = [:first, :after, :last, :before]

--- a/lib/graphql/relay/base_connection.rb
+++ b/lib/graphql/relay/base_connection.rb
@@ -12,6 +12,7 @@ module GraphQL
     #   - {#max_page_size} (the specified maximum page size that can be returned from a connection)
     #
     class BaseConnection
+      extend Forwardable
       # Just to encode data in the cursor, use something that won't conflict
       CURSOR_SEPARATOR = "---"
 
@@ -50,11 +51,12 @@ module GraphQL
       attr_reader :nodes, :arguments, :max_page_size, :parent, :field
 
       # Make a connection, wrapping `nodes`
-      # @param [Object] The collection of nodes
-      # @param Query arguments
-      # @param field [Object] The underlying field
+      # @param nodes [Object] The collection of nodes
+      # @param arguments [GraphQL::Query::Arguments] Query arguments
+      # @param field [GraphQL::Field] The underlying field
       # @param max_page_size [Int] The maximum number of results to return
       # @param parent [Object] The object which this collection belongs to
+      # @param context [GraphQL::Query::Context] The context from the field being resolved
       def initialize(nodes, arguments, field: nil, max_page_size: nil, parent: nil, context: nil)
         @nodes = nodes
         @arguments = arguments
@@ -65,13 +67,8 @@ module GraphQL
         @encoder = context ? @context.schema.cursor_encoder : GraphQL::Schema::Base64Encoder
       end
 
-      def encode(plaintext)
-        @encoder.encode(plaintext)
-      end
 
-      def decode(ciphertext)
-        @encoder.decode(ciphertext)
-      end
+      def_delegators :@encoder, :encode, :decode
 
       # Provide easy access to provided arguments:
       METHODS_FROM_ARGUMENTS = [:first, :after, :last, :before]

--- a/lib/graphql/relay/connection_resolve.rb
+++ b/lib/graphql/relay/connection_resolve.rb
@@ -14,18 +14,18 @@ module GraphQL
         if lazy_method
           GraphQL::Execution::Lazy.new do
             resolved_nodes = nodes.public_send(lazy_method)
-            build_connection(resolved_nodes, args, obj)
+            build_connection(resolved_nodes, args, obj, ctx)
           end
         else
-          build_connection(nodes, args, obj)
+          build_connection(nodes, args, obj, ctx)
         end
       end
 
       private
 
-      def build_connection(nodes, args, parent)
+      def build_connection(nodes, args, parent, ctx)
         connection_class = GraphQL::Relay::BaseConnection.connection_for_nodes(nodes)
-        connection_class.new(nodes, args, field: @field, max_page_size: @max_page_size, parent: parent)
+        connection_class.new(nodes, args, field: @field, max_page_size: @max_page_size, parent: parent, context: ctx)
       end
     end
   end

--- a/lib/graphql/relay/relation_connection.rb
+++ b/lib/graphql/relay/relation_connection.rb
@@ -12,7 +12,7 @@ module GraphQL
           raise("Can't generate cursor, item not found in connection: #{item}")
         else
           offset = starting_offset + item_index + 1
-          Base64.strict_encode64(offset.to_s)
+          encode(offset.to_s)
         end
       end
 
@@ -37,7 +37,7 @@ module GraphQL
       end
 
       def offset_from_cursor(cursor)
-        Base64.decode64(cursor).to_i
+        decode(cursor).to_i
       end
 
       def starting_offset

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "graphql/schema/base_64_encoder"
 require "graphql/schema/catchall_middleware"
 require "graphql/schema/default_type_error"
 require "graphql/schema/invalid_type_error"
@@ -55,6 +56,7 @@ module GraphQL
       :max_depth, :max_complexity,
       :orphan_types, :resolve_type, :type_error,
       :object_from_id, :id_from_object,
+      :cursor_encoder,
       directives: ->(schema, directives) { schema.directives = directives.reduce({}) { |m, d| m[d.name] = d; m  }},
       instrument: -> (schema, type, instrumenter) { schema.instrumenters[type] << instrumenter },
       query_analyzer: ->(schema, analyzer) { schema.query_analyzers << analyzer },
@@ -67,7 +69,8 @@ module GraphQL
       :query_execution_strategy, :mutation_execution_strategy, :subscription_execution_strategy,
       :max_depth, :max_complexity,
       :orphan_types, :directives,
-      :query_analyzers, :middleware, :instrumenters, :lazy_methods
+      :query_analyzers, :middleware, :instrumenters, :lazy_methods,
+      :cursor_encoder
 
     class << self
       attr_accessor :default_execution_strategy
@@ -101,6 +104,7 @@ module GraphQL
       @type_error_proc = DefaultTypeError
       @instrumenters = Hash.new { |h, k| h[k] = [] }
       @lazy_methods = GraphQL::Execution::Lazy::LazyMethodMap.new
+      @cursor_encoder = Base64Encoder
       # Default to the built-in execution strategy:
       @query_execution_strategy = self.class.default_execution_strategy
       @mutation_execution_strategy = self.class.default_execution_strategy

--- a/lib/graphql/schema/base_64_encoder.rb
+++ b/lib/graphql/schema/base_64_encoder.rb
@@ -2,11 +2,11 @@ module GraphQL
   class Schema
     # @api private
     module Base64Encoder
-      def self.encode(plaintext)
+      def self.encode(plaintext, nonce: false)
         Base64.strict_encode64(plaintext)
       end
 
-      def self.decode(ciphertext)
+      def self.decode(ciphertext, nonce: false)
         Base64.decode64(ciphertext)
       end
     end

--- a/lib/graphql/schema/base_64_encoder.rb
+++ b/lib/graphql/schema/base_64_encoder.rb
@@ -1,0 +1,14 @@
+module GraphQL
+  class Schema
+    # @api private
+    module Base64Encoder
+      def self.encode(plaintext)
+        Base64.strict_encode64(plaintext)
+      end
+
+      def self.decode(ciphertext)
+        Base64.decode64(ciphertext)
+      end
+    end
+  end
+end

--- a/spec/graphql/relay/base_connection_spec.rb
+++ b/spec/graphql/relay/base_connection_spec.rb
@@ -2,9 +2,7 @@
 require 'spec_helper'
 
 describe GraphQL::Relay::BaseConnection do
-
   describe ".connection_for_nodes" do
-
     it "resolves most specific connection type" do
       class SpecialArray < Array; end
       class SpecialArrayConnection < GraphQL::Relay::BaseConnection; end
@@ -12,9 +10,39 @@ describe GraphQL::Relay::BaseConnection do
 
       nodes = SpecialArray.new
 
-      GraphQL::Relay::BaseConnection.connection_for_nodes(nodes)
-        .must_equal SpecialArrayConnection
+      conn_class = GraphQL::Relay::BaseConnection.connection_for_nodes(nodes)
+      assert_equal conn_class, SpecialArrayConnection
+    end
+  end
+
+  describe "#encode / #decode" do
+    module ReverseEncoder
+      module_function
+      def encode(str); str.reverse; end
+      def decode(str); str.reverse; end
     end
 
+    let(:schema) { OpenStruct.new(cursor_encoder: ReverseEncoder) }
+    let(:context) { OpenStruct.new(schema: schema) }
+
+    it "Uses the schema's encoder" do
+      conn = GraphQL::Relay::BaseConnection.new([], {}, context: context)
+
+      assert_equal "1/nosreP", conn.encode("Person/1")
+      assert_equal "Person/1", conn.decode("1/nosreP")
+    end
+
+    it "defaults to base64" do
+      conn = GraphQL::Relay::BaseConnection.new([], {}, context: nil)
+
+      assert_equal "UGVyc29uLzE=", conn.encode("Person/1")
+      assert_equal "Person/1", conn.decode("UGVyc29uLzE=")
+    end
+
+    it "handles trimmed base64" do
+      conn = GraphQL::Relay::BaseConnection.new([], {}, context: nil)
+
+      assert_equal "Person/1", conn.decode("UGVyc29uLzE")
+    end
   end
 end

--- a/spec/graphql/relay/base_connection_spec.rb
+++ b/spec/graphql/relay/base_connection_spec.rb
@@ -18,8 +18,8 @@ describe GraphQL::Relay::BaseConnection do
   describe "#encode / #decode" do
     module ReverseEncoder
       module_function
-      def encode(str); str.reverse; end
-      def decode(str); str.reverse; end
+      def encode(str, nonce: false); str.reverse; end
+      def decode(str, nonce: false); str.reverse; end
     end
 
     let(:schema) { OpenStruct.new(cursor_encoder: ReverseEncoder) }


### PR DESCRIPTION
If you write a custom connection, you can generate cursors however you want. But this option gives some flexibility to encoding cursor data for built-in connections.