### PR TITLE
feat(define) improve typo error message and backtrace

### DIFF
--- a/lib/graphql/define/defined_object_proxy.rb
+++ b/lib/graphql/define/defined_object_proxy.rb
@@ -16,22 +16,13 @@ module GraphQL
         if definition
           definition.call(@target, *args, &block)
         else
-          p "Failed to find config #{name} in #{inspect}"
-          super
+          msg = "#{@target.class.name} can't define '#{name}'"
+          raise NoMethodError, msg, caller
         end
       end
 
       def respond_to_missing?(name, include_private = false)
-        return true if @dictionary[name]
-        super
-      end
-
-      def to_s
-        inspect
-      end
-
-      def inspect
-        "<DefinedObjectProxy #{@target} (#{@dictionary.keys})>"
+        @dictionary[name] || super
       end
     end
   end

--- a/spec/graphql/define/instance_definable_spec.rb
+++ b/spec/graphql/define/instance_definable_spec.rb
@@ -115,4 +115,22 @@ describe GraphQL::Define::InstanceDefinable do
       assert_equal :green, arugula.metadata[:color]
     end
   end
+
+  describe "typos" do
+    it "provides the right class name, method name and line number" do
+      err = assert_raises(NoMethodError) {
+        beet = Garden::Vegetable.define {
+          name "Beet"
+          nonsense :Blah
+        }
+        beet.name
+      }
+      assert_includes err.message, "Garden::Vegetable"
+      assert_includes err.message, "nonsense"
+      first_backtrace = err.backtrace.first
+      # This is the offset from the assertion to the `nonsense` call,
+      # it might change when this test changes:
+      assert_includes first_backtrace, "#{__LINE__ - 9}"
+    end
+  end
 end


### PR DESCRIPTION

Was: 

```
#<GraphQL::Define::DefinedObjectProxy::NoDefinitionError: Garden::Vegetable can't define 'nonsense'>
.../gems/graphql/lib/graphql/define/defined_object_proxy.rb:23:in `method_missing'
/your/application/code.rb:124
```
Is: 

```
#<NoMethodError: Garden::Vegetable can't define 'nonsense'>
/your/application/code.rb:124
```