### PR TITLE
fix(ArgumentsValidator) ignore input object if the argument's type isn't input object

### DIFF
--- a/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
+++ b/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
@@ -67,6 +67,22 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
     assert_includes(errors, fragment_error)
   end
 
+  describe "using input objects for enums" do
+    let(:query_string) { <<-GRAPHQL
+      {
+        yakSource: searchDairy(product: [{source: {a: 1, b: 2}, fatContent: 1.1}]) { __typename }
+      }
+    GRAPHQL
+    }
+
+    it "adds an error" do
+      # TODO:
+      # It's annoying that this error cascades up, there should only be one:
+      assert_equal 2, errors.length
+    end
+  end
+
+
   describe "null value" do
     describe "nullable arg" do
       let(:schema) {


### PR DESCRIPTION
Oops, the logic previously said "skip if the argument's type is scalar", but this left it broken for enum types as shown in #531. So fix the logic: "skip if the argument's type _isn't_ input object" 