### PR TITLE
Apply default values that are 'false'

### DIFF
--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -99,7 +99,7 @@ module GraphQL
           coerced_value = input_field_defn.default_value
         end
 
-        if coerced_value || value.key?(input_key)
+        if !coerced_value.nil? || value.key?(input_key)
           input_values[input_key] = coerced_value
         end
       end

--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -95,12 +95,10 @@ module GraphQL
 
         if value.key?(input_key)
           coerced_value = input_field_defn.type.coerce_input(field_value)
-        else
-          coerced_value = input_field_defn.default_value
-        end
-
-        if !coerced_value.nil? || value.key?(input_key)
           input_values[input_key] = coerced_value
+        elsif input_field_defn.default_value?
+          default_value = input_field_defn.default_value
+          input_values[input_key] = default_value
         end
       end
 

--- a/spec/graphql/input_object_type_spec.rb
+++ b/spec/graphql/input_object_type_spec.rb
@@ -239,6 +239,7 @@ describe GraphQL::InputObjectType do
         a: String
         b: Int!
         c: String = "Default"
+        d: Boolean = false
       }
     |) }
     let(:input_type) { schema.types['ExampleInputObject'] }
@@ -273,6 +274,13 @@ describe GraphQL::InputObjectType do
       assert !result.key?('a')
       assert_equal 1, result['b']
       assert_equal 'Test', result['c']
+    end
+
+    it "false default values are returned" do
+      input = MinimumInputObject.new({"b" => 1})
+      result = input_type.coerce_input(input)
+
+      assert_equal false, result['d']
     end
   end
 


### PR DESCRIPTION
Unless I'm mistaking the intent it appears I've encountered an issue with `false` `default_value`s not being applied. I believe this is because the conditional in `InputObjectType` checks that the coerced value is falsey and not explicitly `nil`, meaning that `false` values are being left behind.

See attached patch for (what I suspect) is the correct behaviour. I think my test might be a bit flimsy so I'm open to suggestions. =)

Thanks!

### Current Behavior

```ruby
  IntroduceShipMutation = GraphQL::Relay::Mutation.define do
    name "IntroduceShip"
    description "Add a ship to this faction"

    input_field :isCoolShip, types.Boolean, default_value: false
    return_type types.Boolean

    resolve ->(_, inputs, _) { inputs[:isCoolShip] }
  end
```

- Considering the above mutation when called with variables `{ "clientMutationId": "xxx" }` the result is `nil`.
- Considering the above mutation when called with variables `{ "clientMutationId": "xxx", "isCoolShip": null }` the result is `nil`.
- Considering the above mutation when called with variables `{ "clientMutationId": "xxx", "isCoolShip": false }` the result is `false`.
- Considering the above mutation when called with variables `{ "clientMutationId": "xxx", "isCoolShip": true }` the result is `true`.

#### Anomaly 

It's also worth noting that inline variables are unaffected. For instance if I ran the following query the result would be `false`. [Seemingly relevant snippet](https://github.com/rmosolgo/graphql-ruby/blob/master/lib/graphql/query/literal_input.rb#L63-L69).

```graphql
mutation {
  introduceShipMutation(input: { clientMutationId: "xxx" }) # result would be false
}
```

### Expected Behavior

```ruby
  IntroduceShipMutation = GraphQL::Relay::Mutation.define do
    name "IntroduceShip"
    description "Add a ship to this faction"

    input_field :isCoolShip, types.Boolean, default_value: false
    return_type types.Boolean

    resolve ->(_, inputs, _) { inputs[:isCoolShip] }
  end
```

- Considering the above mutation when called with variables `{ "clientMutationId": "xxx" }` the result is `false`.
- Considering the above mutation when called with variables `{ "clientMutationId": "xxx", "isCoolShip": null }` the result is `false`.
- Considering the above mutation when called with variables `{ "clientMutationId": "xxx", "isCoolShip": false }` the result is `false`.
- Considering the above mutation when called with variables `{ "clientMutationId": "xxx", "isCoolShip": true }` the result is `true`.