### PR TITLE
refactor(Schema::Validation) only warn on __

### DIFF
--- a/lib/graphql/schema/validation.rb
+++ b/lib/graphql/schema/validation.rb
@@ -178,14 +178,23 @@ module GraphQL
         }
 
         RESERVED_TYPE_NAME = ->(type) {
-          return unless type.name.start_with?('__')
-          return if INTROSPECTION_TYPES[type.name] && INTROSPECTION_TYPES[type.name] == type
-          "Name #{type.name.inspect} must not begin with \"__\", which is reserved by GraphQL introspection."
+          if type.name.start_with?('__') && INTROSPECTION_TYPES[type.name] != type
+            # TODO: make this a hard failure in a later version
+            warn("Name #{type.name.inspect} must not begin with \"__\", which is reserved by GraphQL introspection.")
+            nil
+          else
+            # ok name
+          end
         }
 
         RESERVED_NAME = ->(named_thing) {
-          return unless named_thing.name.start_with?('__')
-          "Name #{named_thing.name.inspect} must not begin with \"__\", which is reserved by GraphQL introspection."
+          if named_thing.name.start_with?('__')
+            # TODO: make this a hard failure in a later version
+            warn("Name #{named_thing.name.inspect} must not begin with \"__\", which is reserved by GraphQL introspection.")
+            nil
+          else
+            # no worries
+          end
         }
       end
 

--- a/spec/graphql/schema/validation_spec.rb
+++ b/spec/graphql/schema/validation_spec.rb
@@ -7,6 +7,10 @@ describe GraphQL::Schema::Validation do
     assert_includes validation_error, error_substring
   end
 
+  def assert_validation_warns(object, warning)
+    assert_output("", warning + "\n") { GraphQL::Schema::Validation.validate(object) }
+  end
+
   describe "validating Fields" do
     let(:unnamed_field) {
       GraphQL::Field.define do
@@ -53,7 +57,7 @@ describe GraphQL::Schema::Validation do
     end
 
     it "cannot use reserved name" do
-      assert_error_includes invalid_name_field, 'Name "__Something" must not begin with "__", which is reserved by GraphQL introspection.'
+      assert_validation_warns invalid_name_field, 'Name "__Something" must not begin with "__", which is reserved by GraphQL introspection.'
     end
 
     it "requires a BaseType for type" do
@@ -94,7 +98,7 @@ describe GraphQL::Schema::Validation do
     end
 
     it "cannot use reserved name" do
-      assert_error_includes invalid_name_type, 'Name "__Something" must not begin with "__", which is reserved by GraphQL introspection.'
+      assert_validation_warns invalid_name_type, 'Name "__Something" must not begin with "__", which is reserved by GraphQL introspection.'
     end
 
     it "requires String-or-nil description" do
@@ -256,7 +260,7 @@ describe GraphQL::Schema::Validation do
     end
 
     it "cannot use reserved name" do
-      assert_error_includes invalid_name_argument, 'Name "__Something" must not begin with "__", which is reserved by GraphQL introspection.'
+      assert_validation_warns invalid_name_argument, 'Name "__Something" must not begin with "__", which is reserved by GraphQL introspection.'
     end
 
     it "allows null default value for nullable argument" do


### PR DESCRIPTION
As I was preparing the changelog for 1.3.0, I realized that we could make this transition more gradual. I don't want to put a blocker in front of people who want to upgrade! 

In a later version, we can make this fail by default but provide an option to use the old way. Then maybe someday we can remove it altogether. (I didn't take that approach now because `Schema::Valdiation`'s design is not conducive to it.)

@chollier, this one is for you :)