### PR TITLE
refactor(Typecast) remove unused compatible? function

### DIFF
--- a/lib/graphql/execution/typecast.rb
+++ b/lib/graphql/execution/typecast.rb
@@ -1,38 +1,8 @@
 # frozen_string_literal: true
 module GraphQL
   module Execution
-    # GraphQL object `{value, current_type}` can be cast to `potential_type` when:
-    # - `current_type == potential_type`
-    # - `current_type` is a union and it contains `potential_type`
-    # - `potential_type` is a union and it contains `current_type`
-    # - `current_type` is an interface and `potential_type` implements it
-    # - `potential_type` is an interface and `current_type` implements it
     module Typecast
-      # While `value` is exposed by GraphQL as an instance of `current_type`,
-      # should it _also_ be treated as an instance of `potential_type`?
-      #
-      # This is used for checking whether fragments apply to an object.
-      #
-      # @param current_type [GraphQL::BaseType] the type which GraphQL is using now
-      # @param potential_type [GraphQL::BaseType] can this type be used from here?
-      # @param query_ctx [GraphQL::Query::Context] the context for the current query
-      # @return [Boolean] true if `value` be evaluated as a `potential_type`
-      def self.compatible?(current_type, potential_type, query_ctx)
-        if current_type == potential_type
-          true
-        elsif current_type.kind.union?
-          current_type.possible_types.include?(potential_type)
-        elsif potential_type.kind.union?
-          potential_type.include?(current_type)
-        elsif current_type.kind.interface? && potential_type.kind.object?
-          potential_type.interfaces.include?(current_type)
-        elsif potential_type.kind.interface? && current_type.kind.object?
-          current_type.interfaces.include?(potential_type)
-        else
-          false
-        end
-      end
-
+      # @return [Boolean]
       def self.subtype?(parent_type, child_type)
         if parent_type == child_type
           # Equivalent types are subtypes

--- a/spec/graphql/execution/typecast_spec.rb
+++ b/spec/graphql/execution/typecast_spec.rb
@@ -2,56 +2,6 @@
 require "spec_helper"
 
 describe GraphQL::Execution::Typecast do
-  let(:milk_value) { MILKS[1] }
-  let(:cheese_value) { CHEESES[1] }
-
-  let(:schema) { Dummy::Schema }
-  let(:context) { GraphQL::Query::Context.new(query: OpenStruct.new(schema: schema), values: nil) }
-
-  describe "compatible" do
-    def compatible?(*args)
-      GraphQL::Execution::Typecast.compatible?(*args)
-    end
-
-    it "resolves correctly when both types are the same" do
-      assert compatible?(Dummy::MilkType, Dummy::MilkType, context)
-
-      assert !compatible?(Dummy::MilkType, Dummy::CheeseType, context)
-    end
-
-    it "resolves a union type to a matching member" do
-      assert compatible?(Dummy::DairyProductUnion, Dummy::MilkType, context)
-      assert compatible?(Dummy::DairyProductUnion, Dummy::CheeseType, context)
-
-      assert !compatible?(Dummy::DairyProductUnion, GraphQL::INT_TYPE, context)
-      assert !compatible?(Dummy::DairyProductUnion, Dummy::HoneyType, context)
-    end
-
-    it "resolves correcty when potential type is UnionType and current type is a member of that union" do
-      assert compatible?(Dummy::MilkType, Dummy::DairyProductUnion, context)
-      assert compatible?(Dummy::CheeseType, Dummy::DairyProductUnion, context)
-
-      assert !compatible?(Dummy::DairyAppQueryType, Dummy::DairyProductUnion, context)
-      assert !compatible?(Dummy::EdibleInterface, Dummy::DairyProductUnion, context)
-    end
-
-    it "resolves an object type to one of its interfaces" do
-      assert compatible?(Dummy::CheeseType, Dummy::EdibleInterface, context)
-      assert compatible?(Dummy::MilkType, Dummy::EdibleInterface, context)
-
-      assert !compatible?(Dummy::DairyAppQueryType, Dummy::EdibleInterface, context)
-      assert !compatible?(Dummy::LocalProductInterface, Dummy::EdibleInterface, context)
-    end
-
-    it "resolves an interface to a matching member" do
-      assert compatible?(Dummy::EdibleInterface, Dummy::CheeseType, context)
-      assert compatible?(Dummy::EdibleInterface, Dummy::MilkType, context)
-
-      assert !compatible?(Dummy::EdibleInterface, GraphQL::STRING_TYPE, context)
-      assert !compatible?(Dummy::EdibleInterface, Dummy::DairyProductInputType, context)
-    end
-  end
-
   describe ".subtype?" do
     def subtype?(*args)
       GraphQL::Execution::Typecast.subtype?(*args)


### PR DESCRIPTION
I noticed this function was unused. It wasn't _marked_ private, but it wasn't publicized in the guides and it hasn't _worked_ for quite a while, since it uses the long-dead `InterfaceType#possible_types` method.