### PR TITLE
Fix(generators) rename base class so it's not a generator

### DIFF
--- a/lib/generators/graphql/interface_generator.rb
+++ b/lib/generators/graphql/interface_generator.rb
@@ -9,7 +9,7 @@ module Graphql
     # ```
     # rails g graphql:interface NamedEntityType name:String!
     # ```
-    class InterfaceGenerator < TypeGenerator
+    class InterfaceGenerator < TypeGeneratorBase
       desc "Create a GraphQL::InterfaceType with the given name and fields"
       source_root File.expand_path('../templates', __FILE__)
 

--- a/lib/generators/graphql/object_generator.rb
+++ b/lib/generators/graphql/object_generator.rb
@@ -11,7 +11,7 @@ module Graphql
     # ```
     #
     # Add the Node interface with `--node`.
-    class ObjectGenerator < TypeGenerator
+    class ObjectGenerator < TypeGeneratorBase
       desc "Create a GraphQL::ObjectType with the given name and fields"
       source_root File.expand_path('../templates', __FILE__)
 

--- a/lib/generators/graphql/type_generator.rb
+++ b/lib/generators/graphql/type_generator.rb
@@ -4,7 +4,7 @@ require 'graphql'
 
 module Graphql
   module Generators
-    class TypeGenerator < Rails::Generators::Base
+    class TypeGeneratorBase < Rails::Generators::Base
       argument :type_name,
         type: :string,
         required: true,

--- a/lib/generators/graphql/union_generator.rb
+++ b/lib/generators/graphql/union_generator.rb
@@ -9,7 +9,7 @@ module Graphql
     # ```
     # rails g graphql:union SearchResultType ImageType AudioType
     # ```
-    class UnionGenerator < TypeGenerator
+    class UnionGenerator < TypeGeneratorBase
       desc "Create a GraphQL::UnionType with the given name and possible types"
       source_root File.expand_path('../templates', __FILE__)
 


### PR DESCRIPTION
Oops, this was showing as a false positive:

```
$ rails g graphql:type -h
Usage:
  rails generate graphql:type TypeName [options]

Runtime options:
  -f, [--force]                    # Overwrite files that already exist
  -p, [--pretend], [--no-pretend]  # Run but do not make any changes
  -q, [--quiet], [--no-quiet]      # Suppress status output
  -s, [--skip], [--no-skip]        # Skip files that already exist

Description:
    Create graphql files for type generator.
```

now, appropriately: 

```
$ rails g graphql:type -h
Could not find generator 'graphql:type'. Maybe you meant 'graphql:object', 'graphql:loader' or 'graphql:union'
Run `rails generate --help` for more options.
```

cc @cjoudrey 