### PR TITLE
Mutation error: dont raise when mutation is nil

### DIFF
--- a/lib/graphql/relay/mutation.rb
+++ b/lib/graphql/relay/mutation.rb
@@ -199,7 +199,7 @@ module GraphQL
           end
 
           if @wrap_result
-            if !mutation_result.is_a?(Hash)
+            if mutation_result && !mutation_result.is_a?(Hash)
               raise StandardError, "Expected `#{mutation_result}` to be a Hash."\
                 " Return a hash when using `return_field` or specify a custom `return_type`."
             end


### PR DESCRIPTION
@rmosolgo 

Should not raise when mutation returns nil, only if its returning something that is not a hash.