### PR TITLE
refactor(Schema) raise definition errors lazily to avoid messing with Rails constant loading

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -58,6 +58,7 @@ module GraphQL
       :query_execution_strategy, :mutation_execution_strategy, :subscription_execution_strategy,
       :max_depth, :max_complexity,
       :orphan_types, :resolve_type, :type_error, :parse_error,
+      :raise_definition_error,
       :object_from_id, :id_from_object,
       :default_mask,
       :cursor_encoder,
@@ -74,7 +75,8 @@ module GraphQL
       :max_depth, :max_complexity,
       :orphan_types, :directives,
       :query_analyzers, :instrumenters, :lazy_methods,
-      :cursor_encoder
+      :cursor_encoder,
+      :raise_definition_error
 
     # @return [MiddlewareChain] MiddlewareChain which is applied to fields during execution
     attr_accessor :middleware
@@ -179,8 +181,12 @@ module GraphQL
       @definition_error = nil
       nil
     rescue StandardError => err
-      # Raise this error _later_ to avoid messing with Rails constant loading
-      @definition_error = err
+      if @raise_definition_error
+        raise
+      else
+        # Raise this error _later_ to avoid messing with Rails constant loading
+        @definition_error = err
+      end
       nil
     end
 

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -96,6 +96,7 @@ module GraphQL
     attr_reader :static_validator, :object_from_id_proc, :id_from_object_proc, :resolve_type_proc
 
     def initialize
+      @definition_error = nil
       @orphan_types = []
       @directives = DIRECTIVES.reduce({}) { |m, d| m[d.name] = d; m }
       @static_validator = GraphQL::StaticValidation::Validator.new(schema: self)
@@ -175,6 +176,11 @@ module GraphQL
       validation_error = Validation.validate(self)
       validation_error && raise(NotImplementedError, validation_error)
       build_instrumented_field_map
+      @definition_error = nil
+      nil
+    rescue StandardError => err
+      # Raise this error _later_ to avoid messing with Rails constant loading
+      @definition_error = err
       nil
     end
 
@@ -195,12 +201,16 @@ module GraphQL
       @types ||= build_types_map
     end
 
-    # Execute a query on itself.
-    # See {Query#initialize} for arguments.
+    # Execute a query on itself. Raises an error if the schema definition is invalid.
+    # @see {Query#initialize} for arguments.
     # @return [Hash] query result, ready to be serialized as JSON
     def execute(*args)
-      query_obj = GraphQL::Query.new(self, *args)
-      query_obj.result
+      if @definition_error
+        raise @definition_error
+      else
+        query_obj = GraphQL::Query.new(self, *args)
+        query_obj.result
+      end
     end
 
     # Resolve field named `field_name` for type `parent_type`.

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -105,6 +105,8 @@ module GraphQL
           raise InvalidDocumentError.new('Must provide schema definition with query type or a type named Query.') unless query_root_type
 
           Schema.define do
+            raise_definition_error true
+
             query query_root_type
             mutation mutation_root_type
             subscription subscription_root_type

--- a/lib/graphql/schema/loader.rb
+++ b/lib/graphql/schema/loader.rb
@@ -30,7 +30,7 @@ module GraphQL
           kargs[root] = types.fetch(type.fetch("name")) if type
         end
 
-        Schema.define(**kargs)
+        Schema.define(**kargs, raise_definition_error: true)
       end
 
       NullResolveType = ->(obj, ctx) {

--- a/spec/graphql/field_spec.rb
+++ b/spec/graphql/field_spec.rb
@@ -90,7 +90,7 @@ describe GraphQL::Field do
       dummy_query.fields["symbol_name"] = invalid_field
 
       err = assert_raises(GraphQL::Schema::InvalidTypeError) {
-        GraphQL::Schema.define(query: dummy_query)
+        GraphQL::Schema.define(query: dummy_query, raise_definition_error: true)
       }
       assert_equal "QueryType is invalid: field :symbol_name name must return String, not Symbol (:symbol_name)", err.message
     end


### PR DESCRIPTION
Fixes #651 

I don't know why, but raising an error during `Schema.define` causes `Types` to appear in `ActiveSupport::Dependencies.autoloaded_constants` _twice_. As a result, `ActiveSupport.remove_unloadable_constants!` goes into a loop and the server hangs. Sad! 

Moving the `raise` into `#execute` circumvents the issue by allowing the constant to load properly. The user experience _should_ be the same: you can't execute a query on an invalid schema. 

(Technically, this arrangement is a bit more flexible: you _could_ define an invalid schema, then `.redefine` it to become valid. This was impossible before, but obviously it doesn't matter much 😆 )