### PR TITLE
fix(rubocop) target Ruby 2.3 for proper frozen_string_literal checking

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   DisabledByDefault: true
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.3
   Exclude:
     - 'lib/graphql/language/lexer.rb'
     - 'lib/graphql/language/parser.rb'

--- a/benchmark/run.rb
+++ b/benchmark/run.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "dummy/schema"
 require "benchmark/ips"
 require 'ruby-prof'

--- a/lib/graphql/define/assign_mutation_function.rb
+++ b/lib/graphql/define/assign_mutation_function.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Define
     module AssignMutationFunction

--- a/lib/graphql/function.rb
+++ b/lib/graphql/function.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   # A reusable container for field logic, including arguments, resolve, return type, and documentation.
   #

--- a/lib/graphql/internal_representation/node.rb
+++ b/lib/graphql/internal_representation/node.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module InternalRepresentation
     class Node

--- a/lib/graphql/internal_representation/rewrite.rb
+++ b/lib/graphql/internal_representation/rewrite.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module InternalRepresentation
     # While visiting an AST, build a normalized, flattened tree of {InternalRepresentation::Node}s.

--- a/lib/graphql/relay/range_add.rb
+++ b/lib/graphql/relay/range_add.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module Relay
     # This provides some isolation from `GraphQL::Relay` internals.

--- a/lib/graphql/runtime_type_error.rb
+++ b/lib/graphql/runtime_type_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class RuntimeTypeError < GraphQL::Error
   end

--- a/lib/graphql/schema/base_64_encoder.rb
+++ b/lib/graphql/schema/base_64_encoder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Schema
     # @api private

--- a/lib/graphql/schema/null_mask.rb
+++ b/lib/graphql/schema/null_mask.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   class Schema
     # @api private

--- a/lib/graphql/static_validation/definition_dependencies.rb
+++ b/lib/graphql/static_validation/definition_dependencies.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQL
   module StaticValidation
     # Track fragment dependencies for operations

--- a/spec/generators/graphql/function_generator_spec.rb
+++ b/spec/generators/graphql/function_generator_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 require "generators/graphql/function_generator"
 

--- a/spec/generators/graphql/install_generator_spec.rb
+++ b/spec/generators/graphql/install_generator_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 require "generators/graphql/install_generator"
 

--- a/spec/generators/graphql/interface_generator_spec.rb
+++ b/spec/generators/graphql/interface_generator_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 require "generators/graphql/interface_generator"
 

--- a/spec/generators/graphql/loader_generator_spec.rb
+++ b/spec/generators/graphql/loader_generator_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 require "generators/graphql/loader_generator"
 

--- a/spec/generators/graphql/mutation_generator_spec.rb
+++ b/spec/generators/graphql/mutation_generator_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 require "generators/graphql/mutation_generator"
 

--- a/spec/generators/graphql/object_generator_spec.rb
+++ b/spec/generators/graphql/object_generator_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 require "generators/graphql/object_generator"
 

--- a/spec/generators/graphql/union_generator_spec.rb
+++ b/spec/generators/graphql/union_generator_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 require "generators/graphql/union_generator"
 

--- a/spec/graphql/directive/skip_directive_spec.rb
+++ b/spec/graphql/directive/skip_directive_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Directive::SkipDirective do

--- a/spec/graphql/function_spec.rb
+++ b/spec/graphql/function_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Function do

--- a/spec/graphql/relay/range_add_spec.rb
+++ b/spec/graphql/relay/range_add_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::Relay::RangeAdd do

--- a/spec/support/base_generator_test.rb
+++ b/spec/support/base_generator_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 class BaseGeneratorTest < Rails::Generators::TestCase


### PR DESCRIPTION
Apparently this cop only runs if target ruby is 2.3+