### PR TITLE
fix(Execute) use a FieldResult for all SelectionResults because they may have lazy children

### DIFF
--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -83,11 +83,8 @@ module GraphQL
           continue_resolve_field(selection, parent_type, field, raw_value, field_ctx)
         end
 
-        if (
-            result == PROPAGATE_NULL ||
-            result.is_a?(GraphQL::Execution::Lazy) ||
-            (result.is_a?(SelectionResult) && result.invalid_null?)
-          )
+        case result
+        when PROPAGATE_NULL, GraphQL::Execution::Lazy, SelectionResult
           FieldResult.new(
             owner: owner,
             field: field,

--- a/lib/graphql/execution/lazy.rb
+++ b/lib/graphql/execution/lazy.rb
@@ -30,18 +30,19 @@ module GraphQL
       def value
         if !@resolved
           @resolved = true
-          @value = @get_value_func.call
+          @value = begin
+            @get_value_func.call
+          rescue GraphQL::ExecutionError => err
+            err
+          end
         end
         @value
-      rescue GraphQL::ExecutionError => err
-        @resolved = true
-        @value = err
       end
 
       # @return [Lazy] A {Lazy} whose value depends on another {Lazy}, plus any transformations in `block`
       def then(&block)
         self.class.new {
-          next_val = block.call(value)
+          block.call(value)
         }
       end
     end

--- a/spec/graphql/relay/connection_type_spec.rb
+++ b/spec/graphql/relay/connection_type_spec.rb
@@ -56,5 +56,26 @@ describe GraphQL::Relay::ConnectionType do
         assert_equal ["Yavin", "Echo Base", "Secret Hideout"] , bases["nodes"].map { |e| e["name"] }
       end
     end
+
+
+    describe "when an execution error is raised" do
+      let(:query_string) {%|
+        {
+          basesWithNullName {
+            edges {
+              node {
+                name
+              }
+            }
+          }
+        }
+      |}
+
+      it "nullifies the parent and adds an error" do
+        result = star_wars_query(query_string)
+        assert_equal nil, result["data"]["basesWithNullName"]["edges"][0]["node"]
+        assert_equal "Boom!", result["errors"][0]["message"]
+      end
+    end
   end
 end


### PR DESCRIPTION
Oops, this was an overly-aggressive optimization! 

Fixes #596 