### PR TITLE
Ensure returned String types are encoded as UTF-8

### DIFF
--- a/lib/graphql/string_type.rb
+++ b/lib/graphql/string_type.rb
@@ -3,7 +3,11 @@ GraphQL::STRING_TYPE = GraphQL::ScalarType.define do
   name "String"
   description "Represents textual data as UTF-8 character sequences. This type is most often used by GraphQL to represent free-form human-readable text."
 
-  coerce_result ->(value) { value.to_s }
+  coerce_result ->(value) {
+    str = value.to_s
+    str.encoding == Encoding::US_ASCII || str.encoding == Encoding::UTF_8 ? str : nil
+  }
+
   coerce_input ->(value) { value.is_a?(String) ? value : nil }
   default_scalar true
 end

--- a/spec/graphql/string_type_spec.rb
+++ b/spec/graphql/string_type_spec.rb
@@ -8,6 +8,13 @@ describe GraphQL::STRING_TYPE do
     assert_equal(true, string_type.default_scalar?)
   end
 
+  describe "coerce_result" do
+    it "requires string to be encoded as UTF-8" do
+      binary_str = "\0\0\0foo\255\255\255".dup.force_encoding("BINARY")
+      assert_equal nil, string_type.coerce_result(binary_str)
+    end
+  end
+
   describe "coerce_input" do
     it "accepts strings" do
       assert_equal "str", string_type.coerce_input("str")


### PR DESCRIPTION
Today its possible to return binary or non-utf8 compatible strings as GraphQL String scalars. If this happens it will likely crash later when the actual JSON serialization step. This sort of thing is really hard to track down, especially if most of the time you're returning valid but untagged UTF-8 data and invalid data slips in crashing the entire response.

Since UTF-8 is a requirement, I think it would be good to enforce at the scalar casting phase.

Test failure depends on https://github.com/rmosolgo/graphql-ruby/pull/516.

My concern is that this is a backwards incompatible change. Should we add some kind of flag to opt into this behavior?

Also, I'm letting US-ASCII data through as it should be a proper subset of UTF-8. An alternative would be to upgrade the encoding to UTF-8. Or we could just enforce strict UTF-8. This should be fine in most case, but I discovered a number of introspection APIs return Ruby `Class#name` strings which are encoded as US-ASCII by default. We could encode those at the callsites, but it was just more code.