### PR TITLE
feat(Execute) specify requirements of list objects

### DIFF
--- a/lib/graphql/compatibility/execution_specification.rb
+++ b/lib/graphql/compatibility/execution_specification.rb
@@ -82,6 +82,21 @@ module GraphQL
             assert_equal false, flh.key?("org_n"), "It doesn't apply other type fields"
           end
 
+          def test_it_iterates_over_each
+            query_string = %|
+              query getData($nodeId: ID = "1002") {
+                node(id: $nodeId) {
+                  ... on Person {
+                    organizations { name }
+                  }
+                }
+              }
+            |
+
+            res = execute_query(query_string)
+            assert_equal ["SNCC"], res["data"]["node"]["organizations"].map { |o| o["name"] }
+          end
+
           def test_it_propagates_nulls_to_field
             query_string = %|
             query getOrg($id: ID = "2001"){

--- a/lib/graphql/compatibility/execution_specification/specification_schema.rb
+++ b/lib/graphql/compatibility/execution_specification/specification_schema.rb
@@ -37,6 +37,17 @@ module GraphQL
           "2003" => BOGUS_NODE,
         }
 
+        # A list object must implement #each
+        class CustomCollection
+          def initialize(storage)
+            @storage = storage
+          end
+
+          def each
+            @storage.each { |i| yield(i) }
+          end
+        end
+
         module TestMiddleware
           def self.call(parent_type, parent_object, field_definition, field_args, query_context, next_middleware)
             query_context[:middleware_log] && query_context[:middleware_log] << field_definition.name
@@ -81,7 +92,7 @@ module GraphQL
             end
             field :organizations, types[organization_type] do
               resolve ->(obj, args, ctx) {
-                obj.organization_ids.map { |id| DATA[id] }
+                CustomCollection.new(obj.organization_ids.map { |id| DATA[id] })
               }
             end
             field :first_organization, !organization_type do

--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -148,15 +148,17 @@ module GraphQL
             field_type.coerce_result(value, field_ctx.query.warden)
           when GraphQL::TypeKinds::LIST
             wrapped_type = field_type.of_type
-            result = value.each_with_index.map do |inner_value, index|
+            i = 0
+            result = []
+            value.each do |inner_value|
               inner_ctx = field_ctx.spawn(
-                key: index,
+                key: i,
                 selection: selection,
                 parent_type: parent_type,
                 field: field_defn,
               )
 
-              inner_result = resolve_value(
+              result << resolve_value(
                 parent_type,
                 field_defn,
                 wrapped_type,
@@ -164,7 +166,7 @@ module GraphQL
                 selection,
                 inner_ctx,
               )
-              inner_result
+              i += 1
             end
             result
           when GraphQL::TypeKinds::NON_NULL

--- a/lib/graphql/query/serial_execution/value_resolution.rb
+++ b/lib/graphql/query/serial_execution/value_resolution.rb
@@ -22,15 +22,17 @@ module GraphQL
               field_type.coerce_result(value, query_ctx.query.warden)
             when GraphQL::TypeKinds::LIST
               wrapped_type = field_type.of_type
-              result = value.each_with_index.map do |inner_value, index|
+              result = []
+              i = 0
+              value.each do |inner_value|
                 inner_ctx = query_ctx.spawn(
-                  key: index,
+                  key: i,
                   selection: selection,
                   parent_type: wrapped_type,
                   field: field_defn,
                 )
 
-                inner_result = resolve(
+                result << resolve(
                   parent_type,
                   field_defn,
                   wrapped_type,
@@ -38,7 +40,7 @@ module GraphQL
                   selection,
                   inner_ctx,
                 )
-                inner_result
+                i += 1
               end
               result
             when GraphQL::TypeKinds::NON_NULL


### PR DESCRIPTION
Previously, it was an unspecified requirement that any object behind a `List` type had to implement `each_with_index` to return an enumerator. 

Now, it's a specified requirement that any `List` object must implement `#each`, yielding each member.