### PR TITLE
Add graphql-query-resolver

### DIFF
--- a/guides/related_projects.md
+++ b/guides/related_projects.md
@@ -13,6 +13,7 @@ Want to add something? Please open a pull request [on GitHub](https://github.com
 - Rails Helpers:
   - [`graphql-activerecord`](https://github.com/goco-inc/graphql-activerecord)
   - [`graphql-rails-resolve`](https://github.com/colepatrickturner/graphql-rails-resolver)
+  - [`graphql-query-resolver`](https://github.com/nettofarah/graphql-query-resolver), a graphql-ruby add-on to minimize N+1 queries.
 - [optics-agent-ruby](https://github.com/apollostack/optics-agent-ruby), a graphql-ruby agent for use with the [Apollo Optics](http://www.apollodata.com/optics) GraphQL performance tool.
 
 ## Blog Posts


### PR DESCRIPTION
GraphQL::QueryResolver is an add-on to graphql-ruby that allows your field resolvers to minimize N+1 SELECTS issued by ActiveRecord.