### PR TITLE
Set UTF-8 encoding other parsed tokens

### DIFF
--- a/lib/graphql/language/lexer.rb
+++ b/lib/graphql/language/lexer.rb
@@ -990,7 +990,7 @@ end
       def self.record_comment(ts, te, meta)
         token = GraphQL::Language::Token.new(
           name: :COMMENT,
-          value: meta[:data][ts...te].pack("c*"),
+          value: meta[:data][ts...te].pack("c*").force_encoding("UTF-8"),
           line: meta[:line],
           col: meta[:col],
           prev_token: meta[:previous_token],
@@ -1004,7 +1004,7 @@ end
       def self.emit(token_name, ts, te, meta)
         meta[:tokens] << token = GraphQL::Language::Token.new(
           name: token_name,
-          value: meta[:data][ts...te].pack("c*"),
+          value: meta[:data][ts...te].pack("c*").force_encoding("UTF-8"),
           line: meta[:line],
           col: meta[:col],
           prev_token: meta[:previous_token],

--- a/lib/graphql/language/lexer.rl
+++ b/lib/graphql/language/lexer.rl
@@ -145,7 +145,7 @@ module GraphQL
       def self.record_comment(ts, te, meta)
         token = GraphQL::Language::Token.new(
           name: :COMMENT,
-          value: meta[:data][ts...te].pack("c*"),
+          value: meta[:data][ts...te].pack("c*").force_encoding("UTF-8"),
           line: meta[:line],
           col: meta[:col],
           prev_token: meta[:previous_token],
@@ -159,7 +159,7 @@ module GraphQL
       def self.emit(token_name, ts, te, meta)
         meta[:tokens] << token = GraphQL::Language::Token.new(
           name: token_name,
-          value: meta[:data][ts...te].pack("c*"),
+          value: meta[:data][ts...te].pack("c*").force_encoding("UTF-8"),
           line: meta[:line],
           col: meta[:col],
           prev_token: meta[:previous_token],


### PR DESCRIPTION
So I was trying to track down why most AST `Language::Node`s had UTF-8 tagged strings and why a few others were untagged as binary.

Stuff like `Language::Node#name` gets surfaced in different ways on introspection queries. This leads to some binary tagged strings leaking into execution result.

I figured fixing the encoding at the source would be the best way to solve this. It looks like some of these strings are already being retagged after they are repacked. https://github.com/rmosolgo/graphql-ruby/blob/571ceab99f3076f269a3d92cc133d559151e3bfd/lib/graphql/language/lexer.rl#L190

Does the parser even support parsing input strings in anything else besides UTF-8?