### PR TITLE
Stop resolving siblings if one of them propagates a `null`

### DIFF
--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -41,6 +41,13 @@ module GraphQL
           end
 
           selection_result.set(name, field_result)
+
+          # If the last subselection caused a null to propagate to _this_ selection,
+          # then we may as well quit executing fields because they
+          # won't be in the response
+          if selection_result.invalid_null?
+            break
+          end
         end
 
         selection_result

--- a/spec/graphql/execution/execute_spec.rb
+++ b/spec/graphql/execution/execute_spec.rb
@@ -3,3 +3,59 @@ require "spec_helper"
 
 ExecuteSuite = GraphQL::Compatibility::ExecutionSpecification.build_suite(GraphQL::Execution::Execute)
 LazyExecuteSuite = GraphQL::Compatibility::LazyExecutionSpecification.build_suite(GraphQL::Execution::Execute)
+
+describe GraphQL::Execution::Execute do
+  describe "null values on mutation roots" do
+    module MutationNullTestRoot
+      INTS = []
+      def self.pushInt(args, ctx)
+        if args[:int] == 13
+          nil
+        else
+          INTS << args[:int]
+          args[:int]
+        end
+      end
+
+      def ints
+        INTS
+      end
+    end
+
+    let(:schema) { GraphQL::Schema.from_definition <<-GRAPHQL
+      type Mutation {
+        pushInt(int: Int!): Int!
+      }
+
+      type Query {
+        ints: [Int!]
+      }
+    GRAPHQL
+    }
+
+    let(:root) { MutationNullTestRoot }
+
+    before do
+      MutationNullTestRoot::INTS.clear
+    end
+
+    it "returns values for other mutations" do
+      query_str = <<-GRAPHQL
+      mutation {
+        one: pushInt(int: 1)
+        thirteen: pushInt(int: 13)
+        two: pushInt(int: 2)
+      }
+      GRAPHQL
+
+      res = schema.execute(query_str, root_value: root)
+      assert_equal [1, 2], MutationNullTestRoot::INTS
+      expected_data = {
+        "one" => 1,
+        "thirteen" => nil,
+        "two" => 2,
+      }
+      assert_equal(expected_data, res["data"])
+    end
+  end
+end

--- a/spec/graphql/execution/execute_spec.rb
+++ b/spec/graphql/execution/execute_spec.rb
@@ -8,7 +8,7 @@ describe GraphQL::Execution::Execute do
   describe "null values on mutation roots" do
     module MutationNullTestRoot
       INTS = []
-      def self.pushInt(args, ctx)
+      def self.push(args, ctx)
         if args[:int] == 13
           nil
         else
@@ -24,7 +24,7 @@ describe GraphQL::Execution::Execute do
 
     let(:schema) { GraphQL::Schema.from_definition <<-GRAPHQL
       type Mutation {
-        pushInt(int: Int!): Int!
+        push(int: Int!): Int!
       }
 
       type Query {
@@ -42,20 +42,15 @@ describe GraphQL::Execution::Execute do
     it "returns values for other mutations" do
       query_str = <<-GRAPHQL
       mutation {
-        one: pushInt(int: 1)
-        thirteen: pushInt(int: 13)
-        two: pushInt(int: 2)
+        one: push(int: 1)
+        thirteen: push(int: 13)
+        two: push(int: 2)
       }
       GRAPHQL
 
       res = schema.execute(query_str, root_value: root)
-      assert_equal [1, 2], MutationNullTestRoot::INTS
-      expected_data = {
-        "one" => 1,
-        "thirteen" => nil,
-        "two" => 2,
-      }
-      assert_equal(expected_data, res["data"])
+      assert_equal [1], MutationNullTestRoot::INTS
+      assert_equal(nil, res["data"])
     end
   end
 end


### PR DESCRIPTION
Addressing #573 