### PR TITLE
refactor(Field) Rebuild the default NameResolve when name is changed

### DIFF
--- a/lib/graphql/field.rb
+++ b/lib/graphql/field.rb
@@ -220,6 +220,8 @@ module GraphQL
       @name = new_name
 
       if old_name != new_name && @resolve_proc.is_a?(Field::Resolve::NameResolve)
+        # Since the NameResolve would use the old field name,
+        # reset resolve proc when the name has changed
         self.resolve = nil
       end
     end

--- a/lib/graphql/field.rb
+++ b/lib/graphql/field.rb
@@ -215,15 +215,12 @@ module GraphQL
       @clean_type ||= GraphQL::BaseType.resolve_related_type(@dirty_type)
     end
 
-    # You can only set a field's name _once_ -- this to prevent
-    # passing the same {Field} to multiple `.field` calls.
-    #
-    # This is important because {#name} may be used by {#resolve}.
     def name=(new_name)
-      if @name.nil?
-        @name = new_name
-      elsif @name != new_name
-        raise("Can't rename an already-named field. (Tried to rename \"#{@name}\" to \"#{new_name}\".) If you're passing a field with the `field:` argument, make sure it's an unused instance of GraphQL::Field.")
+      old_name = @name
+      @name = new_name
+
+      if old_name != new_name && @resolve_proc.is_a?(Field::Resolve::NameResolve)
+        self.resolve = nil
       end
     end
 

--- a/spec/graphql/field_spec.rb
+++ b/spec/graphql/field_spec.rb
@@ -192,6 +192,20 @@ describe GraphQL::Field do
       )
     end
 
+    it "keeps the same resolve_proc when it is a built in property resolve" do
+      int_field = GraphQL::Field.define do
+        name "a"
+        property :c
+      end
+
+      int_field_2 = int_field.redefine(name: "b")
+
+      object = Struct.new(:a, :b, :c).new(1, 2, 3)
+
+      assert_equal 3, int_field.resolve_proc.call(object, nil, nil)
+      assert_equal 3, int_field_2.resolve_proc.call(object, nil, nil)
+    end
+
     it "copies metadata, even out-of-bounds assignments" do
       int_field = GraphQL::Field.define do
         metadata(:a, 1)


### PR DESCRIPTION
Name changes when redefining a field now reset the resolve proc instead of raising.

@rmosolgo 