### PR TITLE
Better error msg mutation result

### DIFF
--- a/lib/graphql/relay/mutation.rb
+++ b/lib/graphql/relay/mutation.rb
@@ -199,6 +199,11 @@ module GraphQL
           end
 
           if @wrap_result
+            unless mutation_result == nil || mutation_result.is_a?(Hash)
+              raise StandardError, "Expected `#{mutation_result}` to be a Hash."\
+                " Return a hash when using `return_field` or specify a custom `return_type`."
+            end
+
             @mutation.result_class.new(client_mutation_id: args[:input][:clientMutationId], result: mutation_result)
           else
             mutation_result

--- a/lib/graphql/relay/mutation.rb
+++ b/lib/graphql/relay/mutation.rb
@@ -199,7 +199,7 @@ module GraphQL
           end
 
           if @wrap_result
-            unless mutation_result == nil || mutation_result.is_a?(Hash)
+            if !mutation_result.is_a?(Hash)
               raise StandardError, "Expected `#{mutation_result}` to be a Hash."\
                 " Return a hash when using `return_field` or specify a custom `return_type`."
             end

--- a/spec/graphql/schema/reduce_types_spec.rb
+++ b/spec/graphql/schema/reduce_types_spec.rb
@@ -58,7 +58,7 @@ describe GraphQL::Schema::ReduceTypes do
     let(:another_invalid_type) {
       GraphQL::ObjectType.define do
         name "AnotherInvalidType"
-        field :someField, String
+        field :someField, ![types.String]
       end
     }
 

--- a/spec/graphql/schema/reduce_types_spec.rb
+++ b/spec/graphql/schema/reduce_types_spec.rb
@@ -58,7 +58,7 @@ describe GraphQL::Schema::ReduceTypes do
     let(:another_invalid_type) {
       GraphQL::ObjectType.define do
         name "AnotherInvalidType"
-        field :someField, ![types.String]
+        field :someField, String
       end
     }
 


### PR DESCRIPTION
In a Relay Mutation with a generated payload type using `return_field`, if you make the mistake of returning anything but a Hash, you'll get an exception when building the result. `NoMethodError each`.

This is pretty hard to debug for someone new to the gem, would be great to raise a helpful exception here.

@rmosolgo

cc @cjoudrey 