### PR TITLE
Fix mutations using :as option on arguments

### DIFF
--- a/lib/graphql/relay/mutation.rb
+++ b/lib/graphql/relay/mutation.rb
@@ -169,9 +169,8 @@ module GraphQL
             input_field :clientMutationId, types.String, "A unique identifier for the client performing the mutation."
             relay_mutation.arguments.each do |input_field_name, field_obj|
               kwargs = {}
-              if field_obj.default_value?
-                kwargs[:default_value] = field_obj.default_value
-              end
+              kwargs[:default_value] = field_obj.default_value if field_obj.default_value?
+              kwargs[:as] = field_obj.as
               input_field(input_field_name, field_obj.type, field_obj.description, **kwargs)
             end
             mutation(relay_mutation)


### PR DESCRIPTION
Using `:as` on mutations arguments is ignored:

```ruby
LoginMutation = GraphQL::Relay::Mutation.define do
  name 'Login'
  input_field :username, !types.String, as: :user_name # The :as option has no effect
  input_field :password, !types.String

  # ...
end
```