### PR TITLE
Fix initialization of LazyFindPerson on Lazy Execution documentation

### DIFF
--- a/guides/schema/lazy_execution.md
+++ b/guides/schema/lazy_execution.md
@@ -67,7 +67,7 @@ end
 ```ruby
 field :author, PersonType do
   resolve ->(obj, args, ctx) {
-    LazyFindPerson(ctx, obj.author_id)
+    LazyFindPerson.new(ctx, obj.author_id)
   }
 end
 ```


### PR DESCRIPTION
Fix initialization of LazyFindPerson on Lazy Execution documentation.
Missing: ```.new```