### PR TITLE
Adds Apollo to docs

### DIFF
--- a/guides/index.md
+++ b/guides/index.md
@@ -109,3 +109,7 @@ If you're building a backend for [Relay](http://facebook.github.io/relay/), you'
 
 - A JSON dump of the schema, which you can get by sending [`GraphQL::Introspection::INTROSPECTION_QUERY`](https://github.com/rmosolgo/graphql-ruby/blob/master/lib/graphql/introspection/introspection_query.rb)
 - Relay-specific helpers for GraphQL, see the `GraphQL::Relay` guides.
+
+## Use with Apollo Client
+
+[Apollo Client](http://dev.apollodata.com/) is a full featured, simple to use GraphQL client with convenient integrations for popular view layers. You don't need to do anything special to connect Apollo Client to a `graphql-ruby` server.

--- a/guides/related_projects.md
+++ b/guides/related_projects.md
@@ -13,6 +13,7 @@ Want to add something? Please open a pull request [on GitHub](https://github.com
 - Rails Helpers:
   - [`graphql-activerecord`](https://github.com/goco-inc/graphql-activerecord)
   - [`graphql-rails-resolve`](https://github.com/colepatrickturner/graphql-rails-resolver)
+- [optics-agent-ruby](https://github.com/apollostack/optics-agent-ruby), a graphql-ruby agent for use with the [Apollo Optics](http://www.apollodata.com/optics) GraphQL performance tool.
 
 ## Blog Posts
 


### PR DESCRIPTION
Makes it clear the Apollo Client and graphql-ruby are totally compatible.