### PR TITLE
feat(Relay::Node) allow passing a custom resolver to the node and nod…

### DIFF
--- a/lib/graphql/relay/node.rb
+++ b/lib/graphql/relay/node.rb
@@ -4,7 +4,7 @@ module GraphQL
     # Helpers for working with Relay-specific Node objects.
     module Node
       # @return [GraphQL::Field] a field for finding objects by their global ID.
-      def self.field
+      def self.field(resolve: nil)
         # We have to define it fresh each time because
         # its name will be modified and its description
         # _may_ be modified.
@@ -12,17 +12,17 @@ module GraphQL
           type(GraphQL::Relay::Node.interface)
           description("Fetches an object given its ID.")
           argument(:id, !types.ID, "ID of the object.")
-          resolve(GraphQL::Relay::Node::FindNode)
+          resolve(resolve || GraphQL::Relay::Node::FindNode)
           relay_node_field(true)
         end
       end
 
-      def self.plural_field
+      def self.plural_field(resolve: nil)
         GraphQL::Field.define do
           type(!types[GraphQL::Relay::Node.interface])
           description("Fetches a list of objects given a list of IDs.")
           argument(:ids, !types[!types.ID], "IDs of the objects.")
-          resolve(GraphQL::Relay::Node::FindNodes)
+          resolve(resolve || GraphQL::Relay::Node::FindNodes)
           relay_nodes_field(true)
         end
       end

--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -220,7 +220,13 @@ module StarWars
     end
 
     field :node, GraphQL::Relay::Node.field
+    field :nodeWithCustomResolver, GraphQL::Relay::Node.field(
+      resolve: ->(_, _, _) { StarWars::DATA["Faction"]["1"] }
+    )
     field :nodes, GraphQL::Relay::Node.plural_field
+    field :nodesWithCustomResolver, GraphQL::Relay::Node.plural_field(
+      resolve: ->(_, _, _) { [StarWars::DATA["Faction"]["1"], StarWars::DATA["Faction"]["2"]] }
+    )
   end
 
   MutationType = GraphQL::ObjectType.define do


### PR DESCRIPTION
…es fields

Context:

Wanted to batch the `node` and `nodes` field which requires you to return a lazy object in `object_from_id`

If you do that, by default the `nodes` field would return an array of promises / lazy things `[Promise, Promise, Promise]`.

Of course, `graphql-ruby` cant magically guess this is an array of lazy objects, and not all implementations have something like `Promise.all([...])` so that would be hard to add.

With this PR this would allow somebody to override the default resolve when something like this:

```ruby
GraphQL::Relay::Node.plural_field(
  resolve: ->(_, args, ctx) { Promise.all(args[:ids].map { |id| ctx.query.schema.object_from_id(id, ctx) }) }
)