### PR TITLE
feat(InstanceDefinable) use #dup; make schema members #dup-able

### DIFF
--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -9,14 +9,20 @@ module GraphQL
         global_id_field: GraphQL::Define::AssignGlobalIdField,
       }
 
-    attr_accessor :name, :description
     ensure_defined(:name, :description)
 
-    # @!attribute name
-    #   @return [String] the name of this type, must be unique within a Schema
+    def initialize_copy(other)
+      super
+      # Reset these derived defaults
+      @connection_type = nil
+      @edge_type = nil
+    end
 
-    # @!attribute description
-    #  @return [String, nil] a description for this type
+    # @return [String] the name of this type, must be unique within a Schema
+    attr_accessor :name
+
+    # @return [String, nil] a description for this type
+    attr_accessor :description
 
     # @param other [GraphQL::BaseType] compare to this object
     # @return [Boolean] are these types equivalent? (incl. non-null, list)
@@ -103,22 +109,24 @@ module GraphQL
       end
     end
 
-    # Get the default connection type for this object type
+    # @return [GraphQL::ObjectType] The default connection type for this object type
     def connection_type
       @connection_type ||= define_connection
     end
 
     # Define a custom connection type for this object type
+    # @return [GraphQL::ObjectType]
     def define_connection(**kwargs, &block)
       GraphQL::Relay::ConnectionType.create_type(self, **kwargs, &block)
     end
 
-    # Get the default edge type for this object type
+    # @return [GraphQL::ObjectType] The default edge type for this object type
     def edge_type
       @edge_type ||= define_edge
     end
 
     # Define a custom edge type for this object type
+    # @return [GraphQL::ObjectType]
     def define_edge(**kwargs, &block)
       GraphQL::Relay::EdgeType.create_type(self, **kwargs, &block)
     end

--- a/lib/graphql/define/instance_definable.rb
+++ b/lib/graphql/define/instance_definable.rb
@@ -95,15 +95,19 @@ module GraphQL
         nil
       end
 
-      # Make a new instance of this class, then
-      # re-run any definitions on that object.
+      # Shallow-copy this object, then apply new definitions to the copy.
+      # @see {#define} for arguments
       # @return [InstanceDefinable] A new instance, with any extended definitions
       def redefine(**kwargs, &block)
         ensure_defined
-        new_instance = self.class.new
-        applied_definitions.each { |defn| new_instance.define(defn.define_keywords, &defn.define_proc) }
-        new_instance.define(**kwargs, &block)
-        new_instance
+        new_inst = self.dup
+        new_inst.define(**kwargs, &block)
+        new_inst
+      end
+
+      def initialize_copy(other)
+        super
+        @metadata = other.metadata.dup
       end
 
       private
@@ -126,14 +130,8 @@ module GraphQL
           if defn.define_proc
             defn_proxy.instance_eval(&defn.define_proc)
           end
-
-          applied_definitions << defn
         end
         nil
-      end
-
-      def applied_definitions
-        @applied_definitions ||= []
       end
 
       class Definition

--- a/lib/graphql/enum_type.rb
+++ b/lib/graphql/enum_type.rb
@@ -79,6 +79,12 @@ module GraphQL
       @values_by_name = {}
     end
 
+    def initialize_copy(other)
+      super
+      self.values = other.values.values
+    end
+
+
     # @param new_values [Array<EnumValue>] The set of values contained in this type
     def values=(new_values)
       @values_by_name = {}

--- a/lib/graphql/execution/lazy/lazy_method_map.rb
+++ b/lib/graphql/execution/lazy/lazy_method_map.rb
@@ -28,6 +28,10 @@ module GraphQL
         def get(value)
           @storage[value.class]
         end
+
+        def each
+          @storage.each { |k, v| yield(k,v) }
+        end
       end
     end
   end

--- a/lib/graphql/field.rb
+++ b/lib/graphql/field.rb
@@ -128,11 +128,6 @@ module GraphQL
       :relay_node_field,
       argument: GraphQL::Define::AssignArgument
 
-    attr_accessor :name, :deprecation_reason, :description, :property, :hash_key, :mutation, :arguments, :complexity
-
-    # @return [Boolean] True if this is the Relay find-by-id field
-    attr_accessor :relay_node_field
-
     ensure_defined(
       :name, :deprecation_reason, :description, :description=, :property, :hash_key, :mutation, :arguments, :complexity,
       :resolve, :resolve=, :lazy_resolve, :lazy_resolve=, :lazy_resolve_proc,
@@ -140,23 +135,38 @@ module GraphQL
       :relay_node_field,
     )
 
+    # @return [Boolean] True if this is the Relay find-by-id field
+    attr_accessor :relay_node_field
+
     # @return [<#call(obj, args, ctx)>] A proc-like object which can be called to return the field's value
     attr_reader :resolve_proc
 
     # @return [<#call(obj, args, ctx)>] A proc-like object which can be called trigger a lazy resolution
     attr_reader :lazy_resolve_proc
 
-    # @!attribute name
-    #   @return [String] The name of this field on its {GraphQL::ObjectType} (or {GraphQL::InterfaceType})
+    # @return [String] The name of this field on its {GraphQL::ObjectType} (or {GraphQL::InterfaceType})
+    attr_accessor :name
 
-    # @!attribute arguments
-    #   @return [Hash<String => GraphQL::Argument>] Map String argument names to their {GraphQL::Argument} implementations
+    # @return [String, nil] The client-facing description of this field
+    attr_accessor :description
 
-    # @!attribute mutation
-    #   @return [GraphQL::Relay::Mutation, nil] The mutation this field was derived from, if it was derived from a mutation
+    # @return [String, nil] The client-facing reason why this field is deprecated (if present, the field is deprecated)
+    attr_accessor :deprecation_reason
 
-    # @!attribute complexity
-    #   @return [Numeric, Proc] The complexity for this field (default: 1), as a constant or a proc like `->(query_ctx, args, child_complexity) { } # Numeric`
+    # @return [Hash<String => GraphQL::Argument>] Map String argument names to their {GraphQL::Argument} implementations
+    attr_accessor :arguments
+
+    # @return [GraphQL::Relay::Mutation, nil] The mutation this field was derived from, if it was derived from a mutation
+    attr_accessor :mutation
+
+    # @return [Numeric, Proc] The complexity for this field (default: 1), as a constant or a proc like `->(query_ctx, args, child_complexity) { } # Numeric`
+    attr_accessor :complexity
+
+    # @return [Symbol, nil] The method to call on `obj` to return this field (overrides {#name} if present)
+    attr_accessor :property
+
+    # @return [Object, nil] The key to access with `obj.[]` to resolve this field (overrides {#name} if present)
+    attr_accessor :hash_key
 
     def initialize
       @complexity = 1
@@ -164,6 +174,11 @@ module GraphQL
       @resolve_proc = build_default_resolver
       @lazy_resolve_proc = DefaultLazyResolve
       @relay_node_field = false
+    end
+
+    def initialize_copy(other)
+      super
+      @arguments = other.arguments.dup
     end
 
     # Get a value for this field

--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -45,6 +45,11 @@ module GraphQL
       @arguments = {}
     end
 
+    def initialize_copy(other)
+      super
+      @arguments = other.arguments.dup
+    end
+
     def kind
       GraphQL::TypeKinds::INPUT_OBJECT
     end

--- a/lib/graphql/interface_type.rb
+++ b/lib/graphql/interface_type.rb
@@ -32,6 +32,11 @@ module GraphQL
       @fields = {}
     end
 
+    def initialize_copy(other)
+      super
+      @fields = other.fields.dup
+    end
+
     def kind
       GraphQL::TypeKinds::INTERFACE
     end

--- a/lib/graphql/object_type.rb
+++ b/lib/graphql/object_type.rb
@@ -39,6 +39,13 @@ module GraphQL
       @dirty_interfaces = []
     end
 
+    def initialize_copy(other)
+      super
+      @clean_interfaces = nil
+      @dirty_interfaces = other.dirty_interfaces.dup
+      @fields = other.fields.dup
+    end
+
     # @param new_interfaces [Array<GraphQL::Interface>] interfaces that this type implements
     def interfaces=(new_interfaces)
       @clean_interfaces = nil
@@ -68,6 +75,10 @@ module GraphQL
     def all_fields
       interface_fields.merge(self.fields).values
     end
+
+    protected
+
+    attr_reader :dirty_interfaces
 
     private
 

--- a/lib/graphql/union_type.rb
+++ b/lib/graphql/union_type.rb
@@ -27,10 +27,17 @@ module GraphQL
     accepts_definitions :possible_types, :resolve_type
     ensure_defined :possible_types
 
+    def initialize_copy(other)
+      super
+      @clean_possible_types = nil
+      @dirty_possible_types = other.dirty_possible_types.dup
+    end
+
     def kind
       GraphQL::TypeKinds::UNION
     end
 
+    # @return [Boolean] True if `child_type_defn` is a member of this {UnionType}
     def include?(child_type_defn)
       possible_types.include?(child_type_defn)
     end
@@ -40,6 +47,7 @@ module GraphQL
       @dirty_possible_types = new_possible_types
     end
 
+    # @return [Array<GraphQL::ObjectType>] Types which may be found in this union
     def possible_types
       @clean_possible_types ||= begin
         if @dirty_possible_types.respond_to?(:map)
@@ -49,5 +57,9 @@ module GraphQL
         end
       end
     end
+
+    protected
+
+    attr_reader :dirty_possible_types
   end
 end

--- a/spec/graphql/base_type_spec.rb
+++ b/spec/graphql/base_type_spec.rb
@@ -26,4 +26,16 @@ describe GraphQL::BaseType do
   it "Accepts arbitrary metadata" do
     assert_equal ["Cheese"], CheeseType.metadata[:class_names]
   end
+
+  describe "#dup" do
+    it "resets connection types" do
+      # Make sure the defaults have been calculated
+      cheese_edge = CheeseType.edge_type
+      cheese_conn = CheeseType.connection_type
+      cheese_2 = CheeseType.dup
+      cheese_2.name = "Cheese2"
+      refute_equal cheese_edge, cheese_2.edge_type
+      refute_equal cheese_conn, cheese_2.connection_type
+    end
+  end
 end

--- a/spec/graphql/enum_type_spec.rb
+++ b/spec/graphql/enum_type_spec.rb
@@ -89,4 +89,13 @@ describe GraphQL::EnumType do
     enum = GraphQL::EnumType.define(name: "DairyAnimal", values: [cow, goat])
     assert_equal({ "COW" => cow, "GOAT" => goat }, enum.values)
   end
+
+  describe "#dup" do
+    it "copies the values map without altering the original" do
+      enum_2 = enum.dup
+      enum_2.add_value(GraphQL::EnumType::EnumValue.define(name: "MUSKRAT"))
+      assert_equal(6, enum.values.size)
+      assert_equal(7, enum_2.values.size)
+    end
+  end
 end

--- a/spec/graphql/field_spec.rb
+++ b/spec/graphql/field_spec.rb
@@ -165,5 +165,21 @@ describe GraphQL::Field do
       assert_equal 1, int_field.arguments.size
       assert_equal 2, int_field_2.arguments.size
     end
+
+    it "copies metadata, even out-of-bounds assignments" do
+      int_field = GraphQL::Field.define do
+        metadata(:a, 1)
+        argument :value, types.Int
+      end
+      int_field.metadata[:b] = 2
+
+      int_field_2 = int_field.redefine do
+        metadata(:c, 3)
+        argument :value_2, types.Int
+      end
+
+      assert_equal({a: 1, b: 2}, int_field.metadata)
+      assert_equal({a: 1, b: 2, c: 3}, int_field_2.metadata)
+    end
   end
 end

--- a/spec/graphql/input_object_type_spec.rb
+++ b/spec/graphql/input_object_type_spec.rb
@@ -253,4 +253,13 @@ describe GraphQL::InputObjectType do
       end
     end
   end
+
+  describe "#dup" do
+    it "shallow-copies internal state" do
+      input_object_2 = input_object.dup
+      input_object_2.arguments["nonsense"] = GraphQL::Argument.define(name: "int", type: GraphQL::INT_TYPE)
+      assert_equal 4, input_object.arguments.size
+      assert_equal 5, input_object_2.arguments.size
+    end
+  end
 end

--- a/spec/graphql/interface_type_spec.rb
+++ b/spec/graphql/interface_type_spec.rb
@@ -84,4 +84,13 @@ describe GraphQL::InterfaceType do
       end
     end
   end
+
+  describe "#dup" do
+    it "copies the fields without altering the original" do
+      interface_2 = interface.dup
+      interface_2.fields["extra"] = GraphQL::Field.define(name: "extra", type: GraphQL::BOOLEAN_TYPE)
+      assert_equal 3, interface.fields.size
+      assert_equal 4, interface_2.fields.size
+    end
+  end
 end

--- a/spec/graphql/object_type_spec.rb
+++ b/spec/graphql/object_type_spec.rb
@@ -46,4 +46,22 @@ describe GraphQL::ObjectType do
       assert_equal(field_from_iface.property, nil)
     end
   end
+
+  describe "#dup" do
+    it "copies fields and interfaces without altering the original" do
+      type.interfaces # load the internal cache
+      type_2 = type.dup
+
+      # IRL, use `+=`, not this
+      # (this tests the internal cache)
+      type_2.interfaces << type
+
+      type_2.fields["nonsense"] = GraphQL::Field.define(name: "nonsense", type: type)
+
+      assert_equal 3, type.interfaces.size
+      assert_equal 4, type_2.interfaces.size
+      assert_equal 8, type.fields.size
+      assert_equal 9, type_2.fields.size
+    end
+  end
 end

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -297,4 +297,17 @@ type Query {
       assert_equal false, schema.lazy?({})
     end
   end
+
+  describe "#dup" do
+    it "copies internal state" do
+      schema_2 = schema.dup
+      refute schema_2.types.equal?(schema.types)
+
+      refute schema_2.instrumenters.equal?(schema.instrumenters)
+      assert_equal schema_2.instrumenters, schema.instrumenters
+
+      refute schema_2.middleware.equal?(schema.middleware)
+      assert_equal schema_2.middleware, schema.middleware
+    end
+  end
 end

--- a/spec/graphql/union_type_spec.rb
+++ b/spec/graphql/union_type_spec.rb
@@ -95,4 +95,14 @@ describe GraphQL::UnionType do
       end
     end
   end
+
+  describe "#dup" do
+    it "copies possible types without affecting the orginal" do
+      union.possible_types # load the internal cache
+      union_2 = union.dup
+      union_2.possible_types << type_3
+      assert_equal 2, union.possible_types.size
+      assert_equal 3, union_2.possible_types.size
+    end
+  end
 end


### PR DESCRIPTION
this makes `#redefine` use `#dup` instead of keeping a log of previous `#define` calls and replaying them. 

The advantage is that any change _outside_ of a `#define` call (eg, assigning a metadata key directly) _will_ be captured by `#redefine`. 

The disadvantage is that it's possible for bugs to slip in where `#dup`-ed objects are accidentally sharing some state!