### PR TITLE
feat(benchmark) add basic benchmark tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -94,3 +94,22 @@ namespace :site do
     puts 'Done.'
   end
 end
+
+namespace :bench do
+  def prepare_benchmark
+    $LOAD_PATH << "./lib" << "./spec/support"
+    require_relative("./benchmark/run.rb")
+  end
+
+  desc "Benchmark the introspection query"
+  task :query do
+    prepare_benchmark
+    GraphQLBenchmark.run("query")
+  end
+
+  desc "Benchmark validating the introspection query"
+  task :validate do
+    prepare_benchmark
+    GraphQLBenchmark.run("validate")
+  end
+end

--- a/benchmark/run.rb
+++ b/benchmark/run.rb
@@ -1,0 +1,23 @@
+require "dummy/schema"
+require "benchmark/ips"
+
+module GraphQLBenchmark
+  QUERY_STRING = GraphQL::Introspection::INTROSPECTION_QUERY
+  DOCUMENT = GraphQL.parse(QUERY_STRING)
+  SCHEMA = Dummy::Schema
+
+  module_function
+  def self.run(task)
+    Benchmark.ips do |x|
+      case task
+      when "query"
+        x.report("query") { SCHEMA.execute(document: DOCUMENT) }
+      when "validate"
+        x.report("validate") { SCHEMA.validate(DOCUMENT) }
+      else
+        raise("Unexpected task #{task}")
+      end
+      x.compare!
+    end
+  end
+end

--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{lib}/**/*", "MIT-LICENSE", "readme.md", ".yardopts"]
   s.test_files = Dir["spec/**/*"]
 
+  s.add_development_dependency "benchmark-ips"
   s.add_development_dependency "codeclimate-test-reporter", "~>0.4"
   s.add_development_dependency "guard", "~> 2.12"
   s.add_development_dependency "guard-bundler", "~> 2.1"

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "graphql"
 require_relative "./data"
 module Dummy
   class NoSuchDairyError < StandardError; end


### PR DESCRIPTION
I've had some code like this in my local directory for a long time and I thought I'd share it. I don't claim that it's the most scientific measure in the world, but maybe it'll get the ball rolling!

```
~/code/graphql $ be rake bench:query
Warming up --------------------------------------
               query     3.000  i/100ms
Calculating -------------------------------------
               query     38.278  (± 5.2%) i/s -    192.000  in   5.026674s
~/code/graphql $ be rake bench:validate
Warming up --------------------------------------
            validate    37.000  i/100ms
Calculating -------------------------------------
            validate    372.743  (± 3.5%) i/s -      1.887k in   5.069387s
```