### PR TITLE
Make LazyMethodMap thread-safe using Concurrent::Map as backing storage

### DIFF
--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -44,4 +44,6 @@ Gem::Specification.new do |s|
 
   # website stuff
   s.add_development_dependency "github-pages"
+
+  s.add_dependency 'concurrent-ruby', '~> 1.0'
 end

--- a/lib/graphql/execution/lazy/lazy_method_map.rb
+++ b/lib/graphql/execution/lazy/lazy_method_map.rb
@@ -1,22 +1,19 @@
 # frozen_string_literal: true
+
+require 'concurrent'
+
 module GraphQL
   module Execution
     class Lazy
       # {GraphQL::Schema} uses this to match returned values to lazy resolution methods.
       # Methods may be registered for classes, they apply to its subclasses also.
       # The result of this lookup is cached for future resolutions.
+      # Instances of this class are thread-safe.
       # @api private
       # @see {Schema#lazy?} looks up values from this map
       class LazyMethodMap
         def initialize
-          @storage = Hash.new do |h, value_class|
-            registered_superclass = h.each_key.find { |lazy_class| value_class < lazy_class }
-            if registered_superclass.nil?
-              h[value_class] = nil
-            else
-              h[value_class] = h[registered_superclass]
-            end
-          end
+          @storage = Concurrent::Map.new
         end
 
         # @param lazy_class [Class] A class which represents a lazy value (subclasses may also be used)
@@ -28,11 +25,20 @@ module GraphQL
         # @param value [Object] an object which may have a `lazy_value_method` registered for its class or superclasses
         # @return [Symbol, nil] The `lazy_value_method` for this object, or nil
         def get(value)
-          @storage[value.class]
+          @storage.compute_if_absent(value.class) { find_superclass_method(value.class) }
         end
 
         def each
           @storage.each { |k, v| yield(k,v) }
+        end
+
+        private
+
+        def find_superclass_method(value_class)
+          @storage.each { |lazy_class, lazy_value_method|
+            return lazy_value_method if value_class < lazy_class
+          }
+          nil
         end
       end
     end


### PR DESCRIPTION
#### This is my proposal for an alternative to #631 using the concurrent-ruby gem instead of explicit locking to deal with #628.

As identified in #628, the previous LazyMethodMap implementation was not thread-safe, which could cause issues when using graphql and a ruby threaded webserver (runtime errors and potentially initializing the same location more than once).

This affected both MRI and JRuby.

To fix this, this commit switches LazyMethopMap's backing storage from a regular ruby Hash into a Concurrent::Map from the concurrent-ruby gem (adding this gem as a dependency), thus making this class thread-safe.

Fixes #628