### PR TITLE
Add support for functional overrides

### DIFF
--- a/lib/graphql/define/assign_object_field.rb
+++ b/lib/graphql/define/assign_object_field.rb
@@ -36,6 +36,20 @@ module GraphQL
           raise("Couldn't find a field argument, received: #{field || type_or_field}")
         end
 
+        if field && function && block_given?
+          overrides = GraphQL::Field.define(kwargs, &block)
+
+          if overrides.description
+            field.description = overrides.description
+          end
+
+          if !overrides.arguments.empty?
+            overrides.arguments.each_pair do |name, values|
+              field.arguments[name] = values
+            end
+          end
+        end
+
         # Attach the field to the type
         owner_type.fields[name_s] = field
       end

--- a/spec/graphql/function_spec.rb
+++ b/spec/graphql/function_spec.rb
@@ -71,4 +71,35 @@ describe GraphQL::Function do
       assert_equal "graphql", res["data"]["test"]["name"]
     end
   end
+
+  describe "when overriding" do
+    let(:schema) {
+      query_type = GraphQL::ObjectType.define do
+        name "Query"
+        field :overwrittenDescription, function: TestFunc.new do
+          description "I have altered the description"
+        end
+
+        field :overwrittenArguments, function: TestFunc.new do
+          argument :anArg, types.Int
+          argument :oneMoreArg, types.String
+        end
+      end
+
+      GraphQL::Schema.define do
+        query(query_type)
+      end
+    }
+
+    it "can override description" do
+      field = schema.query.fields["overwrittenDescription"]
+      assert_equal "I have altered the description", field.description
+    end
+
+    it "can add to arguments" do
+      field = schema.query.fields["overwrittenArguments"]
+
+      assert_equal ["name", "anArg", "oneMoreArg"], field.arguments.keys
+    end
+  end
 end

--- a/spec/graphql/function_spec.rb
+++ b/spec/graphql/function_spec.rb
@@ -36,6 +36,7 @@ describe GraphQL::Function do
       query_type = GraphQL::ObjectType.define do
         name "Query"
         field :test, function: TestFunc.new
+        connection :testConn, function: TestFunc.new
       end
 
       relay_mutation = GraphQL::Relay::Mutation.define do


### PR DESCRIPTION
This PR demonstrates how overriding function definitions might work. 

The DSL is a little bleh, but, given a `function: kwarg`, I couldn't think of any other way to support overrides other than passing in a block, too. I didn't think that supporting

``` ruby
field :overwrittenDescription, "A description", function: TestFunc.new
```

made much sense.

Happy to address any feedback or changes here. ✌️ 