### PR TITLE
Weird duplicate connection error

### DIFF
--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -17,7 +17,6 @@ module StarWars
     global_id_field :id
     field :name, types.String
     field :planet, types.String
-    connection :ships, Ship.connection_type
   end
 
   # Use an optional block to add fields to the connection type:

--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -8,6 +8,7 @@ module StarWars
     interfaces [GraphQL::Relay::Node.interface]
     global_id_field :id
     field :name, types.String
+    connection :ships, Ship.connection_type
   end
 
   BaseType = GraphQL::ObjectType.define do
@@ -16,6 +17,7 @@ module StarWars
     global_id_field :id
     field :name, types.String
     field :planet, types.String
+    connection :ships, Ship.connection_type
   end
 
   # Use an optional block to add fields to the connection type:

--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -8,6 +8,7 @@ module StarWars
     interfaces [GraphQL::Relay::Node.interface]
     global_id_field :id
     field :name, types.String
+    # Test cyclical connection types:
     connection :ships, Ship.connection_type
   end
 


### PR DESCRIPTION
I've got this weird error going on in my sample app where I get a Duplicate type definition error on any connection used more than once.

I was able to reproduce in the tests:
`/graphql-ruby/lib/graphql/schema/type_map.rb:24:in `[]=': Duplicate type definition found for name 'ShipConnection'`

If i add anything that touches the object in `def connection_type` on `BaseType`,  (https://github.com/rmosolgo/graphql-ruby/blob/master/lib/graphql/base_type.rb#L142) then the error goes away :thinking:

This makes me think theres something lazily loaded / something is resetting `@connection_type` to `nil`, voiding the memoization.

@rmosolgo