### PR TITLE
Make sure the variant name of an enum is a string

### DIFF
--- a/lib/graphql/define/assign_enum_value.rb
+++ b/lib/graphql/define/assign_enum_value.rb
@@ -5,7 +5,7 @@ module GraphQL
     module AssignEnumValue
       def self.call(enum_type, name, desc = nil, deprecation_reason: nil, value: name, &block)
         enum_value = GraphQL::EnumType::EnumValue.define(
-          name: name,
+          name: name.to_s,
           description: desc,
           deprecation_reason: deprecation_reason,
           value: value,

--- a/spec/graphql/enum_type_spec.rb
+++ b/spec/graphql/enum_type_spec.rb
@@ -67,6 +67,18 @@ describe GraphQL::EnumType do
     end
   end
 
+  it "accepts a symbol as a variant and Ruby-land value" do
+    enum = GraphQL::EnumType.define do
+      name 'MessageFormat'
+      value :markdown
+    end
+
+    variant = enum.values['markdown']
+
+    assert_equal(variant.name, 'markdown')
+    assert_equal(variant.value, :markdown)
+  end
+
   it "has value description" do
     assert_equal("Animal with horns", enum.values["GOAT"].description)
   end


### PR DESCRIPTION
Hello. Thank you for implementing & maintaining graphql-ruby.

I'd like to ensure that names of enum values are strings. I think that passing a symbol for the 2nd argument (`name`) is right since it is also used for the default value of `value`. However, the variant name can't be other than a string in GraphQL-land.

