### PR TITLE
Bug with ArrayConnection

### DIFF
--- a/lib/graphql/relay/array_connection.rb
+++ b/lib/graphql/relay/array_connection.rb
@@ -32,7 +32,7 @@ module GraphQL
 
       # Apply cursors to edges
       def sliced_nodes
-        @sliced_nodes ||= nodes[starting_offset..-1]
+        @sliced_nodes ||= nodes[starting_offset..-1] || []
       end
 
       def index_from_cursor(cursor)

--- a/spec/graphql/relay/array_connection_spec.rb
+++ b/spec/graphql/relay/array_connection_spec.rb
@@ -81,6 +81,12 @@ describe GraphQL::Relay::ArrayConnection do
       assert_equal(["X-Wing", "Y-Wing"], get_names(result))
     end
 
+    it 'handles cursors beyond the bounds of the array' do
+      overreaching_cursor = Base64.strict_encode64("100")
+      result = star_wars_query(query_string, "after" => overreaching_cursor, "first" => 2)
+      assert_equal([], get_names(result))
+    end
+
     it 'applies custom arguments' do
       result = star_wars_query(query_string, "nameIncludes" => "Wing", "first" => 2)
       names = get_names(result)

--- a/spec/graphql/relay/relation_connection_spec.rb
+++ b/spec/graphql/relay/relation_connection_spec.rb
@@ -97,6 +97,12 @@ describe GraphQL::Relay::RelationConnection do
 
     end
 
+    it 'handles cursors beyond the bounds of the array' do
+      overreaching_cursor = Base64.strict_encode64("100")
+      result = star_wars_query(query_string, "after" => overreaching_cursor, "first" => 2)
+      assert_equal([], get_names(result))
+    end
+
     it "applies custom arguments" do
       result = star_wars_query(query_string, "first" => 1, "nameIncludes" => "ea")
       assert_equal(["Death Star"], get_names(result))


### PR DESCRIPTION
This fixes a bug with the ArrayConnection. The failure condition is if the field resolver returns an array with N elements, and you then query against that connection with the starting offset of N+1.

```
2.3.1 :004 > x = (0...20).to_a
 => [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19] 
2.3.1 :005 > x[21..-1]
 => nil 
```

The `sliced_nodes` method ends up returning `nil`. And then `paged_nodes` tries to do:
```ruby
items.first(limit)
```
And it 💥  because of a null reference. This can happen if the connection _used_ to have plenty of elements in it, but now it doesn't anymore.

