### PR TITLE
Fix last offset in array_connection

### DIFF
--- a/lib/graphql/relay/array_connection.rb
+++ b/lib/graphql/relay/array_connection.rb
@@ -43,7 +43,7 @@ module GraphQL
         @starting_offset = if before
           [previous_offset, 0].max
         elsif last
-          nodes.count - last
+          [nodes.count - last, 0].max
         else
           previous_offset
         end


### PR DESCRIPTION
Wrong offset is used right now if collection passed to `array_connection` is too small.