### PR TITLE
feat(BuildFromDefinition) allow resolver hashes to have defaults

### DIFF
--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -27,10 +27,14 @@ module GraphQL
         end
 
         def call(type, field, obj, args, ctx)
-          @resolve_hash
-            .fetch(type.name)
-            .fetch(field.name)
-            .call(obj,args,ctx)
+          type_hash = @resolve_hash[type.name]
+          type_hash && (resolver = type_hash[field.name])
+
+          if resolver.nil?
+            raise(KeyError, "resolver not found for #{type.name}.#{field.name}")
+          else
+            resolver.call(obj, args, ctx)
+          end
         end
       end
 


### PR DESCRIPTION
Using `#[]` instead of `#fetch` allows hash fallbacks to be used, reducing boilerplate