### PR TITLE
feat(Schema.from_definition) accept custom resolve behavior for runnable schemas

### DIFF
--- a/lib/graphql/field/resolve.rb
+++ b/lib/graphql/field/resolve.rb
@@ -24,16 +24,11 @@ module GraphQL
       # Resolve the field by `public_send`ing `@method_name`
       class MethodResolve < BuiltInResolve
         def initialize(field)
-          @field = field
           @method_name = field.property.to_sym
         end
 
         def call(obj, args, ctx)
-          if @field.arguments.any?
-            obj.public_send(@method_name, args, ctx)
-          else
-            obj.public_send(@method_name)
-          end
+          obj.public_send(@method_name)
         end
       end
 
@@ -56,11 +51,7 @@ module GraphQL
         end
 
         def call(obj, args, ctx)
-          if @field.arguments.any?
-            obj.public_send(@field.name, args, ctx)
-          else
-            obj.public_send(@field.name)
-          end
+          obj.public_send(@field.name)
         end
       end
     end

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -359,10 +359,11 @@ module GraphQL
     end
 
     # Create schema from an IDL schema.
-    # @param definition_string String A schema definition string
+    # @param definition_string [String] A schema definition string
+    # @param default_resolve [<#call(type, field, obj, args, ctx)>] A callable for handling field resolution
     # @return [GraphQL::Schema] the schema described by `document`
-    def self.from_definition(definition_string)
-      GraphQL::Schema::BuildFromDefinition.from_definition(definition_string)
+    def self.from_definition(string, default_resolve: BuildFromDefinition::DefaultResolve)
+      GraphQL::Schema::BuildFromDefinition.from_definition(string, default_resolve: default_resolve)
     end
 
     # Error that is raised when [#Schema#from_definition] is passed an invalid schema definition string.

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -21,11 +21,29 @@ module GraphQL
       end
 
       # @api private
+      class ResolveMap
+        def initialize(resolve_hash)
+          @resolve_hash = resolve_hash
+        end
+
+        def call(type, field, obj, args, ctx)
+          @resolve_hash
+            .fetch(type.name)
+            .fetch(field.name)
+            .call(obj,args,ctx)
+        end
+      end
+
+      # @api private
       module Builder
         extend self
 
         def build(document, default_resolve: DefaultResolve)
           raise InvalidDocumentError.new('Must provide a document ast.') if !document || !document.is_a?(GraphQL::Language::Nodes::Document)
+
+          if default_resolve.is_a?(Hash)
+            default_resolve = ResolveMap.new(default_resolve)
+          end
 
           schema_definition = nil
           types = {}

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -3,16 +3,28 @@ module GraphQL
   class Schema
     module BuildFromDefinition
       class << self
-        def from_definition(definition_string)
+        def from_definition(definition_string, default_resolve:)
           document = GraphQL::parse(definition_string)
-          Builder.build(document)
+          Builder.build(document, default_resolve: default_resolve)
         end
       end
 
+      # @api private
+      module DefaultResolve
+        def self.call(type, field, obj, args, ctx)
+          if field.arguments.any?
+            obj.public_send(field.name, args, ctx)
+          else
+            obj.public_send(field.name)
+          end
+        end
+      end
+
+      # @api private
       module Builder
         extend self
 
-        def build(document)
+        def build(document, default_resolve: DefaultResolve)
           raise InvalidDocumentError.new('Must provide a document ast.') if !document || !document.is_a?(GraphQL::Language::Nodes::Document)
 
           schema_definition = nil
@@ -29,7 +41,7 @@ module GraphQL
             when GraphQL::Language::Nodes::EnumTypeDefinition
               types[definition.name] = build_enum_type(definition, type_resolver)
             when GraphQL::Language::Nodes::ObjectTypeDefinition
-              types[definition.name] = build_object_type(definition, type_resolver)
+              types[definition.name] = build_object_type(definition, type_resolver, default_resolve: default_resolve)
             when GraphQL::Language::Nodes::InterfaceTypeDefinition
               types[definition.name] = build_interface_type(definition, type_resolver)
             when GraphQL::Language::Nodes::UnionTypeDefinition
@@ -128,11 +140,13 @@ module GraphQL
           )
         end
 
-        def build_object_type(object_type_definition, type_resolver)
-          GraphQL::ObjectType.define(
+        def build_object_type(object_type_definition, type_resolver, default_resolve:)
+          type_def = nil
+          typed_resolve_fn = ->(field, obj, args, ctx) { default_resolve.call(type_def, field, obj, args, ctx) }
+          type_def = GraphQL::ObjectType.define(
             name: object_type_definition.name,
             description: object_type_definition.description,
-            fields: Hash[build_fields(object_type_definition.fields, type_resolver)],
+            fields: Hash[build_fields(object_type_definition.fields, type_resolver, default_resolve: typed_resolve_fn)],
             interfaces: object_type_definition.interfaces.map{ |interface_name| type_resolver.call(interface_name) },
           )
         end
@@ -209,11 +223,11 @@ module GraphQL
           GraphQL::InterfaceType.define(
             name: interface_type_definition.name,
             description: interface_type_definition.description,
-            fields: Hash[build_fields(interface_type_definition.fields, type_resolver)],
+            fields: Hash[build_fields(interface_type_definition.fields, type_resolver, default_resolve: nil)],
           )
         end
 
-        def build_fields(field_definitions, type_resolver)
+        def build_fields(field_definitions, type_resolver, default_resolve:)
           field_definitions.map do |field_definition|
             field_arguments = Hash[field_definition.arguments.map do |argument|
               kwargs = {}
@@ -232,16 +246,15 @@ module GraphQL
               [argument.name, arg]
             end]
 
-            [
-              field_definition.name,
-              GraphQL::Field.define(
-                name: field_definition.name,
-                description: field_definition.description,
-                type: type_resolver.call(field_definition.type),
-                arguments: field_arguments,
-                deprecation_reason: build_deprecation_reason(field_definition.directives),
-              )
-            ]
+            field = GraphQL::Field.define(
+              name: field_definition.name,
+              description: field_definition.description,
+              type: type_resolver.call(field_definition.type),
+              arguments: field_arguments,
+              resolve: ->(obj, args, ctx) { default_resolve.call(field, obj, args, ctx) },
+              deprecation_reason: build_deprecation_reason(field_definition.directives),
+            )
+            [field_definition.name, field]
           end
         end
 

--- a/spec/graphql/field_spec.rb
+++ b/spec/graphql/field_spec.rb
@@ -32,36 +32,6 @@ describe GraphQL::Field do
     assert_equal([number], field.arguments)
   end
 
-  it "passing arguments to root_value when fields accepting arguments" do
-    schema = GraphQL::Schema.from_definition(" 
-      type Todo {text: String, from_context: String}
-      type Query { all_todos: [Todo]}
-      type Mutation { todo_add(text: String!): Todo}
-    ")
-    Todo = Struct.new(:text, :from_context)
-    class RootResolver
-      attr_accessor :todos
-
-      def initialize
-        @todos = [Todo.new("Pay the bills.")]
-      end
-
-      def all_todos
-        @todos
-      end
-
-      def todo_add(args, ctx) # this is a method and accepting arguments
-        todo = Todo.new(args[:text], ctx[:context_value])
-        @todos << todo
-        todo
-      end
-    end
-    root_values = RootResolver.new
-    schema.execute("mutation { todoAdd: todo_add(text: \"Buy Milk\") { text } }", root_value: root_values, context: {context_value: "bar"})
-    result = schema.execute("query { allTodos: all_todos { text, from_context } }", root_value: root_values)
-    assert_equal(result.to_json, '{"data":{"allTodos":[{"text":"Pay the bills.","from_context":null},{"text":"Buy Milk","from_context":"bar"}]}}')
-  end
-
   describe ".property " do
     let(:field) do
       GraphQL::Field.define do

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -700,4 +700,80 @@ SCHEMA
       assert_equal 'Specified query type "Foo" not found in document.', err.message
     end
   end
+
+  describe "executable schemas from string" do
+    let(:schema_defn) {
+      <<-GRAPHQL
+        type Todo {text: String, from_context: String}
+        type Query { all_todos: [Todo]}
+        type Mutation { todo_add(text: String!): Todo}
+      GRAPHQL
+    }
+
+    Todo = Struct.new(:text, :from_context)
+
+    class RootResolver
+      attr_accessor :todos
+
+      def initialize
+        @todos = [Todo.new("Pay the bills.")]
+      end
+
+      def all_todos
+        @todos
+      end
+
+      def todo_add(args, ctx) # this is a method and accepting arguments
+        todo = Todo.new(args[:text], ctx[:context_value])
+        @todos << todo
+        todo
+      end
+    end
+
+    it "calls methods with args if args are defined" do
+      schema = GraphQL::Schema.from_definition(schema_defn)
+      root_values = RootResolver.new
+      schema.execute("mutation { todoAdd: todo_add(text: \"Buy Milk\") { text } }", root_value: root_values, context: {context_value: "bar"})
+      result = schema.execute("query { allTodos: all_todos { text, from_context } }", root_value: root_values)
+      assert_equal(result.to_json, '{"data":{"allTodos":[{"text":"Pay the bills.","from_context":null},{"text":"Buy Milk","from_context":"bar"}]}}')
+    end
+
+    describe "custom resolve behavior" do
+      class AppResolver
+        def initialize
+          @todos = [Todo.new("Pay the bills.")]
+          @resolves = {
+            "Query" => {
+              "all_todos" => ->(obj, args, ctx) { @todos },
+            },
+            "Mutation" => {
+              "todo_add" => ->(obj, args, ctx) {
+                todo = Todo.new(args[:text], ctx[:context_value])
+                @todos << todo
+                todo
+              },
+            },
+            "Todo" => {
+              "text" => ->(obj, args, ctx) { obj.text },
+              "from_context" => ->(obj, args, ctx) { obj.from_context },
+            }
+          }
+        end
+
+        def call(type, field, obj, args, ctx)
+          @resolves
+            .fetch(type.name)
+            .fetch(field.name)
+            .call(obj, args, ctx)
+        end
+      end
+
+      it "accepts a default_resolve callable" do
+        schema = GraphQL::Schema.from_definition(schema_defn, default_resolve: AppResolver.new)
+        schema.execute("mutation { todoAdd: todo_add(text: \"Buy Milk\") { text } }", context: {context_value: "bar"})
+        result = schema.execute("query { allTodos: all_todos { text, from_context } }")
+        assert_equal(result.to_json, '{"data":{"allTodos":[{"text":"Pay the bills.","from_context":null},{"text":"Buy Milk","from_context":"bar"}]}}')
+      end
+    end
+  end
 end

--- a/spec/graphql/schema/warden_spec.rb
+++ b/spec/graphql/schema/warden_spec.rb
@@ -112,7 +112,7 @@ module MaskHelpers
 
   module Data
     UVULAR_TRILL = OpenStruct.new({name: "Uvular Trill", symbol: "ʀ", manner: "TRILL"})
-    def self.unit(args, ctx)
+    def self.unit
       UVULAR_TRILL
     end
   end


### PR DESCRIPTION
With this patch: 

- Previous behavior for DSL-created schemas is unchanged 
- New default behavior for IDL-created schemas is unchanged 
- Custom execution for IDL-created schemas is possible 

I've included an example in the specs how field resolution can be specified any way you can imagine. In that example, resolve functions are provided in a two-level map, `{ type_name => { field_name => resolve_fn } }`. What do you think, is this a good fit?

Also, lexical scopes are fun :) 

cc/ @f @tberman @theorygeek 



