### PR TITLE
Refactor validation: resolve fragments once

### DIFF
--- a/lib/graphql/static_validation.rb
+++ b/lib/graphql/static_validation.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "graphql/static_validation/message"
 require "graphql/static_validation/arguments_validator"
+require "graphql/static_validation/definition_dependencies"
 require "graphql/static_validation/type_stack"
 require "graphql/static_validation/validator"
 require "graphql/static_validation/validation_context"

--- a/lib/graphql/static_validation/definition_dependencies.rb
+++ b/lib/graphql/static_validation/definition_dependencies.rb
@@ -1,0 +1,160 @@
+module GraphQL
+  module StaticValidation
+    # Track fragment dependencies for operations
+    # and expose the fragment definitions which
+    # are used by a given operation
+    class DefinitionDependencies
+      def self.mount(visitor)
+        deps = self.new
+        deps.mount(visitor)
+        deps
+      end
+
+      def initialize
+        # { name => node } pairs for query roots
+        @definitions = {}
+
+        # Fragment nodes with no depednencies (no spreads inside them)
+        # It gets built up, then destroyed during resolution
+        @independent_fragments = []
+
+        # This tracks dependencies from fragment to Node where it was used
+        # { frag_name => [dependent_node, dependent_node]}
+        @dependent_definitions = Hash.new { |h, k| h[k] = Set.new }
+
+        # When we encounter a spread,
+        # this node is the one who depends on it
+        @current_parent = nil
+
+        # First-level usages of spreads within definitions
+        # (When a key has an empty list as its value,
+        #  we can resolve that key's depenedents)
+        # { node => [string, string ...] }
+        @immediate_dependencies = Hash.new { |h, k| h[k] = Set.new }
+      end
+
+      # A map of operation definitions to an array of that operation's dependencies
+      # @return [DependencyMap]
+      def dependency_map(&block)
+        @dependency_map ||= resolve_dependencies(&block)
+      end
+
+
+      def mount(visitor)
+        visitor[GraphQL::Language::Nodes::OperationDefinition] << -> (node, prev_node) {
+          @definitions[node.name] = node
+          @current_parent = node
+        }
+
+        visitor[GraphQL::Language::Nodes::OperationDefinition].leave << -> (node, prev_node) {
+          @current_parent = nil
+        }
+
+        visitor[GraphQL::Language::Nodes::FragmentDefinition] << -> (node, prev_node) {
+          @definitions[node.name] = node
+          @current_parent = node
+        }
+
+        visitor[GraphQL::Language::Nodes::FragmentDefinition].leave << -> (node, prev_node) {
+          if @immediate_dependencies[node].none?
+            @independent_fragments << @current_parent
+          end
+          @current_parent = nil
+        }
+
+        visitor[GraphQL::Language::Nodes::FragmentSpread] << -> (node, prev_node) {
+          # Track both sides of the dependency
+          @dependent_definitions[node.name] << @current_parent
+          @immediate_dependencies[@current_parent] << node
+        }
+      end
+
+      # Map definition AST nodes to the definition AST nodes they depend on.
+      # Expose circular depednencies.
+      class DependencyMap
+        # @return [Array<GraphQL::Language::Nodes::FragmentDefinition>]
+        attr_reader :cyclical_definitions
+
+        # @return [Hash<Node, Array<GraphQL::Language::Nodes::FragmentSpread>>]
+        attr_reader :unmet_dependencies
+
+        # @return [Array<GraphQL::Language::Nodes::FragmentDefinition>]
+        attr_reader :unused_dependencies
+
+        def initialize
+          @dependencies = Hash.new { |h, k| h[k] = [] }
+          @cyclical_definitions = []
+          @unmet_dependencies = Hash.new { |h, k| h[k] = [] }
+          @unused_dependencies = []
+        end
+
+        def invalid_fragment_name?(frag_name)
+          @cyclical_definitions.any? { |d| d.name == frag_name } || @unmet_dependencies.each_key.any? { |d| d.name == frag_name}
+        end
+
+        # @return [Array<GraphQL::Language::Nodes::AbstractNode>] dependencies for `definition_node`
+        def [](definition_node)
+          @dependencies[definition_node]
+        end
+      end
+
+      private
+
+      # Return a hash of { node => [node, node ... ]} pairs
+      # Keys are top-level definitions
+      # Values are arrays of flattened dependencies
+      def resolve_dependencies
+        dependency_map = DependencyMap.new
+
+        while fragment_node = @independent_fragments.pop
+          fragment_name = fragment_node.name
+          # Since it's independent, let's remove it from here.
+          # That way, we can use the remainder to identify cycles
+          @immediate_dependencies.delete(fragment_node)
+          fragment_usages = @dependent_definitions[fragment_name]
+          if fragment_usages.none?
+            dependency_map.unused_dependencies << fragment_node
+          else
+            fragment_usages.each do |definition_node|
+              # Register the dependency AND second-order dependencies
+              dependency_map[definition_node] << fragment_node
+              dependency_map[definition_node].concat(dependency_map[fragment_node])
+              # Since we've regestered it, remove it from our to-do list
+              deps = @immediate_dependencies[definition_node]
+              deps.delete_if { |spread| spread.name == fragment_name }
+              if block_given?
+                yield(definition_node, fragment_node)
+              end
+              if deps.none? && definition_node.is_a?(GraphQL::Language::Nodes::FragmentDefinition)
+                # If all of this definition's dependencies have
+                # been resolved, we can now resolve its
+                # own dependents.
+                @independent_fragments << definition_node
+              end
+            end
+          end
+        end
+
+        # If any dependencies were _unmet_
+        # (eg, spreads with no corresponding definition)
+        # then they're still in there
+        @immediate_dependencies.each do |defn_node, deps|
+          deps.each do |spread|
+            if @definitions[spread.name].nil?
+              dependency_map.unmet_dependencies[defn_node] << spread
+              deps.delete(spread)
+            end
+          end
+          if deps.none?
+            @immediate_dependencies.delete(defn_node)
+          end
+        end
+
+        # Anything left in @immediate_dependencies is cyclical
+        dependency_map.cyclical_definitions.concat(@immediate_dependencies.keys)
+
+        dependency_map
+      end
+    end
+  end
+end

--- a/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb
+++ b/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb
@@ -23,11 +23,14 @@ module GraphQL
 
         context.visitor[GraphQL::Language::Nodes::Document].leave << ->(doc_node, parent) {
           spreads_to_validate.each do |frag_spread|
-            fragment_child_name = context.fragments[frag_spread.node.name].type.name
-            fragment_child = context.warden.get_type(fragment_child_name)
-            # Might be non-existent type name
-            if fragment_child
-              validate_fragment_in_scope(frag_spread.parent_type, fragment_child, frag_spread.node, context)
+            frag_node = context.fragments[frag_spread.node.name]
+            if frag_node
+              fragment_child_name = frag_node.type.name
+              fragment_child = context.warden.get_type(fragment_child_name)
+              # Might be non-existent type name
+              if fragment_child
+                validate_fragment_in_scope(frag_spread.parent_type, fragment_child, frag_spread.node, context)
+              end
             end
           end
         }

--- a/lib/graphql/static_validation/rules/fragments_are_finite.rb
+++ b/lib/graphql/static_validation/rules/fragments_are_finite.rb
@@ -5,38 +5,13 @@ module GraphQL
       include GraphQL::StaticValidation::Message::MessageHelper
 
       def validate(context)
-        context.visitor[GraphQL::Language::Nodes::FragmentDefinition] << ->(node, parent) {
-          if has_nested_spread?(node, [], context)
-            context.errors << message("Fragment #{node.name} contains an infinite loop", node)
+        context.visitor[GraphQL::Language::Nodes::Document].leave << ->(_n, _p) do
+          dependency_map = context.dependencies
+          dependency_map.cyclical_definitions.each do |defn|
+            if defn.is_a?(GraphQL::Language::Nodes::FragmentDefinition)
+              context.errors << message("Fragment #{defn.name} contains an infinite loop", defn)
+            end
           end
-        }
-      end
-
-      private
-
-      def has_nested_spread?(fragment_def, parent_fragment_names, context)
-        nested_spreads = get_spreads(fragment_def.selections)
-
-        nested_spreads.any? do |spread|
-          nested_def = context.fragments[spread.name]
-          if nested_def.nil?
-            # this is another kind of error
-            false
-          else
-            parent_fragment_names.include?(spread.name) || has_nested_spread?(nested_def, parent_fragment_names + [fragment_def.name], context)
-          end
-        end
-      end
-
-      # Find spreads contained in this selection & return them in a flat array
-      def get_spreads(selection)
-        case selection
-        when GraphQL::Language::Nodes::FragmentSpread
-          [selection]
-        when GraphQL::Language::Nodes::Field, GraphQL::Language::Nodes::InlineFragment
-          get_spreads(selection.selections)
-        when Array
-          selection.map { |s| get_spreads(s) }.flatten
         end
       end
     end

--- a/lib/graphql/static_validation/rules/fragments_are_used.rb
+++ b/lib/graphql/static_validation/rules/fragments_are_used.rb
@@ -5,48 +5,19 @@ module GraphQL
       include GraphQL::StaticValidation::Message::MessageHelper
 
       def validate(context)
-        v = context.visitor
-        used_fragments = []
-        defined_fragments = []
-
-        v[GraphQL::Language::Nodes::Document] << ->(node, parent) {
-          defined_fragments = node.definitions
-            .select { |defn| defn.is_a?(GraphQL::Language::Nodes::FragmentDefinition) }
-            .map { |node| FragmentInstance.new(node: node) }
-        }
-
-        v[GraphQL::Language::Nodes::FragmentSpread] << ->(node, parent) {
-          used_fragments << FragmentInstance.new(node: node)
-          if defined_fragments.none? { |defn| defn.name == node.name }
-            GraphQL::Language::Visitor::SKIP
+        context.visitor[GraphQL::Language::Nodes::Document].leave << ->(_n, _p) do
+          dependency_map = context.dependencies
+          dependency_map.unmet_dependencies.each do |op_defn, spreads|
+            spreads.each do |fragment_spread|
+              context.errors << message("Fragment #{fragment_spread.name} was used, but not defined", fragment_spread)
+            end
           end
-        }
-        v[GraphQL::Language::Nodes::Document].leave << ->(node, parent) { add_errors(context, used_fragments, defined_fragments) }
-      end
 
-      private
-
-      def add_errors(context, used_fragments, defined_fragments)
-        undefined_fragments = find_difference(used_fragments, defined_fragments.map(&:name))
-        undefined_fragments.each do |fragment|
-          context.errors << message("Fragment #{fragment.name} was used, but not defined", fragment.node)
-        end
-
-        unused_fragments = find_difference(defined_fragments, used_fragments.map(&:name))
-        unused_fragments.each do |fragment|
-          context.errors << message("Fragment #{fragment.name} was defined, but not used", fragment.node)
-        end
-      end
-
-      def find_difference(fragments, allowed_fragment_names)
-        fragments.select {|f| f.name && !allowed_fragment_names.include?(f.name) }
-      end
-
-      class FragmentInstance
-        attr_reader :name, :node
-        def initialize(node:)
-          @node = node
-          @name = node.name
+          dependency_map.unused_dependencies.each do |fragment|
+            if !fragment.name.nil?
+              context.errors << message("Fragment #{fragment.name} was defined, but not used", fragment)
+            end
+          end
         end
       end
     end

--- a/lib/graphql/static_validation/validation_context.rb
+++ b/lib/graphql/static_validation/validation_context.rb
@@ -12,7 +12,11 @@ module GraphQL
     # It also provides limited access to the {TypeStack} instance,
     # which tracks state as you climb in and out of different fields.
     class ValidationContext
-      attr_reader :query, :schema, :document, :errors, :visitor, :fragments, :operations, :warden
+      attr_reader :query, :schema,
+        :document, :errors, :visitor,
+        :fragments, :operations, :warden,
+        :dependencies
+
       def initialize(query)
         @query = query
         @schema = query.schema
@@ -33,6 +37,23 @@ module GraphQL
         @errors = []
         @visitor = GraphQL::Language::Visitor.new(document)
         @type_stack = GraphQL::StaticValidation::TypeStack.new(schema, visitor)
+        definition_dependencies = DefinitionDependencies.mount(visitor)
+        @on_dependency_resolve_handler = nil
+        visitor[GraphQL::Language::Nodes::Document].leave << -> (_n, _p) {
+          @dependencies = definition_dependencies.dependency_map(&@on_dependency_resolve_handler)
+        }
+      end
+
+
+      def on_dependency_resolve(&handler)
+        if @on_dependency_resolve_handler
+          # This is a make-believe API :S
+          # Rewrite is the only thing that actually needs this handler
+          # Is there a better way to get these two parts of code to talk?
+          raise("Already assigned a handler, multiple assignment is not supported")
+        else
+          @on_dependency_resolve_handler = handler
+        end
       end
 
       def object_types

--- a/spec/graphql/internal_representation/rewrite_spec.rb
+++ b/spec/graphql/internal_representation/rewrite_spec.rb
@@ -129,11 +129,11 @@ describe GraphQL::InternalRepresentation::Rewrite do
       op_node = rewrite_result[nil]
 
       cheese_field = op_node.typed_children[Dummy::DairyAppQueryType]["cheese"]
-      assert_equal ["id1", "id2", "fatContent", "similarCow", "flavor"], cheese_field.typed_children[Dummy::CheeseType].keys
+      assert_equal ["fatContent", "flavor", "id1", "id2", "similarCow"], cheese_field.typed_children[Dummy::CheeseType].keys.sort
       assert_equal ["fatContent", "origin"], cheese_field.typed_children[Dummy::EdibleInterface].keys
       # Merge:
       similar_cow_field = cheese_field.typed_children[Dummy::CheeseType]["similarCow"]
-      assert_equal ["similarCowSource", "fatContent", "similarCheese", "id"], similar_cow_field.typed_children[Dummy::CheeseType].keys
+      assert_equal ["fatContent", "id", "similarCheese", "similarCowSource"], similar_cow_field.typed_children[Dummy::CheeseType].keys.sort
       # Deep merge:
       similar_sheep_field = similar_cow_field.typed_children[Dummy::CheeseType]["similarCheese"]
       assert_equal ["flavor", "source"], similar_sheep_field.typed_children[Dummy::CheeseType].keys
@@ -153,7 +153,6 @@ describe GraphQL::InternalRepresentation::Rewrite do
       cheese_flavor_node = cheese_field.typed_children[Dummy::CheeseType]["flavor"]
       assert_equal Dummy::CheeseType.get_field("flavor"), cheese_flavor_node.definition
       assert_equal Dummy::CheeseType, cheese_flavor_node.owner_type
-
 
       # nested spread inside fragment definition:
       cheese_2_field = op_node.typed_children[Dummy::DairyAppQueryType]["cheese2"].typed_children[Dummy::CheeseType]["similarCheese"]

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require_relative "./data"
 module Dummy
   class NoSuchDairyError < StandardError; end
 


### PR DESCRIPTION
This is a long-standing pet peeve of mine: several of the validators make their own ad-hoc traversals of the AST, which defeats the purpose of the visitor and wastes time. 

I've extracted some code from #268 and applied it here. I think there might be a couple other places I can use this, I'll take another look before I merge.

So far, we get a slight speed-up: 

- Master: 

  ```
  validate    285.846  (± 4.5%) i/s -      1.428k in   5.006162s
  validate    284.037  (± 3.9%) i/s -      1.428k in   5.035883s
  validate    273.442  (± 7.3%) i/s -      1.372k in   5.049888s
  validate    279.002  (± 3.9%) i/s -      1.404k in   5.040443s
  ```

- This branch: 

  ```
  validate    294.472  (± 5.1%) i/s -      1.479k in   5.036770s
  validate    297.198  (± 4.4%) i/s -      1.500k in   5.057434s
  validate    295.390  (± 3.4%) i/s -      1.479k in   5.012943s
  ```