### PR TITLE
Fix documentation for Query#initialize "except" keyword argument

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -32,6 +32,7 @@ module GraphQL
     # @param max_depth [Numeric] the maximum number of nested selections allowed for this query (falls back to schema-level value)
     # @param max_complexity [Numeric] the maximum field complexity for this query (falls back to schema-level value)
     # @param except [<#call(schema_member, context)>] If provided, objects will be hidden from the schema when `.call(schema_member, context)` returns truthy
+    # @param only [<#call(schema_member, context)>] If provided, objects will be hidden from the schema when `.call(schema_member, context)` returns false
     def initialize(schema, query_string = nil, document: nil, context: nil, variables: {}, validate: true, operation_name: nil, root_value: nil, max_depth: nil, max_complexity: nil, except: nil, only: nil)
       fail ArgumentError, "a query string or document is required" unless query_string || document
 

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -31,7 +31,7 @@ module GraphQL
     # @param root_value [Object] the object used to resolve fields on the root type
     # @param max_depth [Numeric] the maximum number of nested selections allowed for this query (falls back to schema-level value)
     # @param max_complexity [Numeric] the maximum field complexity for this query (falls back to schema-level value)
-    # @param except [<#call(schema_member)>] If provided, objects will be hidden from the schema when `.call(schema_member)` returns truthy
+    # @param except [<#call(schema_member, context)>] If provided, objects will be hidden from the schema when `.call(schema_member, context)` returns truthy
     def initialize(schema, query_string = nil, document: nil, context: nil, variables: {}, validate: true, operation_name: nil, root_value: nil, max_depth: nil, max_complexity: nil, except: nil, only: nil)
       fail ArgumentError, "a query string or document is required" unless query_string || document
 


### PR DESCRIPTION
As per [this warning](https://github.com/cjoudrey/graphql-ruby/blob/40da6dc463bb0efc04574a92225eadfb6e6d3011/lib/graphql/query.rb#L302), `except` method should accept two arguments. This is just a quick change to the docs to reflect this.

As a side note, I noticed [rubydoc](http://www.rubydoc.info/github/rmosolgo/graphql-ruby/file/CHANGELOG.md) is outdated. Is there anything we need to do to force a rebuild of the docs?