### PR TITLE
Type reflections

### DIFF
--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -6,6 +6,7 @@ module GraphQL
     include GraphQL::Define::InstanceDefinable
     accepts_definitions :name, :description,
         :introspection,
+        :default_scalar,
         {
           connection: GraphQL::Define::AssignConnection,
           global_id_field: GraphQL::Define::AssignGlobalIdField,
@@ -19,6 +20,7 @@ module GraphQL
       @connection_type = nil
       @edge_type = nil
       @introspection = false
+      @default_scalar = false
     end
 
     # @return [String] the name of this type, must be unique within a Schema
@@ -26,14 +28,19 @@ module GraphQL
 
     # @return [String, nil] a description for this type
     attr_accessor :description
- 
+
     # @return [Boolean] Is this type a predefined introspection type?
     def introspection?
       @introspection
     end
 
+    # @return [Boolean] Is this type a built-in scalar type? (eg, `String`, `Int`)
+    def default_scalar?
+      @default_scalar
+    end
+
     # @api private
-    attr_writer :introspection
+    attr_writer :introspection, :default_scalar
 
     # @param other [GraphQL::BaseType] compare to this object
     # @return [Boolean] are these types equivalent? (incl. non-null, list)

--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -7,20 +7,25 @@ module GraphQL
     accepts_definitions :name, :description,
         :introspection,
         :default_scalar,
+        :default_relay,
         {
           connection: GraphQL::Define::AssignConnection,
           global_id_field: GraphQL::Define::AssignGlobalIdField,
         }
 
-    ensure_defined(:name, :description, :introspection?)
+    ensure_defined(:name, :description, :introspection?, :default_scalar?)
+
+    def initialize
+      @introspection = false
+      @default_scalar = false
+      @default_relay = false
+    end
 
     def initialize_copy(other)
       super
       # Reset these derived defaults
       @connection_type = nil
       @edge_type = nil
-      @introspection = false
-      @default_scalar = false
     end
 
     # @return [String] the name of this type, must be unique within a Schema
@@ -39,8 +44,13 @@ module GraphQL
       @default_scalar
     end
 
+    # @return [Boolean] Is this type a built-in Relay type? (`Node`, `PageInfo`)
+    def default_relay?
+      @default_relay
+    end
+
     # @api private
-    attr_writer :introspection, :default_scalar
+    attr_writer :introspection, :default_scalar, :default_relay
 
     # @param other [GraphQL::BaseType] compare to this object
     # @return [Boolean] are these types equivalent? (incl. non-null, list)

--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -4,18 +4,21 @@ module GraphQL
   class BaseType
     include GraphQL::Define::NonNullWithBang
     include GraphQL::Define::InstanceDefinable
-    accepts_definitions :name, :description, {
-        connection: GraphQL::Define::AssignConnection,
-        global_id_field: GraphQL::Define::AssignGlobalIdField,
-      }
+    accepts_definitions :name, :description,
+        :introspection,
+        {
+          connection: GraphQL::Define::AssignConnection,
+          global_id_field: GraphQL::Define::AssignGlobalIdField,
+        }
 
-    ensure_defined(:name, :description)
+    ensure_defined(:name, :description, :introspection?)
 
     def initialize_copy(other)
       super
       # Reset these derived defaults
       @connection_type = nil
       @edge_type = nil
+      @introspection = false
     end
 
     # @return [String] the name of this type, must be unique within a Schema
@@ -23,6 +26,14 @@ module GraphQL
 
     # @return [String, nil] a description for this type
     attr_accessor :description
+ 
+    # @return [Boolean] Is this type a predefined introspection type?
+    def introspection?
+      @introspection
+    end
+
+    # @api private
+    attr_writer :introspection
 
     # @param other [GraphQL::BaseType] compare to this object
     # @return [Boolean] are these types equivalent? (incl. non-null, list)

--- a/lib/graphql/boolean_type.rb
+++ b/lib/graphql/boolean_type.rb
@@ -5,4 +5,5 @@ GraphQL::BOOLEAN_TYPE = GraphQL::ScalarType.define do
 
   coerce_input ->(value) { (value == true || value == false) ? value : nil }
   coerce_result ->(value) { !!value }
+  default_scalar true
 end

--- a/lib/graphql/directive.rb
+++ b/lib/graphql/directive.rb
@@ -8,10 +8,12 @@ module GraphQL
   #
   class Directive
     include GraphQL::Define::InstanceDefinable
-    accepts_definitions :locations, :name, :description, :arguments, argument: GraphQL::Define::AssignArgument
+    accepts_definitions :locations, :name, :description, :arguments, :default, argument: GraphQL::Define::AssignArgument
 
     attr_accessor :locations, :arguments, :name, :description
-    ensure_defined(:locations, :arguments, :name, :description)
+    # @api private
+    attr_writer :default
+    ensure_defined(:locations, :arguments, :name, :description, :default?)
 
     LOCATIONS = [
       QUERY =                  :QUERY,
@@ -58,6 +60,7 @@ module GraphQL
 
     def initialize
       @arguments = {}
+      @default = false
     end
 
     def to_s
@@ -74,6 +77,11 @@ module GraphQL
 
     def on_operation?
       locations.include?(QUERY) && locations.include?(MUTATION) && locations.include?(SUBSCRIPTION)
+    end
+
+    # @return [Boolean] Is this directive supplied by default? (eg `@skip`)
+    def default?
+      @default
     end
   end
 end

--- a/lib/graphql/directive.rb
+++ b/lib/graphql/directive.rb
@@ -8,12 +8,12 @@ module GraphQL
   #
   class Directive
     include GraphQL::Define::InstanceDefinable
-    accepts_definitions :locations, :name, :description, :arguments, :default, argument: GraphQL::Define::AssignArgument
+    accepts_definitions :locations, :name, :description, :arguments, :default_directive, argument: GraphQL::Define::AssignArgument
 
     attr_accessor :locations, :arguments, :name, :description
     # @api private
-    attr_writer :default
-    ensure_defined(:locations, :arguments, :name, :description, :default?)
+    attr_writer :default_directive
+    ensure_defined(:locations, :arguments, :name, :description, :default_directive?)
 
     LOCATIONS = [
       QUERY =                  :QUERY,
@@ -60,7 +60,7 @@ module GraphQL
 
     def initialize
       @arguments = {}
-      @default = false
+      @default_directive = false
     end
 
     def to_s
@@ -80,8 +80,8 @@ module GraphQL
     end
 
     # @return [Boolean] Is this directive supplied by default? (eg `@skip`)
-    def default?
-      @default
+    def default_directive?
+      @default_directive
     end
   end
 end

--- a/lib/graphql/directive/deprecated_directive.rb
+++ b/lib/graphql/directive/deprecated_directive.rb
@@ -9,5 +9,5 @@ GraphQL::Directive::DeprecatedDirective = GraphQL::Directive.define do
     "in [Markdown](https://daringfireball.net/projects/markdown/)."
 
   argument :reason, GraphQL::STRING_TYPE, reason_description, default_value: GraphQL::Directive::DEFAULT_DEPRECATION_REASON
-  default true
+  default_directive true
 end

--- a/lib/graphql/directive/deprecated_directive.rb
+++ b/lib/graphql/directive/deprecated_directive.rb
@@ -9,4 +9,5 @@ GraphQL::Directive::DeprecatedDirective = GraphQL::Directive.define do
     "in [Markdown](https://daringfireball.net/projects/markdown/)."
 
   argument :reason, GraphQL::STRING_TYPE, reason_description, default_value: GraphQL::Directive::DEFAULT_DEPRECATION_REASON
+  default true
 end

--- a/lib/graphql/directive/include_directive.rb
+++ b/lib/graphql/directive/include_directive.rb
@@ -4,5 +4,5 @@ GraphQL::Directive::IncludeDirective = GraphQL::Directive.define do
   description "Directs the executor to include this field or fragment only when the `if` argument is true."
   locations([GraphQL::Directive::FIELD, GraphQL::Directive::FRAGMENT_SPREAD, GraphQL::Directive::INLINE_FRAGMENT])
   argument :if, !GraphQL::BOOLEAN_TYPE, 'Included when true.'
-  default true
+  default_directive true
 end

--- a/lib/graphql/directive/include_directive.rb
+++ b/lib/graphql/directive/include_directive.rb
@@ -4,4 +4,5 @@ GraphQL::Directive::IncludeDirective = GraphQL::Directive.define do
   description "Directs the executor to include this field or fragment only when the `if` argument is true."
   locations([GraphQL::Directive::FIELD, GraphQL::Directive::FRAGMENT_SPREAD, GraphQL::Directive::INLINE_FRAGMENT])
   argument :if, !GraphQL::BOOLEAN_TYPE, 'Included when true.'
+  default true
 end

--- a/lib/graphql/directive/skip_directive.rb
+++ b/lib/graphql/directive/skip_directive.rb
@@ -5,5 +5,5 @@ GraphQL::Directive::SkipDirective = GraphQL::Directive.define do
   locations([GraphQL::Directive::FIELD, GraphQL::Directive::FRAGMENT_SPREAD, GraphQL::Directive::INLINE_FRAGMENT])
 
   argument :if, !GraphQL::BOOLEAN_TYPE, 'Skipped when true.'
-  default true
+  default_directive true
 end

--- a/lib/graphql/directive/skip_directive.rb
+++ b/lib/graphql/directive/skip_directive.rb
@@ -5,4 +5,5 @@ GraphQL::Directive::SkipDirective = GraphQL::Directive.define do
   locations([GraphQL::Directive::FIELD, GraphQL::Directive::FRAGMENT_SPREAD, GraphQL::Directive::INLINE_FRAGMENT])
 
   argument :if, !GraphQL::BOOLEAN_TYPE, 'Skipped when true.'
+  default true
 end

--- a/lib/graphql/enum_type.rb
+++ b/lib/graphql/enum_type.rb
@@ -76,6 +76,7 @@ module GraphQL
     ensure_defined(:values, :validate_non_null_input, :coerce_non_null_input, :coerce_result)
 
     def initialize
+      super
       @values_by_name = {}
     end
 

--- a/lib/graphql/float_type.rb
+++ b/lib/graphql/float_type.rb
@@ -5,4 +5,5 @@ GraphQL::FLOAT_TYPE = GraphQL::ScalarType.define do
 
   coerce_input ->(value) { value.is_a?(Numeric) ? value.to_f : nil }
   coerce_result ->(value) { value.to_f }
+  default_scalar true
 end

--- a/lib/graphql/id_type.rb
+++ b/lib/graphql/id_type.rb
@@ -12,4 +12,5 @@ GraphQL::ID_TYPE = GraphQL::ScalarType.define do
       nil
     end
   }
+  default_scalar true
 end

--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -42,6 +42,7 @@ module GraphQL
 
 
     def initialize
+      super
       @arguments = {}
     end
 

--- a/lib/graphql/int_type.rb
+++ b/lib/graphql/int_type.rb
@@ -5,4 +5,5 @@ GraphQL::INT_TYPE = GraphQL::ScalarType.define do
 
   coerce_input ->(value) { value.is_a?(Numeric) ? value.to_i : nil }
   coerce_result ->(value) { value.to_i }
+  default_scalar true
 end

--- a/lib/graphql/interface_type.rb
+++ b/lib/graphql/interface_type.rb
@@ -29,6 +29,7 @@ module GraphQL
     ensure_defined :fields
 
     def initialize
+      super
       @fields = {}
     end
 

--- a/lib/graphql/introspection/directive_location_enum.rb
+++ b/lib/graphql/introspection/directive_location_enum.rb
@@ -7,4 +7,5 @@ GraphQL::Introspection::DirectiveLocationEnum = GraphQL::EnumType.define do
   GraphQL::Directive::LOCATIONS.each do |location|
     value(location.to_s, GraphQL::Directive::LOCATION_DESCRIPTIONS[location], value: location)
   end
+  introspection true
 end

--- a/lib/graphql/introspection/directive_type.rb
+++ b/lib/graphql/introspection/directive_type.rb
@@ -14,4 +14,5 @@ GraphQL::Introspection::DirectiveType = GraphQL::ObjectType.define do
   field :onOperation, !types.Boolean, deprecation_reason: "Use `locations`.", property: :on_operation?
   field :onFragment, !types.Boolean, deprecation_reason: "Use `locations`.", property: :on_fragment?
   field :onField, !types.Boolean, deprecation_reason: "Use `locations`.", property: :on_field?
+  introspection true
 end

--- a/lib/graphql/introspection/enum_value_type.rb
+++ b/lib/graphql/introspection/enum_value_type.rb
@@ -10,4 +10,5 @@ GraphQL::Introspection::EnumValueType = GraphQL::ObjectType.define do
     resolve ->(obj, a, c) { !!obj.deprecation_reason }
   end
   field :deprecationReason, types.String, property: :deprecation_reason
+  introspection true
 end

--- a/lib/graphql/introspection/field_type.rb
+++ b/lib/graphql/introspection/field_type.rb
@@ -11,4 +11,5 @@ GraphQL::Introspection::FieldType = GraphQL::ObjectType.define do
     resolve ->(obj, a, c) { !!obj.deprecation_reason }
   end
   field :deprecationReason, types.String, property: :deprecation_reason
+  introspection true
 end

--- a/lib/graphql/introspection/input_value_type.rb
+++ b/lib/graphql/introspection/input_value_type.rb
@@ -17,4 +17,5 @@ GraphQL::Introspection::InputValueType = GraphQL::ObjectType.define do
       end
     }
   end
+  introspection true
 end

--- a/lib/graphql/introspection/schema_type.rb
+++ b/lib/graphql/introspection/schema_type.rb
@@ -24,4 +24,6 @@ GraphQL::Introspection::SchemaType = GraphQL::ObjectType.define do
   field :directives, !types[!GraphQL::Introspection::DirectiveType], "A list of all directives supported by this server." do
     resolve ->(obj, arg, ctx) { obj.directives.values }
   end
+
+  introspection true
 end

--- a/lib/graphql/introspection/type_kind_enum.rb
+++ b/lib/graphql/introspection/type_kind_enum.rb
@@ -5,4 +5,5 @@ GraphQL::Introspection::TypeKindEnum = GraphQL::EnumType.define do
   GraphQL::TypeKinds::TYPE_KINDS.each do |type_kind|
     value(type_kind.name, type_kind.description)
   end
+  introspection true
 end

--- a/lib/graphql/introspection/type_type.rb
+++ b/lib/graphql/introspection/type_type.rb
@@ -22,4 +22,5 @@ GraphQL::Introspection::TypeType = GraphQL::ObjectType.define do
   field :enumValues,    GraphQL::Introspection::EnumValuesField
   field :inputFields,   GraphQL::Introspection::InputFieldsField
   field :ofType,        GraphQL::Introspection::OfTypeField
+  introspection true
 end

--- a/lib/graphql/list_type.rb
+++ b/lib/graphql/list_type.rb
@@ -28,6 +28,7 @@ module GraphQL
     include GraphQL::BaseType::ModifiesAnotherType
     attr_reader :of_type
     def initialize(of_type:)
+      super()
       @of_type = of_type
     end
 

--- a/lib/graphql/non_null_type.rb
+++ b/lib/graphql/non_null_type.rb
@@ -33,6 +33,7 @@ module GraphQL
 
     attr_reader :of_type
     def initialize(of_type:)
+      super()
       @of_type = of_type
     end
 

--- a/lib/graphql/object_type.rb
+++ b/lib/graphql/object_type.rb
@@ -35,6 +35,7 @@ module GraphQL
 
 
     def initialize
+      super
       @fields = {}
       @dirty_interfaces = []
     end

--- a/lib/graphql/relay/node.rb
+++ b/lib/graphql/relay/node.rb
@@ -23,6 +23,7 @@ module GraphQL
           name "Node"
           description "An object with an ID."
           field :id, !types.ID, "ID of the object."
+          default_relay true
         end
       end
 

--- a/lib/graphql/relay/page_info.rb
+++ b/lib/graphql/relay/page_info.rb
@@ -9,6 +9,7 @@ module GraphQL
       field :hasPreviousPage, !types.Boolean, "Indicates if there are any pages prior to the current page", property: :has_previous_page
       field :startCursor, types.String, "When paginating backwards, the cursor to continue", property: :start_cursor
       field :endCursor, types.String, "When paginating forwards, the cursor to continue", property: :end_cursor
+      default_relay true
     end
   end
 end

--- a/lib/graphql/schema/printer.rb
+++ b/lib/graphql/schema/printer.rb
@@ -54,7 +54,7 @@ module GraphQL
       IS_USER_DEFINED_MEMBER = ->(member) {
         case member
         when GraphQL::BaseType
-          !member.name.start_with?("__")
+          !member.introspection?
         when GraphQL::Directive
           !member.default?
         else

--- a/lib/graphql/schema/printer.rb
+++ b/lib/graphql/schema/printer.rb
@@ -42,14 +42,6 @@ module GraphQL
 
       private
 
-      BUILTIN_SCALARS = [
-        GraphQL::STRING_TYPE,
-        GraphQL::BOOLEAN_TYPE,
-        GraphQL::INT_TYPE,
-        GraphQL::FLOAT_TYPE,
-        GraphQL::ID_TYPE,
-      ]
-
       # By default, these are included in a schema printout
       IS_USER_DEFINED_MEMBER = ->(member) {
         case member
@@ -62,12 +54,12 @@ module GraphQL
         end
       }
 
-      private_constant :BUILTIN_SCALARS, :IS_USER_DEFINED_MEMBER
+      private_constant :IS_USER_DEFINED_MEMBER
 
       def print_filtered_schema(schema, warden:)
         directive_definitions = warden.directives.map { |directive| print_directive(warden, directive) }
 
-        printable_types = warden.types - BUILTIN_SCALARS
+        printable_types = warden.types.reject(&:default_scalar?)
 
         type_definitions = printable_types
           .sort_by(&:name)

--- a/lib/graphql/schema/printer.rb
+++ b/lib/graphql/schema/printer.rb
@@ -42,8 +42,6 @@ module GraphQL
 
       private
 
-      BUILTIN_DIRECTIVE_NAMES = Set.new(['skip', 'include', 'deprecated'])
-
       BUILTIN_SCALARS = [
         GraphQL::STRING_TYPE,
         GraphQL::BOOLEAN_TYPE,
@@ -58,13 +56,13 @@ module GraphQL
         when GraphQL::BaseType
           !member.name.start_with?("__")
         when GraphQL::Directive
-          !BUILTIN_DIRECTIVE_NAMES.include?(member.name)
+          !member.default?
         else
           true
         end
       }
 
-      private_constant :BUILTIN_DIRECTIVE_NAMES, :BUILTIN_SCALARS, :IS_USER_DEFINED_MEMBER
+      private_constant :BUILTIN_SCALARS, :IS_USER_DEFINED_MEMBER
 
       def print_filtered_schema(schema, warden:)
         directive_definitions = warden.directives.map { |directive| print_directive(warden, directive) }

--- a/lib/graphql/schema/printer.rb
+++ b/lib/graphql/schema/printer.rb
@@ -48,7 +48,7 @@ module GraphQL
         when GraphQL::BaseType
           !member.introspection?
         when GraphQL::Directive
-          !member.default?
+          !member.default_directive?
         else
           true
         end

--- a/lib/graphql/schema/validation.rb
+++ b/lib/graphql/schema/validation.rb
@@ -178,7 +178,7 @@ module GraphQL
         }
 
         RESERVED_TYPE_NAME = ->(type) {
-          if type.name.start_with?('__') && INTROSPECTION_TYPES[type.name] != type
+          if type.name.start_with?('__') && !type.introspection?
             # TODO: make this a hard failure in a later version
             warn("Name #{type.name.inspect} must not begin with \"__\", which is reserved by GraphQL introspection.")
             nil
@@ -246,17 +246,6 @@ module GraphQL
           Rules::SCHEMA_INSTRUMENTERS_ARE_VALID,
         ],
       }
-
-      INTROSPECTION_TYPES = Hash[[
-        GraphQL::Introspection::TypeType,
-        GraphQL::Introspection::TypeKindEnum,
-        GraphQL::Introspection::FieldType,
-        GraphQL::Introspection::InputValueType,
-        GraphQL::Introspection::EnumValueType,
-        GraphQL::Introspection::DirectiveType,
-        GraphQL::Introspection::DirectiveLocationEnum,
-        GraphQL::Introspection::SchemaType,
-      ].map{ |type| [type.name, type] }]
     end
   end
 end

--- a/lib/graphql/string_type.rb
+++ b/lib/graphql/string_type.rb
@@ -5,4 +5,5 @@ GraphQL::STRING_TYPE = GraphQL::ScalarType.define do
 
   coerce_result ->(value) { value.to_s }
   coerce_input ->(value) { value.is_a?(String) ? value : nil }
+  default_scalar true
 end

--- a/lib/graphql/union_type.rb
+++ b/lib/graphql/union_type.rb
@@ -27,6 +27,12 @@ module GraphQL
     accepts_definitions :possible_types
     ensure_defined :possible_types
 
+    def initialize
+      super
+      @dirty_possible_types = []
+      @clean_possible_types = nil
+    end
+
     def initialize_copy(other)
       super
       @clean_possible_types = nil

--- a/spec/graphql/directive/skip_directive_spec.rb
+++ b/spec/graphql/directive/skip_directive_spec.rb
@@ -3,6 +3,6 @@ require "spec_helper"
 describe GraphQL::Directive::SkipDirective do
   let(:directive) { GraphQL::Directive::SkipDirective }
   it "is a default directive" do
-    assert directive.default?
+    assert directive.default_directive?
   end
 end

--- a/spec/graphql/directive/skip_directive_spec.rb
+++ b/spec/graphql/directive/skip_directive_spec.rb
@@ -1,0 +1,8 @@
+require "spec_helper"
+
+describe GraphQL::Directive::SkipDirective do
+  let(:directive) { GraphQL::Directive::SkipDirective }
+  it "is a default directive" do
+    assert directive.default?
+  end
+end

--- a/spec/graphql/directive_spec.rb
+++ b/spec/graphql/directive_spec.rb
@@ -134,7 +134,7 @@ describe GraphQL::Directive do
           let(:skip?) { true }
           it "is included" do assert field_included? end
         end
-      end      
+      end
     end
     describe "when evaluating conflicting @skip and @include on query selection and fragment" do
       let(:query_string) {"
@@ -215,13 +215,19 @@ describe GraphQL::Directive do
   end
 
   describe "defining a directive" do
-    it "can accept an array of arguments" do
-      directive = GraphQL::Directive.define do
+    let(:directive) {
+      GraphQL::Directive.define do
         arguments [GraphQL::Argument.define(name: 'skip')]
       end
+    }
 
+    it "can accept an array of arguments" do
       assert_equal 1, directive.arguments.length
       assert_equal 'skip', directive.arguments.first.name
+    end
+
+    it "is not default" do
+      assert_equal false, directive.default?
     end
   end
 end

--- a/spec/graphql/directive_spec.rb
+++ b/spec/graphql/directive_spec.rb
@@ -227,7 +227,7 @@ describe GraphQL::Directive do
     end
 
     it "is not default" do
-      assert_equal false, directive.default?
+      assert_equal false, directive.default_directive?
     end
   end
 end

--- a/spec/graphql/relay/node_spec.rb
+++ b/spec/graphql/relay/node_spec.rb
@@ -2,6 +2,12 @@
 require "spec_helper"
 
 describe GraphQL::Relay::Node do
+  describe ".interface" do
+    it "is a default relay type" do
+      assert_equal true, GraphQL::Relay::Node.interface.default_relay?
+    end
+  end
+
   describe ".field" do
     describe "Custom global IDs" do
       before do

--- a/spec/graphql/relay/page_info_spec.rb
+++ b/spec/graphql/relay/page_info_spec.rb
@@ -37,6 +37,10 @@ describe GraphQL::Relay::PageInfo do
     }
   |}
 
+  it "is a default relay type" do
+    assert_equal true, GraphQL::Relay::PageInfo.default_relay?
+  end
+
   describe 'hasNextPage / hasPreviousPage' do
     it "hasNextPage is true if there are more items" do
       result = star_wars_query(query_string, "first" => 2)

--- a/spec/graphql/scalar_type_spec.rb
+++ b/spec/graphql/scalar_type_spec.rb
@@ -11,6 +11,10 @@ describe GraphQL::ScalarType do
   }
   let(:bignum) { 2 ** 128 }
 
+  it "is not a default scalar" do
+    assert_equal(false, custom_scalar.default_scalar?)
+  end
+
   it "coerces nil into nil" do
     assert_equal(nil, custom_scalar.coerce_input(nil))
   end

--- a/spec/graphql/string_type_spec.rb
+++ b/spec/graphql/string_type_spec.rb
@@ -2,15 +2,21 @@
 require "spec_helper"
 
 describe GraphQL::STRING_TYPE do
+  let(:string_type) { GraphQL::STRING_TYPE }
+
+  it "is a default scalar" do
+    assert_equal(true, string_type.default_scalar?)
+  end
+
   describe "coerce_input" do
     it "accepts strings" do
-      assert_equal "str", GraphQL::STRING_TYPE.coerce_input("str")
+      assert_equal "str", string_type.coerce_input("str")
     end
 
     it "doesn't accept other types" do
-      assert_equal nil, GraphQL::STRING_TYPE.coerce_input(100)
-      assert_equal nil, GraphQL::STRING_TYPE.coerce_input(true)
-      assert_equal nil, GraphQL::STRING_TYPE.coerce_input(0.999)
+      assert_equal nil, string_type.coerce_input(100)
+      assert_equal nil, string_type.coerce_input(true)
+      assert_equal nil, string_type.coerce_input(0.999)
     end
   end
 end


### PR DESCRIPTION
When metaprogramming a GraphQL schema, it comes in handy to check for special types: introspection types, built-in scalars and built-in relay types. 

Now, `BaseType` responds to checks for those things. 

Additionally, built-in directives are flagged as such. (There's not really a way to add directives from user-space yet, but ... someday 😎 .)