### PR TITLE
Fix coerece for generated schemas

### DIFF
--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -84,6 +84,8 @@ module GraphQL
           raise(NotImplementedError, "Generated Schema cannot use Interface or Union types for execution.")
         }
 
+        NullScalarCoerce = ->(val) { val }
+
         def build_enum_type(enum_type_definition, type_resolver)
           GraphQL::EnumType.define(
             name: enum_type_definition.name,
@@ -113,6 +115,7 @@ module GraphQL
           GraphQL::ScalarType.define(
             name: scalar_type_definition.name,
             description: scalar_type_definition.description,
+            coerce: NullScalarCoerce,
           )
         end
 

--- a/lib/graphql/schema/loader.rb
+++ b/lib/graphql/schema/loader.rb
@@ -120,7 +120,9 @@ module GraphQL
               ScalarType.define(
                 name: type["name"],
                 description: type["description"]
-              )
+              ) do
+                coerce ->(value) { value }
+              end
             end
           when "UNION"
             UnionType.define(

--- a/lib/graphql/schema/loader.rb
+++ b/lib/graphql/schema/loader.rb
@@ -36,6 +36,8 @@ module GraphQL
         raise(NotImplementedError, "This schema was loaded from string, so it can't resolve types for objects")
       }
 
+      NullScalarCoerce = ->(val) { val }
+
       class << self
         private
 
@@ -119,10 +121,9 @@ module GraphQL
             else
               ScalarType.define(
                 name: type["name"],
-                description: type["description"]
-              ) do
-                coerce ->(value) { value }
-              end
+                description: type["description"],
+                coerce: NullScalarCoerce,
+              )
             end
           when "UNION"
             UnionType.define(

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -1,9 +1,13 @@
 require "spec_helper"
 
 describe GraphQL::Schema::BuildFromDefinition do
+  # Build a schema from `definition` and assert that it
+  # prints out the same string.
+  # Then return the built schema.
   def build_schema_and_compare_output(definition)
     built_schema = GraphQL::Schema.from_definition(definition)
     assert_equal definition, GraphQL::Schema::Printer.print_schema(built_schema)
+    built_schema
   end
 
   describe '.build' do
@@ -345,7 +349,10 @@ type Root {
 }
       SCHEMA
 
-      build_schema_and_compare_output(schema.chop)
+      built_schema = build_schema_and_compare_output(schema.chop)
+      custom_scalar = built_schema.types["CustomScalar"]
+      assert_equal true, custom_scalar.valid_input?("anything", PermissiveWarden)
+      assert_equal true, custom_scalar.valid_input?(12345, PermissiveWarden)
     end
 
     it 'supports input object' do

--- a/spec/graphql/schema/loader_spec.rb
+++ b/spec/graphql/schema/loader_spec.rb
@@ -197,6 +197,12 @@ describe GraphQL::Schema::Loader do
       assert loaded_schema.execute(GraphQL::Introspection::INTROSPECTION_QUERY)
     end
 
+    it "has no-op coerce functions" do
+      custom_scalar = loaded_schema.types["BigInt"]
+      assert_equal true, custom_scalar.valid_input?("anything", PermissiveWarden)
+      assert_equal true, custom_scalar.valid_input?(12345, PermissiveWarden)
+    end
+
     it "sets correct default values on custom scalar arguments" do
       type = loaded_schema.types["Comment"]
       field = type.fields['fieldWithArg']


### PR DESCRIPTION
Previously, custom scalars had `nil` coerce functions, which would case validation to fail with `NoMethodError`. Now, they have no-op functions which consider _anything_ valid. It limits the strength of the validation, but it's better than the NoMethodError! 

Thanks @nevesenin for tracking this down in #424! 