### PR TITLE
Fix: don't include children of skipped nodes

### DIFF
--- a/lib/graphql/analysis/query_depth.rb
+++ b/lib/graphql/analysis/query_depth.rb
@@ -25,7 +25,7 @@ module GraphQL
       def call(memo, visit_type, irep_node)
         if irep_node.ast_node.is_a?(GraphQL::Language::Nodes::Field)
           # Don't validate introspection fields or skipped nodes
-          not_validated_node = GraphQL::Schema::DYNAMIC_FIELDS.include?(irep_node.definition_name) || irep_node.skipped?
+          not_validated_node = GraphQL::Schema::DYNAMIC_FIELDS.include?(irep_node.definition_name)
           if visit_type == :enter
             if not_validated_node
               memo[:skip_depth] += 1

--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -27,12 +27,11 @@ module GraphQL
         selection_result = SelectionResult.new
 
         selection.typed_children[current_type].each do |name, subselection|
-          field = query.get_field(current_type, subselection.definition_name)
           field_result = resolve_field(
             selection_result,
             subselection,
             current_type,
-            field,
+            subselection.definition,
             object,
             query_ctx
           )

--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -27,7 +27,6 @@ module GraphQL
         selection_result = SelectionResult.new
 
         selection.typed_children[current_type].each do |name, subselection|
-          next if subselection.skipped?
           field = query.get_field(current_type, subselection.definition_name)
           field_result = resolve_field(
             selection_result,

--- a/lib/graphql/internal_representation/node.rb
+++ b/lib/graphql/internal_representation/node.rb
@@ -28,33 +28,6 @@ module GraphQL
       # @return [GraphQL::BaseType]
       attr_reader :return_type
 
-      # TODO This should be part of the directive, not hardcoded here
-      def skipped?
-        if !defined?(@skipped)
-          nodes_skipped = true
-          for n in ast_nodes
-            nodes_skipped &&= !GraphQL::Execution::DirectiveChecks.include?(n.directives, @query)
-          end
-
-          @skipped = if nodes_skipped
-            true
-          elsif @ast_spreads
-            nodes_skipped = true
-            for n in @ast_spreads
-              nodes_skipped &&= !GraphQL::Execution::DirectiveChecks.include?(n.directives, @query)
-            end
-            nodes_skipped
-          else
-            false
-          end
-        end
-        @skipped
-      end
-
-      def included?
-        !skipped?
-      end
-
       def initialize(
           name:, owner_type:, query:, return_type:,
           ast_nodes: [],

--- a/lib/graphql/internal_representation/node.rb
+++ b/lib/graphql/internal_representation/node.rb
@@ -15,11 +15,6 @@ module GraphQL
         @ast_nodes ||= Set.new
       end
 
-      # @return [Set<Language::Nodes::AbstractNode>]
-      def ast_spreads
-        @ast_spreads ||= Set.new
-      end
-
       # @return [Set<GraphQL::Field>] Field definitions for this node (there should only be one!)
       def definitions
         @definitions ||= Set.new
@@ -31,7 +26,6 @@ module GraphQL
       def initialize(
           name:, owner_type:, query:, return_type:,
           ast_nodes: [],
-          ast_spreads: nil,
           definitions: nil, typed_children: nil
         )
         @name = name
@@ -39,7 +33,6 @@ module GraphQL
         @owner_type = owner_type
         @typed_children = typed_children || Hash.new { |h1, k1| h1[k1] = {} }
         @ast_nodes = ast_nodes
-        @ast_spreads = ast_spreads
         @definitions = definitions
         @return_type = return_type
       end

--- a/lib/graphql/internal_representation/rewrite.rb
+++ b/lib/graphql/internal_representation/rewrite.rb
@@ -40,6 +40,7 @@ module GraphQL
         # Spreads that you're inside (only the last one matters)
         spreads_stack = []
         fragment_definitions = Hash.new {|h, k| h[k] = {} }
+        skip_nodes = Set.new
 
         visit_op = VisitDefinition.new(context, @operations, nodes_stack, scope_stack)
         visitor[Nodes::OperationDefinition].enter << visit_op.method(:enter)
@@ -55,11 +56,18 @@ module GraphQL
           # - They _may_ apply their directives to their children
           next_scope = Set.new
           prev_scope = scope_stack.last
-          each_type(query, context.type_definition) do |obj_type|
-            # What this fragment can apply to is also determined by
-            # the scope around it (it can't widen the scope)
-            if prev_scope.include?(obj_type)
-              next_scope.add(obj_type)
+
+          if skip?(ast_node, query)
+            skip_nodes.add(ast_node)
+          end
+
+          if skip_nodes.none?
+            each_type(query, context.type_definition) do |obj_type|
+              # What this fragment can apply to is also determined by
+              # the scope around it (it can't widen the scope)
+              if prev_scope.include?(obj_type)
+                next_scope.add(obj_type)
+              end
             end
           end
           scope_stack.push(next_scope)
@@ -67,6 +75,10 @@ module GraphQL
         }
 
         visitor[Nodes::InlineFragment].leave << ->(ast_node, ast_parent) {
+          if skip_nodes.include?(ast_node)
+            skip_nodes.delete(ast_node)
+          end
+
           scope_stack.pop
           spreads_stack.pop
         }
@@ -76,31 +88,38 @@ module GraphQL
           parent_nodes = nodes_stack.last
           next_nodes = []
           next_scope = Set.new
-          applicable_scope = scope_stack.last
-          applicable_spread = spreads_stack.last
 
-          applicable_scope.each do |obj_type|
-            # Can't use context.field_definition because that might be
-            # a definition on an interface type
-            field_defn = query.get_field(obj_type, ast_node.name)
-            if field_defn.nil?
-              # It's a non-existent field
-            else
-              field_return_type = field_defn.type.unwrap
-              each_type(query, field_return_type) do |obj_type|
-                next_scope.add(obj_type)
-              end
-              parent_nodes.each do |parent_node|
-                node = parent_node.typed_children[obj_type][node_name] ||= Node.new(
-                  name: node_name,
-                  owner_type: obj_type,
-                  query: query,
-                  return_type: field_return_type,
-                )
-                node.ast_nodes.push(ast_node)
-                node.definitions.add(field_defn)
-                applicable_spread && node.ast_spreads.add(applicable_spread)
-                next_nodes << node
+          if skip?(ast_node, query)
+            skip_nodes.add(ast_node)
+          end
+
+          if skip_nodes.none?
+            applicable_scope = scope_stack.last
+            applicable_spread = spreads_stack.last
+
+            applicable_scope.each do |obj_type|
+              # Can't use context.field_definition because that might be
+              # a definition on an interface type
+              field_defn = query.get_field(obj_type, ast_node.name)
+              if field_defn.nil?
+                # It's a non-existent field
+              else
+                field_return_type = field_defn.type.unwrap
+                each_type(query, field_return_type) do |obj_type|
+                  next_scope.add(obj_type)
+                end
+                parent_nodes.each do |parent_node|
+                  node = parent_node.typed_children[obj_type][node_name] ||= Node.new(
+                    name: node_name,
+                    owner_type: obj_type,
+                    query: query,
+                    return_type: field_return_type,
+                  )
+                  node.ast_nodes.push(ast_node)
+                  node.definitions.add(field_defn)
+                  applicable_spread && node.ast_spreads.add(applicable_spread)
+                  next_nodes << node
+                end
               end
             end
           end
@@ -110,14 +129,20 @@ module GraphQL
         }
 
         visitor[Nodes::Field].leave << ->(ast_node, ast_parent) {
+          if skip_nodes.include?(ast_node)
+            skip_nodes.delete(ast_node)
+          end
+
           nodes_stack.pop
           scope_stack.pop
           spreads_stack.pop
         }
 
         visitor[Nodes::FragmentSpread].enter << ->(ast_node, ast_parent) {
-          # Register the irep nodes that depend on this AST node:
-          spread_parents[ast_node].merge(nodes_stack.last)
+          if skip_nodes.none? && !skip?(ast_node, query)
+            # Register the irep nodes that depend on this AST node:
+            spread_parents[ast_node].merge(nodes_stack.last)
+          end
         }
 
         # Resolve fragment spreads.
@@ -180,6 +205,11 @@ module GraphQL
         else
           raise "Unexpected owner type: #{owner_type.inspect}"
         end
+      end
+
+      def skip?(ast_node, query)
+        dir = ast_node.directives
+        dir.any? && !GraphQL::Execution::DirectiveChecks.include?(dir, query)
       end
 
       class VisitDefinition

--- a/lib/graphql/query/serial_execution/field_resolution.rb
+++ b/lib/graphql/query/serial_execution/field_resolution.rb
@@ -11,7 +11,7 @@ module GraphQL
           @parent_type = parent_type
           @target = target
           @query = query_ctx.query
-          @field = @query.get_field(parent_type, irep_node.definition_name)
+          @field = irep_node.definition
           @field_ctx = query_ctx.spawn(
             key: irep_node.name,
             selection: selection,

--- a/lib/graphql/query/serial_execution/selection_resolution.rb
+++ b/lib/graphql/query/serial_execution/selection_resolution.rb
@@ -7,7 +7,6 @@ module GraphQL
           selection_result = {}
 
           selection.typed_children[current_type].each do |name, subselection|
-            next if subselection.skipped?
             selection_result.merge!(query_ctx.execution_strategy.field_resolution.new(
               subselection,
               current_type,

--- a/spec/graphql/directive_spec.rb
+++ b/spec/graphql/directive_spec.rb
@@ -28,6 +28,24 @@ describe GraphQL::Directive do
     |
     }
 
+    describe "child fields" do
+      let(:query_string) { <<-GRAPHQL
+      {
+        __type(name: "Cheese") {
+          fields { name }
+          fields @skip(if: true) { isDeprecated }
+        }
+      }
+      GRAPHQL
+      }
+
+      it "skips child fields too" do
+        first_field = result["data"]["__type"]["fields"].first
+        assert first_field.key?("name")
+        assert !first_field.key?("isDeprecated")
+      end
+    end
+
     it "intercepts fields" do
       expected = { "data" =>{
         "cheese" => {

--- a/spec/graphql/internal_representation/rewrite_spec.rb
+++ b/spec/graphql/internal_representation/rewrite_spec.rb
@@ -152,10 +152,10 @@ describe GraphQL::InternalRepresentation::Rewrite do
       doc = rewrite_result[schema.types["Query"]]["getPlant"]
       plant_selection = doc.typed_children[schema.types["Query"]]["plant"]
       leaf_type_selection = plant_selection.typed_children[schema.types["Nut"]]["leafType"]
-      # Each occurrence in the AST:
-      assert_equal 4, leaf_type_selection.ast_nodes.size
+      # Only unskipped occurrences in the AST
+      assert_equal 2, leaf_type_selection.ast_nodes.size
       # Inclusion contexts:
-      assert_equal 4, leaf_type_selection.ast_spreads.size
+      assert_equal 2, leaf_type_selection.ast_spreads.size
     end
   end
 

--- a/spec/graphql/internal_representation/rewrite_spec.rb
+++ b/spec/graphql/internal_representation/rewrite_spec.rb
@@ -154,8 +154,6 @@ describe GraphQL::InternalRepresentation::Rewrite do
       leaf_type_selection = plant_selection.typed_children[schema.types["Nut"]]["leafType"]
       # Only unskipped occurrences in the AST
       assert_equal 2, leaf_type_selection.ast_nodes.size
-      # Inclusion contexts:
-      assert_equal 2, leaf_type_selection.ast_spreads.size
     end
   end
 


### PR DESCRIPTION
Oops, I realized this while I was falling asleep a couple nights ago! It makes much more sense to just skip these altogether during the rewrite, then you don't have to worry about them down the line. 

What's more is that I can imagine extracting this to a `rewrite_node` hook, something like 

```ruby 
def rewrite_node(query, ast_node) 
  if include?(query, ast_node)
    yield(ast_node) 
  else 
     # do nothing, the node is skipped 
  end 
end 
```

That could be the beginning of a custom directive API ... :thinking: 