### PR TITLE
fix proc syntax ordering on validation errors

### DIFF
--- a/lib/graphql/schema/validation.rb
+++ b/lib/graphql/schema/validation.rb
@@ -132,7 +132,7 @@ module GraphQL
 
         SCHEMA_CAN_RESOLVE_TYPES = ->(schema) {
           if schema.types.values.any? { |type| type.kind.resolves? } && schema.resolve_type_proc.nil?
-            "schema contains Interfaces or Unions, so you must define a `resolve_type (obj, ctx) -> { ... }` function"
+            "schema contains Interfaces or Unions, so you must define a `resolve_type -> (obj, ctx) { ... }` function"
           else
             # :+1:
           end
@@ -141,7 +141,7 @@ module GraphQL
         SCHEMA_CAN_FETCH_IDS = ->(schema) {
           has_node_field = schema.query && schema.query.all_fields.any?(&:relay_node_field)
           if has_node_field && schema.object_from_id_proc.nil?
-            "schema contains `node(id:...)` field, so you must define a `object_from_id (id, ctx) -> { ... }` function"
+            "schema contains `node(id:...)` field, so you must define a `object_from_id -> (id, ctx) { ... }` function"
           else
             # :rocket:
           end
@@ -150,7 +150,7 @@ module GraphQL
         SCHEMA_CAN_GENERATE_IDS = ->(schema) {
           has_id_field = schema.types.values.any? { |t| t.kind.fields? && t.all_fields.any? { |f| f.resolve_proc.is_a?(GraphQL::Relay::GlobalIdResolve) } }
           if has_id_field && schema.id_from_object_proc.nil?
-            "schema contains `global_id_field`, so you must define a `id_from_object (obj, type, ctx) -> { ... }` function"
+            "schema contains `global_id_field`, so you must define a `id_from_object -> (obj, type, ctx) { ... }` function"
           else
             # :ok_hand:
           end


### PR DESCRIPTION
An actual definition would look like this:

```ruby
resolve_type -> (obj, ctx) { ... }
```

with the dash rocket coming before the argument list.