### PR TITLE
fix(LazyMethodMap) wrap hash modification with a mutex

### DIFF
--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "benchmark-ips"
   s.add_development_dependency "codeclimate-test-reporter", "~>0.4"
+  s.add_development_dependency "concurrent-ruby", "~>1.0"
   s.add_development_dependency "guard", "~> 2.12"
   s.add_development_dependency "guard-bundler", "~> 2.1"
   s.add_development_dependency "guard-minitest", "~> 2.4"

--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -42,6 +42,4 @@ Gem::Specification.new do |s|
 
   # website stuff
   s.add_development_dependency "github-pages"
-
-  s.add_dependency 'concurrent-ruby', '~> 1.0'
 end

--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -42,4 +42,6 @@ Gem::Specification.new do |s|
 
   # website stuff
   s.add_development_dependency "github-pages"
+
+  s.add_dependency 'concurrent-ruby', '~> 1.0'
 end

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -126,8 +126,7 @@ module GraphQL
 
       @possible_types = GraphQL::Schema::PossibleTypes.new(self)
 
-      @lazy_methods = GraphQL::Execution::Lazy::LazyMethodMap.new
-      other.lazy_methods.each { |lazy_class, lazy_method| @lazy_methods.set(lazy_class, lazy_method) }
+      @lazy_methods = other.lazy_methods.dup
 
       @instrumenters = Hash.new { |h, k| h[k] = [] }
       other.instrumenters.each do |key, insts|

--- a/spec/graphql/execution/lazy/lazy_method_map_spec.rb
+++ b/spec/graphql/execution/lazy/lazy_method_map_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::Execution::Lazy::LazyMethodMap do
+  def self.test_lazy_method_map
+    it "handles multithreaded access" do
+      a = Class.new
+      b = Class.new(a)
+      c = Class.new(b)
+      lazy_method_map.set(a, :a)
+      threads = 1000.times.map do |i|
+        Thread.new {
+          d = Class.new(c)
+          assert_equal :a, lazy_method_map.get(d.new)
+        }
+      end
+      threads.map(&:join)
+    end
+
+    it "dups" do
+      a = Class.new
+      b = Class.new(a)
+      c = Class.new(b)
+      lazy_method_map.set(a, :a)
+      lazy_method_map.get(b.new)
+      lazy_method_map.get(c.new)
+
+      dup_map = lazy_method_map.dup
+      assert_equal 3, dup_map.instance_variable_get(:@storage).size
+      assert_equal :a, dup_map.get(a.new)
+      assert_equal :a, dup_map.get(b.new)
+      assert_equal :a, dup_map.get(c.new)
+    end
+  end
+
+  describe "with a plain hash" do
+    let(:lazy_method_map) { GraphQL::Execution::Lazy::LazyMethodMap.new(use_concurrent: false) }
+    test_lazy_method_map
+
+    it "has a Ruby Hash inside" do
+      storage = lazy_method_map
+        .instance_variable_get(:@storage)
+        .instance_variable_get(:@storage)
+      assert_instance_of Hash, storage
+    end
+  end
+
+  describe "with a Concurrent::Map" do
+    let(:lazy_method_map) { GraphQL::Execution::Lazy::LazyMethodMap.new(use_concurrent: true) }
+    test_lazy_method_map
+
+    it "has a Concurrent::Map inside" do
+      storage = lazy_method_map.instance_variable_get(:@storage)
+      assert_instance_of Concurrent::Map, storage
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,6 @@ require "sqlite3" if RUBY_ENGINE == 'ruby'
 require "sequel"
 require "graphql"
 require "benchmark"
-require "concurrent"
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/reporters"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require "sqlite3" if RUBY_ENGINE == 'ruby'
 require "sequel"
 require "graphql"
 require "benchmark"
+require "concurrent"
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/reporters"


### PR DESCRIPTION
This mapping of `class => lazy_method_name` was not threadsafe because two threads could run the hash's default value block at the same time, resulting in a modification during enumeration, which is not allowed. 

So, I've wrapped the modifications in a mutex. Key _hits_ in `.get` won't be synchronized, is that safe?

I originally wrote a test for this: 

```ruby 
# frozen_string_literal: true
require "spec_helper"

describe GraphQL::Execution::Lazy::LazyMethodMap do
  let(:lazy_method_map) { GraphQL::Execution::Lazy::LazyMethodMap.new }
  it "handles multithreaded access" do
    a = Class.new
    b = Class.new(a)
    c = Class.new(b)
    lazy_method_map.set(a, :a)
    1000.times.map do |i|
      Thread.new {
        d = Class.new(c)
        lazy_method_map.get(d)
      }
    end.map(&:join)
  end
end
```

But on CRuby, I couldn't make it fail without putting an explicit `Thread.pass` in the `.find` block. So I didn't commit the test, since it didn't _really_ work. Is there another way I could test this?