### PR TITLE
Ensure defined when reading the resolve proc

### DIFF
--- a/lib/graphql/field.rb
+++ b/lib/graphql/field.rb
@@ -130,7 +130,7 @@ module GraphQL
 
     ensure_defined(
       :name, :deprecation_reason, :description, :description=, :property, :hash_key, :mutation, :arguments, :complexity,
-      :resolve, :resolve=, :lazy_resolve, :lazy_resolve=, :lazy_resolve_proc,
+      :resolve, :resolve=, :lazy_resolve, :lazy_resolve=, :lazy_resolve_proc, :resolve_proc,
       :type, :type=, :name=, :property=, :hash_key=,
       :relay_node_field,
     )

--- a/spec/graphql/field_spec.rb
+++ b/spec/graphql/field_spec.rb
@@ -190,4 +190,13 @@ describe GraphQL::Field do
       assert_equal({a: 1, b: 2, c: 3}, int_field_2.metadata)
     end
   end
+
+  describe "#resolve_proc" do
+    it "ensures the definition was called" do
+      field = GraphQL::Field.define do
+        resolve ->(o, a, c) { :whatever }
+      end
+      assert_instance_of Proc, field.resolve_proc
+    end
+  end
 end


### PR DESCRIPTION
If you have two instrumenters and they both read `#resolve_proc`, one of them will get a stale value because the previous definition wasn't run! 