### PR TITLE
Fixes rmosolgo/graphql-ruby/issues#446 - Use explicit quirks_mode: true on JSON.generate

### DIFF
--- a/lib/graphql/static_validation/rules/fields_will_merge.rb
+++ b/lib/graphql/static_validation/rules/fields_will_merge.rb
@@ -92,7 +92,7 @@ module GraphQL
           when GraphQL::Language::Nodes::Enum
             "#{arg.name}"
           else
-            JSON.dump(arg)
+            JSON.generate(arg, { quirks_mode: true })
           end
         end
 


### PR DESCRIPTION
Fixes #446 

Problem: 

```
 [ERROR] only generation of JSON objects or arrays allowed
arg: true
```

Solution: Enable `quirks_mode` so that `JSON.generate` will handle an `arg` of `true`.

```ruby
def print_arg(arg)
  case arg
  when GraphQL::Language::Nodes::VariableIdentifier
    "$#{arg.name}"
  when GraphQL::Language::Nodes::Enum
    "#{arg.name}"
  else
    JSON.generate(arg, { quirks_mode: true })
  end
end
```