### PR TITLE
Allow public access to context for Relay Connection

### DIFF
--- a/lib/graphql/relay/base_connection.rb
+++ b/lib/graphql/relay/base_connection.rb
@@ -47,7 +47,7 @@ module GraphQL
         end
       end
 
-      attr_reader :nodes, :arguments, :max_page_size, :parent, :field
+      attr_reader :nodes, :arguments, :max_page_size, :parent, :field, :context
 
       # Make a connection, wrapping `nodes`
       # @param nodes [Object] The collection of nodes

--- a/spec/graphql/relay/base_connection_spec.rb
+++ b/spec/graphql/relay/base_connection_spec.rb
@@ -15,6 +15,22 @@ describe GraphQL::Relay::BaseConnection do
     end
   end
 
+  describe "#context" do
+    module Encoder
+      module_function
+      def encode(str, nonce: false); str; end
+      def decode(str, nonce: false); str; end
+    end
+
+    let(:schema) { OpenStruct.new(cursor_encoder: Encoder) }
+    let(:context) { OpenStruct.new(schema: schema) }
+
+    it "Has public access to the field context" do
+      conn = GraphQL::Relay::BaseConnection.new([], {}, context: context)
+      assert_equal context, conn.context
+    end
+  end
+
   describe "#encode / #decode" do
     module ReverseEncoder
       module_function


### PR DESCRIPTION
I need access to the context in a custom EdgeClass so we can do authorization checks on the edge resource. Adding `context` to the `attr_reader` seems like the easiest approach.