### PR TITLE
Remove useless assignments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,9 @@ Lint/DefEndAlignment:
 Lint/EndAlignment:
   EnforcedStyleAlignWith: variable
 
+Lint/UselessAssignment:
+  Enabled: true
+
 Metrics/ParameterLists:
   Max: 7
   CountKeywordArgs: false

--- a/lib/graphql/analysis/query_complexity.rb
+++ b/lib/graphql/analysis/query_complexity.rb
@@ -53,7 +53,6 @@ module GraphQL
       # Get a complexity value for a field,
       # by getting the number or calling its proc
       def get_complexity(irep_node, query, child_complexity)
-        type_defn = irep_node.owner_type
         field_defn = irep_node.definition
         defined_complexity = field_defn.complexity
         case defined_complexity

--- a/lib/graphql/compatibility/execution_specification.rb
+++ b/lib/graphql/compatibility/execution_specification.rb
@@ -334,7 +334,7 @@ module GraphQL
                 __typename
               }
             }|
-            res = execute_query(query_string, context: {middleware_log: log})
+            execute_query(query_string, context: {middleware_log: log})
             assert_equal ["node", "__typename"], log
           end
 

--- a/lib/graphql/compatibility/lazy_execution_specification.rb
+++ b/lib/graphql/compatibility/lazy_execution_specification.rb
@@ -162,7 +162,7 @@ module GraphQL
             |
 
             log = []
-            res = self.class.lazy_schema.execute(query_str, context: {lazy_instrumentation: log, pushes: []})
+            self.class.lazy_schema.execute(query_str, context: {lazy_instrumentation: log, pushes: []})
             expected_log = [
               "PUSH",
               "Query.push: 1",

--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -23,8 +23,6 @@ module GraphQL
       private
 
       def resolve_selection(object, current_type, selection, query_ctx, mutation: false )
-        query = query_ctx.query
-
         selection_result = SelectionResult.new
 
         selection.typed_children[current_type].each do |name, subselection|
@@ -174,7 +172,7 @@ module GraphQL
             result
           when GraphQL::TypeKinds::NON_NULL
             wrapped_type = field_type.of_type
-            inner_value = resolve_value(
+            resolve_value(
               owner,
               parent_type,
               field_defn,

--- a/lib/graphql/schema/catchall_middleware.rb
+++ b/lib/graphql/schema/catchall_middleware.rb
@@ -27,7 +27,7 @@ module GraphQL
       # whose message is {MESSAGE}
       def self.call(parent_type, parent_object, field_definition, field_args, query_context)
         yield
-      rescue StandardError => err
+      rescue StandardError
         GraphQL::ExecutionError.new(MESSAGE)
       end
     end

--- a/lib/graphql/schema/validation.rb
+++ b/lib/graphql/schema/validation.rb
@@ -39,7 +39,6 @@ module GraphQL
         def self.assert_property_mapping(property_name, from_class, to_class)
           ->(obj) {
             property_value = obj.public_send(property_name)
-            error_message = nil
             if !property_value.is_a?(Hash)
               "#{property_name} must be a hash of {#{from_class.name} => #{to_class.name}}, not a #{property_value.class.name} (#{property_value.inspect})"
             else

--- a/lib/graphql/static_validation/arguments_validator.rb
+++ b/lib/graphql/static_validation/arguments_validator.rb
@@ -33,7 +33,7 @@ module GraphQL
       private
 
       def parent_name(parent, type_defn)
-        field_name = if parent.is_a?(GraphQL::Language::Nodes::Field)
+        if parent.is_a?(GraphQL::Language::Nodes::Field)
           parent.alias || parent.name
         elsif parent.is_a?(GraphQL::Language::Nodes::InputObject)
           type_defn.name

--- a/lib/graphql/static_validation/rules/operation_names_are_valid.rb
+++ b/lib/graphql/static_validation/rules/operation_names_are_valid.rb
@@ -12,7 +12,7 @@ module GraphQL
         }
 
         context.visitor[GraphQL::Language::Nodes::Document].leave << ->(node, _parent) {
-          op_count = op_names.values.inject(0) { |m, v| m += v.size }
+          op_count = op_names.values.inject(0) { |m, v| m + v.size }
 
           op_names.each do |name, nodes|
             if name.nil? && op_count > 1

--- a/spec/graphql/base_type_spec.rb
+++ b/spec/graphql/base_type_spec.rb
@@ -39,10 +39,11 @@ describe GraphQL::BaseType do
     it "resets connection types" do
       # Make sure the defaults have been calculated
       obj_edge = obj_type.edge_type
+      obj_conn = obj_type.connection_type
       obj_2 = obj_type.dup
       obj_2.name = "Cheese2"
       refute_equal obj_edge, obj_2.edge_type
-      refute_equal obj_edge, obj_2.connection_type
+      refute_equal obj_conn, obj_2.connection_type
     end
   end
 

--- a/spec/graphql/base_type_spec.rb
+++ b/spec/graphql/base_type_spec.rb
@@ -39,7 +39,6 @@ describe GraphQL::BaseType do
     it "resets connection types" do
       # Make sure the defaults have been calculated
       obj_edge = obj_type.edge_type
-      obj_conn = obj_type.connection_type
       obj_2 = obj_type.dup
       obj_2.name = "Cheese2"
       refute_equal obj_edge, obj_2.edge_type

--- a/spec/graphql/language/lexer_spec.rb
+++ b/spec/graphql/language/lexer_spec.rb
@@ -39,7 +39,6 @@ describe GraphQL::Language::Lexer do
     end
 
     it "clears the previous_token between runs" do
-      tok_1 = subject.tokenize(query_string)
       tok_2 = subject.tokenize(query_string)
       assert_equal nil, tok_2[0].prev_token
     end

--- a/spec/graphql/relay/array_connection_spec.rb
+++ b/spec/graphql/relay/array_connection_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 describe GraphQL::Relay::ArrayConnection do
   def get_names(result)
     ships = result["data"]["rebels"]["ships"]["edges"]
-    names = ships.map { |e| e["node"]["name"] }
+    ships.map { |e| e["node"]["name"] }
   end
 
   def get_last_cursor(result)

--- a/spec/graphql/relay/page_info_spec.rb
+++ b/spec/graphql/relay/page_info_spec.rb
@@ -16,7 +16,7 @@ describe GraphQL::Relay::PageInfo do
 
   let(:cursor_of_last_base) {
     result = star_wars_query(query_string, "first" => 100)
-    last_cursor = get_last_cursor(result)
+    get_last_cursor(result)
   }
 
   let(:query_string) {%|

--- a/spec/graphql/relay/relation_connection_spec.rb
+++ b/spec/graphql/relay/relation_connection_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 describe GraphQL::Relay::RelationConnection do
   def get_names(result)
     ships = result["data"]["empire"]["bases"]["edges"]
-    names = ships.map { |e| e["node"]["name"] }
+    ships.map { |e| e["node"]["name"] }
   end
 
   def get_page_info(result)
@@ -253,7 +253,7 @@ describe GraphQL::Relay::RelationConnection do
 
     def get_names(result, field_name)
       bases = result["data"]["empire"][field_name]["edges"]
-      base_names = bases.map { |b| b["node"]["name"] }
+      bases.map { |b| b["node"]["name"] }
     end
 
     it "applies the default value" do
@@ -269,7 +269,7 @@ describe GraphQL::Relay::RelationConnection do
   describe "with a Sequel::Dataset" do
     def get_names(result)
       ships = result["data"]["empire"]["basesAsSequelDataset"]["edges"]
-      names = ships.map { |e| e["node"]["name"] }
+      ships.map { |e| e["node"]["name"] }
     end
 
     def get_page_info(result)

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -225,7 +225,7 @@ module Dummy
 
     def call(obj, args, ctx)
       id_string = args["id"].to_s # Cheese has Int type, Milk has ID type :(
-      id, item = @data.find { |id, item| id.to_s == id_string }
+      _id, item = @data.find { |id, item| id.to_s == id_string }
       item
     end
   end


### PR DESCRIPTION
Hello.

I noticed there are some assignments which look unnecessary. I think that removing them makes codes more readable since it avoids unnecessary guessing. That's why I removed some assignments and added [a rule](https://github.com/bbatsov/rubocop/blob/master/manual/cops_lint.md#lintuselessassignment) to `.rubocop.yml`.

Thank you!