### PR TITLE
nil for GraphQL::Language::Nodes::NullValue input

### DIFF
--- a/lib/graphql/query/literal_input.rb
+++ b/lib/graphql/query/literal_input.rb
@@ -7,6 +7,8 @@ module GraphQL
         case ast_node
         when nil
           nil
+        when Language::Nodes::NullValue
+          nil
         when Language::Nodes::VariableIdentifier
           variables[ast_node.name]
         else


### PR DESCRIPTION
Hi,

I created a query type ```fooCollection(uuid: [Uuid!]....)```.
When executing a query like this
```
query bar($uuid: [Uuid!]) {
    fooCollection(uuid: $uuid) {
      totalCount
      edges {
        node {
          uuid
        }
      }
    }
  }
```
with variables ```{uuid: nil}``` the query arguments look like this:
```
#<GraphQL::Query::Arguments:0x00000005468430>
{"uuid"=>nil}
```
Same when executing the query via GraphiQL interface with variables ```{"uuid": null}```. This is what I expected

But when I execute this
```
{
  fooCollection(uuid: null) {
    totalCount
    edges {
      node {
        uuid
      }
    }
  }
}
```
query arguments is
```
#<GraphQL::Query::Arguments:0x000000054f9700>
{"uuid"=>[nil]}
```
which is not what I expected.

This PR would fix that, but I'm not sure if the fix is at the right place.