### PR TITLE
Validate interfaces, don't inherit by default with `implements`

### DIFF
--- a/lib/graphql/compatibility/execution_specification/counter_schema.rb
+++ b/lib/graphql/compatibility/execution_specification/counter_schema.rb
@@ -10,7 +10,7 @@ module GraphQL
           has_count_interface = GraphQL::InterfaceType.define do
             name "HasCount"
             field :count, types.Int
-            field :counter, ->{ counter_type }
+            field :counter, ->{ has_count_interface }
           end
 
           counter_type = GraphQL::ObjectType.define do
@@ -29,7 +29,7 @@ module GraphQL
 
           has_counter_interface = GraphQL::InterfaceType.define do
             name "HasCounter"
-            field :counter, counter_type
+            field :counter, has_count_interface
           end
 
           query_type = GraphQL::ObjectType.define do
@@ -41,7 +41,7 @@ module GraphQL
           schema = GraphQL::Schema.define(
             query: query_type,
             resolve_type: ->(o, c) { o == :counter ? counter_type : nil },
-            orphan_types: [alt_counter_type],
+            orphan_types: [alt_counter_type, counter_type],
             query_execution_strategy: execution_strategy,
           )
           schema.metadata[:count] = 0

--- a/lib/graphql/execution/typecast.rb
+++ b/lib/graphql/execution/typecast.rb
@@ -32,6 +32,48 @@ module GraphQL
           false
         end
       end
+
+      def self.subtype?(parent_type, child_type)
+        if parent_type == child_type
+          # Equivalent types are subtypes
+          true
+        elsif child_type.is_a?(GraphQL::NonNullType)
+          # A non-null type is a subtype of a nullable type
+          # if its inner type is a subtype of that type
+          if parent_type.is_a?(GraphQL::NonNullType)
+            subtype?(parent_type.of_type, child_type.of_type)
+          else
+            subtype?(parent_type, child_type.of_type)
+          end
+        else
+          case parent_type
+          when GraphQL::InterfaceType
+            # A type is a subtype of an interface
+            # if it implements that interface
+            case child_type
+            when GraphQL::ObjectType
+              child_type.interfaces.include?(parent_type)
+            else
+              false
+            end
+          when GraphQL::UnionType
+            # A type is a subtype of that interface
+            # if the union includes that interface
+            parent_type.possible_types.include?(child_type)
+          when GraphQL::ListType
+            # A list type is a subtype of another list type
+            # if its inner type is a subtype of the other inner type
+            case child_type
+            when GraphQL::ListType
+              subtype?(parent_type.of_type, child_type.of_type)
+            else
+              false
+            end
+          else
+            false
+          end
+        end
+      end
     end
   end
 end

--- a/lib/graphql/schema/validation.rb
+++ b/lib/graphql/schema/validation.rb
@@ -196,6 +196,40 @@ module GraphQL
             # no worries
           end
         }
+
+        INTERFACES_ARE_IMPLEMENTED = ->(obj_type) {
+          field_errors = []
+          obj_type.interfaces.each do |interface_type|
+            interface_type.fields.each do |field_name, field_defn|
+              object_field = obj_type.get_field(field_name)
+              if object_field.nil?
+                field_errors << %|"#{field_name}" is required by #{interface_type.name} but not implemented by #{obj_type.name}|
+              elsif !GraphQL::Execution::Typecast.subtype?(field_defn.type, object_field.type)
+                field_errors << %|"#{field_name}" is required by #{interface_type.name} to return #{field_defn.type} but #{obj_type.name}.#{field_name} returns #{object_field.type}|
+              else
+                field_defn.arguments.each do |arg_name, arg_defn|
+                  object_field_arg = object_field.arguments[arg_name]
+                  if object_field_arg.nil?
+                    field_errors << %|"#{arg_name}" argument is required by #{interface_type.name}.#{field_name} but not accepted by #{obj_type.name}.#{field_name}|
+                  elsif arg_defn.type != object_field_arg.type
+                    field_errors << %|"#{arg_name}" is required by #{interface_type.name}.#{field_defn.name} to accept #{arg_defn.type} but #{obj_type.name}.#{field_name} accepts #{object_field_arg.type} for "#{arg_name}"|
+                  end
+                end
+
+                object_field.arguments.each do |arg_name, arg_defn|
+                  if field_defn.arguments[arg_name].nil? && arg_defn.type.is_a?(GraphQL::NonNullType)
+                    field_errors << %|"#{arg_name}" is not accepted by #{interface_type.name}.#{field_name} but required by #{obj_type.name}.#{field_name}|
+                  end
+                end
+              end
+            end
+          end
+          if field_errors.any?
+            "#{obj_type.name} failed to implement some interfaces: #{field_errors.join(", ")}"
+          else
+            nil
+          end
+        }
       end
 
       # A mapping of `{Class => [Proc, Proc...]}` pairs.
@@ -227,6 +261,7 @@ module GraphQL
         GraphQL::ObjectType => [
           Rules.assert_property_list_of(:interfaces, GraphQL::InterfaceType),
           Rules::FIELDS_ARE_VALID,
+          Rules::INTERFACES_ARE_IMPLEMENTED,
         ],
         GraphQL::InputObjectType => [
           Rules::ARGUMENTS_ARE_STRING_TO_ARGUMENT,

--- a/spec/graphql/execution/typecast_spec.rb
+++ b/spec/graphql/execution/typecast_spec.rb
@@ -8,45 +8,90 @@ describe GraphQL::Execution::Typecast do
   let(:schema) { Dummy::Schema }
   let(:context) { GraphQL::Query::Context.new(query: OpenStruct.new(schema: schema), values: nil) }
 
-  def compatible?(*args)
-    GraphQL::Execution::Typecast.compatible?(*args)
+  describe "compatible" do
+    def compatible?(*args)
+      GraphQL::Execution::Typecast.compatible?(*args)
+    end
+
+    it "resolves correctly when both types are the same" do
+      assert compatible?(Dummy::MilkType, Dummy::MilkType, context)
+
+      assert !compatible?(Dummy::MilkType, Dummy::CheeseType, context)
+    end
+
+    it "resolves a union type to a matching member" do
+      assert compatible?(Dummy::DairyProductUnion, Dummy::MilkType, context)
+      assert compatible?(Dummy::DairyProductUnion, Dummy::CheeseType, context)
+
+      assert !compatible?(Dummy::DairyProductUnion, GraphQL::INT_TYPE, context)
+      assert !compatible?(Dummy::DairyProductUnion, Dummy::HoneyType, context)
+    end
+
+    it "resolves correcty when potential type is UnionType and current type is a member of that union" do
+      assert compatible?(Dummy::MilkType, Dummy::DairyProductUnion, context)
+      assert compatible?(Dummy::CheeseType, Dummy::DairyProductUnion, context)
+
+      assert !compatible?(Dummy::DairyAppQueryType, Dummy::DairyProductUnion, context)
+      assert !compatible?(Dummy::EdibleInterface, Dummy::DairyProductUnion, context)
+    end
+
+    it "resolves an object type to one of its interfaces" do
+      assert compatible?(Dummy::CheeseType, Dummy::EdibleInterface, context)
+      assert compatible?(Dummy::MilkType, Dummy::EdibleInterface, context)
+
+      assert !compatible?(Dummy::DairyAppQueryType, Dummy::EdibleInterface, context)
+      assert !compatible?(Dummy::LocalProductInterface, Dummy::EdibleInterface, context)
+    end
+
+    it "resolves an interface to a matching member" do
+      assert compatible?(Dummy::EdibleInterface, Dummy::CheeseType, context)
+      assert compatible?(Dummy::EdibleInterface, Dummy::MilkType, context)
+
+      assert !compatible?(Dummy::EdibleInterface, GraphQL::STRING_TYPE, context)
+      assert !compatible?(Dummy::EdibleInterface, Dummy::DairyProductInputType, context)
+    end
   end
 
-  it "resolves correctly when both types are the same" do
-    assert compatible?(Dummy::MilkType, Dummy::MilkType, context)
+  describe ".subtype?" do
+    def subtype?(*args)
+      GraphQL::Execution::Typecast.subtype?(*args)
+    end
 
-    assert !compatible?(Dummy::MilkType, Dummy::CheeseType, context)
-  end
+    it "counts the same type as a subtype" do
+      assert subtype?(Dummy::MilkType, Dummy::MilkType)
+      assert !subtype?(Dummy::MilkType, Dummy::CheeseType)
+      assert subtype?(Dummy::MilkType.to_list_type.to_non_null_type, Dummy::MilkType.to_list_type.to_non_null_type)
+    end
 
-  it "resolves a union type to a matching member" do
-    assert compatible?(Dummy::DairyProductUnion, Dummy::MilkType, context)
-    assert compatible?(Dummy::DairyProductUnion, Dummy::CheeseType, context)
+    it "counts member types as subtypes" do
+      assert subtype?(Dummy::EdibleInterface, Dummy::CheeseType)
+      assert subtype?(Dummy::EdibleInterface, Dummy::MilkType)
+      assert subtype?(Dummy::DairyProductUnion, Dummy::MilkType)
+      assert subtype?(Dummy::DairyProductUnion, Dummy::CheeseType)
 
-    assert !compatible?(Dummy::DairyProductUnion, GraphQL::INT_TYPE, context)
-    assert !compatible?(Dummy::DairyProductUnion, Dummy::HoneyType, context)
-  end
+      assert !subtype?(Dummy::DairyAppQueryType, Dummy::DairyProductUnion)
+      assert !subtype?(Dummy::CheeseType, Dummy::DairyProductUnion)
+      assert !subtype?(Dummy::EdibleInterface, Dummy::DairyProductUnion)
+      assert !subtype?(Dummy::EdibleInterface, GraphQL::STRING_TYPE)
+      assert !subtype?(Dummy::EdibleInterface, Dummy::DairyProductInputType)
+    end
 
-  it "resolves correcty when potential type is UnionType and current type is a member of that union" do
-    assert compatible?(Dummy::MilkType, Dummy::DairyProductUnion, context)
-    assert compatible?(Dummy::CheeseType, Dummy::DairyProductUnion, context)
+    it "counts lists as subtypes if their inner types are subtypes" do
+      assert subtype?(Dummy::EdibleInterface.to_list_type, Dummy::MilkType.to_list_type)
+      assert subtype?(Dummy::DairyProductUnion.to_list_type, Dummy::MilkType.to_list_type)
+      assert !subtype?(Dummy::CheeseType.to_list_type, Dummy::DairyProductUnion.to_list_type)
+      assert !subtype?(Dummy::EdibleInterface.to_list_type, Dummy::DairyProductUnion.to_list_type)
+      assert !subtype?(Dummy::EdibleInterface.to_list_type, GraphQL::STRING_TYPE.to_list_type)
+    end
 
-    assert !compatible?(Dummy::DairyAppQueryType, Dummy::DairyProductUnion, context)
-    assert !compatible?(Dummy::EdibleInterface, Dummy::DairyProductUnion, context)
-  end
-
-  it "resolves an object type to one of its interfaces" do
-    assert compatible?(Dummy::CheeseType, Dummy::EdibleInterface, context)
-    assert compatible?(Dummy::MilkType, Dummy::EdibleInterface, context)
-
-    assert !compatible?(Dummy::DairyAppQueryType, Dummy::EdibleInterface, context)
-    assert !compatible?(Dummy::LocalProductInterface, Dummy::EdibleInterface, context)
-  end
-
-  it "resolves an interface to a matching member" do
-    assert compatible?(Dummy::EdibleInterface, Dummy::CheeseType, context)
-    assert compatible?(Dummy::EdibleInterface, Dummy::MilkType, context)
-
-    assert !compatible?(Dummy::EdibleInterface, GraphQL::STRING_TYPE, context)
-    assert !compatible?(Dummy::EdibleInterface, Dummy::DairyProductInputType, context)
+    it "counts non-null types as subtypes of nullable parent types" do
+      assert subtype?(Dummy::MilkType, Dummy::MilkType.to_non_null_type)
+      assert subtype?(Dummy::EdibleInterface, Dummy::MilkType.to_non_null_type)
+      assert subtype?(Dummy::EdibleInterface.to_non_null_type, Dummy::MilkType.to_non_null_type)
+      assert subtype?(
+        GraphQL::STRING_TYPE.to_non_null_type.to_list_type,
+        GraphQL::STRING_TYPE.to_non_null_type.to_list_type.to_non_null_type,
+      )
+    end
   end
 end

--- a/spec/graphql/introspection/type_type_spec.rb
+++ b/spec/graphql/introspection/type_type_spec.rb
@@ -52,7 +52,7 @@ describe GraphQL::Introspection::TypeType do
           {"type"=>{"kind"=>"NON_NULL","name"=>nil, "ofType"=>{"name"=>"ID"}}},
           {"type"=>{"kind"=>"NON_NULL","name"=>nil, "ofType"=>{"name"=>"String"}}},
           {"type"=>{"kind"=>"INTERFACE", "name"=>"Edible", "ofType"=>nil}},
-          {"type"=>{"kind"=>"ENUM","name"=>"DairyAnimal", "ofType"=>nil}},
+          {"type"=>{"kind"=>"NON_NULL","name"=>nil,"ofType"=>{"name"=>"DairyAnimal"}}},
         ]
       },
       "dairyAnimal"=>{

--- a/spec/graphql/object_type_spec.rb
+++ b/spec/graphql/object_type_spec.rb
@@ -15,8 +15,19 @@ describe GraphQL::ObjectType do
     assert_equal(22, type.description.length)
   end
 
-  it "may have interfaces" do
-    assert_equal([Dummy::EdibleInterface, Dummy::AnimalProductInterface, Dummy::LocalProductInterface], type.interfaces)
+  describe "interfaces" do
+    it "may have interfaces" do
+      assert_equal([Dummy::EdibleInterface, Dummy::AnimalProductInterface, Dummy::LocalProductInterface], type.interfaces)
+    end
+
+    it "raises if the interfaces arent an array" do
+      type = GraphQL::ObjectType.define do
+        name "InvalidInterfaces"
+        interfaces(55)
+      end
+
+      assert_raises(ArgumentError) { type.name }
+    end
   end
 
   it "accepts fields definition" do
@@ -59,6 +70,29 @@ describe GraphQL::ObjectType do
       end
 
       assert_equal([Dummy::EdibleInterface, Dummy::AnimalProductInterface], type.interfaces)
+    end
+
+    it "can be used to inherit fields from the interface" do
+      type_1 = GraphQL::ObjectType.define do
+        name 'Hello'
+        implements Dummy::EdibleInterface
+        implements Dummy::AnimalProductInterface
+      end
+
+      type_2 = GraphQL::ObjectType.define do
+        name 'Hello'
+        implements Dummy::EdibleInterface
+        implements Dummy::AnimalProductInterface, inherit: true
+      end
+
+      type_3 = GraphQL::ObjectType.define do
+        name 'Hello'
+        implements Dummy::EdibleInterface, Dummy::AnimalProductInterface, inherit: true
+      end
+
+      assert_equal [], type_1.all_fields.map(&:name)
+      assert_equal ["source"], type_2.all_fields.map(&:name)
+      assert_equal ["fatContent", "origin", "selfAsEdible", "source"], type_3.all_fields.map(&:name)
     end
   end
 

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -24,7 +24,7 @@ module Dummy
   AnimalProductInterface = GraphQL::InterfaceType.define do
     name "AnimalProduct"
     description "Comes from an animal, no joke"
-    field :source, !types.String, "Animal which produced this product"
+    field :source, !DairyAnimalEnum, "Animal which produced this product"
   end
 
   BeverageUnion = GraphQL::UnionType.define do
@@ -98,7 +98,7 @@ module Dummy
     description "Dairy beverage"
     interfaces [EdibleInterface, AnimalProductInterface, LocalProductInterface]
     field :id, !types.ID
-    field :source, DairyAnimalEnum, "Animal which produced this milk", hash_key: :source
+    field :source, !DairyAnimalEnum, "Animal which produced this milk", hash_key: :source
     field :origin, !types.String, "Place the milk comes from"
     field :flavors, types[types.String], "Chocolate, Strawberry, etc" do
       argument :limit, types.Int


### PR DESCRIPTION
I'd like to take advantage of the new `implements` method to improve interface support. Currently: 

- `interfaces(...)` causes an object to "inherit" fields from the interface 
- the object can override those fields in breaking ways 
- there is no way to _prevent_ inheritance 

What I want to do is: 

- `implements SomeInterface` _doesn't_ inherit fields from the interface 
- `implements SomeInterface, inherit: true` inherits definitions from the interface 
- Add a proper interface validation to schema setup


Cleanup task: 

- [ ] It looks like `Typecast.compatible?` is unused, it should be removed
