### PR TITLE
refactor(Query) return parse error to client instead of crashing

### DIFF
--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -17,6 +17,14 @@ module GraphQL
       @col = col
       @query = query
     end
+
+    def to_h
+      locations = line ? [{ "line" => line, "column" => col }] : []
+      {
+        "message" => message,
+        "locations" => locations,
+      }
+    end
   end
 
   # Turn a query string into an AST

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -63,8 +63,14 @@ module GraphQL
         @provided_variables = variables
       end
       @query_string = query_string
-      @document = document || GraphQL.parse(query_string)
-      @document.definitions.each do |part|
+      @parse_error = nil
+      @document = document || begin
+        GraphQL.parse(query_string)
+      rescue GraphQL::ParseError => err
+        @parse_error = err
+        nil
+      end
+      @document && @document.definitions.each do |part|
         if part.is_a?(GraphQL::Language::Nodes::FragmentDefinition)
           @fragments[part.name] = part
         elsif part.is_a?(GraphQL::Language::Nodes::OperationDefinition)
@@ -111,6 +117,9 @@ module GraphQL
           instrumenters.each { |i| i.before_query(self) }
           @result = if !valid?
             all_errors = validation_errors + analysis_errors
+            if @parse_error
+              all_errors << @parse_error
+            end
             if all_errors.any?
               { "errors" => all_errors.map(&:to_h) }
             else
@@ -204,7 +213,7 @@ module GraphQL
     def valid?
       @was_validated ||= begin
         @was_validated = true
-        @valid = document_valid? && query_valid? && variables.errors.none?
+        @valid = @parse_error.nil? && document_valid? && query_valid? && variables.errors.none?
         true
       end
 

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -420,4 +420,24 @@ describe GraphQL::Query do
       assert_equal({"cheeseId" => 2}, query.provided_variables)
     end
   end
+
+  describe "parse errors" do
+    it "adds an entry to the errors key" do
+      res = schema.execute(" { ")
+      assert_equal 1, res["errors"].length
+      assert_equal "Unexpected end of document", res["errors"][0]["message"]
+      assert_equal [], res["errors"][0]["locations"]
+
+      res = schema.execute <<-GRAPHQL
+        {
+          getStuff
+          nonsense
+          This is broken 1
+        }
+      GRAPHQL
+      assert_equal 1, res["errors"].length
+      assert_equal %|Parse error on "1" (INT) at [4, 26]|, res["errors"][0]["message"]
+      assert_equal({"line" => 4, "column" => 26}, res["errors"][0]["locations"][0])
+    end
+  end
 end


### PR DESCRIPTION
An invalid query string leads to a crash which is a pain. Better to inform the client that the query was invalid!