### PR TITLE
Passing arguments to root_value (and sub-fields) fields when they are methods.

### DIFF
--- a/lib/graphql/field/resolve.rb
+++ b/lib/graphql/field/resolve.rb
@@ -35,7 +35,7 @@ module GraphQL
 
         def call(obj, args, ctx)
           if method_with_arguments?(@method_name, obj, args)
-            obj.public_send(@method_name, args)
+            obj.public_send(@method_name, args, ctx)
           else
             obj.public_send(@method_name)
           end
@@ -62,7 +62,7 @@ module GraphQL
 
         def call(obj, args, ctx)
           if method_with_arguments?(@field.name, obj, args)
-            obj.public_send(@field.name, args)
+            obj.public_send(@field.name, args, ctx)
           else
             obj.public_send(@field.name)
           end

--- a/lib/graphql/field/resolve.rb
+++ b/lib/graphql/field/resolve.rb
@@ -19,6 +19,12 @@ module GraphQL
 
       # These only require `obj` as input
       class BuiltInResolve
+        protected
+        def method_with_arguments?(method, obj, args)
+          args.to_h.keys.size > 0 &&
+          obj.methods.include?(method.to_sym) &&
+          obj.method(method).parameters.size > 0
+        end
       end
 
       # Resolve the field by `public_send`ing `@method_name`
@@ -28,7 +34,11 @@ module GraphQL
         end
 
         def call(obj, args, ctx)
-          obj.public_send(@method_name)
+          if method_with_arguments?(@method_name, obj, args)
+            obj.public_send(@method_name, args)
+          else
+            obj.public_send(@method_name)
+          end
         end
       end
 
@@ -51,7 +61,11 @@ module GraphQL
         end
 
         def call(obj, args, ctx)
-          obj.public_send(@field.name)
+          if method_with_arguments?(@field.name, obj, args)
+            obj.public_send(@field.name, args)
+          else
+            obj.public_send(@field.name)
+          end
         end
       end
     end

--- a/spec/graphql/field_spec.rb
+++ b/spec/graphql/field_spec.rb
@@ -35,27 +35,30 @@ describe GraphQL::Field do
   it "passing arguments to root_value when fields accepting arguments" do
     schema = GraphQL::Schema.from_definition(" 
       type Todo {text: String}
-      type Query { allTodos: [Todo]}
-      type Mutation { todoAdd(text: String!): Todo}
+      type Query { all_todos: [Todo]}
+      type Mutation { todo_add(text: String!): Todo}
     ")
     Todo = Struct.new(:text)
     class RootResolver
       attr_accessor :todos
+
       def initialize
         @todos = [Todo.new("Pay the bills.")]
       end
-      def allTodos
+
+      def all_todos
         @todos
       end
-      def todoAdd(args) # this is a method and accepting arguments
+
+      def todo_add(args) # this is a method and accepting arguments
         todo = Todo.new(args[:text])
         @todos << todo
         todo
       end
     end
     root_values = RootResolver.new
-    schema.execute("mutation { todoAdd(text: \"Buy Milk\") { text } }", root_value: root_values)
-    result = schema.execute("query { allTodos { text } }", root_value: root_values)
+    schema.execute("mutation { todoAdd: todo_add(text: \"Buy Milk\") { text } }", root_value: root_values)
+    result = schema.execute("query { allTodos: all_todos { text } }", root_value: root_values)
     assert_equal(result.to_json, '{"data":{"allTodos":[{"text":"Pay the bills."},{"text":"Buy Milk"}]}}')
   end
 

--- a/spec/graphql/query/variables_spec.rb
+++ b/spec/graphql/query/variables_spec.rb
@@ -33,6 +33,12 @@ describe GraphQL::Query::Variables do
     end
 
     describe "nullable variables" do
+      module ObjectWithThingsCount
+        def self.thingsCount(args, ctx) # rubocop:disable Style/MethodName
+          1
+        end
+      end
+
       let(:schema) { GraphQL::Schema.from_definition(%|
         type Query {
           thingsCount(ids: [ID!]): Int!
@@ -45,7 +51,7 @@ describe GraphQL::Query::Variables do
         }
       |}
       let(:result) {
-        schema.execute(query_string, variables: provided_variables, root_value: OpenStruct.new(thingsCount: 1))
+        schema.execute(query_string, variables: provided_variables, root_value: ObjectWithThingsCount)
       }
 
       describe "when they are present, but null" do

--- a/spec/graphql/schema/warden_spec.rb
+++ b/spec/graphql/schema/warden_spec.rb
@@ -112,7 +112,7 @@ module MaskHelpers
 
   module Data
     UVULAR_TRILL = OpenStruct.new({name: "Uvular Trill", symbol: "ʀ", manner: "TRILL"})
-    def self.unit
+    def self.unit(args, ctx)
       UVULAR_TRILL
     end
   end


### PR DESCRIPTION
This will allow us to build method-like fields just like the example on http://graphql.org/graphql-js/.

With this, I will be able to use class methods as simple resolvers. It makes simple and modular usages possible and it's more intuitive.

```ruby
Todo = Struct.new(:text)

class Root
  attr_accessor :todos

  def initialize
    @todos = [
      Todo.new("Pay the bills."),
      Todo.new("Go to dentist."),
      Todo.new("Buy milk.")
    ]
  end

  def todoAdd(args)
    todo = Todo.new(args[:text])
    @todos << todo
    todo
  end

  def allTodos
    @todos
  end
end

app = Root.new

Schema.execute("mutation {
  todoAdd(text: \"Heyo\") {
     text
  }
}", root_value: app)

result = Schema.execute("query {
  allTodos {
    text
  }
}", root_value: app)
```

Since it covers all the method-like argument accepting fields, it will work on any level.