### PR TITLE
Support concurrent-ruby 1.0.0

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -14,6 +14,7 @@ end
 appraise 'rails_4.2' do
   gem 'activerecord', '~> 4.2.4'
   gem 'actionpack', '~> 4.2.4'
+  gem 'concurrent-ruby', '1.0.0'
 end
 
 appraise 'rails_5.0' do

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -7,5 +7,6 @@ gem "sqlite3", :platform => :ruby
 gem "activerecord-jdbcsqlite3-adapter", :platform => :jruby
 gem "activerecord", "~> 4.2.4"
 gem "actionpack", "~> 4.2.4"
+gem "concurrent-ruby", "1.0.0"
 
 gemspec :path => "../"

--- a/lib/graphql/execution/lazy/lazy_method_map.rb
+++ b/lib/graphql/execution/lazy/lazy_method_map.rb
@@ -43,7 +43,7 @@ module GraphQL
         private
 
         def find_superclass_method(value_class)
-          @storage.each { |lazy_class, lazy_value_method|
+          @storage.each_pair { |lazy_class, lazy_value_method|
             return lazy_value_method if value_class < lazy_class
           }
           nil
@@ -54,7 +54,7 @@ module GraphQL
           extend Forwardable
           # Technically this should be under the mutex too,
           # but I know it's only used when the lock is already acquired.
-          def_delegators :@storage, :each, :size
+          def_delegators :@storage, :each_pair, :size
 
           def initialize
             @semaphore = Mutex.new


### PR DESCRIPTION
Fixes #662 

Before: 
> `NoMethodError: undefined method `each' for #<Concurrent::Map:0x007fdb279f9048>`

After: 

> `✓`