### PR TITLE
Better test coverage for FieldsWillMerge validation

### DIFF
--- a/lib/graphql/static_validation/rules/fields_will_merge.rb
+++ b/lib/graphql/static_validation/rules/fields_will_merge.rb
@@ -77,7 +77,7 @@ module GraphQL
 
           args = defs.map { |defn| reduce_list(defn.arguments)}.uniq
           if args.length != 1
-            errors << message("Field '#{name}' has an argument conflict: #{args.map {|a| print_arg(a) }.join(" or ")}?", defs.first, context: context)
+            errors << message("Field '#{name}' has an argument conflict: #{args.map{|arg| JSON.dump(arg)}.join(" or ")}?", defs.first, context: context)
           end
 
           @errors = errors
@@ -89,6 +89,8 @@ module GraphQL
           case arg
           when GraphQL::Language::Nodes::VariableIdentifier
             "$#{arg.name}"
+          when GraphQL::Language::Nodes::Enum
+            "#{arg.name}"
           else
             JSON.dump(arg)
           end
@@ -98,7 +100,7 @@ module GraphQL
         # can't look up args, the names just have to match
         def reduce_list(args)
           args.reduce({}) do |memo, a|
-            memo[a.name] = NAMED_VALUES.include?(a.value.class) ? a.value.name : a.value
+            memo[a.name] = print_arg(a.value)
             memo
           end
         end

--- a/spec/graphql/static_validation/rules/fields_will_merge_spec.rb
+++ b/spec/graphql/static_validation/rules/fields_will_merge_spec.rb
@@ -4,41 +4,524 @@ require "spec_helper"
 describe GraphQL::StaticValidation::FieldsWillMerge do
   include StaticValidationHelpers
 
-  let(:query_string) {"
-    query getCheese($sourceVar: [DairyAnimal!] = [YAK]) {
-      cheese(id: 1) {
-        id,
-        nickname: flavor,
-        nickname: fatContent,
-        fatContent
-        differentLevel: fatContent
-        similarCheese(source: $sourceVar) { __typename }
+  let(:schema) {
+    GraphQL::Schema.from_definition(%|
+      type Query {
+        dog: Dog
+        cat: Cat
+        pet: Pet
+        toy: Toy
+      }
 
-        similarCow: similarCheese(source: COW) {
-          similarCowSource: source,
-          differentLevel: fatContent
-        }
-        ...cheeseFields
-        ... on Cheese {
-          fatContent: flavor
-          similarCheese(source: SHEEP) { __typename }
+      enum PetCommand {
+        SIT
+        HEEL
+        JUMP
+        DOWN
+      }
+
+      enum ToySize {
+        SMALL
+        LARGE
+      }
+
+      interface Pet {
+        name(surname: Boolean = false): String!
+        nickname: String
+        toys: [Toy!]!
+      }
+
+      type Dog implements Pet {
+        name(surname: Boolean = false): String!
+        nickname: String
+        doesKnowCommand(dogCommand: PetCommand): Boolean!
+        barkVolume: Int!
+        toys: [Toy!]!
+      }
+
+      type Cat implements Pet {
+        name(surname: Boolean = false): String!
+        nickname: String
+        doesKnowCommand(catCommand: PetCommand): Boolean!
+        meowVolume: Int!
+        toys: [Toy!]!
+      }
+
+      type Toy {
+        name: String!
+        size: ToySize!
+        image(maxWidth: Int!): String!
+      }
+    |)
+  }
+
+  describe "unique fields" do
+    let(:query_string) {%|
+      {
+        dog {
+          name
+          nickname
         }
       }
-    }
-    fragment cheeseFields on Cheese {
-      fatContent,
-      similarCow: similarCheese(source: COW) { similarCowSource: id, id }
-      id @skip(if: true)
-    }
-  "}
+    |}
 
-  it "finds field naming conflicts" do
-    expected_errors = [
-      "Field 'nickname' has a field conflict: flavor or fatContent?",             # alias conflict in query
-      "Field 'fatContent' has a field conflict: fatContent or flavor?",           # alias/name conflict in query and fragment
-      "Field 'similarCheese' has an argument conflict: {\"source\":\"sourceVar\"} or {\"source\":\"SHEEP\"}?", # different arguments
-      "Field 'similarCowSource' has a field conflict: source or id?",           # nested conflict
-    ]
-    assert_equal(expected_errors, error_messages)
+    it "passes rule" do
+      assert_equal [], errors
+    end
+  end
+
+  describe "identical fields" do
+    let(:query_string) {%|
+      {
+        dog {
+          name
+          name
+        }
+      }
+    |}
+
+    it "passes rule" do
+      assert_equal [], errors
+    end
+  end
+
+  describe "identical fields with identical args" do
+    let(:query_string) {%|
+      {
+        dog {
+          doesKnowCommand(dogCommand: SIT)
+          doesKnowCommand(dogCommand: SIT)
+        }
+      }
+    |}
+
+    it "passes rule" do
+      assert_equal [], errors
+    end
+  end
+
+  describe "identical fields with identical values" do
+    let(:query_string) {%|
+      query($dogCommand: PetCommand) {
+        dog {
+          doesKnowCommand(dogCommand: $dogCommand)
+          doesKnowCommand(dogCommand: $dogCommand)
+        }
+      }
+    |}
+
+    it "passes rule" do
+      assert_equal [], errors
+    end
+  end
+
+  describe "identical aliases and fields" do
+    let(:query_string) {%|
+      {
+        dog {
+          otherName: name
+          otherName: name
+        }
+      }
+    |}
+
+    it "passes rule" do
+      assert_equal [], errors
+    end
+  end
+
+  describe "different args with different aliases" do
+    let(:query_string) {%|
+      {
+        dog {
+          knowsSit: doesKnowCommand(dogCommand: SIT)
+          knowsDown: doesKnowCommand(dogCommand: DOWN)
+        }
+      }
+    |}
+
+    it "passes rule" do
+      assert_equal [], errors
+    end
+  end
+
+  describe "conflicting args value and var" do
+    let(:query_string) {%|
+      query ($dogCommand: PetCommand) {
+        dog {
+          doesKnowCommand(dogCommand: SIT)
+          doesKnowCommand(dogCommand: $dogCommand)
+        }
+      }
+    |}
+
+    it "fails rule" do
+      assert_equal [%q(Field 'doesKnowCommand' has an argument conflict: {"dogCommand":"SIT"} or {"dogCommand":"dogCommand"}?)], error_messages
+    end
+  end
+
+  describe "conflicting args value and var" do
+    let(:query_string) {%|
+      query ($varOne: PetCommand, $varTwo: PetCommand) {
+        dog {
+          doesKnowCommand(dogCommand: $varOne)
+          doesKnowCommand(dogCommand: $varTwo)
+        }
+      }
+    |}
+
+    it "fails rule" do
+      assert_equal [%q(Field 'doesKnowCommand' has an argument conflict: {"dogCommand":"varOne"} or {"dogCommand":"varTwo"}?)], error_messages
+    end
+  end
+
+  describe "different directives with different aliases" do
+    let(:query_string) {%|
+      {
+        dog {
+          nameIfTrue: name @include(if: true)
+          nameIfFalse: name @include(if: false)
+        }
+      }
+    |}
+
+    it "passes rule" do
+      assert_equal [], errors
+    end
+  end
+
+  describe "different skip/include directives accepted" do
+    let(:query_string) {%|
+      {
+        dog {
+          name @include(if: true)
+          name @include(if: false)
+        }
+      }
+    |}
+
+    it "passes rule" do
+      assert_equal [], errors
+    end
+  end
+
+  describe "same aliases with different field targets" do
+    let(:query_string) {%|
+      {
+        dog {
+          fido: name
+          fido: nickname
+        }
+      }
+    |}
+
+    it "fails rule" do
+      assert_equal ["Field 'fido' has a field conflict: name or nickname?"], error_messages
+    end
+  end
+
+  describe "alias masking direct field access" do
+    let(:query_string) {%|
+      {
+        dog {
+          name: nickname
+          name
+        }
+      }
+    |}
+
+    it "fails rule" do
+      assert_equal ["Field 'name' has a field conflict: nickname or name?"], error_messages
+    end
+  end
+
+  describe "different args, second adds an argument" do
+    let(:query_string) {%|
+      {
+        dog {
+          doesKnowCommand
+          doesKnowCommand(dogCommand: HEEL)
+        }
+      }
+    |}
+
+    it "fails rule" do
+      assert_equal [%q(Field 'doesKnowCommand' has an argument conflict: {} or {"dogCommand":"HEEL"}?)], error_messages
+    end
+  end
+
+  describe "different args, second missing an argument" do
+    let(:query_string) {%|
+      {
+        dog {
+          doesKnowCommand(dogCommand: SIT)
+          doesKnowCommand
+        }
+      }
+    |}
+
+    it "fails rule" do
+      assert_equal [%q(Field 'doesKnowCommand' has an argument conflict: {"dogCommand":"SIT"} or {}?)], error_messages
+    end
+  end
+
+  describe "conflicting args" do
+    let(:query_string) {%|
+      {
+        dog {
+          doesKnowCommand(dogCommand: SIT)
+          doesKnowCommand(dogCommand: HEEL)
+        }
+      }
+    |}
+
+    it "fails rule" do
+      assert_equal [%q(Field 'doesKnowCommand' has an argument conflict: {"dogCommand":"SIT"} or {"dogCommand":"HEEL"}?)], error_messages
+    end
+  end
+
+  describe "conflicting arg values" do
+    let(:query_string) {%|
+      {
+        toy {
+          image(maxWidth: 10)
+          image(maxWidth: 20)
+        }
+      }
+    |}
+
+    it "fails rule" do
+      assert_equal [%q(Field 'image' has an argument conflict: {"maxWidth":10} or {"maxWidth":20}?)], error_messages
+    end
+  end
+
+  describe "encounters conflict in fragments" do
+    let(:query_string) {%|
+      {
+        pet {
+          ...A
+          ...B
+          name
+        }
+      }
+
+      fragment A on Dog {
+        x: name
+      }
+
+      fragment B on Dog {
+        x: nickname
+        name: nickname
+      }
+    |}
+
+    it "fails rule" do
+      assert_equal [
+        "Field 'x' has a field conflict: name or nickname?",
+        "Field 'name' has a field conflict: nickname or name?",
+      ], error_messages
+    end
+  end
+
+  describe "deep conflict" do
+    let(:query_string) {%|
+      {
+        dog {
+          x: name
+        }
+
+        dog {
+          x: nickname
+        }
+      }
+    |}
+
+    it "fails rule" do
+      assert_equal ["Field 'x' has a field conflict: name or nickname?"], error_messages
+    end
+  end
+
+  describe "deep conflict with multiple issues" do
+    let(:query_string) {%|
+      {
+        dog {
+          x: name
+          y: barkVolume
+        }
+
+        dog {
+          x: nickname
+          y: doesKnowCommand
+        }
+      }
+    |}
+
+    it "fails rule" do
+      assert_equal [
+        "Field 'x' has a field conflict: name or nickname?",
+        "Field 'y' has a field conflict: barkVolume or doesKnowCommand?",
+      ], error_messages
+    end
+  end
+
+  describe "very deep conflict" do
+    let(:query_string) {%|
+      {
+        dog {
+          toys {
+            x: name
+          }
+        }
+
+        dog {
+          toys {
+            x: size
+          }
+        }
+      }
+    |}
+
+    it "fails rule" do
+      assert_equal [
+        "Field 'x' has a field conflict: name or size?",
+      ], error_messages
+    end
+  end
+
+  describe "return types must be unambiguous" do
+    let(:schema) {
+      GraphQL::Schema.from_definition(%|
+        type Query {
+          someBox: SomeBox
+          connection: Connection
+        }
+
+        type Edge {
+          id: ID
+          name: String
+        }
+
+        interface SomeBox {
+          deepBox: SomeBox
+          unrelatedField: String
+        }
+
+        type StringBox implements SomeBox {
+          scalar: String
+          deepBox: StringBox
+          unrelatedField: String
+          listStringBox: [StringBox]
+          stringBox: StringBox
+          intBox: IntBox
+        }
+
+        type IntBox implements SomeBox {
+          scalar: Int
+          deepBox: IntBox
+          unrelatedField: String
+          listStringBox: [StringBox]
+          stringBox: StringBox
+          intBox: IntBox
+        }
+
+        interface NonNullStringBox1 {
+          scalar: String!
+        }
+
+        type NonNullStringBox1Impl implements SomeBox, NonNullStringBox1 {
+          scalar: String!
+          unrelatedField: String
+          deepBox: SomeBox
+        }
+
+        interface NonNullStringBox2 {
+          scalar: String!
+        }
+
+        type NonNullStringBox2Impl implements SomeBox, NonNullStringBox2 {
+          scalar: String!
+          unrelatedField: String
+          deepBox: SomeBox
+        }
+
+        type Connection {
+          edges: [Edge]
+        }
+      |)
+    }
+
+    describe "compatible return shapes on different return types" do
+      let(:query_string) {%|
+        {
+          someBox {
+            ... on SomeBox {
+              deepBox {
+                unrelatedField
+              }
+            }
+            ... on StringBox {
+              deepBox {
+                unrelatedField
+              }
+            }
+          }
+        }
+      |}
+
+      it "passes rule" do
+        assert_equal [], errors
+      end
+    end
+
+    describe "reports correctly when a non-exclusive follows an exclusive" do
+      let(:query_string) {%|
+        {
+          someBox {
+            ... on IntBox {
+              deepBox {
+                ...X
+              }
+            }
+          }
+          someBox {
+            ... on StringBox {
+              deepBox {
+                ...Y
+              }
+            }
+          }
+          memoed: someBox {
+            ... on IntBox {
+              deepBox {
+                ...X
+              }
+            }
+          }
+          memoed: someBox {
+            ... on StringBox {
+              deepBox {
+                ...Y
+              }
+            }
+          }
+          other: someBox {
+            ...X
+          }
+          other: someBox {
+            ...Y
+          }
+        }
+        fragment X on SomeBox {
+          scalar
+        }
+        fragment Y on SomeBox {
+          scalar: unrelatedField
+        }
+      |}
+
+      it "fails rule" do
+        assert_includes error_messages, "Field 'scalar' has a field conflict: scalar or unrelatedField?"
+      end
+    end
   end
 end

--- a/spec/graphql/static_validation/rules/fields_will_merge_spec.rb
+++ b/spec/graphql/static_validation/rules/fields_will_merge_spec.rb
@@ -156,7 +156,7 @@ describe GraphQL::StaticValidation::FieldsWillMerge do
     |}
 
     it "fails rule" do
-      assert_equal [%q(Field 'doesKnowCommand' has an argument conflict: {"dogCommand":"SIT"} or {"dogCommand":"dogCommand"}?)], error_messages
+      assert_equal [%q(Field 'doesKnowCommand' has an argument conflict: {"dogCommand":"SIT"} or {"dogCommand":"$dogCommand"}?)], error_messages
     end
   end
 
@@ -171,7 +171,7 @@ describe GraphQL::StaticValidation::FieldsWillMerge do
     |}
 
     it "fails rule" do
-      assert_equal [%q(Field 'doesKnowCommand' has an argument conflict: {"dogCommand":"varOne"} or {"dogCommand":"varTwo"}?)], error_messages
+      assert_equal [%q(Field 'doesKnowCommand' has an argument conflict: {"dogCommand":"$varOne"} or {"dogCommand":"$varTwo"}?)], error_messages
     end
   end
 
@@ -291,7 +291,7 @@ describe GraphQL::StaticValidation::FieldsWillMerge do
     |}
 
     it "fails rule" do
-      assert_equal [%q(Field 'image' has an argument conflict: {"maxWidth":10} or {"maxWidth":20}?)], error_messages
+      assert_equal [%q(Field 'image' has an argument conflict: {"maxWidth":"10"} or {"maxWidth":"20"}?)], error_messages
     end
   end
 


### PR DESCRIPTION
I ported over a bunch of tests from [graphql-js](https://github.com/graphql/graphql-js/blob/ba422261bfec5ad653a6812fab4718f4f22101c2/src/validation/__tests__/OverlappingFieldsCanBeMerged-test.js).

I also made a change to how we report variable names in error messages. It was previously broken as we were calling `print_arg` on `arg` which was always a `String`.

Before: `Field 'doesKnowCommand' has an argument conflict: {"dogCommand":"SIT"} or {"dogCommand":"dogCommand"}?`

After: `Field 'doesKnowCommand' has an argument conflict: {"dogCommand":"SIT"} or {"dogCommand":"$dogCommand"}?`

There is a few tests that I didn't add because they caused the build to fail (for example: #418). We can either add them to the spec commented out, or I can open an issue for each failing test.

:eyes: @rmosolgo 