### PR TITLE
Reuse Arguments when only default values are present

### DIFF
--- a/lib/graphql/directive.rb
+++ b/lib/graphql/directive.rb
@@ -13,7 +13,7 @@ module GraphQL
     attr_accessor :locations, :arguments, :name, :description
     # @api private
     attr_writer :default_directive
-    ensure_defined(:locations, :arguments, :name, :description, :default_directive?)
+    ensure_defined(:locations, :arguments, :name, :description, :default_directive?, :default_arguments)
 
     LOCATIONS = [
       QUERY =                  :QUERY,
@@ -82,6 +82,11 @@ module GraphQL
     # @return [Boolean] Is this directive supplied by default? (eg `@skip`)
     def default_directive?
       @default_directive
+    end
+
+    # @return [GraphQL::Query::Arguments] Arguments to use when no args are provided in the query
+    def default_arguments
+      @default_arguments ||= GraphQL::Query::LiteralInput.defaults_for(self.arguments)
     end
   end
 end

--- a/lib/graphql/field.rb
+++ b/lib/graphql/field.rb
@@ -132,7 +132,7 @@ module GraphQL
       :name, :deprecation_reason, :description, :description=, :property, :hash_key, :mutation, :arguments, :complexity,
       :resolve, :resolve=, :lazy_resolve, :lazy_resolve=, :lazy_resolve_proc,
       :type, :type=, :name=, :property=, :hash_key=,
-      :relay_node_field,
+      :relay_node_field, :default_arguments
     )
 
     # @return [Boolean] True if this is the Relay find-by-id field
@@ -174,11 +174,13 @@ module GraphQL
       @resolve_proc = build_default_resolver
       @lazy_resolve_proc = DefaultLazyResolve
       @relay_node_field = false
+      @default_arguments = nil
     end
 
     def initialize_copy(other)
       super
       @arguments = other.arguments.dup
+      @default_arguments = nil
     end
 
     # Get a value for this field
@@ -258,6 +260,11 @@ module GraphQL
       GraphQL::Execution::Lazy.new {
         lazy_resolve(obj, args, ctx)
       }
+    end
+
+    # @return [GraphQL::Query::Arguments] Arguments to use when no args are provided in the query
+    def default_arguments
+      @default_arguments ||= GraphQL::Query::LiteralInput.defaults_for(self.arguments)
     end
 
     private

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -178,11 +178,16 @@ module GraphQL
     # @return [GraphQL::Query::Arguments] Arguments for this node, merging default values, literal values and query variables
     def arguments_for(irep_node, definition)
       @arguments_cache[irep_node][definition] ||= begin
-        GraphQL::Query::LiteralInput.from_arguments(
-          irep_node.ast_node.arguments,
-          definition.arguments,
-          self.variables
-        )
+        ast_arguments = irep_node.ast_node.arguments
+        if ast_arguments.none?
+          definition.default_arguments
+        else
+          GraphQL::Query::LiteralInput.from_arguments(
+            irep_node.ast_node.arguments,
+            definition.arguments,
+            self.variables
+          )
+        end
       end
     end
 

--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -47,6 +47,8 @@ module GraphQL
         end
       end
 
+      NO_ARGS = self.new({}, argument_definitions: [])
+
       private
 
       class ArgumentValue

--- a/lib/graphql/query/literal_input.rb
+++ b/lib/graphql/query/literal_input.rb
@@ -29,10 +29,15 @@ module GraphQL
         end
       end
 
-      def self.from_arguments(ast_arguments, argument_defns, variables)
-        if argument_defns.none?
-          return GraphQL::Query::Arguments::NO_ARGS
+      def self.defaults_for(argument_defns)
+        if argument_defns.none? { |name, arg| arg.default_value? }
+          GraphQL::Query::Arguments::NO_ARGS
+        else
+          from_arguments([], argument_defns, nil)
         end
+      end
+
+      def self.from_arguments(ast_arguments, argument_defns, variables)
 
         values_hash = {}
         indexed_arguments = ast_arguments.each_with_object({}) { |a, memo| memo[a.name] = a }

--- a/lib/graphql/query/literal_input.rb
+++ b/lib/graphql/query/literal_input.rb
@@ -30,6 +30,10 @@ module GraphQL
       end
 
       def self.from_arguments(ast_arguments, argument_defns, variables)
+        if argument_defns.none?
+          return GraphQL::Query::Arguments::NO_ARGS
+        end
+
         values_hash = {}
         indexed_arguments = ast_arguments.each_with_object({}) { |a, memo| memo[a.name] = a }
 

--- a/spec/graphql/query/arguments_spec.rb
+++ b/spec/graphql/query/arguments_spec.rb
@@ -141,6 +141,19 @@ describe GraphQL::Query::Arguments do
             1
           }
         end
+
+        field :noDefaultsTest, types.Int do
+          argument :a, types.Int
+          argument :b, types.Int
+          resolve ->(obj, args, ctx) {
+            arg_values_array << args
+            1
+          }
+          resolve ->(obj, args, ctx) {
+            arg_values_array << args
+            1
+          }
+        end
       end
 
       GraphQL::Schema.define(query: query)
@@ -165,11 +178,12 @@ describe GraphQL::Query::Arguments do
       assert_equal({"a" => 1, "b" => 2}, last_args.to_h)
     end
 
-    it "works from query literals" do
-      schema.execute("{ noArgTest }")
+    it "uses Field#default_arguments when no args are provided" do
+      schema.execute("{ argTest noArgTest noDefaultsTest }")
 
-      last_args = arg_values.last
-      assert GraphQL::Query::Arguments::NO_ARGS.eql?(last_args)
+      assert schema.query.get_field("argTest").default_arguments.eql?(arg_values[0])
+      assert GraphQL::Query::Arguments::NO_ARGS.eql?(arg_values[1])
+      assert GraphQL::Query::Arguments::NO_ARGS.eql?(arg_values[2])
     end
 
     it "works from variables" do

--- a/spec/graphql/query/arguments_spec.rb
+++ b/spec/graphql/query/arguments_spec.rb
@@ -134,6 +134,13 @@ describe GraphQL::Query::Arguments do
             1
           }
         end
+
+        field :noArgTest, types.Int do
+          resolve ->(obj, args, ctx) {
+            arg_values_array << args
+            1
+          }
+        end
       end
 
       GraphQL::Schema.define(query: query)
@@ -156,6 +163,13 @@ describe GraphQL::Query::Arguments do
       assert_equal true, last_args.key?(:b)
       assert_equal false, last_args.key?(:c)
       assert_equal({"a" => 1, "b" => 2}, last_args.to_h)
+    end
+
+    it "works from query literals" do
+      schema.execute("{ noArgTest }")
+
+      last_args = arg_values.last
+      assert GraphQL::Query::Arguments::NO_ARGS.eql?(last_args)
     end
 
     it "works from variables" do


### PR DESCRIPTION
We make a lot more `Query::Arguments` instances than we really _need_. When no arguments are present in the query string, the `Arguments` will always be populated with the same, static default values. So we can reuse an `Arguments` instance for those.

This improvement has a smaller impact than I thought it would. I forgot that `Arguments` instances were created per-AST-node, so the number doesn't grow with the size of the response (Instead, it grows with the size of the query string). 

Running the introspection query on the test schema reduces the number of Arguments instances from  64 to 2 

- before: 

  ```
  %self     total      self      wait     child     calls  name
  # ...
  0.04      0.000     0.000     0.000     0.000       64   GraphQL::Query::Arguments#initialize
  ```

- after: 

  ```
  %self     total      self      wait     child     calls  name
  # ...
  0.00      0.000     0.000     0.000     0.000        2   GraphQL::Query::Arguments#initialize
  ```