### PR TITLE
refactor(InstanceDefinable) swap out method defns when they're pending

### DIFF
--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -31,7 +31,7 @@ module GraphQL
     )
 
     attr_accessor :mutation, :arguments
-    ensure_defined(:mutation, :arguments)
+    ensure_defined(:mutation, :arguments, :input_fields)
     alias :input_fields :arguments
 
     # @!attribute mutation

--- a/lib/graphql/relay/mutation.rb
+++ b/lib/graphql/relay/mutation.rb
@@ -58,7 +58,11 @@ module GraphQL
       )
       attr_accessor :name, :description, :fields, :arguments, :return_type
 
-      ensure_defined(:name, :description, :fields, :arguments, :return_type, :resolve=, :field, :result_class, :input_type)
+      ensure_defined(
+        :input_fields, :return_fields, :name, :description,
+        :fields, :arguments, :return_type, :resolve=,
+        :field, :result_class, :input_type
+      )
       # For backwards compat, but do we need this separate API?
       alias :return_fields :fields
       alias :input_fields :arguments


### PR DESCRIPTION
I'm looking for some way to remove the overhead of lazy definitions. 

We delay calling `define { }` blocks to avoid circular dependencies, but we pay an overhead because on every call, we make sure that we don't have an outstanding `define { }` block. 

Here's one attempt. It seems a bit faster, but it's pretty gnarly code. I'll clean it up a bit if it looks promising, but either way, we're plucking methods and moving them around 😖 . This isn't _meant_ to be on any hot paths -- methods get messed with during definition, but once the schema starts taking queries, they stay put.

Here's a benchmark running the introspection query on the test schema: 

```
~/code/graphql $ git co master
Switched to branch 'master'
~/code/graphql $ ruby -Ilib:spec/support introspection_profile.rb
Warming up --------------------------------------
                 Run     2.000  i/100ms
Calculating -------------------------------------
                 Run     29.030  (± 3.4%) i/s -    146.000  in   5.039016s
~/code/graphql $ ruby -Ilib:spec/support introspection_profile.rb
Warming up --------------------------------------
                 Run     2.000  i/100ms
Calculating -------------------------------------
                 Run     28.404  (± 3.5%) i/s -    142.000  in   5.010195s
~/code/graphql $ ruby -Ilib:spec/support introspection_profile.rb
Warming up --------------------------------------
                 Run     2.000  i/100ms
Calculating -------------------------------------
                 Run     28.905  (± 3.5%) i/s -    146.000  in   5.058662s
~/code/graphql $ git co pending-methods
Switched to branch 'pending-methods'
~/code/graphql $ ruby -Ilib:spec/support introspection_profile.rb
Warming up --------------------------------------
                 Run     2.000  i/100ms
Calculating -------------------------------------
                 Run     30.676  (± 6.5%) i/s -    154.000  in   5.034065s
~/code/graphql $ ruby -Ilib:spec/support introspection_profile.rb
Warming up --------------------------------------
                 Run     3.000  i/100ms
Calculating -------------------------------------
                 Run     30.609  (± 3.3%) i/s -    153.000  in   5.005618s
~/code/graphql $ ruby -Ilib:spec/support introspection_profile.rb
Warming up --------------------------------------
                 Run     2.000  i/100ms
Calculating -------------------------------------
                 Run     31.278  (± 3.2%) i/s -    158.000  in   5.058078s
~/code/graphql $
```


Here's the method call profile, before and after: 

(They're the same, except after doesn't have `ensure_defined`)

![image](https://cloud.githubusercontent.com/assets/2231765/21918002/789376ce-d91a-11e6-8542-0b7a2aaea7f6.png)
