### PR TITLE
fix(defaultValue) serialize and load enum values as bare identifiers

### DIFF
--- a/lib/graphql/introspection/input_value_type.rb
+++ b/lib/graphql/introspection/input_value_type.rb
@@ -11,7 +11,16 @@ GraphQL::Introspection::InputValueType = GraphQL::ObjectType.define do
     resolve ->(obj, args, ctx) {
       if obj.default_value?
         value = obj.default_value
-        value.nil? ? 'null' : GraphQL::Language.serialize(obj.type.coerce_result(value))
+        if value.nil?
+          'null'
+        else
+          coerced_default_value = obj.type.coerce_result(value)
+          if obj.type.unwrap.is_a?(GraphQL::EnumType)
+            coerced_default_value
+          else
+            GraphQL::Language.serialize(coerced_default_value)
+          end
+        end
       else
         nil
       end

--- a/lib/graphql/schema/loader.rb
+++ b/lib/graphql/schema/loader.rb
@@ -107,7 +107,14 @@ module GraphQL
             )
           when "ARGUMENT"
             kwargs = {}
-            kwargs[:default_value] = JSON.parse(type["defaultValue"], quirks_mode: true) if type["defaultValue"]
+            if type["defaultValue"]
+              kwargs[:default_value] = begin
+                JSON.parse(type["defaultValue"], quirks_mode: true)
+              rescue JSON::ParserError
+                # Enum values are not valid JSON, they're bare identifiers
+                type["default_value"]
+              end
+            end
 
             Argument.define(
               name: type["name"],

--- a/spec/graphql/schema/loader_spec.rb
+++ b/spec/graphql/schema/loader_spec.rb
@@ -103,6 +103,7 @@ describe GraphQL::Schema::Loader do
         argument :id, !types.ID
         argument :varied, variant_input_type, default_value: { id: "123", int: 234, float: 2.3, enum: :foo, sub: [{ string: "str" }] }
         argument :variedWithNull, variant_input_type_with_nulls, default_value: { id: nil, int: nil, float: nil, enum: nil, sub: nil, bigint: nil, bool: nil }
+        argument :enum, choice_type, default_value: :foo
       end
 
       field :content do


### PR DESCRIPTION
Oops, apparently they should be `FOO`, not `"FOO"` (which makes sense as the ["String encoding (using the GraphQL language)"](https://facebook.github.io/graphql/#sec-The-__InputValue-Type)). This is what comes from GraphQL js according to #592.