### PR TITLE
feat(Mutation) support lazy return values

### DIFF
--- a/lib/graphql/relay/mutation.rb
+++ b/lib/graphql/relay/mutation.rb
@@ -182,6 +182,18 @@ module GraphQL
             mutation_result = nil
           end
 
+          if ctx.schema.lazy?(mutation_result)
+            @mutation.field.prepare_lazy(mutation_result, args, ctx).then { |inner_obj|
+              build_result(inner_obj, args)
+            }
+          else
+            build_result(mutation_result, args)
+          end
+        end
+
+        private
+
+        def build_result(mutation_result, args)
           if @wrap_result
             @mutation.result_class.new(client_mutation_id: args[:input][:clientMutationId], result: mutation_result)
           else

--- a/spec/graphql/relay/mutation_spec.rb
+++ b/spec/graphql/relay/mutation_spec.rb
@@ -44,6 +44,11 @@ describe GraphQL::Relay::Mutation do
     assert_equal(expected, result)
   end
 
+  it "supports lazy resolution" do
+    result = star_wars_query(query_string, "clientMutationId" => "1234", "shipName" => "Slave II")
+    assert_equal "Slave II", result["data"]["introduceShip"]["shipEdge"]["node"]["name"]
+  end
+
   it "returns the result & clientMutationId" do
     result = star_wars_query(query_string, "clientMutationId" => "1234")
     expected = {"data" => {

--- a/spec/support/star_wars_schema.rb
+++ b/spec/support/star_wars_schema.rb
@@ -158,14 +158,34 @@ IntroduceShipMutation = GraphQL::Relay::Mutation.define do
   # Here's the mutation operation:
   resolve ->(root_obj, inputs, ctx) {
     faction_id = inputs["factionId"]
-    return GraphQL::ExecutionError.new("Sorry, Millennium Falcon ship is reserved") if inputs["shipName"] == 'Millennium Falcon'
-    ship = STAR_WARS_DATA.create_ship(inputs["shipName"], faction_id)
-    faction = STAR_WARS_DATA["Faction"][faction_id]
-    connection_class = GraphQL::Relay::BaseConnection.connection_for_nodes(faction.ships)
-    ships_connection = connection_class.new(faction.ships, inputs)
-    ship_edge = GraphQL::Relay::Edge.new(ship, ships_connection)
-    { shipEdge: ship_edge, faction: faction }
+    if inputs["shipName"] == 'Millennium Falcon'
+      GraphQL::ExecutionError.new("Sorry, Millennium Falcon ship is reserved")
+
+    else
+      ship = STAR_WARS_DATA.create_ship(inputs["shipName"], faction_id)
+      faction = STAR_WARS_DATA["Faction"][faction_id]
+      connection_class = GraphQL::Relay::BaseConnection.connection_for_nodes(faction.ships)
+      ships_connection = connection_class.new(faction.ships, inputs)
+      ship_edge = GraphQL::Relay::Edge.new(ship, ships_connection)
+      result = {
+        shipEdge: ship_edge,
+        faction: faction
+      }
+      if inputs["shipName"] == "Slave II"
+        LazyWrapper.new(result)
+      else
+        result
+      end
+    end
   }
+end
+
+
+class LazyWrapper
+  attr_reader :value
+  def initialize(value)
+    @value = value
+  end
 end
 
 QueryType = GraphQL::ObjectType.define do
@@ -217,4 +237,6 @@ StarWarsSchema = GraphQL::Schema.define do
   id_from_object ->(object, type, ctx) do
     GraphQL::Schema::UniqueWithinType.encode(type.name, object.id)
   end
+
+  lazy_resolve(LazyWrapper, :value)
 end


### PR DESCRIPTION
Now, a mutation can return a lazy value (like a graphql-batch Promise).

Thanks @theorygeek for pointing this out ... by the way, did it _ever_ work, I mean, did it work in a previous version? (I was looking back over the changes of this code and I couldn't figure out how it ever worked 😆 )