### PR TITLE
feat(Arguments) accept a prepare function to modify or validate arguments

### DIFF
--- a/guides/schema/types_and_fields.md
+++ b/guides/schema/types_and_fields.md
@@ -132,6 +132,20 @@ field :post, PostType do
 end
 ```
 
+Provide a `prepare` function to modify or validate the value of an argument before the field's `resolve` function is executed:
+
+```ruby
+field :posts, types[PostType] do
+  argument :startDate, types.String, prepare: ->(startDate) {
+    # return the prepared argument or GraphQL::ExecutionError.new("msg")
+    # to halt the execution of the field and add "msg" to the `errors` key.
+  }
+  resolve ->(obj, args, ctx) {
+    # use prepared args['startDate']
+  }
+end
+```
+
 Only certain types are valid for arguments:
 
 - {{ "GraphQL::ScalarType" | api_doc }}, including built-in scalars (string, int, float, boolean, ID)

--- a/lib/graphql/argument.rb
+++ b/lib/graphql/argument.rb
@@ -40,6 +40,15 @@ module GraphQL
 
     ensure_defined(:name, :description, :default_value, :type=, :type, :as, :expose_as, :prepare)
 
+    # @api private
+    module DefaultPrepare
+      def self.call(value); value; end
+    end
+
+    def initialize
+      @prepare_proc = DefaultPrepare
+    end
+
     def initialize_copy(other)
       @expose_as = nil
     end
@@ -75,7 +84,6 @@ module GraphQL
     # @param value
     # @return [Object] The prepared `value` for this argument or `value` itself if no `prepare` function exists.
     def prepare(value)
-      return value unless @prepare_proc.respond_to?(:call)
       @prepare_proc.call(value)
     end
 
@@ -87,7 +95,7 @@ module GraphQL
 
     NO_DEFAULT_VALUE = Object.new
     # @api private
-    def self.from_dsl(name, type = nil, description = nil, default_value: NO_DEFAULT_VALUE, as: nil, prepare: nil, &block)
+    def self.from_dsl(name, type = nil, description = nil, default_value: NO_DEFAULT_VALUE, as: nil, prepare: DefaultPrepare, &block)
       argument = if block_given?
         GraphQL::Argument.define(&block)
       else

--- a/lib/graphql/argument.rb
+++ b/lib/graphql/argument.rb
@@ -14,13 +14,31 @@ module GraphQL
   #   GraphQL::InputObjectType.define do
   #     argument :newName, !types.String
   #   end
+  #
+  # @example defining an argument with a `prepare` function
+  #   GraphQL::Field.define do
+  #     argument :userId, types.ID, prepare: ->(userId) do
+  #       User.find_by(id: userId)
+  #     end
+  #   end
+  #
+  # @example returning an {ExecutionError} from a `prepare` function
+  #   GraphQL::Field.define do
+  #     argument :date do
+  #       type !types.String
+  #       prepare ->(date) do
+  #         return GraphQL::ExecutionError.new("Invalid date format") unless DateValidator.valid?(date)
+  #         Time.zone.parse(date)
+  #       end
+  #     end
+  #   end
 
   class Argument
     include GraphQL::Define::InstanceDefinable
-    accepts_definitions :name, :type, :description, :default_value, :as
+    accepts_definitions :name, :type, :description, :default_value, :as, :prepare
     attr_accessor :type, :description, :default_value, :name, :as
 
-    ensure_defined(:name, :description, :default_value, :type=, :type, :as, :expose_as)
+    ensure_defined(:name, :description, :default_value, :type=, :type, :as, :expose_as, :prepare)
 
     def initialize_copy(other)
       @expose_as = nil
@@ -54,9 +72,22 @@ module GraphQL
       @expose_as ||= (@as || @name).to_s
     end
 
+    # @param value
+    # @return [Object] The prepared `value` for this argument or `value` itself if no `prepare` function exists.
+    def prepare(value)
+      return value unless @prepare_proc.respond_to?(:call)
+      @prepare_proc.call(value)
+    end
+
+    # Assign a `prepare` function to prepare this argument's value before `resolve` functions are called.
+    # @param prepare_proc [Proc]
+    def prepare=(prepare_proc)
+      @prepare_proc = prepare_proc
+    end
+
     NO_DEFAULT_VALUE = Object.new
     # @api private
-    def self.from_dsl(name, type = nil, description = nil, default_value: NO_DEFAULT_VALUE, as: nil, &block)
+    def self.from_dsl(name, type = nil, description = nil, default_value: NO_DEFAULT_VALUE, as: nil, prepare: nil, &block)
       argument = if block_given?
         GraphQL::Argument.define(&block)
       else
@@ -70,6 +101,7 @@ module GraphQL
         argument.default_value = default_value
       end
       argument.as = as
+      argument.prepare = prepare
 
 
       argument

--- a/lib/graphql/query/literal_input.rb
+++ b/lib/graphql/query/literal_input.rb
@@ -47,14 +47,21 @@ module GraphQL
           # First, check the argument in the AST.
           # If the value is a variable,
           # only add a value if the variable is actually present.
-          # Otherwise, coerce the value in the AST and add it.
+          # Otherwise, coerce the value in the AST, prepare the value and add it.
           if ast_arg
-            if ast_arg.value.is_a?(GraphQL::Language::Nodes::VariableIdentifier)
-              if variables.key?(ast_arg.value.name)
-                values_hash[ast_arg.name] = coerce(arg_defn.type, ast_arg.value, variables)
+            value_is_a_variable = ast_arg.value.is_a?(GraphQL::Language::Nodes::VariableIdentifier)
+
+            if (!value_is_a_variable || (value_is_a_variable && variables.key?(ast_arg.value.name)))
+
+              value = coerce(arg_defn.type, ast_arg.value, variables)
+              value = arg_defn.prepare(value)
+
+              if value.is_a?(GraphQL::ExecutionError)
+                value.ast_node = ast_arg
+                raise value
               end
-            else
-              values_hash[ast_arg.name] = coerce(arg_defn.type, ast_arg.value, variables)
+
+              values_hash[ast_arg.name] = value
             end
           end
 

--- a/spec/graphql/argument_spec.rb
+++ b/spec/graphql/argument_spec.rb
@@ -57,4 +57,17 @@ describe GraphQL::Argument do
       assert_equal arg_3.expose_as, "ff"
     end
   end
+
+  describe "prepare" do
+    it "accepts a prepare proc and calls it to generate the prepared value" do
+      prepare_proc = Proc.new { |arg| arg + 1 }
+      argument = GraphQL::Argument.define(name: :plusOne, type: GraphQL::INT_TYPE, prepare: prepare_proc)
+      assert_equal argument.prepare(1), 2
+    end
+
+    it "returns the value itself if no prepare proc is provided" do
+      argument = GraphQL::Argument.define(name: :someNumber, type: GraphQL::INT_TYPE)
+      assert_equal argument.prepare(1), 1
+    end
+  end
 end

--- a/spec/graphql/query/literal_input_spec.rb
+++ b/spec/graphql/query/literal_input_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::Query::LiteralInput do
+  describe ".from_arguments" do
+    describe "arguments are prepared" do
+      let(:schema) {
+        query = GraphQL::ObjectType.define do
+          name "Query"
+
+          field :addOneToArgumentValue do
+            type !types.Int
+            argument :value do
+              type !types.Int
+              prepare ->(arg) do
+                return GraphQL::ExecutionError.new("Can't return more than 3 digits") if arg > 998
+                arg + 1
+              end
+            end
+            resolve ->(t, a, c) { a[:value] }
+          end
+        end
+
+        GraphQL::Schema.define(query: query)
+      }
+
+      it "prepares values from query literals" do
+        result = schema.execute("{ addOneToArgumentValue(value: 1) }")
+        assert_equal(result["data"]["addOneToArgumentValue"], 2)
+      end
+
+      it "prepares values from variables" do
+        result = schema.execute("query ($value: Int!) { addOneToArgumentValue(value: $value) }", variables: { "value" => 1} )
+        assert_equal(result["data"]["addOneToArgumentValue"], 2)
+      end
+
+      it "prepares values correctly if called multiple times with different arguments" do
+        result = schema.execute("{ first: addOneToArgumentValue(value: 1) second: addOneToArgumentValue(value: 2) }")
+        assert_equal(result["data"]["first"], 2)
+        assert_equal(result["data"]["second"], 3)
+      end
+
+      it "adds message to errors key if an ExecutionError is returned from the prepare function" do
+        result = schema.execute("{ addOneToArgumentValue(value: 999) }")
+        assert_equal(result["errors"][0]["message"], "Can't return more than 3 digits")
+        assert_equal(result["errors"][0]["locations"][0]["line"], 1)
+        assert_equal(result["errors"][0]["locations"][0]["column"], 25)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is an attempt to implement the argument `prepare` function discussed on https://github.com/rmosolgo/graphql-ruby/issues/540. I'm not too familiar with this code base, so I'm open to any suggestions you may have. 

Also, my specs for `LiteralInput.from_arguments` look more like end-to-end tests than unit tests. Let me know if you'd like to move them to a better spec file or test the feature in a different way.