### PR TITLE
fix(VariableUsagesAreAllowed) handle unexpected input objects

### DIFF
--- a/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
+++ b/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
@@ -82,7 +82,6 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
     end
   end
 
-
   describe "null value" do
     describe "nullable arg" do
       let(:schema) {

--- a/spec/graphql/static_validation/rules/variable_usages_are_allowed_spec.rb
+++ b/spec/graphql/static_validation/rules/variable_usages_are_allowed_spec.rb
@@ -63,4 +63,21 @@ describe GraphQL::StaticValidation::VariableUsagesAreAllowed do
     ]
     assert_equal(expected, errors)
   end
+
+  describe "input objects that are out of place" do
+    let(:query_string) { <<-GRAPHQL
+      query getCheese($id: ID!) {
+        cheese(id: {blah: $id} ) {
+          __typename @nonsense(id: {blah: $id})
+          nonsense(id: {blah: {blah: $id}})
+        }
+      }
+    GRAPHQL
+    }
+
+    it "adds an error" do
+      assert_equal 3, errors.length
+      assert_equal "Argument 'id' on Field 'cheese' has an invalid value. Expected type 'Int!'.", errors[0]["message"]
+    end
+  end
 end


### PR DESCRIPTION
Fixes #636 and adds tests for those other cases, which must be short-circuited by `GraphQL::Language::Visitor::SKIP`. 

