### PR TITLE
feat(AbstractNode) add #path to get AST path

### DIFF
--- a/lib/graphql/static_validation/message.rb
+++ b/lib/graphql/static_validation/message.rb
@@ -6,19 +6,19 @@ module GraphQL
       # Convenience for validators
       module MessageHelper
         # Error `message` is located at `node`
-        def message(message, nodes, context: nil, path: nil)
-          path ||= context.path
+        def message(message, nodes)
           nodes = Array(nodes)
-          GraphQL::StaticValidation::Message.new(message, nodes: nodes, path: path)
+          GraphQL::StaticValidation::Message.new(message, nodes: nodes)
         end
       end
 
       attr_reader :message, :path
 
-      def initialize(message, path: [], nodes: [])
+      def initialize(message, path: nil, nodes: [])
         @message = message
         @nodes = nodes
-        @path = path
+        first_node = nodes.first
+        @path = path ? path : (first_node ? first_node.path : [])
       end
 
       # A hash representation of this Message

--- a/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb
+++ b/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb
@@ -9,7 +9,7 @@ module GraphQL
         if !context.valid_literal?(node.value, arg_defn.type)
           kind_of_node = node_type(parent)
           error_arg_name = parent_name(parent, defn)
-          context.errors << message("Argument '#{node.name}' on #{kind_of_node} '#{error_arg_name}' has an invalid value. Expected type '#{arg_defn.type}'.", parent, context: context)
+          context.errors << message("Argument '#{node.name}' on #{kind_of_node} '#{error_arg_name}' has an invalid value. Expected type '#{arg_defn.type}'.", node)
         end
       end
     end

--- a/lib/graphql/static_validation/rules/arguments_are_defined.rb
+++ b/lib/graphql/static_validation/rules/arguments_are_defined.rb
@@ -7,7 +7,7 @@ module GraphQL
         if argument_defn.nil?
           kind_of_node = node_type(parent)
           error_arg_name = parent_name(parent, defn)
-          context.errors << message("#{kind_of_node} '#{error_arg_name}' doesn't accept argument '#{node.name}'", parent, context: context)
+          context.errors << message("#{kind_of_node} '#{error_arg_name}' doesn't accept argument '#{node.name}'", node)
           GraphQL::Language::Visitor::SKIP
         else
           nil

--- a/lib/graphql/static_validation/rules/directives_are_defined.rb
+++ b/lib/graphql/static_validation/rules/directives_are_defined.rb
@@ -15,7 +15,7 @@ module GraphQL
 
       def validate_directive(ast_directive, directive_names, context)
         if !directive_names.include?(ast_directive.name)
-          context.errors << message("Directive @#{ast_directive.name} is not defined", ast_directive, context: context)
+          context.errors << message("Directive @#{ast_directive.name} is not defined", ast_directive)
           GraphQL::Language::Visitor::SKIP
         else
           nil

--- a/lib/graphql/static_validation/rules/directives_are_in_valid_locations.rb
+++ b/lib/graphql/static_validation/rules/directives_are_in_valid_locations.rb
@@ -44,7 +44,7 @@ module GraphQL
           required_location = SIMPLE_LOCATIONS[ast_parent.class]
           assert_includes_location(directive_defn, ast_directive, required_location, context)
         else
-          context.errors << message("Directives can't be applied to #{ast_parent.class.name}s", ast_directive, context: context)
+          context.errors << message("Directives can't be applied to #{ast_parent.class.name}s", ast_directive)
         end
       end
 
@@ -52,7 +52,7 @@ module GraphQL
         if !directive_defn.locations.include?(required_location)
           location_name = LOCATION_MESSAGE_NAMES[required_location]
           allowed_location_names = directive_defn.locations.map { |loc| LOCATION_MESSAGE_NAMES[loc] }
-          context.errors << message("'@#{directive_defn.name}' can't be applied to #{location_name} (allowed: #{allowed_location_names.join(", ")})", directive_ast, context: context)
+          context.errors << message("'@#{directive_defn.name}' can't be applied to #{location_name} (allowed: #{allowed_location_names.join(", ")})", directive_ast)
         end
       end
     end

--- a/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb
+++ b/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb
@@ -17,13 +17,13 @@ module GraphQL
 
       def validate_field(context, ast_field, parent_type, parent)
         if parent_type.kind.union? && ast_field.name != '__typename'
-          context.errors << message("Selections can't be made directly on unions (see selections on #{parent_type.name})", parent, context: context)
+          context.errors << message("Selections can't be made directly on unions (see selections on #{parent_type.name})", ast_field)
           return GraphQL::Language::Visitor::SKIP
         end
 
         field = context.warden.get_field(parent_type, ast_field.name)
         if field.nil?
-          context.errors << message("Field '#{ast_field.name}' doesn't exist on type '#{parent_type.name}'", ast_field, context: context)
+          context.errors << message("Field '#{ast_field.name}' doesn't exist on type '#{parent_type.name}'", ast_field)
           return GraphQL::Language::Visitor::SKIP
         end
       end

--- a/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb
+++ b/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb
@@ -19,9 +19,9 @@ module GraphQL
         resolved_type = field_defn.type.unwrap
 
         if resolved_type.kind.scalar? && ast_field.selections.any?
-          error = message("Selections can't be made on scalars (field '#{ast_field.name}' returns #{resolved_type.name} but has selections [#{ast_field.selections.map(&:name).join(", ")}])", ast_field, context: context)
+          error = message("Selections can't be made on scalars (field '#{ast_field.name}' returns #{resolved_type.name} but has selections [#{ast_field.selections.map(&:name).join(", ")}])", ast_field)
         elsif resolved_type.kind.object? && ast_field.selections.none?
-          error = message("Objects must have selections (field '#{ast_field.name}' returns #{resolved_type.name} but has no selections)", ast_field, context: context)
+          error = message("Objects must have selections (field '#{ast_field.name}' returns #{resolved_type.name} but has no selections)", ast_field)
         else
           error = nil
         end

--- a/lib/graphql/static_validation/rules/fields_will_merge.rb
+++ b/lib/graphql/static_validation/rules/fields_will_merge.rb
@@ -69,12 +69,12 @@ module GraphQL
 
         names = ast_fields.map(&:name).uniq
         if names.length != 1
-          errors << message("Field '#{name}' has a field conflict: #{names.join(" or ")}?", ast_fields.first, context: context)
+          errors << message("Field '#{name}' has a field conflict: #{names.join(" or ")}?", ast_fields.first)
         end
 
         args = ast_fields.map { |ast_node| field_args_string(ast_node) }.uniq
         if args.length != 1
-          errors << message("Field '#{name}' has an argument conflict: #{args.map{ |arg| GraphQL::Language.serialize(arg) }.join(" or ")}?", ast_fields.first, context: context)
+          errors << message("Field '#{name}' has an argument conflict: #{args.map{ |arg| GraphQL::Language.serialize(arg) }.join(" or ")}?", ast_fields.first)
         end
 
         errors

--- a/lib/graphql/static_validation/rules/fields_will_merge.rb
+++ b/lib/graphql/static_validation/rules/fields_will_merge.rb
@@ -91,6 +91,8 @@ module GraphQL
             "$#{arg.name}"
           when GraphQL::Language::Nodes::Enum
             "#{arg.name}"
+          when GraphQL::Language::Nodes::InputObject
+            "{ #{arg.arguments.sort { |a, b| a.name <=> b.name }.map { |(k, v)| "#{k}: #{print_arg(v)}"}.join(",") } }"
           else
             GraphQL::Language.serialize(arg)
           end

--- a/lib/graphql/static_validation/rules/fields_will_merge.rb
+++ b/lib/graphql/static_validation/rules/fields_will_merge.rb
@@ -2,6 +2,8 @@
 module GraphQL
   module StaticValidation
     class FieldsWillMerge
+      include GraphQL::StaticValidation::Message::MessageHelper
+
       def validate(context)
         fragments = {}
         has_selections = []
@@ -23,9 +25,8 @@ module GraphQL
 
       def find_conflicts(field_map, visited_fragments, context)
         field_map.each do |name, ast_fields|
-          comparison = FieldDefinitionComparison.new(name, ast_fields, context)
-          context.errors.push(*comparison.errors)
-
+          errs = compare_fields(name, ast_fields, context)
+          context.errors.concat(errs)
 
           subfield_map = {}
           ast_fields.each do |defn|
@@ -63,48 +64,25 @@ module GraphQL
       end
 
       # Compare two field definitions, add errors to the list if there are any
-      class FieldDefinitionComparison
-        include GraphQL::StaticValidation::Message::MessageHelper
-        NAMED_VALUES = [GraphQL::Language::Nodes::Enum, GraphQL::Language::Nodes::VariableIdentifier]
-        attr_reader :errors
-        def initialize(name, defs, context)
-          errors = []
+      def compare_fields(name, ast_fields, context)
+        errors = []
 
-          names = defs.map(&:name).uniq
-          if names.length != 1
-            errors << message("Field '#{name}' has a field conflict: #{names.join(" or ")}?", defs.first, context: context)
-          end
-
-          args = defs.map { |defn| reduce_list(defn.arguments)}.uniq
-          if args.length != 1
-            errors << message("Field '#{name}' has an argument conflict: #{args.map{ |arg| GraphQL::Language.serialize(arg) }.join(" or ")}?", defs.first, context: context)
-          end
-
-          @errors = errors
+        names = ast_fields.map(&:name).uniq
+        if names.length != 1
+          errors << message("Field '#{name}' has a field conflict: #{names.join(" or ")}?", ast_fields.first, context: context)
         end
 
-        private
-
-        def print_arg(arg)
-          case arg
-          when GraphQL::Language::Nodes::VariableIdentifier
-            "$#{arg.name}"
-          when GraphQL::Language::Nodes::Enum
-            "#{arg.name}"
-          when GraphQL::Language::Nodes::InputObject
-            "{ #{arg.arguments.sort { |a, b| a.name <=> b.name }.map { |(k, v)| "#{k}: #{print_arg(v)}"}.join(",") } }"
-          else
-            GraphQL::Language.serialize(arg)
-          end
+        args = ast_fields.map { |ast_node| field_args_string(ast_node) }.uniq
+        if args.length != 1
+          errors << message("Field '#{name}' has an argument conflict: #{args.map{ |arg| GraphQL::Language.serialize(arg) }.join(" or ")}?", ast_fields.first, context: context)
         end
 
-        # Turn AST tree into a hash
-        # can't look up args, the names just have to match
-        def reduce_list(args)
-          args.reduce({}) do |memo, a|
-            memo[a.name] = print_arg(a.value)
-            memo
-          end
+        errors
+      end
+
+      def field_args_string(ast_field)
+        ast_field.arguments.each_with_object({}) do |arg, memo|
+          memo[arg.name] = GraphQL::Language::Generation.generate(arg.value)
         end
       end
     end

--- a/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb
+++ b/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb
@@ -10,7 +10,7 @@ module GraphQL
           fragment_parent = context.object_types[-2]
           fragment_child = context.object_types.last
           if fragment_child
-            validate_fragment_in_scope(fragment_parent, fragment_child, node, context, context.path)
+            validate_fragment_in_scope(fragment_parent, fragment_child, node, context)
           end
         }
 
@@ -18,7 +18,7 @@ module GraphQL
 
         context.visitor[GraphQL::Language::Nodes::FragmentSpread] << ->(node, parent) {
           fragment_parent = context.object_types.last
-          spreads_to_validate << FragmentSpread.new(node: node, parent_type: fragment_parent, path: context.path)
+          spreads_to_validate << FragmentSpread.new(node: node, parent_type: fragment_parent)
         }
 
         context.visitor[GraphQL::Language::Nodes::Document].leave << ->(doc_node, parent) {
@@ -27,7 +27,7 @@ module GraphQL
             fragment_child = context.warden.get_type(fragment_child_name)
             # Might be non-existent type name
             if fragment_child
-              validate_fragment_in_scope(frag_spread.parent_type, fragment_child, frag_spread.node, context, frag_spread.path)
+              validate_fragment_in_scope(frag_spread.parent_type, fragment_child, frag_spread.node, context)
             end
           end
         }
@@ -35,7 +35,7 @@ module GraphQL
 
       private
 
-      def validate_fragment_in_scope(parent_type, child_type, node, context, path)
+      def validate_fragment_in_scope(parent_type, child_type, node, context)
         if !child_type.kind.fields?
           # It's not a valid fragment type, this error was handled someplace else
           return
@@ -43,16 +43,16 @@ module GraphQL
         intersecting_types = context.warden.possible_types(parent_type.unwrap) & context.warden.possible_types(child_type.unwrap)
         if intersecting_types.none?
           name = node.respond_to?(:name) ? " #{node.name}" : ""
-          context.errors << message("Fragment#{name} on #{child_type.name} can't be spread inside #{parent_type.name}", node, path: path)
+          context.errors << message("Fragment#{name} on #{child_type.name} can't be spread inside #{parent_type.name}", node)
         end
       end
 
       class FragmentSpread
-        attr_reader :node, :parent_type, :path
-        def initialize(node:, parent_type:, path:)
+        extend Forwardable
+        attr_reader :node, :parent_type
+        def initialize(node:, parent_type:)
           @node = node
           @parent_type = parent_type
-          @path = path
         end
       end
     end

--- a/lib/graphql/static_validation/rules/fragment_types_exist.rb
+++ b/lib/graphql/static_validation/rules/fragment_types_exist.rb
@@ -22,7 +22,7 @@ module GraphQL
         type_name = node.type.name
         type = context.warden.get_type(type_name)
         if type.nil?
-          context.errors << message("No such type #{type_name}, so it can't be a fragment condition", node, context: context)
+          context.errors << message("No such type #{type_name}, so it can't be a fragment condition", node)
           GraphQL::Language::Visitor::SKIP
         end
       end

--- a/lib/graphql/static_validation/rules/fragments_are_finite.rb
+++ b/lib/graphql/static_validation/rules/fragments_are_finite.rb
@@ -7,7 +7,7 @@ module GraphQL
       def validate(context)
         context.visitor[GraphQL::Language::Nodes::FragmentDefinition] << ->(node, parent) {
           if has_nested_spread?(node, [], context)
-            context.errors << message("Fragment #{node.name} contains an infinite loop", node, context: context)
+            context.errors << message("Fragment #{node.name} contains an infinite loop", node)
           end
         }
       end

--- a/lib/graphql/static_validation/rules/fragments_are_named.rb
+++ b/lib/graphql/static_validation/rules/fragments_are_named.rb
@@ -12,7 +12,7 @@ module GraphQL
 
       def validate_name_exists(node, context)
         if node.name.nil?
-          context.errors << message("Fragment definition has no name", node, context: context)
+          context.errors << message("Fragment definition has no name", node)
         end
       end
     end

--- a/lib/graphql/static_validation/rules/fragments_are_on_composite_types.rb
+++ b/lib/graphql/static_validation/rules/fragments_are_on_composite_types.rb
@@ -27,7 +27,7 @@ module GraphQL
           type_name = node_type.to_query_string
           type_def = context.warden.get_type(type_name)
           if type_def.nil? || !type_def.kind.composite?
-            context.errors <<  message("Invalid fragment on type #{type_name} (must be Union, Interface or Object)", node, context: context)
+            context.errors <<  message("Invalid fragment on type #{type_name} (must be Union, Interface or Object)", node)
             GraphQL::Language::Visitor::SKIP
           end
         end

--- a/lib/graphql/static_validation/rules/mutation_root_exists.rb
+++ b/lib/graphql/static_validation/rules/mutation_root_exists.rb
@@ -11,7 +11,7 @@ module GraphQL
 
         visitor[GraphQL::Language::Nodes::OperationDefinition].enter << ->(ast_node, prev_ast_node) {
           if ast_node.operation_type == 'mutation'
-            context.errors << message('Schema is not configured for mutations', ast_node, context: context)
+            context.errors << message('Schema is not configured for mutations', ast_node)
             return GraphQL::Language::Visitor::SKIP
           end
         }

--- a/lib/graphql/static_validation/rules/required_arguments_are_present.rb
+++ b/lib/graphql/static_validation/rules/required_arguments_are_present.rb
@@ -30,7 +30,7 @@ module GraphQL
 
         missing_names = required_argument_names - present_argument_names
         if missing_names.any?
-          context.errors << message("#{ast_node.class.name.split("::").last} '#{ast_node.name}' is missing required arguments: #{missing_names.join(", ")}", ast_node, context: context)
+          context.errors << message("#{ast_node.class.name.split("::").last} '#{ast_node.name}' is missing required arguments: #{missing_names.join(", ")}", ast_node)
         end
       end
     end

--- a/lib/graphql/static_validation/rules/subscription_root_exists.rb
+++ b/lib/graphql/static_validation/rules/subscription_root_exists.rb
@@ -11,7 +11,7 @@ module GraphQL
 
         visitor[GraphQL::Language::Nodes::OperationDefinition].enter << ->(ast_node, prev_ast_node) {
           if ast_node.operation_type == 'subscription'
-            context.errors << message('Schema is not configured for subscriptions', ast_node, context: context)
+            context.errors << message('Schema is not configured for subscriptions', ast_node)
             return GraphQL::Language::Visitor::SKIP
           end
         }

--- a/lib/graphql/static_validation/rules/unique_directives_per_location.rb
+++ b/lib/graphql/static_validation/rules/unique_directives_per_location.rb
@@ -26,8 +26,7 @@ module GraphQL
           if used_directives[directive_name]
             context.errors << message(
               "The directive \"#{directive_name}\" can only be used once at this location.",
-              [used_directives[directive_name], ast_directive],
-              context: context
+              [used_directives[directive_name], ast_directive]
             )
           else
             used_directives[directive_name] = ast_directive

--- a/lib/graphql/static_validation/rules/variable_default_values_are_correctly_typed.rb
+++ b/lib/graphql/static_validation/rules/variable_default_values_are_correctly_typed.rb
@@ -15,11 +15,11 @@ module GraphQL
       def validate_default_value(node, context)
         value = node.default_value
         if node.type.is_a?(GraphQL::Language::Nodes::NonNullType)
-          context.errors << message("Non-null variable $#{node.name} can't have a default value", node, context: context)
+          context.errors << message("Non-null variable $#{node.name} can't have a default value", node)
         else
           type = context.schema.type_from_ast(node.type)
           if !context.valid_literal?(value, type)
-            context.errors << message("Default value for $#{node.name} doesn't match type #{type}", node, context: context)
+            context.errors << message("Default value for $#{node.name} doesn't match type #{type}", node)
           end
         end
       end

--- a/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb
+++ b/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb
@@ -64,7 +64,7 @@ module GraphQL
       end
 
       def create_error(error_message, var_type, ast_var, arg_defn, arg_node, context)
-        message("#{error_message} on variable $#{ast_var.name} and argument #{arg_node.name} (#{var_type.to_s} / #{arg_defn.type.to_s})", arg_node, context: context)
+        message("#{error_message} on variable $#{ast_var.name} and argument #{arg_node.name} (#{var_type.to_s} / #{arg_defn.type.to_s})", arg_node)
       end
 
       def list_dimension(type)

--- a/lib/graphql/static_validation/rules/variables_are_input_types.rb
+++ b/lib/graphql/static_validation/rules/variables_are_input_types.rb
@@ -17,9 +17,9 @@ module GraphQL
         type = context.warden.get_type(type_name)
 
         if type.nil?
-          context.errors << message("#{type_name} isn't a defined input type (on $#{node.name})", node, context: context)
+          context.errors << message("#{type_name} isn't a defined input type (on $#{node.name})", node)
         elsif !type.kind.input?
-          context.errors << message("#{type.name} isn't a valid input type (on $#{node.name})", node, context: context)
+          context.errors << message("#{type.name} isn't a valid input type (on $#{node.name})", node)
         end
       end
 

--- a/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb
+++ b/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb
@@ -15,7 +15,7 @@ module GraphQL
       include GraphQL::StaticValidation::Message::MessageHelper
 
       class VariableUsage
-        attr_accessor :ast_node, :used_by, :declared_by, :path
+        attr_accessor :ast_node, :used_by, :declared_by
         def used?
           !!@used_by
         end
@@ -54,7 +54,6 @@ module GraphQL
           node.variables.each { |var|
             var_usage = var_hash[var.name]
             var_usage.declared_by = node
-            var_usage.path = context.path
           }
         }
         context.visitor[GraphQL::Language::Nodes::OperationDefinition].leave << pop_variable_context_stack
@@ -79,7 +78,6 @@ module GraphQL
           usage = declared_variables[node.name]
           usage.used_by = usage_context
           usage.ast_node = node
-          usage.path = context.path
         }
 
 
@@ -110,7 +108,6 @@ module GraphQL
             if child_usage.used?
               parent_usage.ast_node   = child_usage.ast_node
               parent_usage.used_by    = child_usage.used_by
-              parent_usage.path       = child_usage.path
             end
           end
           follow_spreads(def_node, parent_variables, spreads_for_context, fragment_definitions, visited_fragments)
@@ -123,12 +120,12 @@ module GraphQL
         # Declared but not used:
         node_variables
           .select { |name, usage| usage.declared? && !usage.used? }
-          .each { |var_name, usage| context.errors << message("Variable $#{var_name} is declared by #{usage.declared_by.name} but not used", usage.declared_by, path: usage.path) }
+          .each { |var_name, usage| context.errors << message("Variable $#{var_name} is declared by #{usage.declared_by.name} but not used", usage.declared_by) }
 
         # Used but not declared:
         node_variables
           .select { |name, usage| usage.used? && !usage.declared? }
-          .each { |var_name, usage| context.errors << message("Variable $#{var_name} is used by #{usage.used_by.name} but not declared", usage.ast_node, path: usage.path) }
+          .each { |var_name, usage| context.errors << message("Variable $#{var_name} is used by #{usage.used_by.name} but not declared", usage.ast_node) }
       end
     end
   end

--- a/lib/graphql/static_validation/validation_context.rb
+++ b/lib/graphql/static_validation/validation_context.rb
@@ -55,7 +55,9 @@ module GraphQL
       end
 
       # @return [Array<String>] Field names to get to the current field
+      # @deprecated see {GraphQL::Language::Nodes::AbstractNode#path}
       def path
+        warn("ValidationContext#path is deprecated, use AbstractNode#path instead")
         @type_stack.path.dup
       end
 

--- a/spec/graphql/language/nodes_spec.rb
+++ b/spec/graphql/language/nodes_spec.rb
@@ -13,4 +13,35 @@ describe GraphQL::Language::Nodes::AbstractNode do
         subclassed_directive.child_attributes
     end
   end
+
+  describe "path" do
+    let(:doc) { GraphQL.parse <<-GRAPHQL
+      query DoSomeStuff($var: Int = 1) {
+        ... on Stuff {
+          innerField @someDirective(arg: { arg2: $var }) {
+            ... thing
+          }
+        }
+      }
+      GRAPHQL
+    }
+    it "traces operations, fields, fragments, arguments, variables and directives" do
+      definition = doc.definitions.first
+      assert_equal("query DoSomeStuff", definition.path_key)
+      assert_equal(["query DoSomeStuff"], definition.path)
+
+      var = definition.variables.first
+      assert_equal(["query DoSomeStuff", "$var"], var.path)
+
+      inner_field = definition.selections.first.selections.first
+      assert_equal(["query DoSomeStuff", "... on Stuff", "innerField"], inner_field.path)
+
+      directive = inner_field.directives.first
+      assert_equal(["query DoSomeStuff", "... on Stuff", "innerField", "@someDirective"], directive.path)
+      arg = directive.arguments.first.value.arguments.first
+      assert_equal(["query DoSomeStuff", "... on Stuff", "innerField", "@someDirective", "arg", "arg2"], arg.path)
+      spread = inner_field.selections.first
+      assert_equal(["query DoSomeStuff", "... on Stuff", "innerField", "... thing"], spread.path)
+    end
+  end
 end

--- a/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
+++ b/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
@@ -26,42 +26,42 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
 
     query_root_error = {
       "message"=>"Argument 'id' on Field 'stringCheese' has an invalid value. Expected type 'Int!'.",
-      "locations"=>[{"line"=>3, "column"=>7}],
+      "locations"=>[{"line"=>3, "column"=>28}],
       "fields"=>["query getCheese", "stringCheese", "id"],
     }
     assert_includes(errors, query_root_error)
 
     directive_error = {
       "message"=>"Argument 'if' on Directive 'skip' has an invalid value. Expected type 'Boolean!'.",
-      "locations"=>[{"line"=>4, "column"=>30}],
-      "fields"=>["query getCheese", "cheese", "source", "if"],
+      "locations"=>[{"line"=>4, "column"=>36}],
+      "fields"=>["query getCheese", "cheese", "source", "@skip", "if"],
     }
     assert_includes(errors, directive_error)
 
     input_object_error = {
       "message"=>"Argument 'product' on Field 'badSource' has an invalid value. Expected type '[DairyProductInput]'.",
-      "locations"=>[{"line"=>6, "column"=>7}],
+      "locations"=>[{"line"=>6, "column"=>30}],
       "fields"=>["query getCheese", "badSource", "product"],
     }
     assert_includes(errors, input_object_error)
 
     input_object_field_error = {
       "message"=>"Argument 'source' on InputObject 'DairyProductInput' has an invalid value. Expected type 'DairyAnimal!'.",
-      "locations"=>[{"line"=>6, "column"=>40}],
+      "locations"=>[{"line"=>6, "column"=>41}],
       "fields"=>["query getCheese", "badSource", "product", "source"],
     }
     assert_includes(errors, input_object_field_error)
 
     missing_required_field_error = {
       "message"=>"Argument 'product' on Field 'missingSource' has an invalid value. Expected type '[DairyProductInput]'.",
-      "locations"=>[{"line"=>7, "column"=>7}],
+      "locations"=>[{"line"=>7, "column"=>34}],
       "fields"=>["query getCheese", "missingSource", "product"],
     }
     assert_includes(errors, missing_required_field_error)
 
     fragment_error = {
       "message"=>"Argument 'source' on Field 'similarCheese' has an invalid value. Expected type '[DairyAnimal!]!'.",
-      "locations"=>[{"line"=>13, "column"=>7}],
+      "locations"=>[{"line"=>13, "column"=>21}],
       "fields"=>["fragment cheeseFields", "similarCheese", "source"],
     }
     assert_includes(errors, fragment_error)
@@ -104,7 +104,7 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
       it "finds error" do
         assert_equal [{
           "message"=>"Argument 'arg' on Field 'field' has an invalid value. Expected type 'Int!'.",
-          "locations"=>[{"line"=>3, "column"=>11}],
+          "locations"=>[{"line"=>3, "column"=>17}],
           "fields"=>["query", "field", "arg"],
         }], errors
       end
@@ -127,7 +127,7 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
       it "finds error" do
         assert_equal [{
           "message"=>"Argument 'arg' on Field 'field' has an invalid value. Expected type '[Int!]'.",
-          "locations"=>[{"line"=>3, "column"=>11}],
+          "locations"=>[{"line"=>3, "column"=>17}],
           "fields"=>["query", "field", "arg"],
         }], errors
       end
@@ -176,13 +176,13 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
 
         assert_includes errors, {
           "message"=> "Argument 'arg' on Field 'field' has an invalid value. Expected type 'Input'.",
-          "locations"=>[{"line"=>3, "column"=>11}],
+          "locations"=>[{"line"=>3, "column"=>17}],
           "fields"=>["query", "field", "arg"]
         }
 
         assert_includes errors, {
           "message"=>"Argument 'b' on InputObject 'Input' has an invalid value. Expected type 'Int!'.",
-          "locations"=>[{"line"=>3, "column"=>22}],
+          "locations"=>[{"line"=>3, "column"=>32}],
           "fields"=>["query", "field", "arg", "b"]
         }
       end
@@ -199,7 +199,7 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
     it "finds invalid argument types" do
       assert_includes(errors, {
         "message"=>"Argument 'name' on Field '__type' has an invalid value. Expected type 'String!'.",
-        "locations"=>[{"line"=>3, "column"=>9}],
+        "locations"=>[{"line"=>3, "column"=>16}],
         "fields"=>["query", "__type", "name"],
       })
     end

--- a/spec/graphql/static_validation/rules/arguments_are_defined_spec.rb
+++ b/spec/graphql/static_validation/rules/arguments_are_defined_spec.rb
@@ -24,29 +24,29 @@ describe GraphQL::StaticValidation::ArgumentsAreDefined do
 
     query_root_error = {
       "message"=>"Field 'cheese' doesn't accept argument 'silly'",
-      "locations"=>[{"line"=>4, "column"=>7}],
+      "locations"=>[{"line"=>4, "column"=>14}],
       "fields"=>["query getCheese", "cheese", "silly"],
     }
     assert_includes(errors, query_root_error)
 
     input_obj_record = {
       "message"=>"InputObject 'DairyProductInput' doesn't accept argument 'wacky'",
-      "locations"=>[{"line"=>5, "column"=>29}],
+      "locations"=>[{"line"=>5, "column"=>30}],
       "fields"=>["query getCheese", "searchDairy", "product", "wacky"],
     }
     assert_includes(errors, input_obj_record)
 
     fragment_error = {
       "message"=>"Field 'similarCheese' doesn't accept argument 'nonsense'",
-      "locations"=>[{"line"=>9, "column"=>7}],
+      "locations"=>[{"line"=>9, "column"=>36}],
       "fields"=>["fragment cheeseFields", "similarCheese", "nonsense"],
     }
     assert_includes(errors, fragment_error)
 
     directive_error = {
       "message"=>"Directive 'skip' doesn't accept argument 'something'",
-      "locations"=>[{"line"=>10, "column"=>10}],
-      "fields"=>["fragment cheeseFields", "id", "something"],
+      "locations"=>[{"line"=>10, "column"=>16}],
+      "fields"=>["fragment cheeseFields", "id", "@skip", "something"],
     }
     assert_includes(errors, directive_error)
   end
@@ -61,7 +61,7 @@ describe GraphQL::StaticValidation::ArgumentsAreDefined do
     it "finds undefined arguments" do
       assert_includes(errors, {
         "message"=>"Field '__type' doesn't accept argument 'somethingInvalid'",
-        "locations"=>[{"line"=>3, "column"=>9}],
+        "locations"=>[{"line"=>3, "column"=>16}],
         "fields"=>["query", "__type", "somethingInvalid"],
       })
     end

--- a/spec/graphql/static_validation/rules/directives_are_defined_spec.rb
+++ b/spec/graphql/static_validation/rules/directives_are_defined_spec.rb
@@ -20,11 +20,11 @@ describe GraphQL::StaticValidation::DirectivesAreDefined do
         {
           "message"=>"Directive @nonsense is not defined",
           "locations"=>[{"line"=>5, "column"=>16}],
-          "fields"=>["query getCheese", "okCheese", "source"],
+          "fields"=>["query getCheese", "okCheese", "source", "@nonsense"],
         }, {
           "message"=>"Directive @moreNonsense is not defined",
           "locations"=>[{"line"=>7, "column"=>18}],
-          "fields"=>["query getCheese", "okCheese", "... on Cheese", "flavor"],
+          "fields"=>["query getCheese", "okCheese", "... on Cheese", "flavor", "@moreNonsense"],
         }
       ]
       assert_equal(expected, errors)

--- a/spec/graphql/static_validation/rules/directives_are_in_valid_locations_spec.rb
+++ b/spec/graphql/static_validation/rules/directives_are_in_valid_locations_spec.rb
@@ -26,12 +26,12 @@ describe GraphQL::StaticValidation::DirectivesAreInValidLocations do
         {
           "message"=> "'@skip' can't be applied to queries (allowed: fields, fragment spreads, inline fragments)",
           "locations"=>[{"line"=>2, "column"=>21}],
-          "fields"=>["query getCheese"],
+          "fields"=>["query getCheese", "@skip"],
         },
         {
           "message"=>"'@skip' can't be applied to fragment definitions (allowed: fields, fragment spreads, inline fragments)",
           "locations"=>[{"line"=>13, "column"=>33}],
-           "fields"=>["fragment whatever"],
+           "fields"=>["fragment whatever", "@skip"],
         },
       ]
       assert_equal(expected, errors)

--- a/spec/graphql/static_validation/rules/fields_are_defined_on_type_spec.rb
+++ b/spec/graphql/static_validation/rules/fields_are_defined_on_type_spec.rb
@@ -65,7 +65,7 @@ describe GraphQL::StaticValidation::FieldsAreDefinedOnType do
         {
           "message"=>"Selections can't be made directly on unions (see selections on DairyProduct)",
           "locations"=>[
-            {"line"=>3, "column"=>7}
+            {"line"=>3, "column"=>43}
           ],
           "fields"=>["fragment dpFields", "source"],
         }

--- a/spec/graphql/static_validation/rules/fragments_are_used_spec.rb
+++ b/spec/graphql/static_validation/rules/fragments_are_used_spec.rb
@@ -17,7 +17,7 @@ describe GraphQL::StaticValidation::FragmentsAreUsed do
     assert_includes(errors, {
       "message"=>"Fragment unusedFields was defined, but not used",
       "locations"=>[{"line"=>8, "column"=>5}],
-      "fields"=>[],
+      "fields"=>["fragment unusedFields"],
     })
   end
 

--- a/spec/graphql/static_validation/rules/required_arguments_are_present_spec.rb
+++ b/spec/graphql/static_validation/rules/required_arguments_are_present_spec.rb
@@ -36,7 +36,7 @@ describe GraphQL::StaticValidation::RequiredArgumentsArePresent do
     directive_error = {
       "message"=>"Directive 'skip' is missing required arguments: if",
       "locations"=>[{"line"=>10, "column"=>10}],
-      "fields"=>["fragment cheeseFields", "id"],
+      "fields"=>["fragment cheeseFields", "id", "@skip"],
     }
     assert_includes(errors, directive_error)
   end

--- a/spec/graphql/static_validation/rules/unique_directives_per_location_spec.rb
+++ b/spec/graphql/static_validation/rules/unique_directives_per_location_spec.rb
@@ -101,7 +101,7 @@ describe GraphQL::StaticValidation::UniqueDirectivesPerLocation do
       assert_includes errors, {
         "message" => 'The directive "A" can only be used once at this location.',
         "locations" => [{ "line" => 4, "column" => 17 }, { "line" => 4, "column" => 20 }],
-        "fields" => ["query", "type", "field"],
+        "fields" => ["query", "type", "field", "@A"],
       }
     end
   end
@@ -120,13 +120,13 @@ describe GraphQL::StaticValidation::UniqueDirectivesPerLocation do
       assert_includes errors, {
         "message" => 'The directive "A" can only be used once at this location.',
         "locations" => [{ "line" => 4, "column" => 17 }, { "line" => 4, "column" => 20 }],
-        "fields" => ["query", "type", "field"],
+        "fields" => ["query", "type", "field", "@A"],
       }
 
       assert_includes errors, {
         "message" => 'The directive "A" can only be used once at this location.',
         "locations" => [{ "line" => 4, "column" => 17 }, { "line" => 4, "column" => 23 }],
-        "fields" => ["query", "type", "field"],
+        "fields" => ["query", "type", "field", "@A"],
       }
     end
   end
@@ -144,13 +144,13 @@ describe GraphQL::StaticValidation::UniqueDirectivesPerLocation do
       assert_includes errors, {
         "message" => 'The directive "A" can only be used once at this location.',
         "locations" => [{ "line" => 4, "column" => 17 }, { "line" => 4, "column" => 23 }],
-        "fields" => ["query", "type", "field"],
+        "fields" => ["query", "type", "field", "@A"],
       }
 
       assert_includes errors, {
         "message" => 'The directive "B" can only be used once at this location.',
         "locations" => [{ "line" => 4, "column" => 20 }, { "line" => 4, "column" => 26 }],
-        "fields" => ["query", "type", "field"],
+        "fields" => ["query", "type", "field", "@B"],
       }
     end
   end
@@ -168,13 +168,13 @@ describe GraphQL::StaticValidation::UniqueDirectivesPerLocation do
       assert_includes errors, {
         "message" => 'The directive "A" can only be used once at this location.',
         "locations" => [{ "line" => 3, "column" => 14 }, { "line" => 3, "column" => 17 }],
-        "fields" => ["query", "type"],
+        "fields" => ["query", "type", "@A"],
       }
 
       assert_includes errors, {
         "message" => 'The directive "A" can only be used once at this location.',
         "locations" => [{ "line" => 4, "column" => 17 }, { "line" => 4, "column" => 20 }],
-        "fields" => ["query", "type", "field"],
+        "fields" => ["query", "type", "field", "@A"],
       }
     end
   end

--- a/spec/graphql/static_validation/rules/variable_default_values_are_correctly_typed_spec.rb
+++ b/spec/graphql/static_validation/rules/variable_default_values_are_correctly_typed_spec.rb
@@ -29,17 +29,17 @@ describe GraphQL::StaticValidation::VariableDefaultValuesAreCorrectlyTyped do
       {
         "message"=>"Default value for $badInt doesn't match type Int",
         "locations"=>[{"line"=>6, "column"=>7}],
-        "fields"=>["query getCheese"],
+        "fields"=>["query getCheese", "$badInt"],
       },
       {
         "message"=>"Default value for $badInput doesn't match type DairyProductInput",
         "locations"=>[{"line"=>8, "column"=>7}],
-        "fields"=>["query getCheese"],
+        "fields"=>["query getCheese", "$badInput"],
       },
       {
         "message"=>"Non-null variable $nonNull can't have a default value",
         "locations"=>[{"line"=>9, "column"=>7}],
-        "fields"=>["query getCheese"],
+        "fields"=>["query getCheese", "$nonNull"],
       }
     ]
     assert_equal(expected, errors)
@@ -104,17 +104,17 @@ describe GraphQL::StaticValidation::VariableDefaultValuesAreCorrectlyTyped do
           {
             "message"=>"Non-null variable $a can't have a default value",
             "locations"=>[{"line"=>3, "column"=>11}],
-            "fields"=>["query getCheese"]
+            "fields"=>["query getCheese", "$a"]
           },
           {
             "message"=>"Non-null variable $b can't have a default value",
             "locations"=>[{"line"=>4, "column"=>11}],
-            "fields"=>["query getCheese"]
+            "fields"=>["query getCheese", "$b"]
           },
           {
             "message"=>"Default value for $c doesn't match type ComplexInput",
             "locations"=>[{"line"=>5, "column"=>11}],
-            "fields"=>["query getCheese"]
+            "fields"=>["query getCheese", "$c"]
           }
         ]
 

--- a/spec/graphql/static_validation/rules/variables_are_input_types_spec.rb
+++ b/spec/graphql/static_validation/rules/variables_are_input_types_spec.rb
@@ -22,25 +22,25 @@ describe GraphQL::StaticValidation::VariablesAreInputTypes do
     assert_includes(errors, {
       "message"=>"AnimalProduct isn't a valid input type (on $interface)",
       "locations"=>[{"line"=>5, "column"=>7}],
-      "fields"=>["query getCheese"],
+      "fields"=>["query getCheese", "$interface"],
     })
 
     assert_includes(errors, {
       "message"=>"Milk isn't a valid input type (on $object)",
       "locations"=>[{"line"=>6, "column"=>7}],
-      "fields"=>["query getCheese"],
+      "fields"=>["query getCheese", "$object"],
     })
 
     assert_includes(errors, {
       "message"=>"Cheese isn't a valid input type (on $objects)",
       "locations"=>[{"line"=>7, "column"=>7}],
-      "fields"=>["query getCheese"],
+      "fields"=>["query getCheese", "$objects"],
     })
 
     assert_includes(errors, {
       "message"=>"Nonsense isn't a defined input type (on $unknownType)",
       "locations"=>[{"line"=>8, "column"=>7}],
-      "fields"=>["query getCheese"],
+      "fields"=>["query getCheese", "$unknownType"],
     })
   end
 end

--- a/spec/graphql/static_validation/rules/variables_are_used_and_defined_spec.rb
+++ b/spec/graphql/static_validation/rules/variables_are_used_and_defined_spec.rb
@@ -47,12 +47,12 @@ describe GraphQL::StaticValidation::VariablesAreUsedAndDefined do
       {
         "message"=>"Variable $undefinedVar is used by getCheese but not declared",
         "locations"=>[{"line"=>19, "column"=>22}],
-        "fields"=>["query getCheese", "c3", "id"],
+        "fields"=>["query getCheese", "c3", "id", "$undefinedVar"],
       },
       {
         "message"=>"Variable $undefinedFragmentVar is used by innerCheeseFields but not declared",
         "locations"=>[{"line"=>29, "column"=>22}],
-        "fields"=>["fragment innerCheeseFields", "c4", "id"],
+        "fields"=>["fragment innerCheeseFields", "c4", "id", "$undefinedFragmentVar"],
       },
     ]
 


### PR DESCRIPTION
Make AST nodes aware of their parents, so you can ask them for their `#path`. Then, refactor StaticValidation to use that `#path`. (This allows getting the path sometime _later_, after the first validation pass. You can see some areas where `context.path` was cached for later usage; that's not needed anymore.)

This has some potetially-breaking changes: 

- `"fields"` on validation error has changed: 
  - Previously, directives were not included. Now they are. 
  - For some validations on arguments, previously, the argument itself was not present in `"fields"`, now it is 
  - Previously, variable identifiers were not present in `"fields"`, now they are. 
  - I guess you could say "fields" is more of a "path" now, but `"path"` is used for runtime errors
- For some validations on arguments, the error location now points at the _argument_ node, not the _field_ (owner) node
- The validation `message(...)` helper's call signature has changed: kwargs `context` and `path` have been removed, since that information is now available from the AST nodes.