### PR TITLE
feat(Language.serialize) add unified method for serializing values

### DIFF
--- a/lib/graphql/enum_type.rb
+++ b/lib/graphql/enum_type.rb
@@ -111,7 +111,7 @@ module GraphQL
       matching_value = allowed_values.find { |v| v.name == value_name }
 
       if matching_value.nil?
-        result.add_problem("Expected #{JSON.generate(value_name, quirks_mode: true)} to be one of: #{allowed_values.map(&:name).join(', ')}")
+        result.add_problem("Expected #{GraphQL::Language.serialize(value_name)} to be one of: #{allowed_values.map(&:name).join(', ')}")
       end
 
       result

--- a/lib/graphql/introspection/input_value_type.rb
+++ b/lib/graphql/introspection/input_value_type.rb
@@ -11,7 +11,7 @@ GraphQL::Introspection::InputValueType = GraphQL::ObjectType.define do
     resolve ->(obj, args, ctx) {
       if obj.default_value?
         value = obj.default_value
-        value.nil? ? 'null' : JSON.generate(obj.type.coerce_result(value), quirks_mode: true)
+        value.nil? ? 'null' : GraphQL::Language.serialize(obj.type.coerce_result(value))
       else
         nil
       end

--- a/lib/graphql/language.rb
+++ b/lib/graphql/language.rb
@@ -7,3 +7,12 @@ require "graphql/language/parser"
 require "graphql/language/token"
 require "graphql/language/visitor"
 require "graphql/language/comments"
+
+module GraphQL
+  module Language
+    # @api private
+    def self.serialize(value)
+      JSON.generate(value, quirks_mode: true)
+    end
+  end
+end

--- a/lib/graphql/language/generation.rb
+++ b/lib/graphql/language/generation.rb
@@ -151,7 +151,7 @@ module GraphQL
         when Nodes::AbstractNode
           node.to_query_string(indent: indent)
         when FalseClass, Float, Integer, NilClass, String, TrueClass
-          JSON.generate(node, quirks_mode: true)
+          GraphQL::Language.serialize(node)
         when Array
           "[#{node.map { |v| generate(v) }.join(", ")}]".dup
         when Hash

--- a/lib/graphql/scalar_type.rb
+++ b/lib/graphql/scalar_type.rb
@@ -46,7 +46,7 @@ module GraphQL
     def validate_non_null_input(value, warden)
       result = Query::InputValidationResult.new
       if coerce_non_null_input(value).nil?
-        result.add_problem("Could not coerce value #{JSON.generate(value, quirks_mode: true)} to #{name}")
+        result.add_problem("Could not coerce value #{GraphQL::Language.serialize(value)} to #{name}")
       end
       result
     end

--- a/lib/graphql/static_validation/rules/fields_will_merge.rb
+++ b/lib/graphql/static_validation/rules/fields_will_merge.rb
@@ -77,7 +77,7 @@ module GraphQL
 
           args = defs.map { |defn| reduce_list(defn.arguments)}.uniq
           if args.length != 1
-            errors << message("Field '#{name}' has an argument conflict: #{args.map{|arg| JSON.dump(arg)}.join(" or ")}?", defs.first, context: context)
+            errors << message("Field '#{name}' has an argument conflict: #{args.map{ |arg| GraphQL::Language.serialize(arg) }.join(" or ")}?", defs.first, context: context)
           end
 
           @errors = errors
@@ -92,7 +92,7 @@ module GraphQL
           when GraphQL::Language::Nodes::Enum
             "#{arg.name}"
           else
-            JSON.generate(arg, { quirks_mode: true })
+            GraphQL::Language.serialize(arg)
           end
         end
 


### PR DESCRIPTION
Occasionally, we serialize values but forget `quirks_mode` true, resulting in breakage for JSON implementations _other_ than the stdlib one. 

So, let's reduce the risk of doing that again by passing through this one helper.