### PR TITLE
fix(Rewrite) use a Set to avoid storing duplicate AST nodes

### DIFF
--- a/lib/graphql/analysis/analyze_query.rb
+++ b/lib/graphql/analysis/analyze_query.rb
@@ -18,10 +18,8 @@ module GraphQL
 
       irep = query.internal_representation
 
-      irep.each do |root_type, roots|
-        roots.each do |name, op_node|
-          reduce_node(op_node, reducer_states)
-        end
+      irep.each do |name, op_node|
+        reduce_node(op_node, reducer_states)
       end
 
       reducer_states.map(&:finalize_reducer)

--- a/lib/graphql/internal_representation/node.rb
+++ b/lib/graphql/internal_representation/node.rb
@@ -26,7 +26,7 @@ module GraphQL
 
       def initialize(
           name:, owner_type:, query:, return_type:,
-          ast_nodes: [],
+          ast_nodes: nil,
           definitions: nil, typed_children: nil
         )
         @name = name

--- a/lib/graphql/internal_representation/rewrite.rb
+++ b/lib/graphql/internal_representation/rewrite.rb
@@ -22,7 +22,7 @@ module GraphQL
       attr_reader :operations
 
       def initialize
-        @operations = Hash.new {|h, k| h[k] = {} }
+        @operations = {}
       end
 
       def validate(context)
@@ -37,7 +37,7 @@ module GraphQL
         # Array<Set<GraphQL::ObjectType>>
         # Object types that the current point of the irep_tree applies to
         scope_stack = []
-        fragment_definitions = Hash.new {|h, k| h[k] = {} }
+        fragment_definitions = {}
         skip_nodes = Set.new
 
         visit_op = VisitDefinition.new(context, @operations, nodes_stack, scope_stack)
@@ -150,11 +150,9 @@ module GraphQL
           spread_ast_nodes.each do |spread_ast_node|
             parent_nodes = spread_parents[spread_ast_node]
             parent_nodes.each do |parent_node|
-              each_type(query, parent_node.return_type) do |obj_type|
-                fragment_node = fragment_definitions[obj_type][frag_name]
-                if fragment_node
-                  deep_merge_selections(query, parent_node, fragment_node)
-                end
+              fragment_node = fragment_definitions[frag_name]
+              if fragment_node
+                deep_merge_selections(query, parent_node, fragment_node)
               end
             end
           end
@@ -221,16 +219,18 @@ module GraphQL
           defn_name = ast_node.name
           Rewrite.each_type(@query, owner_type) do |obj_type|
             next_scope.add(obj_type)
-            node = Node.new(
-              name: defn_name,
-              owner_type: obj_type,
-              query: @query,
-              ast_nodes: Set.new([ast_node]),
-              return_type: obj_type,
-            )
-            @definitions[obj_type][defn_name] = node
-            next_nodes << node
           end
+
+          node = Node.new(
+            name: defn_name,
+            owner_type: owner_type,
+            query: @query,
+            ast_nodes: Set.new([ast_node]),
+            return_type: owner_type,
+          )
+          @definitions[defn_name] = node
+          next_nodes << node
+
           @nodes_stack.push(next_nodes)
           @scope_stack.push(next_scope)
         end

--- a/lib/graphql/internal_representation/rewrite.rb
+++ b/lib/graphql/internal_representation/rewrite.rb
@@ -111,7 +111,7 @@ module GraphQL
                     query: query,
                     return_type: field_return_type,
                   )
-                  node.ast_nodes.push(ast_node)
+                  node.ast_nodes.add(ast_node)
                   node.definitions.add(field_defn)
                   next_nodes << node
                 end
@@ -169,11 +169,10 @@ module GraphQL
           prev_fields = prev_parent.typed_children[obj_type]
           new_fields.each do |name, new_node|
             prev_node = prev_fields[name]
-            node = if prev_node
-              prev_node.ast_nodes.concat(new_node.ast_nodes)
+            if prev_node
+              prev_node.ast_nodes.merge(new_node.ast_nodes)
               prev_node.definitions.merge(new_node.definitions)
               deep_merge_selections(query, prev_node, new_node)
-              prev_node
             else
               prev_fields[name] = new_node
             end
@@ -226,7 +225,7 @@ module GraphQL
               name: defn_name,
               owner_type: obj_type,
               query: @query,
-              ast_nodes: [ast_node],
+              ast_nodes: Set.new([ast_node]),
               return_type: obj_type,
             )
             @definitions[obj_type][defn_name] = node

--- a/lib/graphql/internal_representation/visit.rb
+++ b/lib/graphql/internal_representation/visit.rb
@@ -6,15 +6,13 @@ module GraphQL
       module_function
       def visit_each_node(operations, handlers)
         # Post-validation: make some assertions about the rewritten query tree
-        operations.each do |obj_type, ops|
-          ops.each do |op_name, op_node|
-            # Yield each node to listeners which were attached by validators
-            op_node.typed_children.each do |obj_type, children|
-              children.each do |name, op_child_node|
-                each_node(op_child_node) do |node|
-                  for h in handlers
-                    h.call(node)
-                  end
+        operations.each do |op_name, op_node|
+          # Yield each node to listeners which were attached by validators
+          op_node.typed_children.each do |obj_type, children|
+            children.each do |name, op_child_node|
+              each_node(op_child_node) do |node|
+                for h in handlers
+                  h.call(node)
                 end
               end
             end

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -157,10 +157,7 @@ module GraphQL
     end
 
     def irep_selection
-      @selection ||= begin
-        root_type = schema.root_type_for_operation(selected_operation.operation_type)
-        internal_representation[root_type][selected_operation.name]
-      end
+      @selection ||= internal_representation[selected_operation.name]
     end
 
 

--- a/spec/graphql/internal_representation/rewrite_spec.rb
+++ b/spec/graphql/internal_representation/rewrite_spec.rb
@@ -105,7 +105,7 @@ describe GraphQL::InternalRepresentation::Rewrite do
     }
 
     it "groups selections by object types which they apply to" do
-      doc = rewrite_result[schema.types["Query"]]["getPlant"]
+      doc = rewrite_result["getPlant"]
 
       plant_selection = doc.typed_children[schema.types["Query"]]["plant"]
       assert_equal ["Fruit", "Grain", "Nut", "Vegetable"], plant_selection.typed_children.keys.map(&:name).sort
@@ -149,7 +149,7 @@ describe GraphQL::InternalRepresentation::Rewrite do
     }
 
     it "applies directives from all contexts" do
-      doc = rewrite_result[schema.types["Query"]]["getPlant"]
+      doc = rewrite_result["getPlant"]
       plant_selection = doc.typed_children[schema.types["Query"]]["plant"]
       leaf_type_selection = plant_selection.typed_children[schema.types["Nut"]]["leafType"]
       # Only unskipped occurrences in the AST
@@ -186,7 +186,7 @@ describe GraphQL::InternalRepresentation::Rewrite do
     }
 
     it "applies spreads to their parents only" do
-      doc = rewrite_result[schema.types["Query"]][nil]
+      doc = rewrite_result[nil]
       plant_selection = doc.typed_children[schema.types["Query"]]["plant"]
       nut_habitat_selections = plant_selection.typed_children[schema.types["Nut"]]["habitats"].typed_children[schema.types["Habitat"]]
       assert_equal ["averageWeight", "residentName", "seasons"], nut_habitat_selections.keys.sort


### PR DESCRIPTION
These were regressions introduced in 1.5.0, inefficiencies in validation