### PR TITLE
refactor(RelationConnection) check for next page when fetching items

### DIFF
--- a/lib/graphql/relay/relation_connection.rb
+++ b/lib/graphql/relay/relation_connection.rb
@@ -17,7 +17,7 @@ module GraphQL
       end
 
       def has_next_page
-        !!(first && count(sliced_nodes.limit(limit + 1)) > limit)
+        !!(first && paged_nodes && @has_next_page)
       end
 
       def has_previous_page
@@ -34,7 +34,22 @@ module GraphQL
 
       # apply first / last limit results
       def paged_nodes
-        @paged_nodes ||= sliced_nodes.limit(limit)
+        @paged_nodes ||= begin
+          if limit
+            limit_more = limit + 1
+            more_nodes = sliced_nodes.limit(limit_more).to_a
+            if more_nodes.size > limit
+              @has_next_page = true
+              more_nodes[0..-2]
+            else
+              @has_next_page = false
+              more_nodes
+            end
+          else
+            @has_next_page = false
+            sliced_nodes
+          end
+        end
       end
 
       # Apply cursors to edges


### PR DESCRIPTION
The code is a mess, but I wanted to try this out, apparently this is how join-monster does it!

Before:

```sql
StarWars::Base Load (0.2ms)  SELECT  "bases".* FROM "bases" WHERE "bases"."id" IN (SELECT "bases"."id" FROM "bases" WHERE "bases"."faction_id" = ?) LIMIT ? OFFSET ?  [["faction_id", 2], ["LIMIT", 2], ["OFFSET", 0]]
(0.2ms)  SELECT COUNT(count_column) FROM (SELECT  1 AS count_column FROM "bases" WHERE "bases"."id" IN (SELECT "bases"."id" FROM "bases" WHERE "bases"."faction_id" = ?) LIMIT ? OFFSET ?) subquery_for_count  [["faction_id", 2], ["LIMIT", 3], ["OFFSET", 0]]
```

After: 

```sql
StarWars::Base Load (0.2ms)  SELECT  "bases".* FROM "bases" WHERE "bases"."id" IN (SELECT "bases"."id" FROM "bases" WHERE
```