### PR TITLE
Add DefinedObjectProxy#use

### DIFF
--- a/lib/graphql/define/defined_object_proxy.rb
+++ b/lib/graphql/define/defined_object_proxy.rb
@@ -11,6 +11,15 @@ module GraphQL
         GraphQL::Define::TypeDefiner.instance
       end
 
+      def use(plugin, **kwargs)
+        # https://bugs.ruby-lang.org/issues/10708
+        if kwargs == {}
+          plugin.use(self)
+        else
+          plugin.use(self, **kwargs)
+        end
+      end
+
       def method_missing(name, *args, &block)
         definition = @dictionary[name]
         if definition

--- a/lib/graphql/define/defined_object_proxy.rb
+++ b/lib/graphql/define/defined_object_proxy.rb
@@ -2,6 +2,8 @@
 module GraphQL
   module Define
     class DefinedObjectProxy
+      attr_reader :target
+
       def initialize(target)
         @target = target
         @dictionary = target.class.dictionary

--- a/lib/graphql/define/instance_definable.rb
+++ b/lib/graphql/define/instance_definable.rb
@@ -21,18 +21,22 @@ module GraphQL
     #
     # @example Make a class definable
     #   class Car
-    #     attr_accessor :make, :model
+    #     include GraphQL::Define::InstanceDefinable
+    #     attr_accessor :make, :model, :doors
     #     accepts_definitions(
     #       # These attrs will be defined with plain setters, `{attr}=`
     #       :make, :model,
     #       # This attr has a custom definition which applies the config to the target
     #       doors: ->(car, doors_count) { doors_count.times { car.doors << Door.new } }
     #     )
+    #     ensure_defined(:make, :model, :doors)
     #
     #     def initialize
     #       @doors = []
     #     end
     #   end
+    #
+    #   class Door; end;
     #
     #   # Create an instance with `.define`:
     #   subaru_baja = Car.define do

--- a/lib/graphql/define/instance_definable.rb
+++ b/lib/graphql/define/instance_definable.rb
@@ -61,6 +61,27 @@ module GraphQL
     #   # Access it from metadata
     #   subaru_baja.metadata[:all_wheel_drive] # => true
     #
+    # @example Extending the definition of a class via a plugin
+    #   # A plugin is any object that responds to `.use(definition)`
+    #   module SubaruCar
+    #     extend self
+    #
+    #     def use(defn)
+    #       # `defn` has the same methods as within `.define { ... }` block
+    #       defn.make "Subaru"
+    #       defn.doors 4
+    #     end
+    #   end
+    #
+    #   # Use the plugin within a `.define { ... }` block
+    #   subaru_baja = Car.define do
+    #     use SubaruCar
+    #     model 'Baja'
+    #   end
+    #
+    #   subaru_baja.make # => "Subaru"
+    #   subaru_baja.doors # => [<Door>, <Door>, <Door>, <Door>]
+    #
     # @example Making a copy with an extended definition
     #   # Create an instance with `.define`:
     #   subaru_baja = Car.define do

--- a/spec/graphql/define/instance_definable_spec.rb
+++ b/spec/graphql/define/instance_definable_spec.rb
@@ -116,6 +116,40 @@ describe GraphQL::Define::InstanceDefinable do
     end
   end
 
+  describe "#use" do
+    module TestPlugin
+      extend self
+
+      def use(defn)
+        defn.name('Arugula')
+      end
+    end
+
+    module TestPluginWithKwargs
+      extend self
+
+      def use(defn, name:)
+        defn.name(name)
+      end
+    end
+
+    it "sends a message to the specified plugin's :use method and access to the proxy object" do
+      arugula = Garden::Vegetable.define do
+        use TestPlugin
+      end
+
+      assert_equal 'Arugula', arugula.name
+    end
+
+    it "passes kwargs to plugin's `use` method" do
+      arugula = Garden::Vegetable.define do
+        use TestPluginWithKwargs, name: 'Arugula'
+      end
+
+      assert_equal 'Arugula', arugula.name
+    end
+  end
+
   describe "typos" do
     it "provides the right class name, method name and line number" do
       err = assert_raises(NoMethodError) {

--- a/spec/graphql/define/instance_definable_spec.rb
+++ b/spec/graphql/define/instance_definable_spec.rb
@@ -117,10 +117,11 @@ describe GraphQL::Define::InstanceDefinable do
   end
 
   describe "#use" do
-    module TestPlugin
-      extend self
+    class TestPlugin
+      attr_reader :target
 
       def use(defn)
+        @target = defn.target
         defn.name('Arugula')
       end
     end
@@ -133,12 +134,15 @@ describe GraphQL::Define::InstanceDefinable do
       end
     end
 
-    it "sends a message to the specified plugin's :use method and access to the proxy object" do
+    it "sends a message to the specified plugin's :use method with access to the proxy object and target object" do
+      plugin = TestPlugin.new
+
       arugula = Garden::Vegetable.define do
-        use TestPlugin
+        use plugin
       end
 
       assert_equal 'Arugula', arugula.name
+      assert_equal arugula, plugin.target
     end
 
     it "passes kwargs to plugin's `use` method" do


### PR DESCRIPTION
@rmosolgo @xuorig @dylanahsmith 

As per the discussion in https://github.com/Shopify/graphql-batch/pull/49, this adds a way to write plugins that have access to the DSL.

**Some example usages:**

```ruby
GraphQL::Schema.define do
  use GraphQL::Batch # This will call GraphQL::Batch.use(self)
end

module GraphQL
  module Batch
    # ...

    def self.use(schema_defn)
      schema_defn.lazy_resolve(Promise, :sync)
      schema_defn.instrument(:query, GraphQL::Batch::Setup)
    end
  end
end
```

You can also accept arguments and keyword arguments:

```ruby
GraphQL::Schema.define do
  # This will call GraphQLPro::Authorization.use(self, strategy: :devise)
  use GraphQLPro::Authorization, strategy: :devise
end
```

This will work on any object that supports `.define` so you could use it on object types and fields too:

```ruby
GraphQL::ObjectType.define do
  field :cheeses, !types[!Cheese] do
    use Pagination
    # ...
  end
end
```

**Questions:**

Plugins currently have no way of knowing the type of the object being defined.

We could either expose `DefinedObjectProxy#target` allowing the plugin to do:

```ruby
def use(schema_defn)
  if schema_defn.target.class != GraphQL::Schema
    raise "GraphQL::Batch plugin can only be used on GraphQL::Schema"  
  end

  # ...
end
```

Or we could pass the `target` as an argument to `use`.

Or any other ideas?