### PR TITLE
Test against latest ruby on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ before_install:
 
 rvm:
 - 2.1.0 # Lowest version officially supported by that gem
-- 2.2.5
-- 2.3.3
-- 2.4.0
+- 2.2.7
+- 2.3.4
+- 2.4.1
 - jruby-9.1.5.0
 
 gemfile:
@@ -24,11 +24,11 @@ matrix:
   allow_failures:
   - rvm: jruby-9.1.5.0
   exclude:
-  - rvm: 2.4.0
+  - rvm: 2.4.1
     gemfile: gemfiles/rails_3.2.gemfile
-  - rvm: 2.4.0
+  - rvm: 2.4.1
     gemfile: gemfiles/rails_4.1.gemfile
-  - rvm: 2.4.0
+  - rvm: 2.4.1
     gemfile: gemfiles/rails_4.2.gemfile
   - rvm: 2.1.0
     gemfile: gemfiles/rails_5.0.gemfile # Rails 5 requires Ruby 2.2.2+


### PR DESCRIPTION
Hello. According to the `.travis.yml`, on 2.2 or later, latest rubies of each minor version have been being used. I've updated them.