### PR TITLE
feat(Arguments) Allow specifying an alternate key for arguments, used in resolvers

### DIFF
--- a/guides/schema/types_and_fields.md
+++ b/guides/schema/types_and_fields.md
@@ -120,6 +120,18 @@ Use `!` to mark an argument as _required_:
 argument :category, !types.String
 ```
 
+Use `as: :alternateName` to use a different key from within your resolvers while
+exposing another key to clients.
+
+```ruby
+field :post, PostType do
+  argument :postId, types.Id, as: :id
+  resolve ->(obj, args, ctx) {
+    Post.find(args['id'])
+  }
+end
+```
+
 Only certain types are valid for arguments:
 
 - {{ "GraphQL::ScalarType" | api_doc }}, including built-in scalars (string, int, float, boolean, ID)

--- a/lib/graphql/argument.rb
+++ b/lib/graphql/argument.rb
@@ -20,7 +20,11 @@ module GraphQL
     accepts_definitions :name, :type, :description, :default_value, :as
     attr_accessor :type, :description, :default_value, :name, :as
 
-    ensure_defined(:name, :description, :default_value, :type=, :type, :as)
+    ensure_defined(:name, :description, :default_value, :type=, :type, :as, :expose_as)
+
+    def initialize_copy(other)
+      @expose_as = nil
+    end
 
     def default_value?
       !!@has_default_value
@@ -43,6 +47,11 @@ module GraphQL
     # @return [GraphQL::BaseType] the input type for this argument
     def type
       @clean_type ||= GraphQL::BaseType.resolve_related_type(@dirty_type)
+    end
+
+    # @return [String] The name of this argument inside `resolve` functions
+    def expose_as
+      @expose_as ||= (@as || @name).to_s
     end
   end
 end

--- a/lib/graphql/argument.rb
+++ b/lib/graphql/argument.rb
@@ -14,7 +14,7 @@ module GraphQL
   #   GraphQL::InputObjectType.define do
   #     argument :newName, !types.String
   #   end
-  #
+
   class Argument
     include GraphQL::Define::InstanceDefinable
     accepts_definitions :name, :type, :description, :default_value, :as

--- a/lib/graphql/argument.rb
+++ b/lib/graphql/argument.rb
@@ -17,10 +17,10 @@ module GraphQL
   #
   class Argument
     include GraphQL::Define::InstanceDefinable
-    accepts_definitions :name, :type, :description, :default_value
-    attr_accessor :type, :description, :default_value, :name
+    accepts_definitions :name, :type, :description, :default_value, :as
+    attr_accessor :type, :description, :default_value, :name, :as
 
-    ensure_defined(:name, :description, :default_value, :type=, :type)
+    ensure_defined(:name, :description, :default_value, :type=, :type, :as)
 
     def default_value?
       !!@has_default_value

--- a/lib/graphql/define/assign_argument.rb
+++ b/lib/graphql/define/assign_argument.rb
@@ -10,7 +10,7 @@ module GraphQL
           GraphQL::Argument.new
         end
 
-        unsupported_keys = rest.keys - [:default_value]
+        unsupported_keys = rest.keys - [:default_value, :as]
         if unsupported_keys.any?
           raise ArgumentError.new("unknown keyword#{unsupported_keys.length > 1 ? 's' : ''}: #{unsupported_keys.join(', ')}")
         end
@@ -19,6 +19,7 @@ module GraphQL
         type && argument.type = type
         description && argument.description = description
         rest.key?(:default_value) && argument.default_value = rest[:default_value]
+        argument.as = rest[:as]
 
         target.arguments[name.to_s] = argument
       end

--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -10,8 +10,14 @@ module GraphQL
       def initialize(values, argument_definitions:)
         @original_values = values
         @argument_values = values.inject({}) do |memo, (inner_key, inner_value)|
-          string_key = inner_key.to_s
-          arg_defn = argument_definitions[string_key]
+          arg_defn = argument_definitions[inner_key.to_s]
+
+          string_key = if arg_defn.as != nil
+            arg_defn.as.to_s
+          else
+            inner_key.to_s
+          end
+
           arg_value = wrap_value(inner_value, arg_defn.type)
           memo[string_key] = ArgumentValue.new(string_key, arg_value, arg_defn)
           memo

--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -12,13 +12,8 @@ module GraphQL
         @argument_values = values.inject({}) do |memo, (inner_key, inner_value)|
           arg_defn = argument_definitions[inner_key.to_s]
 
-          string_key = if arg_defn.as != nil
-            arg_defn.as.to_s
-          else
-            inner_key.to_s
-          end
-
           arg_value = wrap_value(inner_value, arg_defn.type)
+          string_key = arg_defn.expose_as
           memo[string_key] = ArgumentValue.new(string_key, arg_value, arg_defn)
           memo
         end

--- a/spec/graphql/argument_spec.rb
+++ b/spec/graphql/argument_spec.rb
@@ -41,4 +41,9 @@ describe GraphQL::Argument do
     assert argument.default_value.nil?
     assert !argument.default_value?
   end
+
+  it "accepts a as to define " do
+    argument = GraphQL::Argument.define(name: :favoriteFood, type: GraphQL::STRING_TYPE, as: :favFood)
+    assert_equal argument.as , :favFood
+  end
 end

--- a/spec/graphql/argument_spec.rb
+++ b/spec/graphql/argument_spec.rb
@@ -42,7 +42,7 @@ describe GraphQL::Argument do
     assert !argument.default_value?
   end
 
-  it "accepts a as to define " do
+  it "accepts a `as` property to define the arg name at resolve time" do
     argument = GraphQL::Argument.define(name: :favoriteFood, type: GraphQL::STRING_TYPE, as: :favFood)
     assert_equal argument.as , :favFood
   end

--- a/spec/graphql/argument_spec.rb
+++ b/spec/graphql/argument_spec.rb
@@ -42,8 +42,19 @@ describe GraphQL::Argument do
     assert !argument.default_value?
   end
 
-  it "accepts a `as` property to define the arg name at resolve time" do
-    argument = GraphQL::Argument.define(name: :favoriteFood, type: GraphQL::STRING_TYPE, as: :favFood)
-    assert_equal argument.as , :favFood
+  describe "#as, #exposed_as" do
+    it "accepts a `as` property to define the arg name at resolve time" do
+      argument = GraphQL::Argument.define(name: :favoriteFood, type: GraphQL::STRING_TYPE, as: :favFood)
+      assert_equal argument.as, :favFood
+    end
+
+    it "uses `name` or `as` for `expose_as`" do
+      arg_1 = GraphQL::Argument.define(name: :favoriteFood, type: GraphQL::STRING_TYPE, as: :favFood)
+      assert_equal arg_1.expose_as, "favFood"
+      arg_2 = GraphQL::Argument.define(name: :favoriteFood, type: GraphQL::STRING_TYPE)
+      assert_equal arg_2.expose_as, "favoriteFood"
+      arg_3 = arg_2.redefine { as :ff }
+      assert_equal arg_3.expose_as, "ff"
+    end
   end
 end

--- a/spec/graphql/query/arguments_spec.rb
+++ b/spec/graphql/query/arguments_spec.rb
@@ -170,7 +170,7 @@ describe GraphQL::Query::Arguments do
       assert_equal false, arguments.key?("f")
     end
 
-    it "works with `as`" do
+    it "detects keys using `as` to rename an arg at resolve time" do
       schema.execute("{ argTest(c: 1) }")
 
       last_args = arg_values.last

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -330,9 +330,9 @@ module Dummy
     description "The root for mutations in this schema"
     field :pushValue, !types[!types.Int] do
       description("Push a value onto a global array :D")
-      argument :value, !types.Int
+      argument :value, !types.Int, as: :val
       resolve ->(o, args, ctx) {
-        GLOBAL_VALUES << args[:value]
+        GLOBAL_VALUES << args[:val]
         GLOBAL_VALUES
       }
     end


### PR DESCRIPTION
related to https://github.com/rmosolgo/graphql-ruby/issues/540

Allow specifying a key that will present in the `Arguments` at resolve time instead of the specified argument name.

```ruby
field :post, PostType do
  argument :postId, types.Id, as: :id
  resolve ->(obj, args, ctx) {
    Post.find(args['id'])
  }
end
```

good for review @rmosolgo, I'm open to other names for the arg 🤔 