### PR TITLE
feat(Relay::Node) extend node & nodes fields using definition block

### DIFF
--- a/guides/relay/object_identification.md
+++ b/guides/relay/object_identification.md
@@ -102,3 +102,17 @@ QueryType = GraphQL::ObjectType.define do
   # ...
 end
 ```
+
+Both of these fields may be customized using the usual definition block:
+
+```ruby
+QueryType = GraphQL::ObjectType.define do
+  name "Query"
+
+  field :nodes, (GraphQL::Relay::Node.field do
+    resolve ->(_, args, _) { # your own custom logic here }
+  end)
+
+  # ...
+end
+```

--- a/lib/graphql/relay/node.rb
+++ b/lib/graphql/relay/node.rb
@@ -4,27 +4,39 @@ module GraphQL
     # Helpers for working with Relay-specific Node objects.
     module Node
       # @return [GraphQL::Field] a field for finding objects by their global ID.
-      def self.field(resolve: nil)
+      def self.field(**kwargs, &block)
         # We have to define it fresh each time because
         # its name will be modified and its description
         # _may_ be modified.
-        GraphQL::Field.define do
+        field = GraphQL::Field.define do
           type(GraphQL::Relay::Node.interface)
           description("Fetches an object given its ID.")
           argument(:id, !types.ID, "ID of the object.")
-          resolve(resolve || GraphQL::Relay::Node::FindNode)
+          resolve(GraphQL::Relay::Node::FindNode)
           relay_node_field(true)
         end
+
+        if kwargs.any? || block
+          field = field.redefine(kwargs, &block)
+        end
+
+        field
       end
 
-      def self.plural_field(resolve: nil)
-        GraphQL::Field.define do
+      def self.plural_field(**kwargs, &block)
+        field = GraphQL::Field.define do
           type(!types[GraphQL::Relay::Node.interface])
           description("Fetches a list of objects given a list of IDs.")
           argument(:ids, !types[!types.ID], "IDs of the objects.")
-          resolve(resolve || GraphQL::Relay::Node::FindNodes)
+          resolve(GraphQL::Relay::Node::FindNodes)
           relay_nodes_field(true)
         end
+
+        if kwargs.any? || block
+          field = field.redefine(kwargs, &block)
+        end
+
+        field
       end
 
       # @return [GraphQL::InterfaceType] The interface which all Relay types must implement

--- a/spec/graphql/relay/node_spec.rb
+++ b/spec/graphql/relay/node_spec.rb
@@ -9,43 +9,18 @@ describe GraphQL::Relay::Node do
   end
 
   describe ".field" do
-    describe "with custom resolver" do
-      it "executes the custom resolve instead of relay default" do
-        id = "resolver_is_hardcoded_so_this_does_not_matter"
+    it 'accepts a custom definition' do
+      faction = StarWars::DATA['Faction'][1]
 
-        result = star_wars_query(%|{
-          nodeWithCustomResolver(id: "#{id}") {
-            id,
-            ... on Faction {
-              name
-              ships(first: 1) {
-                edges {
-                 node {
-                   name
-                   }
-                }
-              }
-            }
-          }
-        }|)
-
-        expected = {"data" => {
-          "nodeWithCustomResolver"=>{
-            "id"=>"RmFjdGlvbi0x",
-            "name"=>"Alliance to Restore the Republic",
-            "ships"=>{
-              "edges"=>[
-                {"node"=>{
-                    "name" => "X-Wing"
-                  }
-                }
-              ]
-            }
-          }
-        }}
-
-        assert_equal(expected, result)
+      node_field = GraphQL::Relay::Node.field do
+        name "nod3"
+        description "The Relay Node Field"
+        resolve ->(_, _ , _) { faction }
       end
+
+      node_field.name = "nod3"
+      node_field.description = "The Relay Node Field"
+      assert_equal faction, node_field.resolve_proc.call(nil, { 'id' => '1' }, nil)
     end
 
     describe "Custom global IDs" do
@@ -131,53 +106,18 @@ describe GraphQL::Relay::Node do
   end
 
   describe ".plural_identifying_field" do
-    describe "with custom resolver" do
-      it "executes the custom resolve instead of relay default" do
-        id = ["resolver_is_hardcoded_so_this_does_not_matter", "another_id"]
+    it 'accepts a custom definition' do
+      factions = StarWars::DATA['Faction']
 
-        result = star_wars_query(%|{
-          nodesWithCustomResolver(ids: ["#{id[0]}", "#{id[1]}"]) {
-            id,
-            ... on Faction {
-              name
-              ships(first: 1) {
-                edges {
-                 node {
-                   name
-                   }
-                }
-              }
-            }
-          }
-        }|)
-
-        expected = {
-          "data" => {
-            "nodesWithCustomResolver" => [
-              {
-                "id" => "RmFjdGlvbi0x",
-                "name" => "Alliance to Restore the Republic",
-                "ships" => {
-                  "edges"=>[
-                    { "node" => { "name" => "X-Wing" } }
-                  ]
-                }
-              },
-              {
-                "id" => "RmFjdGlvbi0y",
-                "name" => "Galactic Empire",
-                "ships" => {
-                  "edges"=>[
-                    { "node" => { "name" => "TIE Fighter" } }
-                  ]
-                }
-              },
-            ]
-          }
-        }
-
-        assert_equal(expected, result)
+      node_field = GraphQL::Relay::Node.plural_field do
+        name "nodez"
+        description "The Relay Nodes Field"
+        resolve ->(_, _ , _) { factions }
       end
+
+      node_field.name = "nodez"
+      node_field.description = "The Relay Nodes Field"
+      assert_equal factions, node_field.resolve_proc.call(nil, { 'id' => '1' }, nil)
     end
 
     it 'finds objects by ids' do

--- a/spec/graphql/relay/node_spec.rb
+++ b/spec/graphql/relay/node_spec.rb
@@ -18,8 +18,8 @@ describe GraphQL::Relay::Node do
         resolve ->(_, _ , _) { faction }
       end
 
-      node_field.name = "nod3"
-      node_field.description = "The Relay Node Field"
+      assert_equal "nod3", node_field.name
+      assert_equal "The Relay Node Field", node_field.description
       assert_equal faction, node_field.resolve_proc.call(nil, { 'id' => '1' }, nil)
     end
 
@@ -115,8 +115,8 @@ describe GraphQL::Relay::Node do
         resolve ->(_, _ , _) { factions }
       end
 
-      node_field.name = "nodez"
-      node_field.description = "The Relay Nodes Field"
+      assert_equal "nod3", node_field.name
+      assert_equal "The Relay Node Field", node_field.description
       assert_equal factions, node_field.resolve_proc.call(nil, { 'id' => '1' }, nil)
     end
 

--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -220,9 +220,12 @@ module StarWars
     end
 
     field :node, GraphQL::Relay::Node.field
-    field :nodeWithCustomResolver, GraphQL::Relay::Node.field(
-      resolve: ->(_, _, _) { StarWars::DATA["Faction"]["1"] }
-    )
+
+    custom_node_field = GraphQL::Relay::Node.field do
+      resolve ->(_, _, _) { StarWars::DATA["Faction"]["1"] }
+    end
+    field :nodeWithCustomResolver, custom_node_field
+
     field :nodes, GraphQL::Relay::Node.plural_field
     field :nodesWithCustomResolver, GraphQL::Relay::Node.plural_field(
       resolve: ->(_, _, _) { [StarWars::DATA["Faction"]["1"], StarWars::DATA["Faction"]["2"]] }


### PR DESCRIPTION
As mentioned in https://github.com/rmosolgo/graphql-ruby/pull/550 by @rmosolgo. It think its even nicer to allow anything to be redefined on the standard node and nodes field.