### PR TITLE
[Relay] Nodes field definition

### DIFF
--- a/guides/relay/object_identification.md
+++ b/guides/relay/object_identification.md
@@ -89,3 +89,16 @@ QueryType = GraphQL::ObjectType.define do
   # ...
 end
 ```
+
+### `nodes` field
+
+You can also provide a root-level `nodes` field so that Relay can refetch objects by IDs. Similarly, it is provided as `GraphQL::Relay::Node.plural_field`:
+
+```ruby
+QueryType = GraphQL::ObjectType.define do
+  name "Query"
+  # Fetches a list of objects given a list of IDs
+  field :nodes, GraphQL::Relay::Node.plural_field
+  # ...
+end
+```

--- a/lib/graphql/field.rb
+++ b/lib/graphql/field.rb
@@ -126,17 +126,21 @@ module GraphQL
       :type, :arguments,
       :property, :hash_key, :complexity, :mutation,
       :relay_node_field,
+      :relay_nodes_field,
       argument: GraphQL::Define::AssignArgument
 
     ensure_defined(
       :name, :deprecation_reason, :description, :description=, :property, :hash_key, :mutation, :arguments, :complexity,
       :resolve, :resolve=, :lazy_resolve, :lazy_resolve=, :lazy_resolve_proc, :resolve_proc,
       :type, :type=, :name=, :property=, :hash_key=,
-      :relay_node_field, :default_arguments
+      :relay_node_field, :relay_nodes_field, :default_arguments
     )
 
     # @return [Boolean] True if this is the Relay find-by-id field
     attr_accessor :relay_node_field
+
+    # @return [Boolean] True if this is the Relay find-by-ids field
+    attr_accessor :relay_nodes_field
 
     # @return [<#call(obj, args, ctx)>] A proc-like object which can be called to return the field's value
     attr_reader :resolve_proc

--- a/lib/graphql/relay/node.rb
+++ b/lib/graphql/relay/node.rb
@@ -17,7 +17,7 @@ module GraphQL
         end
       end
 
-      def self.plural_identifying_field
+      def self.plural_field
         GraphQL::Field.define do
           type(!types[GraphQL::Relay::Node.interface])
           description("Fetches a list of objects given a list of IDs.")

--- a/lib/graphql/relay/node.rb
+++ b/lib/graphql/relay/node.rb
@@ -17,13 +17,30 @@ module GraphQL
         end
       end
 
+      def self.plural_identifying_field
+        GraphQL::Field.define do
+          type(!types[GraphQL::Relay::Node.interface])
+          description("Fetches a list of objects given a list of IDs.")
+          argument(:ids, !types[!types.ID], "IDs of the objects.")
+          resolve(GraphQL::Relay::Node::FindNodes)
+          relay_nodes_field(true)
+        end
+      end
+
       # @return [GraphQL::InterfaceType] The interface which all Relay types must implement
       def self.interface
         @interface ||= GraphQL::InterfaceType.define do
-          name "Node"
-          description "An object with an ID."
-          field :id, !types.ID, "ID of the object."
-          default_relay true
+          name("Node")
+          description("An object with an ID.")
+          field(:id, !types.ID, "ID of the object.")
+          default_relay(true)
+        end
+      end
+
+      # A field resolve for finding objects by IDs
+      module FindNodes
+        def self.call(obj, args, ctx)
+          args[:ids].map { |id| ctx.query.schema.object_from_id(id, ctx) }
         end
       end
 

--- a/spec/graphql/relay/node_spec.rb
+++ b/spec/graphql/relay/node_spec.rb
@@ -56,7 +56,6 @@ describe GraphQL::Relay::Node do
       end
     end
 
-
     it 'finds objects by id' do
       id = GraphQL::Schema::UniqueWithinType.encode("Faction", "1")
       result = star_wars_query(%|{
@@ -89,6 +88,60 @@ describe GraphQL::Relay::Node do
         }
       }}
       assert_equal(expected, result)
+    end
+  end
+
+  describe ".plural_identifying_field" do
+    it 'finds objects by ids' do
+      id = GraphQL::Schema::UniqueWithinType.encode("Faction", "1")
+      id2 = GraphQL::Schema::UniqueWithinType.encode("Faction", "2")
+
+      result = star_wars_query(%|{
+        nodes(ids: ["#{id}", "#{id2}"]) {
+          id,
+          ... on Faction {
+            name
+            ships(first: 1) {
+              edges {
+               node {
+                 name
+                 }
+              }
+            }
+          }
+        }
+      }|)
+
+      expected = {
+        "data" => {
+          "nodes" => [{
+            "id"=>"RmFjdGlvbi0x",
+            "name"=>"Alliance to Restore the Republic",
+            "ships"=>{
+              "edges"=>[
+                {"node"=>{
+                    "name" => "X-Wing"
+                  }
+                }
+              ]
+            }
+          }, {
+            "id" => "RmFjdGlvbi0y",
+            "name" => "Galactic Empire",
+            "ships" => {
+              "edges" => [
+                { "node" => { "name" => "TIE Fighter" } }
+              ]
+            }
+          }]
+        }
+      }
+
+      assert_equal(expected, result)
+    end
+
+    it 'is marked as relay_nodes_field' do
+      assert GraphQL::Relay::Node.plural_identifying_field.relay_nodes_field
     end
   end
 end

--- a/spec/graphql/relay/node_spec.rb
+++ b/spec/graphql/relay/node_spec.rb
@@ -141,7 +141,7 @@ describe GraphQL::Relay::Node do
     end
 
     it 'is marked as relay_nodes_field' do
-      assert GraphQL::Relay::Node.plural_identifying_field.relay_nodes_field
+      assert GraphQL::Relay::Node.plural_field.relay_nodes_field
     end
   end
 end

--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -210,7 +210,7 @@ module StarWars
     end
 
     field :node, GraphQL::Relay::Node.field
-    field :nodes, GraphQL::Relay::Node.plural_identifying_field
+    field :nodes, GraphQL::Relay::Node.plural_field
   end
 
   MutationType = GraphQL::ObjectType.define do

--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -210,6 +210,7 @@ module StarWars
     end
 
     field :node, GraphQL::Relay::Node.field
+    field :nodes, GraphQL::Relay::Node.plural_identifying_field
   end
 
   MutationType = GraphQL::ObjectType.define do


### PR DESCRIPTION
Adds a helper method to define the `nodes` field.

Was recently added to `graphql-relay-js`: https://github.com/graphql/graphql-relay-js/pull/141

> The nodes field should accept a single argument ids: [ID!]!. It should return one result per input id, in an order matching the input arguments. For ids that do not exist or cannot be fetched, it should return null in order to ensure the ordering requirement."'

Field is talked about in https://github.com/facebook/relay/issues/1496

Suggestions welcome for a better name 💃 