### PR TITLE
refactor(Execute) don't allocate FieldResult if you don't need one

### DIFF
--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -76,11 +76,19 @@ module GraphQL
           continue_resolve_field(selection, parent_type, field, raw_value, field_ctx)
         end
 
-        FieldResult.new(
-          owner: owner,
-          field: field,
-          value: result,
-        )
+        if (
+            result == PROPAGATE_NULL ||
+            result.is_a?(GraphQL::Execution::Lazy) ||
+            (result.is_a?(SelectionResult) && result.invalid_null?)
+          )
+          FieldResult.new(
+            owner: owner,
+            field: field,
+            value: result,
+          )
+        else
+          result
+        end
       end
 
       def continue_resolve_field(selection, parent_type, field, raw_value, field_ctx)


### PR DESCRIPTION
This can reduce GC pressure for very large responses -- sometimes these objects are totally unneeded! 

Here's a before-and-after of the test schema's introspection result: 

![image](https://cloud.githubusercontent.com/assets/2231765/21916997/61b62490-d912-11e6-9d02-57463483fd35.png)
