### PR TITLE
Provide a mechanism to wrap around the execution

### DIFF
--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -6,6 +6,8 @@ module GraphQL
       PROPAGATE_NULL = :__graphql_propagate_null__
 
       def execute(ast_operation, root_type, query)
+        yield query.before_execute.call(query) unless query.before_execute.nil?
+
         result = resolve_selection(
           query.root_value,
           root_type,
@@ -15,6 +17,8 @@ module GraphQL
         )
 
         GraphQL::Execution::Lazy.resolve(result)
+
+        yield query.after_execute.call(query) unless query.after_execute.nil?
 
         result.to_h
       end

--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -19,7 +19,7 @@ module GraphQL
          if query.execute_wrapper.nil?
            result = resolver.call
          else
-           query.execute_wrapper.call(query) { result = resolver.call }
+           result = query.execute_wrapper.call(query, resolver)
          end
 
         GraphQL::Execution::Lazy.resolve(result)

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -24,7 +24,7 @@ module GraphQL
       end
     end
 
-    attr_reader :schema, :document, :context, :fragments, :operations, :root_value, :max_depth, :query_string, :warden, :provided_variables
+    attr_reader :schema, :document, :context, :fragments, :operations, :root_value, :before_execute, :after_execute, :max_depth, :query_string, :warden, :provided_variables
 
     # Prepare query `query_string` on `schema`
     # @param schema [GraphQL::Schema]
@@ -33,11 +33,13 @@ module GraphQL
     # @param variables [Hash] values for `$variables` in the query
     # @param operation_name [String] if the query string contains many operations, this is the one which should be executed
     # @param root_value [Object] the object used to resolve fields on the root type
+    # @param before_execute [Proc] block which is called right before running execute
+    # @param after_execute [Proc] block which is called right after running execute
     # @param max_depth [Numeric] the maximum number of nested selections allowed for this query (falls back to schema-level value)
     # @param max_complexity [Numeric] the maximum field complexity for this query (falls back to schema-level value)
     # @param except [<#call(schema_member, context)>] If provided, objects will be hidden from the schema when `.call(schema_member, context)` returns truthy
     # @param only [<#call(schema_member, context)>] If provided, objects will be hidden from the schema when `.call(schema_member, context)` returns false
-    def initialize(schema, query_string = nil, document: nil, context: nil, variables: {}, validate: true, operation_name: nil, root_value: nil, max_depth: nil, max_complexity: nil, except: nil, only: nil)
+    def initialize(schema, query_string = nil, document: nil, context: nil, variables: {}, validate: true, operation_name: nil, root_value: nil, before_execute: nil, after_execute: nil, max_depth: nil, max_complexity: nil, except: nil, only: nil)
       fail ArgumentError, "a query string or document is required" unless query_string || document
 
       @schema = schema
@@ -54,6 +56,8 @@ module GraphQL
         @query_analyzers << GraphQL::Analysis::MaxQueryComplexity.new(@max_complexity)
       end
       @root_value = root_value
+      @before_execute = before_execute
+      @after_execute = after_execute
       @operation_name = operation_name
       @fragments = {}
       @operations = {}

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -24,7 +24,7 @@ module GraphQL
       end
     end
 
-    attr_reader :schema, :document, :context, :fragments, :operations, :root_value, :before_execute, :after_execute, :max_depth, :query_string, :warden, :provided_variables
+    attr_reader :schema, :document, :context, :fragments, :operations, :root_value, :execute_wrapper, :max_depth, :query_string, :warden, :provided_variables
 
     # Prepare query `query_string` on `schema`
     # @param schema [GraphQL::Schema]
@@ -33,13 +33,12 @@ module GraphQL
     # @param variables [Hash] values for `$variables` in the query
     # @param operation_name [String] if the query string contains many operations, this is the one which should be executed
     # @param root_value [Object] the object used to resolve fields on the root type
-    # @param before_execute [Proc] block which is called right before running execute
-    # @param after_execute [Proc] block which is called right after running execute
+    # @param execute_wrapper [Proc] block which is called as part of running execute
     # @param max_depth [Numeric] the maximum number of nested selections allowed for this query (falls back to schema-level value)
     # @param max_complexity [Numeric] the maximum field complexity for this query (falls back to schema-level value)
     # @param except [<#call(schema_member, context)>] If provided, objects will be hidden from the schema when `.call(schema_member, context)` returns truthy
     # @param only [<#call(schema_member, context)>] If provided, objects will be hidden from the schema when `.call(schema_member, context)` returns false
-    def initialize(schema, query_string = nil, document: nil, context: nil, variables: {}, validate: true, operation_name: nil, root_value: nil, before_execute: nil, after_execute: nil, max_depth: nil, max_complexity: nil, except: nil, only: nil)
+    def initialize(schema, query_string = nil, document: nil, context: nil, variables: {}, validate: true, operation_name: nil, root_value: nil, execute_wrapper: nil, max_depth: nil, max_complexity: nil, except: nil, only: nil)
       fail ArgumentError, "a query string or document is required" unless query_string || document
 
       @schema = schema
@@ -56,8 +55,7 @@ module GraphQL
         @query_analyzers << GraphQL::Analysis::MaxQueryComplexity.new(@max_complexity)
       end
       @root_value = root_value
-      @before_execute = before_execute
-      @after_execute = after_execute
+      @execute_wrapper = execute_wrapper
       @operation_name = operation_name
       @fragments = {}
       @operations = {}

--- a/spec/graphql/execution/execute_spec.rb
+++ b/spec/graphql/execution/execute_spec.rb
@@ -76,4 +76,32 @@ describe GraphQL::Execution::Execute do
       end
     end
   end
+
+  describe "execute callbacks" do
+    let(:schema) { Dummy::Schema }
+    let(:query_string) {%|
+      {
+        cheese(id: 1) {
+          id
+          flavor
+        }
+      }
+    |}
+
+    let(:before_execute) do
+      Proc.new { |query| raise RuntimeError unless query.mutation? }
+    end
+
+    let(:after_execute) do
+      Proc.new { |query| raise RuntimeError unless query.mutation? }
+    end
+
+    it 'calls before_execute when provided' do
+      assert_raises(RuntimeError) { schema.execute(query_string, before_execute: before_execute) }
+    end
+
+    it 'calls after_execute when provided' do
+      assert_raises(RuntimeError) { schema.execute(query_string, after_execute: after_execute) }
+    end
+  end
 end

--- a/spec/graphql/execution/execute_spec.rb
+++ b/spec/graphql/execution/execute_spec.rb
@@ -103,28 +103,28 @@ describe GraphQL::Execution::Execute do
     let(:mutation_string) {%|
       mutation setInOrder {
         first:  pushValue(value: 1)
-        second: pushValue(value: 5)
-        third:  pushValue(value: 2)
-        fourth: replaceValues(input: {values: [6,5,4]})
       }
     |}
 
-    let(:execute_wrapper) do
-      Proc.new do |query|
+    let(:execute_wrapper) {
+      Proc.new do |query, resolver|
+        result = resolver.call
         if query.mutation?
-          raise RuntimeError
+          raise RuntimeError, "#{result} is a weird mutation!"
         else
-          raise TypeError
+          raise TypeError, "#{result} is a weird query!"
         end
       end
-    end
+    }
 
     it 'calls on queries when provided' do
-      assert_raises(TypeError) { schema.execute(query_string, execute_wrapper: execute_wrapper) }
+      err = assert_raises(TypeError) { schema.execute(query_string, execute_wrapper: execute_wrapper) }
+      assert_match /weird query/, err.message
     end
 
     it 'calls on mutations when provided' do
-      assert_raises(RuntimeError) { schema.execute(mutation_string, execute_wrapper: execute_wrapper) }
+      err = assert_raises(RuntimeError) { schema.execute(mutation_string, execute_wrapper: execute_wrapper) }
+      assert_match /weird mutation/, err.message
     end
   end
 end

--- a/spec/graphql/query/executor_spec.rb
+++ b/spec/graphql/query/executor_spec.rb
@@ -98,7 +98,7 @@ describe GraphQL::Query::Executor do
         end
       end
 
-      GraphQL::Schema.define(query: DummyQueryType, mutation: Dummy::DairyAppMutationType, resolve_type: :pass, id_from_object: :pass)
+      GraphQL::Schema.define(query: DummyQueryType, mutation: Dummy::DairyAppMutationType)
     }
     let(:variables) { nil }
     let(:query_string) { %|


### PR DESCRIPTION
I mentioned this briefly in Slack. In general, prior to a query being executed, I need to find a way to determine ultimately which type of query is being acted on, and then do something. Specifically, it would be the difference between selecting a read-only database versus one for writes, like:

``` ruby
Database.use_readonly_db do
  # execute query
end

Database.use_write_db do
  # execute mutation
end
```

There's a way to do this by looking at the `operation_name` and parsing the query for `OperationDefinition `, but it felt very cumbersome, and I wished the gem had a mechanism for it. I imagine this to work as follows:

``` ruby
execute_wrapper = Proc.new do |query, resolver|
                                   if query.mutation?
                                     Database.use_write_db do
                                       return resolver.call
                                      end
                                   else
                                     Database.use_readonly_db(resolver) do
                                       return resolver.call
                                      end
                                   end
                                 end
```

My test fixture for `execute_wrapper` is just a goofy little example because I didn't care about the results at all. I just wanted to show that the query type is being passed and an execution is being made.

Happy to go into more detail or change any aspect of this as necessary!