### PR TITLE
Raise `Query::UserError` when appropriate

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -13,6 +13,9 @@ module GraphQL
   class Query
     extend Forwardable
 
+    class UserError < GraphQL::ExecutionError
+    end
+
     class OperationNameMissingError < GraphQL::ExecutionError
       def initialize(name)
         msg = if name.nil?
@@ -70,7 +73,7 @@ module GraphQL
         elsif part.is_a?(GraphQL::Language::Nodes::OperationDefinition)
           @operations[part.name] = part
         else
-          raise GraphQL::ExecutionError, "GraphQL query cannot contain a schema definition"
+          raise UserError, "GraphQL query cannot contain a schema definition"
         end
       end
 

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -149,7 +149,7 @@ describe GraphQL::Query do
 
       type Query { foo: String }
     '
-    exc = assert_raises(GraphQL::ExecutionError) { GraphQL::Query.new(schema, query_string) }
+    exc = assert_raises(GraphQL::Query::UserError) { GraphQL::Query.new(schema, query_string) }
     assert_equal "GraphQL query cannot contain a schema definition", exc.message
   end
 


### PR DESCRIPTION
I noticed some `ExecutionError`s popping up in our logs, so I started to investigate. It turns out, queries like the following were being executed:

``` graphql
query {
  viewer {
    login
  }
}

type Foo {
  name: String
}
```

We reserve `ExecutionError`s for catastrophic 500s--things that our GraphQL system should have known how to handle, but didn't.

In this case,  this query is the result of bad input, not anything a server should be able to fix. I think this error is much more appropriate as a user error. Implementors should catch `UserError` and find a way to make it appear in the `errors` key. 