### PR TITLE
fix(Warden) also support hiding root types

### DIFF
--- a/lib/graphql/introspection/schema_type.rb
+++ b/lib/graphql/introspection/schema_type.rb
@@ -10,15 +10,15 @@ GraphQL::Introspection::SchemaType = GraphQL::ObjectType.define do
   end
 
   field :queryType, !GraphQL::Introspection::TypeType, "The type that query operations will be rooted at." do
-    resolve ->(obj, arg, ctx) { obj.query }
+    resolve ->(obj, arg, ctx) { ctx.warden.root_type_for_operation("query") }
   end
 
   field :mutationType, GraphQL::Introspection::TypeType, "If this server supports mutation, the type that mutation operations will be rooted at." do
-    resolve ->(obj, arg, ctx) { obj.mutation }
+    resolve ->(obj, arg, ctx) { ctx.warden.root_type_for_operation("mutation") }
   end
 
   field :subscriptionType, GraphQL::Introspection::TypeType, "If this server support subscription, the type that subscription operations will be rooted at." do
-    resolve ->(obj, arg, ctx) { obj.subscription }
+    resolve ->(obj, arg, ctx) { ctx.warden.root_type_for_operation("subscription") }
   end
 
   field :directives, !types[!GraphQL::Introspection::DirectiveType], "A list of all directives supported by this server." do

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -11,6 +11,8 @@ require "graphql/query/variable_validation_error"
 module GraphQL
   # A combination of query string and {Schema} instance which can be reduced to a {#result}.
   class Query
+    extend Forwardable
+
     class OperationNameMissingError < GraphQL::ExecutionError
       def initialize(names)
         msg = "You must provide an operation name from: #{names.join(", ")}"
@@ -202,18 +204,8 @@ module GraphQL
       @valid
     end
 
-    def get_type(type_name)
-      @warden.get_type(type_name)
-    end
+    def_delegators :@warden, :get_type, :get_field, :possible_types, :root_type_for_operation
 
-    def get_field(type, name)
-      @fields ||= Hash.new { |h, k| h[k] = Hash.new { |h2, k2| h2[k2] = @warden.get_field(k, k2) } }
-      @fields[type][name]
-    end
-
-    def possible_types(type)
-      @warden.possible_types(type)
-    end
 
     # @param value [Object] Any runtime value
     # @return [GraphQL::ObjectType, nil] The runtime type of `value` from {Schema#resolve_type}

--- a/lib/graphql/query/executor.rb
+++ b/lib/graphql/query/executor.rb
@@ -28,7 +28,7 @@ module GraphQL
         return {} if operation.nil?
 
         op_type = operation.operation_type
-        root_type = query.schema.root_type_for_operation(op_type)
+        root_type = query.root_type_for_operation(op_type)
         execution_strategy_class = query.schema.execution_strategy_for_operation(op_type)
         execution_strategy = execution_strategy_class.new
 

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -215,6 +215,9 @@ module GraphQL
       @possible_types.possible_types(type_defn)
     end
 
+
+    # @see [GraphQL::Schema::Warden] Resticted access to root types
+    # @return [GraphQL::ObjectType, nil]
     def root_type_for_operation(operation)
       case operation
       when "query"

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -120,6 +120,15 @@ module GraphQL
         @schema.directives.each_value.select { |d| visible?(d) }
       end
 
+      def root_type_for_operation(op_name)
+        root_type = @schema.root_type_for_operation(op_name)
+        if root_type && visible?(root_type)
+          root_type
+        else
+          nil
+        end
+      end
+
       private
 
       def visible_field?(field_defn)

--- a/lib/graphql/static_validation/rules/mutation_root_exists.rb
+++ b/lib/graphql/static_validation/rules/mutation_root_exists.rb
@@ -5,7 +5,7 @@ module GraphQL
       include GraphQL::StaticValidation::Message::MessageHelper
 
       def validate(context)
-        return if context.schema.mutation
+        return if context.warden.root_type_for_operation("mutation")
 
         visitor = context.visitor
 

--- a/lib/graphql/static_validation/rules/subscription_root_exists.rb
+++ b/lib/graphql/static_validation/rules/subscription_root_exists.rb
@@ -5,7 +5,7 @@ module GraphQL
       include GraphQL::StaticValidation::Message::MessageHelper
 
       def validate(context)
-        return if context.schema.subscription
+        return if context.warden.root_type_for_operation("subscription")
 
         visitor = context.visitor
 

--- a/spec/graphql/schema/warden_spec.rb
+++ b/spec/graphql/schema/warden_spec.rb
@@ -96,8 +96,16 @@ module MaskHelpers
     end
   end
 
+  MutationType = GraphQL::ObjectType.define do
+    name "Mutation"
+    field :add_phoneme, PhonemeType do
+      argument :symbol, types.String
+    end
+  end
+
   Schema = GraphQL::Schema.define do
     query QueryType
+    mutation MutationType
     resolve_type -> (obj, ctx) { PhonemeType }
   end
 
@@ -149,6 +157,37 @@ describe GraphQL::Schema::Warden do
 
   def error_messages(query_result)
     query_result["errors"].map { |err| err["message"] }
+  end
+
+  describe "hiding root types" do
+    let(:mask) { ->(m, ctx) { m == MaskHelpers::MutationType } }
+
+    it "acts as if the root doesn't exist" do
+      query_string = %|mutation { add_phoneme(symbol: "ϕ") { name } }|
+      res = MaskHelpers.query_with_mask(query_string, mask)
+      assert MaskHelpers::Schema.mutation # it _does_ exist
+      assert_equal 1, res["errors"].length
+      assert_equal "Schema is not configured for mutations", res["errors"][0]["message"]
+    end
+
+    it "doesn't show in introspection" do
+      query_string = <<-GRAPHQL
+      {
+        __schema {
+          mutationType {
+            name
+          }
+          types {
+            name
+          }
+        }
+      }
+      GRAPHQL
+      res = MaskHelpers.query_with_mask(query_string, mask)
+      assert_equal nil, res["data"]["__schema"]["mutationType"]
+      type_names = res["data"]["__schema"]["types"].map { |t| t["name"] }
+      refute type_names.include?("Mutation")
+    end
   end
 
   describe "hiding fields" do


### PR DESCRIPTION
Oops, @bgentry discovered that hiding _root_ types didn't quite work right!

Now, `root_type_for_operation` is correctly filtered.