### PR TITLE
Ruby 2.4 is deprecating Bignum and Fixnum

### DIFF
--- a/lib/graphql/id_type.rb
+++ b/lib/graphql/id_type.rb
@@ -6,7 +6,7 @@ GraphQL::ID_TYPE = GraphQL::ScalarType.define do
   coerce_result ->(value) { value.to_s }
   coerce_input ->(value) {
     case value
-    when String, Fixnum, Bignum
+    when String, Integer
       value.to_s
     else
       nil


### PR DESCRIPTION
## What's up? 

Hi, we upgraded an app that uses graphql-ruby to **Ruby 2.4** and we're getting a deprecation message on the ID type. 

`/app/vendor/bundle/ruby/2.4.0/gems/graphql-1.4.4/lib/graphql/id_type.rb:9: warning: constant ::Fixnum is deprecated`

https://bugs.ruby-lang.org/issues/12005

## Missing things: 
- Tests: Seems like the `id_type_spec.rb` covered that pretty well, asserting the coercion of integers, doesn't feel there's a need to write a new case unless you feel otherwise
- This might break with Ruby < 2.4, so probably should have an accompanying `gemspec` change. 