### PR TITLE
fix(InstanceDefinable) handle errors during definition 

### DIFF
--- a/spec/graphql/define/instance_definable_spec.rb
+++ b/spec/graphql/define/instance_definable_spec.rb
@@ -78,6 +78,27 @@ describe GraphQL::Define::InstanceDefinable do
       okra.define { name "Okra" }
       assert_equal "Okra", okra.name
     end
+
+    describe "errors in define blocks" do
+      it "preserves the definition block to try again" do
+        magic_number = 12
+
+        radish = Garden::Vegetable.define {
+          name "Pre-error"
+          magic_number += 1
+          if magic_number == 13
+            raise "👻"
+          end
+          name "Radish"
+        }
+
+        # The first call triggers an error:
+        assert_raises(RuntimeError) { radish.name }
+        # Calling definintion-dependent method should re-run the block,
+        # not leave old values around:
+        assert_equal "Radish", radish.name
+      end
+    end
   end
 
   describe "#redefine" do


### PR DESCRIPTION
This always bugs me, when working on Rails, if you load the schema and there's a configuration error in the schema, you have to restart the server in order to reload properly. 

I think it's an issue with Rails constant loading. The constants _are_ successfully loaded, and their definition blocks are stored for later. Then, the blocks are run, but they get an error and :boom:. The blocks are nullified, so what you're left with is useless instances of GraphQL objects. Blah! 

AFAICT this fixes that issue. If the schema hits an error during loading, it will preserve the definition block and re-run it on the next request.