### PR TITLE
Add Connection.nodes shorthand

### DIFF
--- a/lib/graphql/relay/connection_type.rb
+++ b/lib/graphql/relay/connection_type.rb
@@ -2,8 +2,14 @@
 module GraphQL
   module Relay
     module ConnectionType
+      class << self
+        attr_accessor :default_nodes_field
+      end
+
+      self.default_nodes_field = false
+
       # Create a connection which exposes edges of this type
-      def self.create_type(wrapped_type, edge_type: nil, edge_class: nil, nodes_field: false, &block)
+      def self.create_type(wrapped_type, edge_type: nil, edge_class: nil, nodes_field: ConnectionType.default_nodes_field, &block)
         edge_type ||= wrapped_type.edge_type
         edge_class ||= GraphQL::Relay::Edge
         connection_type_name = "#{wrapped_type.name}Connection"

--- a/lib/graphql/relay/connection_type.rb
+++ b/lib/graphql/relay/connection_type.rb
@@ -3,7 +3,7 @@ module GraphQL
   module Relay
     module ConnectionType
       # Create a connection which exposes edges of this type
-      def self.create_type(wrapped_type, edge_type: nil, edge_class: nil, &block)
+      def self.create_type(wrapped_type, edge_type: nil, edge_class: nil, nodes_field: false, &block)
         edge_type ||= wrapped_type.edge_type
         edge_class ||= GraphQL::Relay::Edge
         connection_type_name = "#{wrapped_type.name}Connection"
@@ -15,6 +15,14 @@ module GraphQL
             resolve ->(obj, args, ctx) {
               obj.edge_nodes.map { |item| edge_class.new(item, obj) }
             }
+          end
+          if nodes_field
+            field :nodes, types[wrapped_type] do
+              description "A list of nodes."
+              resolve ->(obj, args, ctx) {
+                obj.edge_nodes
+              }
+            end
           end
           field :pageInfo, !PageInfo, "Information to aid in pagination.", property: :page_info
           block && instance_eval(&block)

--- a/spec/graphql/relay/connection_type_spec.rb
+++ b/spec/graphql/relay/connection_type_spec.rb
@@ -36,5 +36,25 @@ describe GraphQL::Relay::ConnectionType do
         assert_equal [upcased_rebels_name] , bases["edges"].map { |e| e["upcasedParentName"] }.uniq
       end
     end
+
+    describe "connections with nodes field" do
+      let(:query_string) {%|
+        {
+          rebels {
+            bases: basesWithCustomEdge {
+              nodes {
+                name
+              }
+            }
+          }
+        }
+      |}
+
+      it "uses the custom edge and custom connection" do
+        result = star_wars_query(query_string)
+        bases = result["data"]["rebels"]["bases"]
+        assert_equal ["Yavin", "Echo Base", "Secret Hideout"] , bases["nodes"].map { |e| e["name"] }
+      end
+    end
   end
 end

--- a/spec/support/star_wars_schema.rb
+++ b/spec/support/star_wars_schema.rb
@@ -18,7 +18,7 @@ BaseType = GraphQL::ObjectType.define do
 end
 
 # Use an optional block to add fields to the connection type:
-BaseConnectionWithTotalCountType = BaseType.define_connection do
+BaseConnectionWithTotalCountType = BaseType.define_connection(nodes_field: true) do
   name "BasesConnectionWithTotalCount"
   field :totalCount do
     type types.Int
@@ -45,7 +45,7 @@ CustomBaseEdgeType = BaseType.define_edge do
   end
 end
 
-CustomEdgeBaseConnectionType = BaseType.define_connection(edge_class: CustomBaseEdge, edge_type: CustomBaseEdgeType) do
+CustomEdgeBaseConnectionType = BaseType.define_connection(edge_class: CustomBaseEdge, edge_type: CustomBaseEdgeType, nodes_field: true) do
   name "CustomEdgeBaseConnection"
 
   field :totalCountTimes100 do


### PR DESCRIPTION
While the `Connection`/`Edge`/`Node` model provides a useful place to attach join model annotations, most of @github's usage has just been enumerating a connection's node list. Cursor data is simply accessed via `PageInfo.endCursor`.

This change adds and additional `Connection.nodes` as a shortcut for accessing `Connection->edges->node`.

I understand this isn't part of the Relay spec specifically, so maybe it could be opt-in if you think its  necessary?

I'm hoping I'm remember this right, but I believe @dschafer (@facebook) mentioned this alias to me at a GraphQL conference/meetup thing.