### PR TITLE
fix(Mutation) handle errors from lazy values

### DIFF
--- a/lib/graphql/relay/mutation.rb
+++ b/lib/graphql/relay/mutation.rb
@@ -181,23 +181,23 @@ module GraphQL
         def call(obj, args, ctx)
           mutation_result = @resolve.call(obj, args[:input], ctx)
 
-          if mutation_result.is_a?(GraphQL::ExecutionError)
-            ctx.add_error(mutation_result)
-            mutation_result = nil
-          end
-
           if ctx.schema.lazy?(mutation_result)
             @mutation.field.prepare_lazy(mutation_result, args, ctx).then { |inner_obj|
-              build_result(inner_obj, args)
+              build_result(inner_obj, args, ctx)
             }
           else
-            build_result(mutation_result, args)
+            build_result(mutation_result, args, ctx)
           end
         end
 
         private
 
-        def build_result(mutation_result, args)
+        def build_result(mutation_result, args, ctx)
+          if mutation_result.is_a?(GraphQL::ExecutionError)
+            ctx.add_error(mutation_result)
+            mutation_result = nil
+          end
+
           if @wrap_result
             @mutation.result_class.new(client_mutation_id: args[:input][:clientMutationId], result: mutation_result)
           else

--- a/spec/graphql/relay/mutation_spec.rb
+++ b/spec/graphql/relay/mutation_spec.rb
@@ -190,5 +190,28 @@ describe GraphQL::Relay::Mutation do
 
       assert_equal(expected, result)
     end
+
+    it "supports raising an error in a lazy callback" do
+      result = star_wars_query(query_string, "clientMutationId" => "5678", "shipName" => "Ebon Hawk")
+
+      expected = {
+        "data" => {
+          "introduceShip" => {
+            "clientMutationId" => "5678",
+            "shipEdge" => nil,
+            "faction" => nil,
+          }
+        },
+        "errors" => [
+          {
+            "message" => "💥",
+            "locations" => [ { "line" => 3 , "column" => 7}],
+            "path" => ["introduceShip"]
+          }
+        ]
+      }
+
+      assert_equal(expected, result)
+    end
   end
 end

--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -161,7 +161,8 @@ module StarWars
       faction_id = inputs["factionId"]
       if inputs["shipName"] == 'Millennium Falcon'
         GraphQL::ExecutionError.new("Sorry, Millennium Falcon ship is reserved")
-
+      elsif inputs["shipName"] == "Ebon Hawk"
+        LazyWrapper.new { raise GraphQL::ExecutionError.new("💥")}
       else
         ship = DATA.create_ship(inputs["shipName"], faction_id)
         faction = DATA["Faction"][faction_id]
@@ -183,9 +184,16 @@ module StarWars
 
 
   class LazyWrapper
-    attr_reader :value
-    def initialize(value)
-      @value = value
+    def initialize(value = nil, &block)
+      if block_given?
+        @lazy_value = block
+      else
+        @value = value
+      end
+    end
+
+    def value
+      @resolved_value = @value || @lazy_value.call
     end
   end
 


### PR DESCRIPTION
Oops, proper handling for `GraphQL::ExecutionError` should be used for lazy values, too! 

Fixes #527 