### PR TITLE
doc(CONTRIBUTING) Add Sidekiq-like contributing.md

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,0 +1,24 @@
+# Contributing
+
+Thanks for getting involved! I hope the information below will help you contribute to graphql-ruby.
+
+## Issues
+
+When reporting a bug, please include these details when applicable:
+
+- `graphql` version and other applicable versions (Rails, `graphql-batch`, etc)
+- Definitions of schema or relevant types and fields (in Ruby is best, in GraphQL IDL is ok)
+- Example GraphQL query and response (if query execution is involved)
+- Full backtrace (if a Ruby exception is involved)
+
+With these details, we can efficiently hunt down the bug!
+
+## Code
+
+It's important for code to fit in with design and maintenance goals of the project. For this reason, consider an issue to discuss new features or large refactors. That way we can work together to find suitable solution!
+
+## Legal
+
+By submitting a Pull Request, you disavow any rights or claims to any changes submitted to `graphql-ruby` and assign the copyright of those changes to Robert Mosolgo, the author and maintainer of `graphql-ruby`. If you cannot or don't want to reassign those rights (your employment contract for your employer may not allow this), don't submit a PR. Instead, open an issue so that someone else can give it a try.
+
+In short, contributing code means that the code belongs to the maintainer. That's generally what you want, since the burden of upkeep, support and distribution falls on the maintainer anyways. I hope this doesn't prohibit you from contributing!


### PR DESCRIPTION
The tricky part here is the "Legal" section, which requires that PR authors transfer copyrights to the maintainer (me) when contributing code. My goal is to make relicensing possible in the future, but it's the distant future. This clause doesn't apply to previous contributions (81 contributors, ~25% of commits), so relicensing would present a serious challenge! However, I'd like to stop making it _harder_. 

The end goal is to provide a software experience like Sidekiq: rock-solid, well-maintained software with good developer support and a sustainable future :) I plant to improve graphql-pro by adding features, but dual-licensing would make easier to upstream some smaller features (eg monitoring, versioned connections) as time goes on, since graphql-pro would have another viable revenue stream. 

If you have other thoughts, advice or concerns on this, feel free to let me know here, on slack, or by email. As mentioned above, my goal is to provide great software for users at all levels!