### PR TITLE
Add ObjectType#implements

### DIFF
--- a/guides/relay/object_identification.md
+++ b/guides/relay/object_identification.md
@@ -58,7 +58,7 @@ To implement the node interface, include `GraphQL::Relay::Node.interface` in you
 PostType = GraphQL::ObjectType.define do
   name "Post"
   # Implement the "Node" interface for Relay
-  interfaces [GraphQL::Relay::Node.interface]
+  implements GraphQL::Relay::Node.interface
   # ...
 end
 ```

--- a/lib/graphql/object_type.rb
+++ b/lib/graphql/object_type.rb
@@ -48,6 +48,7 @@ module GraphQL
     end
 
     # @param new_interfaces [Array<GraphQL::Interface>] interfaces that this type implements
+    # @deprecated Use `implements` instead of `interfaces`.
     def interfaces=(new_interfaces)
       @clean_interfaces = nil
       @dirty_interfaces = new_interfaces

--- a/lib/graphql/object_type.rb
+++ b/lib/graphql/object_type.rb
@@ -22,7 +22,8 @@ module GraphQL
   #   end
   #
   class ObjectType < GraphQL::BaseType
-    accepts_definitions :implements, :interfaces, :fields, :mutation, field: GraphQL::Define::AssignObjectField
+    accepts_definitions :interfaces, :fields, :mutation, field: GraphQL::Define::AssignObjectField
+    accepts_definitions implements: ->(type, *interfaces) { type.add_interfaces(*interfaces) }
 
     attr_accessor :fields, :mutation
     ensure_defined(:fields, :mutation, :interfaces)
@@ -32,7 +33,6 @@ module GraphQL
 
     # @!attribute mutation
     #   @return [GraphQL::Relay::Mutation, nil] The mutation this field was derived from, if it was derived from a mutation
-
 
     def initialize
       super
@@ -64,10 +64,10 @@ module GraphQL
     end
 
     # @param interface [GraphQL::Interface] add a new interface that this type implements
-    def implements=(interface)
+    def add_interfaces(*interfaces)
       @clean_interfaces = nil
       @dirty_interfaces ||= []
-      @dirty_interfaces << interface
+      @dirty_interfaces.push(*interfaces)
     end
 
     def kind

--- a/lib/graphql/object_type.rb
+++ b/lib/graphql/object_type.rb
@@ -22,7 +22,7 @@ module GraphQL
   #   end
   #
   class ObjectType < GraphQL::BaseType
-    accepts_definitions :interfaces, :fields, :mutation, field: GraphQL::Define::AssignObjectField
+    accepts_definitions :implements, :interfaces, :fields, :mutation, field: GraphQL::Define::AssignObjectField
 
     attr_accessor :fields, :mutation
     ensure_defined(:fields, :mutation, :interfaces)
@@ -61,6 +61,13 @@ module GraphQL
           @dirty_interfaces
         end
       end
+    end
+
+    # @param interface [GraphQL::Interface] add a new interface that this type implements
+    def implements=(interface)
+      @clean_interfaces = nil
+      @dirty_interfaces ||= []
+      @dirty_interfaces << interface
     end
 
     def kind

--- a/spec/graphql/object_type_spec.rb
+++ b/spec/graphql/object_type_spec.rb
@@ -36,7 +36,17 @@ describe GraphQL::ObjectType do
       end
 
       assert_equal([Dummy::EdibleInterface, Dummy::AnimalProductInterface], type.interfaces)
+    end
 
+    it "adds many interfaces" do
+      type = GraphQL::ObjectType.define do
+        name 'Hello'
+        implements Dummy::EdibleInterface, Dummy::AnimalProductInterface
+
+        field :hello, types.String
+      end
+
+      assert_equal([Dummy::EdibleInterface, Dummy::AnimalProductInterface], type.interfaces)
     end
 
     it "preserves existing interfaces and appends a new one" do

--- a/spec/graphql/object_type_spec.rb
+++ b/spec/graphql/object_type_spec.rb
@@ -25,6 +25,33 @@ describe GraphQL::ObjectType do
     assert_equal([last_produced_dairy], cow_type.fields)
   end
 
+  describe "#implements" do
+    it "adds an interface" do
+      type = GraphQL::ObjectType.define do
+        name 'Hello'
+        implements Dummy::EdibleInterface
+        implements Dummy::AnimalProductInterface
+
+        field :hello, types.String
+      end
+
+      assert_equal([Dummy::EdibleInterface, Dummy::AnimalProductInterface], type.interfaces)
+
+    end
+
+    it "preserves existing interfaces and appends a new one" do
+      type = GraphQL::ObjectType.define do
+        name 'Hello'
+        interfaces [Dummy::EdibleInterface]
+        implements Dummy::AnimalProductInterface
+
+        field :hello, types.String
+      end
+
+      assert_equal([Dummy::EdibleInterface, Dummy::AnimalProductInterface], type.interfaces)
+    end
+  end
+
   describe '#get_field' do
     it "exposes fields" do
       field = type.get_field("id")


### PR DESCRIPTION
As per #546, this adds `ObjectType#implements` as a way to add an interface to a type.

**Usage**

```ruby
GraphQL::ObjectType.define do 
  name "Page" 
  implements GraphQL::Relay::Node.interface 
  implements TitledEntityInterface
  # ...
end 
```

You can also pass multiple interfaces at once:

```ruby
GraphQL::ObjectType.define do 
  name "Page" 
  implements GraphQL::Relay::Node.interface, TitledEntityInterface
  # ...
end 
```

:eyes: @rmosolgo 