### PR TITLE
[WIP] Add to_definition to BaseType to print definition

### DIFF
--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -159,6 +159,14 @@ module GraphQL
       GraphQL::Relay::EdgeType.create_type(self, **kwargs, &block)
     end
 
+    # Return a GraphQL string for the type definition
+    # @param schema [GraphQL::Schema]
+    # @param printer [GraphQL::Schema::Printer]
+    # @param context [Hash]
+    # @param only [<#call(member, ctx)>]
+    # @param except [<#call(member, ctx)>]
+    # @param warden [GraphQL::Warden]
+    # @return [String] type definition
     def to_definition(schema, printer: nil, **args)
       printer ||= GraphQL::Schema::Printer.new(schema, **args)
       printer.print_type(self)

--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -158,5 +158,10 @@ module GraphQL
     def define_edge(**kwargs, &block)
       GraphQL::Relay::EdgeType.create_type(self, **kwargs, &block)
     end
+
+    def to_definition(schema, printer: nil, **args)
+      printer ||= GraphQL::Schema::Printer.new(schema, **args)
+      printer.print_type(self)
+    end
   end
 end

--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -162,10 +162,7 @@ module GraphQL
     # Return a GraphQL string for the type definition
     # @param schema [GraphQL::Schema]
     # @param printer [GraphQL::Schema::Printer]
-    # @param context [Hash]
-    # @param only [<#call(member, ctx)>]
-    # @param except [<#call(member, ctx)>]
-    # @param warden [GraphQL::Warden]
+    # @see {GraphQL::Schema::Printer#initialize for additional options}
     # @return [String] type definition
     def to_definition(schema, printer: nil, **args)
       printer ||= GraphQL::Schema::Printer.new(schema, **args)

--- a/lib/graphql/schema/printer.rb
+++ b/lib/graphql/schema/printer.rb
@@ -3,13 +3,47 @@ module GraphQL
   class Schema
     # Used to convert your {GraphQL::Schema} to a GraphQL schema string
     #
-    # @example print your schema to standard output
+    # @example print your schema to standard output (via helper)
     #   MySchema = GraphQL::Schema.define(query: QueryType)
     #   puts GraphQL::Schema::Printer.print_schema(MySchema)
+    #
+    # @example print your schema to standard output
+    #   MySchema = GraphQL::Schema.define(query: QueryType)
+    #   puts GraphQL::Schema::Printer.new(MySchema).print_schema
+    #
+    # @example print a single type to standard output
+    #   query_root = GraphQL::ObjectType.define do
+    #     name "Query"
+    #     description "The query root of this schema"
+    #
+    #     field :post do
+    #       type post_type
+    #       resolve ->(obj, args, ctx) { Post.find(args["id"]) }
+    #     end
+    #   end
+    #
+    #   post_type = GraphQL::ObjectType.define do
+    #     name "Post"
+    #     description "A blog post"
+    #
+    #     field :id, !types.ID
+    #     field :title, !types.String
+    #     field :body, !types.String
+    #   end
+    #
+    #   MySchema = GraphQL::Schema.define(query: query_root)
+    #
+    #   printer = GraphQL::Schema::Printer.new(MySchema)
+    #   puts printer.print_type(post_type)
     #
     class Printer
       attr_reader :schema, :warden
 
+      # @param schema [GraphQL::Schema]
+      # @param context [Hash]
+      # @param only [<#call(member, ctx)>]
+      # @param except [<#call(member, ctx)>]
+      # @param warden [GraphQL::Warden]
       def initialize(schema, context: nil, only: nil, except: nil, warden: nil)
         @schema = schema
         @context = context
@@ -34,16 +68,17 @@ module GraphQL
         printer.print_schema
       end
 
+      # Return a GraphQL schema string for the defined types in the schema
+      # @param schema [GraphQL::Schema]
+      # @param context [Hash]
+      # @param only [<#call(member, ctx)>]
+      # @param except [<#call(member, ctx)>]
       def self.print_schema(schema, **args)
         printer = new(schema, **args)
         printer.print_schema
       end
 
       # Return a GraphQL schema string for the defined types in the schema
-      # @param context [Hash]
-      # @param only [<#call(member, ctx)>]
-      # @param except [<#call(member, ctx)>]
-      # @param schema [GraphQL::Schema]
       def print_schema
         directive_definitions = warden.directives.map { |directive| print_directive(directive) }
 

--- a/spec/graphql/base_type_spec.rb
+++ b/spec/graphql/base_type_spec.rb
@@ -46,4 +46,40 @@ describe GraphQL::BaseType do
       refute_equal obj_edge, obj_2.connection_type
     end
   end
+
+  describe "#to_definition" do
+    post_type = GraphQL::ObjectType.define do
+      name "Post"
+      description "A blog post"
+
+      field :id, !types.ID
+      field :title, !types.String
+      field :body, !types.String
+    end
+
+    query_root = GraphQL::ObjectType.define do
+      name "Query"
+      description "The query root of this schema"
+
+      field :post do
+        type post_type
+        resolve ->(obj, args, ctx) { Post.find(args["id"]) }
+      end
+    end
+
+    schema = GraphQL::Schema.define(query: query_root)
+
+    expected = <<TYPE
+# A blog post
+type Post {
+  id: ID!
+  title: String!
+  body: String!
+}
+TYPE
+
+    it "prints the type definition" do
+      assert_equal expected.chomp, post_type.to_definition(schema)
+    end
+  end
 end

--- a/spec/graphql/schema/printer_spec.rb
+++ b/spec/graphql/schema/printer_spec.rb
@@ -590,4 +590,20 @@ SCHEMA
     context = { names: ["Varied", "Image", "Sub"] }
     assert_equal expected.chomp, schema.to_definition(context: context, except: except_filter)
   end
+
+  describe "#print_type" do
+    it "returns the type schema as a string" do
+      expected = <<SCHEMA
+# A blog post
+type Post {
+  id: ID!
+  title: String!
+  body: String!
+  comments: [Comment!]
+  comments_count: Int! @deprecated(reason: \"Use \\\"comments\\\".\")
+}
+SCHEMA
+      assert_equal expected.chomp, GraphQL::Schema::Printer.new(schema).print_type(schema.types['Post'])
+    end
+  end
 end


### PR DESCRIPTION
Ref https://github.com/rmosolgo/graphql-ruby/issues/534

Refactors `Printer` from a module to a class to make it easier to print out the definition of a single type.

@rmosolgo this is a WIP approach to exposing `print_type`. Wanted to see if you like it before going much further.

Turns out that adding `to_definition` is not that easy for a few reasons:

1. Warden is used in all the printers
2. Warden is scoped to a schema

So adding a `#to_definition` *without* requiring a schema/warden would result in a lot of duplication of the printers. It also might be a bad thing to expose printers without the ability to mask anything.

The one downside to this API is that calling `to_definition` requires a schema.

This was the most direct refactor which also maintains the existing `print_schema` and `print_introspection_schema` methods.

A simpler alternative is to simply make the existing `print_type` a public method so if this approach isn't good, that's a simple fallback.

/cc @xuorig 