### PR TITLE
Fix grouped connection with only `last` argument specified

### DIFF
--- a/lib/graphql/relay/relation_connection.rb
+++ b/lib/graphql/relay/relation_connection.rb
@@ -17,7 +17,7 @@ module GraphQL
       end
 
       def has_next_page
-        !!(first && sliced_nodes.limit(limit + 1).count > limit)
+        !!(first && count(sliced_nodes.limit(limit + 1)) > limit)
       end
 
       def has_previous_page
@@ -25,6 +25,12 @@ module GraphQL
       end
 
       private
+
+      # If a relation contains a `.group` clause, a `.count` will return a Hash.
+      def count(nodes)
+        count_or_hash = nodes.count
+        count_or_hash.is_a?(Integer) ? count_or_hash : count_or_hash.length
+      end
 
       # apply first / last limit results
       def paged_nodes
@@ -45,7 +51,7 @@ module GraphQL
           if before
             [previous_offset, 0].max
           elsif last
-            nodes.count - last
+            count(nodes) - last
           else
             previous_offset
           end

--- a/spec/graphql/relay/relation_connection_spec.rb
+++ b/spec/graphql/relay/relation_connection_spec.rb
@@ -27,6 +27,13 @@ describe GraphQL::Relay::RelationConnection do
             ... basesConnection
           }
         }
+        newestBasesGroupedByFaction(last: 2) {
+          edges {
+            node {
+              name
+            }
+          }
+        }
       }
 
       fragment basesConnection on BasesConnectionWithTotalCount {
@@ -103,6 +110,12 @@ describe GraphQL::Relay::RelationConnection do
       overreaching_cursor = Base64.strict_encode64("100")
       result = star_wars_query(query_string, "after" => overreaching_cursor, "first" => 2)
       assert_equal([], get_names(result))
+    end
+
+    it 'handles grouped connections with only last argument' do
+      result = star_wars_query(query_string, "first" => 1)
+      names = result['data']['newestBasesGroupedByFaction']['edges'].map { |edge| edge['node']['name'] }
+      assert_equal(['Headquarters', 'Secret Hideout'], names)
     end
 
     it "applies custom arguments" do

--- a/spec/graphql/relay/relation_connection_spec.rb
+++ b/spec/graphql/relay/relation_connection_spec.rb
@@ -27,13 +27,6 @@ describe GraphQL::Relay::RelationConnection do
             ... basesConnection
           }
         }
-        newestBasesGroupedByFaction(last: 2) {
-          edges {
-            node {
-              name
-            }
-          }
-        }
       }
 
       fragment basesConnection on BasesConnectionWithTotalCount {
@@ -113,7 +106,19 @@ describe GraphQL::Relay::RelationConnection do
     end
 
     it 'handles grouped connections with only last argument' do
-      result = star_wars_query(query_string, "first" => 1)
+      grouped_conn_query = <<-GRAPHQL
+      query {
+        newestBasesGroupedByFaction(last: 2) {
+          edges {
+            node {
+              name
+            }
+          }
+        }
+      }
+      GRAPHQL
+
+      result = star_wars_query(grouped_conn_query)
       names = result['data']['newestBasesGroupedByFaction']['edges'].map { |edge| edge['node']['name'] }
       assert_equal(['Headquarters', 'Secret Hideout'], names)
     end

--- a/spec/support/star_wars_schema.rb
+++ b/spec/support/star_wars_schema.rb
@@ -202,6 +202,12 @@ QueryType = GraphQL::ObjectType.define do
     resolve ->(obj, args, ctx) { Base.find(3) }
   end
 
+  connection :newestBasesGroupedByFaction, BaseType.connection_type do
+    resolve ->(obj, args, ctx) {
+      Base.order('sum(faction_id) desc').group(:faction_id)
+    }
+  end
+
   field :node, GraphQL::Relay::Node.field
 end
 


### PR DESCRIPTION
If a relation contains a `.group` clause, a `.count` will return a `Hash`. So to know a connection length we have to count also the `Hash`'s content.

_Another solution would be to use `.length` instead of `.count`, but that would not ask the databse, but load all the records into the memory, which… is bad._