### PR TITLE
Optionally pass `ctx` to scalar coerce functions

### DIFF
--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -9,9 +9,6 @@ module GraphQL
   class Error < StandardError
   end
 
-  class CoercionError < Error
-  end
-
   class ParseError < Error
     attr_reader :line, :col, :query
     def initialize(message, line, col, query)
@@ -85,12 +82,11 @@ require "graphql/schema"
 require "graphql/schema/loader"
 require "graphql/schema/printer"
 
-# Order does not matter for these:
-
 require "graphql/analysis_error"
 require "graphql/runtime_type_error"
 require "graphql/invalid_null_error"
 require "graphql/unresolved_type_error"
+require "graphql/string_encoding_error"
 require "graphql/query"
 require "graphql/internal_representation"
 require "graphql/static_validation"

--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -97,11 +97,28 @@ module GraphQL
 
     alias :inspect :to_s
 
-    def valid_input?(value, ctx = GraphQL::Query::NullContext)
+    # Use this in places where there is no `ctx`
+    def valid_isolated_input?(value)
+      valid_input?(value, GraphQL::Query::NullContext)
+    end
+
+    def validate_isolated_input(value)
+      validate_input(value, GraphQL::Query::NullContext)
+    end
+
+    def coerce_isolated_input(value)
+      coerce_input(value, GraphQL::Query::NullContext)
+    end
+
+    def coerce_isolated_result(value)
+      coerce_result(value, GraphQL::Query::NullContext)
+    end
+
+    def valid_input?(value, ctx)
       validate_input(value, ctx).valid?
     end
 
-    def validate_input(value, ctx = GraphQL::Query::NullContext)
+    def validate_input(value, ctx)
       if value.nil?
         GraphQL::Query::InputValidationResult.new
       else
@@ -109,7 +126,7 @@ module GraphQL
       end
     end
 
-    def coerce_input(value, ctx = GraphQL::Query::NullContext)
+    def coerce_input(value, ctx)
       if value.nil?
         nil
       else
@@ -117,7 +134,7 @@ module GraphQL
       end
     end
 
-    def coerce_result(value, ctx = GraphQL::Query::NullContext)
+    def coerce_result(value, ctx)
       raise NotImplementedError
     end
 

--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -97,21 +97,28 @@ module GraphQL
 
     alias :inspect :to_s
 
-    def valid_input?(value, warden)
-      validate_input(value, warden).valid?
+    def valid_input?(value, ctx = GraphQL::Query::NullContext)
+      validate_input(value, ctx).valid?
     end
 
-    def validate_input(value, warden)
+    def validate_input(value, ctx = GraphQL::Query::NullContext)
       if value.nil?
         GraphQL::Query::InputValidationResult.new
       else
-        validate_non_null_input(value, warden)
+        validate_non_null_input(value, ctx)
       end
     end
 
-    def coerce_input(value)
-      return nil if value.nil?
-      coerce_non_null_input(value)
+    def coerce_input(value, ctx = GraphQL::Query::NullContext)
+      if value.nil?
+        nil
+      else
+        coerce_non_null_input(value, ctx)
+      end
+    end
+
+    def coerce_result(value, ctx = GraphQL::Query::NullContext)
+      raise NotImplementedError
     end
 
     # Types with fields may override this

--- a/lib/graphql/boolean_type.rb
+++ b/lib/graphql/boolean_type.rb
@@ -3,7 +3,7 @@ GraphQL::BOOLEAN_TYPE = GraphQL::ScalarType.define do
   name "Boolean"
   description "Represents `true` or `false` values."
 
-  coerce_input ->(value) { (value == true || value == false) ? value : nil }
-  coerce_result ->(value) { !!value }
+  coerce_input ->(value, _ctx) { (value == true || value == false) ? value : nil }
+  coerce_result ->(value, _ctx) { !!value }
   default_scalar true
 end

--- a/lib/graphql/compatibility/execution_specification/specification_schema.rb
+++ b/lib/graphql/compatibility/execution_specification/specification_schema.rb
@@ -61,8 +61,8 @@ module GraphQL
 
           timestamp_type = GraphQL::ScalarType.define do
             name "Timestamp"
-            coerce_input ->(value) { Time.at(value.to_i) }
-            coerce_result ->(value) { value.to_i }
+            coerce_input ->(value, _ctx) { Time.at(value.to_i) }
+            coerce_result ->(value, _ctx) { value.to_i }
           end
 
           named_entity_interface_type = GraphQL::InterfaceType.define do

--- a/lib/graphql/enum_type.rb
+++ b/lib/graphql/enum_type.rb
@@ -105,7 +105,7 @@ module GraphQL
       GraphQL::TypeKinds::ENUM
     end
 
-    def validate_non_null_input(value_name, ctx = GraphQL::Query::NullContext)
+    def validate_non_null_input(value_name, ctx)
       result = GraphQL::Query::InputValidationResult.new
       allowed_values = ctx.warden.enum_values(self)
       matching_value = allowed_values.find { |v| v.name == value_name }
@@ -125,7 +125,7 @@ module GraphQL
     #
     # @param value_name [String] the string representation of this enum value
     # @return [Object] the underlying value for this enum value
-    def coerce_non_null_input(value_name, ctx = GraphQL::Query::NullContext)
+    def coerce_non_null_input(value_name, ctx)
       if @values_by_name.key?(value_name)
         @values_by_name.fetch(value_name).value
       else
@@ -133,7 +133,7 @@ module GraphQL
       end
     end
 
-    def coerce_result(value, ctx = GraphQL::Query::NullContext)
+    def coerce_result(value, ctx)
       warden = ctx.warden
       all_values = warden ? warden.enum_values(self) : @values_by_name.each_value
       enum_value = all_values.find { |val| val.value == value }

--- a/lib/graphql/enum_type.rb
+++ b/lib/graphql/enum_type.rb
@@ -105,9 +105,9 @@ module GraphQL
       GraphQL::TypeKinds::ENUM
     end
 
-    def validate_non_null_input(value_name, warden)
+    def validate_non_null_input(value_name, ctx = GraphQL::Query::NullContext)
       result = GraphQL::Query::InputValidationResult.new
-      allowed_values = warden.enum_values(self)
+      allowed_values = ctx.warden.enum_values(self)
       matching_value = allowed_values.find { |v| v.name == value_name }
 
       if matching_value.nil?
@@ -125,7 +125,7 @@ module GraphQL
     #
     # @param value_name [String] the string representation of this enum value
     # @return [Object] the underlying value for this enum value
-    def coerce_non_null_input(value_name)
+    def coerce_non_null_input(value_name, ctx = GraphQL::Query::NullContext)
       if @values_by_name.key?(value_name)
         @values_by_name.fetch(value_name).value
       else
@@ -133,7 +133,8 @@ module GraphQL
       end
     end
 
-    def coerce_result(value, warden = nil)
+    def coerce_result(value, ctx = GraphQL::Query::NullContext)
+      warden = ctx.warden
       all_values = warden ? warden.enum_values(self) : @values_by_name.each_value
       enum_value = all_values.find { |val| val.value == value }
       if enum_value

--- a/lib/graphql/enum_type.rb
+++ b/lib/graphql/enum_type.rb
@@ -105,34 +105,6 @@ module GraphQL
       GraphQL::TypeKinds::ENUM
     end
 
-    def validate_non_null_input(value_name, ctx)
-      result = GraphQL::Query::InputValidationResult.new
-      allowed_values = ctx.warden.enum_values(self)
-      matching_value = allowed_values.find { |v| v.name == value_name }
-
-      if matching_value.nil?
-        result.add_problem("Expected #{GraphQL::Language.serialize(value_name)} to be one of: #{allowed_values.map(&:name).join(', ')}")
-      end
-
-      result
-    end
-
-    # Get the underlying value for this enum value
-    #
-    # @example get episode value from Enum
-    #   episode = EpisodeEnum.coerce("NEWHOPE")
-    #   episode # => 6
-    #
-    # @param value_name [String] the string representation of this enum value
-    # @return [Object] the underlying value for this enum value
-    def coerce_non_null_input(value_name, ctx)
-      if @values_by_name.key?(value_name)
-        @values_by_name.fetch(value_name).value
-      else
-        nil
-      end
-    end
-
     def coerce_result(value, ctx = nil)
       if ctx.nil?
         warn_deprecated_coerce("coerce_isolated_result")
@@ -165,6 +137,36 @@ module GraphQL
     end
 
     class UnresolvedValueError < GraphQL::Error
+    end
+
+    private
+
+    # Get the underlying value for this enum value
+    #
+    # @example get episode value from Enum
+    #   episode = EpisodeEnum.coerce("NEWHOPE")
+    #   episode # => 6
+    #
+    # @param value_name [String] the string representation of this enum value
+    # @return [Object] the underlying value for this enum value
+    def coerce_non_null_input(value_name, ctx)
+      if @values_by_name.key?(value_name)
+        @values_by_name.fetch(value_name).value
+      else
+        nil
+      end
+    end
+
+    def validate_non_null_input(value_name, ctx)
+      result = GraphQL::Query::InputValidationResult.new
+      allowed_values = ctx.warden.enum_values(self)
+      matching_value = allowed_values.find { |v| v.name == value_name }
+
+      if matching_value.nil?
+        result.add_problem("Expected #{GraphQL::Language.serialize(value_name)} to be one of: #{allowed_values.map(&:name).join(', ')}")
+      end
+
+      result
     end
   end
 end

--- a/lib/graphql/enum_type.rb
+++ b/lib/graphql/enum_type.rb
@@ -133,7 +133,12 @@ module GraphQL
       end
     end
 
-    def coerce_result(value, ctx)
+    def coerce_result(value, ctx = nil)
+      if ctx.nil?
+        warn_deprecated_coerce("coerce_isolated_result")
+        ctx = GraphQL::Query::NullContext
+      end
+
       warden = ctx.warden
       all_values = warden ? warden.enum_values(self) : @values_by_name.each_value
       enum_value = all_values.find { |val| val.value == value }

--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -141,9 +141,9 @@ module GraphQL
         else
           case field_type.kind
           when GraphQL::TypeKinds::SCALAR
-            field_type.coerce_result(value)
+            field_type.coerce_result(value, field_ctx)
           when GraphQL::TypeKinds::ENUM
-            field_type.coerce_result(value, field_ctx.query.warden)
+            field_type.coerce_result(value, field_ctx)
           when GraphQL::TypeKinds::LIST
             inner_type = field_type.of_type
             i = 0

--- a/lib/graphql/float_type.rb
+++ b/lib/graphql/float_type.rb
@@ -3,7 +3,7 @@ GraphQL::FLOAT_TYPE = GraphQL::ScalarType.define do
   name "Float"
   description "Represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point)."
 
-  coerce_input ->(value) { value.is_a?(Numeric) ? value.to_f : nil }
-  coerce_result ->(value) { value.to_f }
+  coerce_input ->(value, _ctx) { value.is_a?(Numeric) ? value.to_f : nil }
+  coerce_result ->(value, _ctx) { value.to_f }
   default_scalar true
 end

--- a/lib/graphql/id_type.rb
+++ b/lib/graphql/id_type.rb
@@ -3,8 +3,8 @@ GraphQL::ID_TYPE = GraphQL::ScalarType.define do
   name "ID"
   description "Represents a unique identifier that is Base64 obfuscated. It is often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"VXNlci0xMA==\"`) or integer (such as `4`) input value will be accepted as an ID."
 
-  coerce_result ->(value) { value.to_s }
-  coerce_input ->(value) {
+  coerce_result ->(value, _ctx) { value.to_s }
+  coerce_input ->(value, _ctx) {
     case value
     when String, Integer
       value.to_s

--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -55,6 +55,49 @@ module GraphQL
       GraphQL::TypeKinds::INPUT_OBJECT
     end
 
+    def coerce_result(value, ctx = nil)
+      if ctx.nil?
+        warn_deprecated_coerce("coerce_isolated_result")
+        ctx = GraphQL::Query::NullContext
+      end
+
+      # Allow the application to provide values as :symbols, and convert them to the strings
+      value = value.reduce({}) { |memo, (k, v)| memo[k.to_s] = v; memo }
+
+      result = {}
+
+      arguments.each do |input_key, input_field_defn|
+        input_value = value[input_key]
+        if value.key?(input_key)
+          result[input_key] = if input_value.nil?
+            nil
+          else
+            input_field_defn.type.coerce_result(input_value, ctx)
+          end
+        end
+      end
+
+      result
+    end
+
+    private
+
+    def coerce_non_null_input(value, ctx)
+      input_values = {}
+
+      arguments.each do |input_key, input_field_defn|
+        field_value = value[input_key]
+
+        if value.key?(input_key)
+          input_values[input_key] = input_field_defn.type.coerce_input(field_value, ctx)
+        elsif input_field_defn.default_value?
+          input_values[input_key] = input_field_defn.default_value
+        end
+      end
+
+      GraphQL::Query::Arguments.new(input_values, argument_definitions: arguments)
+    end
+
     def validate_non_null_input(input, ctx)
       warden = ctx.warden
       result = GraphQL::Query::InputValidationResult.new
@@ -82,47 +125,6 @@ module GraphQL
         field_result = field.type.validate_input(input[name], ctx)
         if !field_result.valid?
           result.merge_result!(name, field_result)
-        end
-      end
-
-      result
-    end
-
-    def coerce_non_null_input(value, ctx)
-      input_values = {}
-
-      arguments.each do |input_key, input_field_defn|
-        field_value = value[input_key]
-
-        if value.key?(input_key)
-          input_values[input_key] = input_field_defn.type.coerce_input(field_value, ctx)
-        elsif input_field_defn.default_value?
-          input_values[input_key] = input_field_defn.default_value
-        end
-      end
-
-      GraphQL::Query::Arguments.new(input_values, argument_definitions: arguments)
-    end
-
-    def coerce_result(value, ctx = nil)
-      if ctx.nil?
-        warn_deprecated_coerce("coerce_isolated_result")
-        ctx = GraphQL::Query::NullContext
-      end
-
-      # Allow the application to provide values as :symbols, and convert them to the strings
-      value = value.reduce({}) { |memo, (k, v)| memo[k.to_s] = v; memo }
-
-      result = {}
-
-      arguments.each do |input_key, input_field_defn|
-        input_value = value[input_key]
-        if value.key?(input_key)
-          result[input_key] = if input_value.nil?
-            nil
-          else
-            input_field_defn.type.coerce_result(input_value, ctx)
-          end
         end
       end
 

--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -104,7 +104,12 @@ module GraphQL
       GraphQL::Query::Arguments.new(input_values, argument_definitions: arguments)
     end
 
-    def coerce_result(value, ctx = GraphQL::Query::NullContext)
+    def coerce_result(value, ctx = nil)
+      if ctx.nil?
+        warn_deprecated_coerce("coerce_isolated_result")
+        ctx = GraphQL::Query::NullContext
+      end
+
       # Allow the application to provide values as :symbols, and convert them to the strings
       value = value.reduce({}) { |memo, (k, v)| memo[k.to_s] = v; memo }
 

--- a/lib/graphql/int_type.rb
+++ b/lib/graphql/int_type.rb
@@ -3,7 +3,7 @@ GraphQL::INT_TYPE = GraphQL::ScalarType.define do
   name "Int"
   description "Represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."
 
-  coerce_input ->(value) { value.is_a?(Numeric) ? value.to_i : nil }
-  coerce_result ->(value) { value.to_i }
+  coerce_input ->(value, _ctx) { value.is_a?(Numeric) ? value.to_i : nil }
+  coerce_result ->(value, _ctx) { value.to_i }
   default_scalar true
 end

--- a/lib/graphql/introspection/input_value_type.rb
+++ b/lib/graphql/introspection/input_value_type.rb
@@ -14,7 +14,7 @@ GraphQL::Introspection::InputValueType = GraphQL::ObjectType.define do
         if value.nil?
           'null'
         else
-          coerced_default_value = obj.type.coerce_result(value)
+          coerced_default_value = obj.type.coerce_result(value, ctx)
           if obj.type.unwrap.is_a?(GraphQL::EnumType)
             coerced_default_value
           else

--- a/lib/graphql/list_type.rb
+++ b/lib/graphql/list_type.rb
@@ -40,7 +40,7 @@ module GraphQL
       "[#{of_type.to_s}]"
     end
 
-    def validate_non_null_input(value, ctx = GraphQL::Query::NullContext)
+    def validate_non_null_input(value, ctx)
       result = GraphQL::Query::InputValidationResult.new
 
       ensure_array(value).each_with_index do |item, index|
@@ -53,11 +53,11 @@ module GraphQL
       result
     end
 
-    def coerce_non_null_input(value, ctx = GraphQL::Query::NullContext)
+    def coerce_non_null_input(value, ctx)
       ensure_array(value).map { |item| of_type.coerce_input(item, ctx) }
     end
 
-    def coerce_result(value, ctx = GraphQL::Query::NullContext)
+    def coerce_result(value, ctx)
       ensure_array(value).map { |item| item.nil? ? nil : of_type.coerce_result(item, ctx) }
     end
 

--- a/lib/graphql/list_type.rb
+++ b/lib/graphql/list_type.rb
@@ -57,7 +57,11 @@ module GraphQL
       ensure_array(value).map { |item| of_type.coerce_input(item, ctx) }
     end
 
-    def coerce_result(value, ctx)
+    def coerce_result(value, ctx = nil)
+      if ctx.nil?
+        warn_deprecated_coerce("coerce_isolated_result")
+        ctx = GraphQL::Query::NullContext
+      end
       ensure_array(value).map { |item| item.nil? ? nil : of_type.coerce_result(item, ctx) }
     end
 

--- a/lib/graphql/list_type.rb
+++ b/lib/graphql/list_type.rb
@@ -40,11 +40,11 @@ module GraphQL
       "[#{of_type.to_s}]"
     end
 
-    def validate_non_null_input(value, warden)
+    def validate_non_null_input(value, ctx = GraphQL::Query::NullContext)
       result = GraphQL::Query::InputValidationResult.new
 
       ensure_array(value).each_with_index do |item, index|
-        item_result = of_type.validate_input(item, warden)
+        item_result = of_type.validate_input(item, ctx)
         if !item_result.valid?
           result.merge_result!(index, item_result)
         end
@@ -53,12 +53,12 @@ module GraphQL
       result
     end
 
-    def coerce_non_null_input(value)
-      ensure_array(value).map { |item| of_type.coerce_input(item) }
+    def coerce_non_null_input(value, ctx = GraphQL::Query::NullContext)
+      ensure_array(value).map { |item| of_type.coerce_input(item, ctx) }
     end
 
-    def coerce_result(value)
-      ensure_array(value).map { |item| item.nil? ? nil : of_type.coerce_result(item) }
+    def coerce_result(value, ctx = GraphQL::Query::NullContext)
+      ensure_array(value).map { |item| item.nil? ? nil : of_type.coerce_result(item, ctx) }
     end
 
     private

--- a/lib/graphql/non_null_type.rb
+++ b/lib/graphql/non_null_type.rb
@@ -30,6 +30,7 @@ module GraphQL
   #
   class NonNullType < GraphQL::BaseType
     include GraphQL::BaseType::ModifiesAnotherType
+    extend Forwardable
 
     attr_reader :of_type
     def initialize(of_type:)
@@ -37,27 +38,21 @@ module GraphQL
       @of_type = of_type
     end
 
-    def valid_input?(value, warden)
-      validate_input(value, warden).valid?
+    def valid_input?(value, ctx)
+      validate_input(value, ctx).valid?
     end
 
-    def validate_input(value, warden)
+    def validate_input(value, ctx)
       if value.nil?
         result = GraphQL::Query::InputValidationResult.new
         result.add_problem("Expected value to not be null")
         result
       else
-        of_type.validate_input(value, warden)
+        of_type.validate_input(value, ctx)
       end
     end
 
-    def coerce_input(value)
-      of_type.coerce_input(value)
-    end
-
-    def coerce_result(value)
-      of_type.coerce_result(value)
-    end
+    def_delegators :@of_type, :coerce_input, :coerce_result
 
     def kind
       GraphQL::TypeKinds::NON_NULL

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -4,6 +4,7 @@ require "graphql/query/arguments_cache"
 require "graphql/query/context"
 require "graphql/query/executor"
 require "graphql/query/literal_input"
+require "graphql/query/null_context"
 require "graphql/query/serial_execution"
 require "graphql/query/variables"
 require "graphql/query/input_validation_result"
@@ -145,8 +146,7 @@ module GraphQL
     def variables
       @variables ||= begin
         vars = GraphQL::Query::Variables.new(
-          @schema,
-          @warden,
+          @context,
           @ast_variables,
           @provided_variables,
         )

--- a/lib/graphql/query/literal_input.rb
+++ b/lib/graphql/query/literal_input.rb
@@ -14,10 +14,9 @@ module GraphQL
         else
           case type
           when GraphQL::ScalarType
-            type.coerce_input(ast_node)
+            type.coerce_input(ast_node, variables.context)
           when GraphQL::EnumType
-            # TODO This should provide ctx
-            type.coerce_input(ast_node.name )
+            type.coerce_input(ast_node.name, variables.context)
           when GraphQL::NonNullType
             LiteralInput.coerce(type.of_type, ast_node, variables)
           when GraphQL::ListType

--- a/lib/graphql/query/literal_input.rb
+++ b/lib/graphql/query/literal_input.rb
@@ -16,7 +16,8 @@ module GraphQL
           when GraphQL::ScalarType
             type.coerce_input(ast_node)
           when GraphQL::EnumType
-            type.coerce_input(ast_node.name)
+            # TODO This should provide ctx
+            type.coerce_input(ast_node.name )
           when GraphQL::NonNullType
             LiteralInput.coerce(type.of_type, ast_node, variables)
           when GraphQL::ListType

--- a/lib/graphql/query/null_context.rb
+++ b/lib/graphql/query/null_context.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+module GraphQL
+  class Query
+    # This object can be `ctx` in places where there is no query
+    class NullContext
+      attr_reader :schema, :query, :warden
+
+      def initialize
+        @query = nil
+        @schema = nil
+        @warden = GraphQL::Schema::Warden.new(
+          GraphQL::Schema::NullMask,
+          context: self,
+          schema: @schema,
+        )
+      end
+
+      class << self
+        extend Forwardable
+
+        def instance
+          @instance = self.new
+        end
+
+        def_delegators :instance, :query, :schema, :warden
+      end
+    end
+  end
+end

--- a/lib/graphql/query/null_context.rb
+++ b/lib/graphql/query/null_context.rb
@@ -7,7 +7,7 @@ module GraphQL
 
       def initialize
         @query = nil
-        @schema = nil
+        @schema = GraphQL::Schema.new
         @warden = GraphQL::Schema::Warden.new(
           GraphQL::Schema::NullMask,
           context: self,

--- a/lib/graphql/query/serial_execution/value_resolution.rb
+++ b/lib/graphql/query/serial_execution/value_resolution.rb
@@ -16,10 +16,8 @@ module GraphQL
             end
           else
             case field_type.kind
-            when GraphQL::TypeKinds::SCALAR
-              field_type.coerce_result(value)
-            when GraphQL::TypeKinds::ENUM
-              field_type.coerce_result(value, query_ctx.query.warden)
+            when GraphQL::TypeKinds::SCALAR, GraphQL::TypeKinds::ENUM
+              field_type.coerce_result(value, query_ctx)
             when GraphQL::TypeKinds::LIST
               wrapped_type = field_type.of_type
               result = []

--- a/lib/graphql/query/variables.rb
+++ b/lib/graphql/query/variables.rb
@@ -8,8 +8,11 @@ module GraphQL
       # @return [Array<GraphQL::Query::VariableValidationError>]  Any errors encountered when parsing the provided variables and literal values
       attr_reader :errors
 
+      attr_reader :context
+
       def initialize(ctx, ast_variables, provided_variables)
         schema = ctx.schema
+        @context = ctx
         @provided_variables = provided_variables
         @errors = []
         @storage = ast_variables.each_with_object({}) do |ast_variable, memo|
@@ -35,7 +38,7 @@ module GraphQL
               memo[variable_name] = variable_type.coerce_input(provided_value, ctx)
             elsif default_value
               # Add the variable if it wasn't provided but it has a default value (including `null`)
-              memo[variable_name] = GraphQL::Query::LiteralInput.coerce(variable_type, default_value, {})
+              memo[variable_name] = GraphQL::Query::LiteralInput.coerce(variable_type, default_value, self)
             end
           end
         end

--- a/lib/graphql/query/variables.rb
+++ b/lib/graphql/query/variables.rb
@@ -8,9 +8,8 @@ module GraphQL
       # @return [Array<GraphQL::Query::VariableValidationError>]  Any errors encountered when parsing the provided variables and literal values
       attr_reader :errors
 
-      def initialize(schema, warden, ast_variables, provided_variables)
-        @schema = schema
-        @warden = warden
+      def initialize(ctx, ast_variables, provided_variables)
+        schema = ctx.schema
         @provided_variables = provided_variables
         @errors = []
         @storage = ast_variables.each_with_object({}) do |ast_variable, memo|
@@ -18,7 +17,7 @@ module GraphQL
           # - First, use the value provided at runtime
           # - Then, fall back to the default value from the query string
           # If it's still nil, raise an error if it's required.
-          variable_type = @schema.type_from_ast(ast_variable.type)
+          variable_type = schema.type_from_ast(ast_variable.type)
           if variable_type.nil?
             # Pass -- it will get handled by a validator
           else
@@ -27,13 +26,13 @@ module GraphQL
             provided_value = @provided_variables[variable_name]
             value_was_provided = @provided_variables.key?(variable_name)
 
-            validation_result = variable_type.validate_input(provided_value, @warden)
+            validation_result = variable_type.validate_input(provided_value, ctx)
             if !validation_result.valid?
               # This finds variables that were required but not provided
               @errors << GraphQL::Query::VariableValidationError.new(ast_variable, variable_type, provided_value, validation_result)
             elsif value_was_provided
               # Add the variable if a value was provided
-              memo[variable_name] = variable_type.coerce_input(provided_value)
+              memo[variable_name] = variable_type.coerce_input(provided_value, ctx)
             elsif default_value
               # Add the variable if it wasn't provided but it has a default value (including `null`)
               memo[variable_name] = GraphQL::Query::LiteralInput.coerce(variable_type, default_value, {})

--- a/lib/graphql/scalar_type.rb
+++ b/lib/graphql/scalar_type.rb
@@ -54,18 +54,6 @@ module GraphQL
       self.coerce_result = proc
     end
 
-    def validate_non_null_input(value, ctx = GraphQL::Query::NullContext)
-      result = Query::InputValidationResult.new
-      if coerce_non_null_input(value, ctx).nil?
-        result.add_problem("Could not coerce value #{GraphQL::Language.serialize(value)} to #{name}")
-      end
-      result
-    end
-
-    def coerce_non_null_input(value, ctx = GraphQL::Query::NullContext)
-      @coerce_input_proc.call(value, ctx)
-    end
-
     def coerce_input=(coerce_input_fn)
       if !coerce_input_fn.nil?
         @coerce_input_proc = ensure_two_arg(coerce_input_fn, :coerce_input)
@@ -108,6 +96,18 @@ module GraphQL
       else
         callable
       end
+    end
+
+    def coerce_non_null_input(value, ctx)
+      @coerce_input_proc.call(value, ctx)
+    end
+
+    def validate_non_null_input(value, ctx)
+      result = Query::InputValidationResult.new
+      if coerce_non_null_input(value, ctx).nil?
+        result.add_problem("Could not coerce value #{GraphQL::Language.serialize(value)} to #{name}")
+      end
+      result
     end
   end
 end

--- a/lib/graphql/scalar_type.rb
+++ b/lib/graphql/scalar_type.rb
@@ -66,19 +66,23 @@ module GraphQL
       @coerce_input_proc.call(value, ctx)
     end
 
-    def coerce_input=(proc)
-      if !proc.nil?
-        @coerce_input_proc = ensure_two_arg(proc)
+    def coerce_input=(coerce_input_fn)
+      if !coerce_input_fn.nil?
+        @coerce_input_proc = ensure_two_arg(coerce_input_fn, :coerce_input)
       end
     end
 
-    def coerce_result(value, ctx = GraphQL::Query::NullContext)
+    def coerce_result(value, ctx = nil)
+      if ctx.nil?
+        warn_deprecated_coerce("coerce_isolated_result")
+        ctx = GraphQL::Query::NullContext
+      end
       @coerce_result_proc.call(value, ctx)
     end
 
-    def coerce_result=(proc)
-      if !proc.nil?
-        @coerce_result_proc = ensure_two_arg(proc)
+    def coerce_result=(coerce_result_fn)
+      if !coerce_result_fn.nil?
+        @coerce_result_proc = ensure_two_arg(coerce_result_fn, :coerce_result)
       end
     end
 
@@ -97,8 +101,9 @@ module GraphQL
       end
     end
 
-    def ensure_two_arg(callable)
+    def ensure_two_arg(callable, method_name)
       if get_arity(callable) == 1
+        warn("Scalar coerce functions receive two values (`val` and `ctx`), one-argument functions are deprecated (see #{name}.#{method_name}).")
         ->(val, ctx) { callable.call(val) }
       else
         callable

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -119,7 +119,7 @@ module GraphQL
           raise(NotImplementedError, "Generated Schema cannot use Interface or Union types for execution.")
         }
 
-        NullScalarCoerce = ->(val) { val }
+        NullScalarCoerce = ->(val, _ctx) { val }
 
         def build_enum_type(enum_type_definition, type_resolver)
           GraphQL::EnumType.define(

--- a/lib/graphql/schema/default_type_error.rb
+++ b/lib/graphql/schema/default_type_error.rb
@@ -6,7 +6,7 @@ module GraphQL
         case type_error
         when GraphQL::InvalidNullError
           ctx.errors << type_error
-        when GraphQL::UnresolvedTypeError
+        when GraphQL::UnresolvedTypeError, GraphQL::StringEncodingError
           raise type_error
         end
       end

--- a/lib/graphql/schema/loader.rb
+++ b/lib/graphql/schema/loader.rb
@@ -37,7 +37,7 @@ module GraphQL
         raise(NotImplementedError, "This schema was loaded from string, so it can't resolve types for objects")
       }
 
-      NullScalarCoerce = ->(val) { val }
+      NullScalarCoerce = ->(val, _ctx) { val }
 
       class << self
         private

--- a/lib/graphql/schema/printer.rb
+++ b/lib/graphql/schema/printer.rb
@@ -218,7 +218,7 @@ module GraphQL
               value.to_s.inspect
             when EnumType
               return 'null' if value.nil?
-              type.coerce_result(value)
+              type.coerce_isolated_result(value)
             when InputObjectType
               return 'null' if value.nil?
               fields = value.to_h.map{ |field_name, field_value|

--- a/lib/graphql/schema/validation.rb
+++ b/lib/graphql/schema/validation.rb
@@ -104,7 +104,7 @@ module GraphQL
 
           if !type.default_value.nil?
             coerced_value = begin
-              type.type.coerce_result(type.default_value)
+              type.type.coerce_isolated_result(type.default_value)
             rescue => ex
               ex
             end

--- a/lib/graphql/static_validation/literal_validator.rb
+++ b/lib/graphql/static_validation/literal_validator.rb
@@ -3,8 +3,9 @@ module GraphQL
   module StaticValidation
     # Test whether `ast_value` is a valid input for `type`
     class LiteralValidator
-      def initialize(warden:)
-        @warden = warden
+      def initialize(context:)
+        @context = context
+        @warden = context.warden
       end
 
       def validate(ast_value, type)
@@ -16,9 +17,9 @@ module GraphQL
           item_type = type.of_type
           ensure_array(ast_value).all? { |val| validate(val, item_type) }
         elsif type.kind.scalar? && !ast_value.is_a?(GraphQL::Language::Nodes::AbstractNode) && !ast_value.is_a?(Array)
-          type.valid_input?(ast_value, @warden)
+          type.valid_input?(ast_value, @context)
         elsif type.kind.enum? && ast_value.is_a?(GraphQL::Language::Nodes::Enum)
-          type.valid_input?(ast_value.name, @warden)
+          type.valid_input?(ast_value.name, @context)
         elsif type.kind.input_object? && ast_value.is_a?(GraphQL::Language::Nodes::InputObject)
           required_input_fields_are_present(type, ast_value) &&
             present_input_field_values_are_valid(type, ast_value)

--- a/lib/graphql/static_validation/validation_context.rb
+++ b/lib/graphql/static_validation/validation_context.rb
@@ -22,7 +22,7 @@ module GraphQL
 
       def initialize(query)
         @query = query
-        @literal_validator = LiteralValidator.new(warden: warden)
+        @literal_validator = LiteralValidator.new(context: query.context)
         @errors = []
         @visitor = GraphQL::Language::Visitor.new(document)
         @type_stack = GraphQL::StaticValidation::TypeStack.new(schema, visitor)

--- a/lib/graphql/string_encoding_error.rb
+++ b/lib/graphql/string_encoding_error.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module GraphQL
+  class StringEncodingError < GraphQL::RuntimeTypeError
+    attr_reader :string
+    def initialize(str)
+      @string = str
+      super("String \"#{str}\" was encoded as #{str.encoding}! GraphQL requires UTF-8 encoding.")
+    end
+  end
+end

--- a/lib/graphql/string_type.rb
+++ b/lib/graphql/string_type.rb
@@ -3,12 +3,12 @@ GraphQL::STRING_TYPE = GraphQL::ScalarType.define do
   name "String"
   description "Represents textual data as UTF-8 character sequences. This type is most often used by GraphQL to represent free-form human-readable text."
 
-  coerce_result ->(value) {
+  coerce_result ->(value, _ctx) {
     str = value.to_s
     return str if str.encoding == Encoding::US_ASCII || str.encoding == Encoding::UTF_8
     raise GraphQL::CoercionError.new("The string `#{str}` was encoded as #{str.encoding}! GraphQL requires all strings to be UTF-8 encoded.")
   }
 
-  coerce_input ->(value) { value.is_a?(String) ? value : nil }
+  coerce_input ->(value, _ctx) { value.is_a?(String) ? value : nil }
   default_scalar true
 end

--- a/lib/graphql/string_type.rb
+++ b/lib/graphql/string_type.rb
@@ -3,10 +3,15 @@ GraphQL::STRING_TYPE = GraphQL::ScalarType.define do
   name "String"
   description "Represents textual data as UTF-8 character sequences. This type is most often used by GraphQL to represent free-form human-readable text."
 
-  coerce_result ->(value, _ctx) {
+  coerce_result ->(value, ctx) {
     str = value.to_s
-    return str if str.encoding == Encoding::US_ASCII || str.encoding == Encoding::UTF_8
-    raise GraphQL::CoercionError.new("The string `#{str}` was encoded as #{str.encoding}! GraphQL requires all strings to be UTF-8 encoded.")
+    if str.encoding == Encoding::US_ASCII || str.encoding == Encoding::UTF_8
+      str
+    else
+      err = GraphQL::StringEncodingError.new(str)
+      ctx.schema.type_error(err, ctx)
+      nil
+    end
   }
 
   coerce_input ->(value, _ctx) { value.is_a?(String) ? value : nil }

--- a/spec/graphql/boolean_type_spec.rb
+++ b/spec/graphql/boolean_type_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 describe GraphQL::BOOLEAN_TYPE do
   describe "coerce_input" do
     def coerce_input(input)
-      GraphQL::BOOLEAN_TYPE.coerce_input(input)
+      GraphQL::BOOLEAN_TYPE.coerce_isolated_input(input)
     end
 
     it "accepts true and false" do

--- a/spec/graphql/enum_type_spec.rb
+++ b/spec/graphql/enum_type_spec.rb
@@ -32,7 +32,7 @@ describe GraphQL::EnumType do
       assert_equal("YAK", enum.coerce_result("YAK"))
       # NOT OK
       assert_raises(GraphQL::EnumType::UnresolvedValueError) {
-        enum.coerce_result("YAK", NothingWarden)
+        enum.coerce_result("YAK", OpenStruct.new(warden: NothingWarden))
       }
     end
   end
@@ -84,7 +84,7 @@ describe GraphQL::EnumType do
   end
 
   describe "validate_input with bad input" do
-    let(:result) { enum.validate_input("bad enum", PermissiveWarden) }
+    let(:result) { enum.validate_input("bad enum") }
 
     it "returns an invalid result" do
       assert(!result.valid?)

--- a/spec/graphql/enum_type_spec.rb
+++ b/spec/graphql/enum_type_spec.rb
@@ -5,31 +5,31 @@ describe GraphQL::EnumType do
   let(:enum) { Dummy::DairyAnimalEnum }
 
   it "coerces names to underlying values" do
-    assert_equal("YAK", enum.coerce_input("YAK"))
-    assert_equal(1, enum.coerce_input("COW"))
+    assert_equal("YAK", enum.coerce_isolated_input("YAK"))
+    assert_equal(1, enum.coerce_isolated_input("COW"))
   end
 
   it "coerces invalid names to nil" do
-    assert_equal(nil, enum.coerce_input("YAKKITY"))
+    assert_equal(nil, enum.coerce_isolated_input("YAKKITY"))
   end
 
   it "coerces result values to value's value" do
-    assert_equal("YAK", enum.coerce_result("YAK"))
-    assert_equal("COW", enum.coerce_result(1))
-    assert_equal("REINDEER", enum.coerce_result('reindeer'))
-    assert_equal("DONKEY", enum.coerce_result(:donkey))
+    assert_equal("YAK", enum.coerce_isolated_result("YAK"))
+    assert_equal("COW", enum.coerce_isolated_result(1))
+    assert_equal("REINDEER", enum.coerce_isolated_result('reindeer'))
+    assert_equal("DONKEY", enum.coerce_isolated_result(:donkey))
   end
 
   it "raises when a result value can't be coerced" do
     assert_raises(GraphQL::EnumType::UnresolvedValueError) {
-      enum.coerce_result(:nonsense)
+      enum.coerce_isolated_result(:nonsense)
     }
   end
 
   describe "resolving with a warden" do
     it "gets values from the warden" do
       # OK
-      assert_equal("YAK", enum.coerce_result("YAK"))
+      assert_equal("YAK", enum.coerce_isolated_result("YAK"))
       # NOT OK
       assert_raises(GraphQL::EnumType::UnresolvedValueError) {
         enum.coerce_result("YAK", OpenStruct.new(warden: NothingWarden))
@@ -84,7 +84,7 @@ describe GraphQL::EnumType do
   end
 
   describe "validate_input with bad input" do
-    let(:result) { enum.validate_input("bad enum") }
+    let(:result) { enum.validate_isolated_input("bad enum") }
 
     it "returns an invalid result" do
       assert(!result.valid?)

--- a/spec/graphql/float_type_spec.rb
+++ b/spec/graphql/float_type_spec.rb
@@ -4,13 +4,13 @@ require "spec_helper"
 describe GraphQL::FLOAT_TYPE do
   describe "coerce_input" do
     it "accepts ints and floats" do
-      assert_equal 1.0, GraphQL::FLOAT_TYPE.coerce_input(1)
-      assert_equal 6.1, GraphQL::FLOAT_TYPE.coerce_input(6.1)
+      assert_equal 1.0, GraphQL::FLOAT_TYPE.coerce_isolated_input(1)
+      assert_equal 6.1, GraphQL::FLOAT_TYPE.coerce_isolated_input(6.1)
     end
 
     it "rejects other types" do
-      assert_equal nil, GraphQL::FLOAT_TYPE.coerce_input("55")
-      assert_equal nil, GraphQL::FLOAT_TYPE.coerce_input(true)
+      assert_equal nil, GraphQL::FLOAT_TYPE.coerce_isolated_input("55")
+      assert_equal nil, GraphQL::FLOAT_TYPE.coerce_isolated_input(true)
     end
   end
 end

--- a/spec/graphql/input_object_type_spec.rb
+++ b/spec/graphql/input_object_type_spec.rb
@@ -26,18 +26,18 @@ describe GraphQL::InputObjectType do
   describe "input validation" do
     it "Accepts anything that yields key-value pairs to #all?" do
       values_obj = MinimumInputObject.new({"source" => "COW", "fatContent" => 0.4})
-      assert input_object.valid_input?(values_obj)
+      assert input_object.valid_isolated_input?(values_obj)
     end
 
     describe "validate_input with non-enumerable input" do
       it "returns a valid result for MinimumInputObject" do
-        result = input_object.validate_input(MinimumInputObject.new({"source" => "COW", "fatContent" => 0.4}))
+        result = input_object.validate_isolated_input(MinimumInputObject.new({"source" => "COW", "fatContent" => 0.4}))
         assert(result.valid?)
       end
 
       it "returns an invalid result for MinimumInvalidInputObject" do
         invalid_input = MinimumInputObject.new({"source" => "KOALA", "fatContent" => 0.4})
-        result = input_object.validate_input(invalid_input)
+        result = input_object.validate_isolated_input(invalid_input)
         assert(!result.valid?)
       end
     end
@@ -57,13 +57,13 @@ describe GraphQL::InputObjectType do
 
       it "returns an invalid result when value is null for non-null argument" do
         invalid_input = MinimumInputObject.new({"a" => "Test", "b" => nil})
-        result = input_type.validate_input(invalid_input)
+        result = input_type.validate_isolated_input(invalid_input)
         assert(!result.valid?)
       end
 
       it "returns valid result when value is null for nullable argument" do
         invalid_input = MinimumInputObject.new({"a" => nil, "b" => 1})
-        result = input_type.validate_input(invalid_input)
+        result = input_type.validate_isolated_input(invalid_input)
         assert(result.valid?)
       end
     end
@@ -76,7 +76,7 @@ describe GraphQL::InputObjectType do
             "fatContent" => 0.4
           }
         end
-        let(:result) { input_object.validate_input(input) }
+        let(:result) { input_object.validate_isolated_input(input) }
 
         it "returns a valid result" do
           assert(result.valid?)
@@ -91,7 +91,7 @@ describe GraphQL::InputObjectType do
               "fatContent" => 0.4,
             )
           end
-          let(:result) { input_object.validate_input(input) }
+          let(:result) { input_object.validate_isolated_input(input) }
 
           it "returns a valid result" do
             assert(result.valid?)
@@ -100,7 +100,7 @@ describe GraphQL::InputObjectType do
       end
 
       describe "with bad enum and float" do
-        let(:result) { input_object.validate_input({"source" => "KOALA", "fatContent" => "bad_num"}) }
+        let(:result) { input_object.validate_isolated_input({"source" => "KOALA", "fatContent" => "bad_num"}) }
 
         it "returns an invalid result" do
           assert(!result.valid?)
@@ -113,7 +113,7 @@ describe GraphQL::InputObjectType do
         end
 
         it "has correct problem explanation" do
-          expected = Dummy::DairyAnimalEnum.validate_input("KOALA").problems[0]["explanation"]
+          expected = Dummy::DairyAnimalEnum.validate_isolated_input("KOALA").problems[0]["explanation"]
 
           source_problem = result.problems.detect { |p| p["path"] == ["source"] }
           actual = source_problem["explanation"]
@@ -123,7 +123,7 @@ describe GraphQL::InputObjectType do
       end
 
       describe 'with a string as input' do
-        let(:result) { input_object.validate_input("just a string") }
+        let(:result) { input_object.validate_isolated_input("just a string") }
 
         it "returns an invalid result" do
           assert(!result.valid?)
@@ -140,7 +140,7 @@ describe GraphQL::InputObjectType do
       end
 
       describe 'with an array as input' do
-        let(:result) { input_object.validate_input(["string array"]) }
+        let(:result) { input_object.validate_isolated_input(["string array"]) }
 
         it "returns an invalid result" do
           assert(!result.valid?)
@@ -157,7 +157,7 @@ describe GraphQL::InputObjectType do
       end
 
       describe 'with a int as input' do
-        let(:result) { input_object.validate_input(10) }
+        let(:result) { input_object.validate_isolated_input(10) }
 
         it "returns an invalid result" do
           assert(!result.valid?)
@@ -174,7 +174,7 @@ describe GraphQL::InputObjectType do
       end
 
       describe "with extra argument" do
-        let(:result) { input_object.validate_input({"source" => "COW", "fatContent" => 0.4, "isDelicious" => false}) }
+        let(:result) { input_object.validate_isolated_input({"source" => "COW", "fatContent" => 0.4, "isDelicious" => false}) }
 
         it "returns an invalid result" do
           assert(!result.valid?)
@@ -193,7 +193,7 @@ describe GraphQL::InputObjectType do
       describe "list with one invalid element" do
         let(:list_type) { GraphQL::ListType.new(of_type: Dummy::DairyProductInputType) }
         let(:result) do
-          list_type.validate_input([
+          list_type.validate_isolated_input([
             { "source" => "COW", "fatContent" => 0.4 },
             { "source" => "KOALA", "fatContent" => 0.4 }
           ])
@@ -213,7 +213,7 @@ describe GraphQL::InputObjectType do
         end
 
         it "has problem with correct explanation" do
-          expected = Dummy::DairyAnimalEnum.validate_input("KOALA").problems[0]["explanation"]
+          expected = Dummy::DairyAnimalEnum.validate_isolated_input("KOALA").problems[0]["explanation"]
           actual = result.problems[0]["explanation"]
           assert_equal(expected, actual)
         end
@@ -223,7 +223,7 @@ describe GraphQL::InputObjectType do
 
   describe "coerce_result" do
     it "omits unspecified arguments" do
-      result = input_object.coerce_result({fatContent: 0.3})
+      result = input_object.coerce_isolated_result({fatContent: 0.3})
       assert_equal ["fatContent"], result.keys
       assert_equal 0.3, result["fatContent"]
     end
@@ -246,7 +246,7 @@ describe GraphQL::InputObjectType do
 
     it "null values are returned in coerced input" do
       input = MinimumInputObject.new({"a" => "Test", "b" => nil,"c" => "Test"})
-      result = input_type.coerce_input(input)
+      result = input_type.coerce_isolated_input(input)
 
       assert_equal 'Test', result['a']
 
@@ -258,7 +258,7 @@ describe GraphQL::InputObjectType do
 
     it "null values are preserved when argument has a default value" do
       input = MinimumInputObject.new({"a" => "Test", "b" => 1, "c" => nil})
-      result = input_type.coerce_input(input)
+      result = input_type.coerce_isolated_input(input)
 
       assert_equal 'Test', result['a']
       assert_equal 1, result['b']
@@ -269,7 +269,7 @@ describe GraphQL::InputObjectType do
 
     it "omitted arguments are not returned" do
       input = MinimumInputObject.new({"b" => 1, "c" => "Test"})
-      result = input_type.coerce_input(input)
+      result = input_type.coerce_isolated_input(input)
 
       assert !result.key?('a')
       assert_equal 1, result['b']
@@ -278,7 +278,7 @@ describe GraphQL::InputObjectType do
 
     it "false default values are returned" do
       input = MinimumInputObject.new({"b" => 1})
-      result = input_type.coerce_input(input)
+      result = input_type.coerce_isolated_input(input)
 
       assert_equal false, result['d']
     end

--- a/spec/graphql/input_object_type_spec.rb
+++ b/spec/graphql/input_object_type_spec.rb
@@ -26,18 +26,18 @@ describe GraphQL::InputObjectType do
   describe "input validation" do
     it "Accepts anything that yields key-value pairs to #all?" do
       values_obj = MinimumInputObject.new({"source" => "COW", "fatContent" => 0.4})
-      assert input_object.valid_input?(values_obj, PermissiveWarden)
+      assert input_object.valid_input?(values_obj)
     end
 
     describe "validate_input with non-enumerable input" do
       it "returns a valid result for MinimumInputObject" do
-        result = input_object.validate_input(MinimumInputObject.new({"source" => "COW", "fatContent" => 0.4}), PermissiveWarden)
+        result = input_object.validate_input(MinimumInputObject.new({"source" => "COW", "fatContent" => 0.4}))
         assert(result.valid?)
       end
 
       it "returns an invalid result for MinimumInvalidInputObject" do
         invalid_input = MinimumInputObject.new({"source" => "KOALA", "fatContent" => 0.4})
-        result = input_object.validate_input(invalid_input, PermissiveWarden)
+        result = input_object.validate_input(invalid_input)
         assert(!result.valid?)
       end
     end
@@ -57,13 +57,13 @@ describe GraphQL::InputObjectType do
 
       it "returns an invalid result when value is null for non-null argument" do
         invalid_input = MinimumInputObject.new({"a" => "Test", "b" => nil})
-        result = input_type.validate_input(invalid_input, PermissiveWarden)
+        result = input_type.validate_input(invalid_input)
         assert(!result.valid?)
       end
 
       it "returns valid result when value is null for nullable argument" do
         invalid_input = MinimumInputObject.new({"a" => nil, "b" => 1})
-        result = input_type.validate_input(invalid_input, PermissiveWarden)
+        result = input_type.validate_input(invalid_input)
         assert(result.valid?)
       end
     end
@@ -76,7 +76,7 @@ describe GraphQL::InputObjectType do
             "fatContent" => 0.4
           }
         end
-        let(:result) { input_object.validate_input(input, PermissiveWarden) }
+        let(:result) { input_object.validate_input(input) }
 
         it "returns a valid result" do
           assert(result.valid?)
@@ -91,7 +91,7 @@ describe GraphQL::InputObjectType do
               "fatContent" => 0.4,
             )
           end
-          let(:result) { input_object.validate_input(input, PermissiveWarden) }
+          let(:result) { input_object.validate_input(input) }
 
           it "returns a valid result" do
             assert(result.valid?)
@@ -100,7 +100,7 @@ describe GraphQL::InputObjectType do
       end
 
       describe "with bad enum and float" do
-        let(:result) { input_object.validate_input({"source" => "KOALA", "fatContent" => "bad_num"}, PermissiveWarden) }
+        let(:result) { input_object.validate_input({"source" => "KOALA", "fatContent" => "bad_num"}) }
 
         it "returns an invalid result" do
           assert(!result.valid?)
@@ -113,7 +113,7 @@ describe GraphQL::InputObjectType do
         end
 
         it "has correct problem explanation" do
-          expected = Dummy::DairyAnimalEnum.validate_input("KOALA", PermissiveWarden).problems[0]["explanation"]
+          expected = Dummy::DairyAnimalEnum.validate_input("KOALA").problems[0]["explanation"]
 
           source_problem = result.problems.detect { |p| p["path"] == ["source"] }
           actual = source_problem["explanation"]
@@ -123,7 +123,7 @@ describe GraphQL::InputObjectType do
       end
 
       describe 'with a string as input' do
-        let(:result) { input_object.validate_input("just a string", PermissiveWarden) }
+        let(:result) { input_object.validate_input("just a string") }
 
         it "returns an invalid result" do
           assert(!result.valid?)
@@ -140,7 +140,7 @@ describe GraphQL::InputObjectType do
       end
 
       describe 'with an array as input' do
-        let(:result) { input_object.validate_input(["string array"], PermissiveWarden) }
+        let(:result) { input_object.validate_input(["string array"]) }
 
         it "returns an invalid result" do
           assert(!result.valid?)
@@ -157,7 +157,7 @@ describe GraphQL::InputObjectType do
       end
 
       describe 'with a int as input' do
-        let(:result) { input_object.validate_input(10, PermissiveWarden) }
+        let(:result) { input_object.validate_input(10) }
 
         it "returns an invalid result" do
           assert(!result.valid?)
@@ -174,7 +174,7 @@ describe GraphQL::InputObjectType do
       end
 
       describe "with extra argument" do
-        let(:result) { input_object.validate_input({"source" => "COW", "fatContent" => 0.4, "isDelicious" => false}, PermissiveWarden) }
+        let(:result) { input_object.validate_input({"source" => "COW", "fatContent" => 0.4, "isDelicious" => false}) }
 
         it "returns an invalid result" do
           assert(!result.valid?)
@@ -196,7 +196,7 @@ describe GraphQL::InputObjectType do
           list_type.validate_input([
             { "source" => "COW", "fatContent" => 0.4 },
             { "source" => "KOALA", "fatContent" => 0.4 }
-          ], PermissiveWarden)
+          ])
         end
 
         it "returns an invalid result" do
@@ -213,7 +213,7 @@ describe GraphQL::InputObjectType do
         end
 
         it "has problem with correct explanation" do
-          expected = Dummy::DairyAnimalEnum.validate_input("KOALA", PermissiveWarden).problems[0]["explanation"]
+          expected = Dummy::DairyAnimalEnum.validate_input("KOALA").problems[0]["explanation"]
           actual = result.problems[0]["explanation"]
           assert_equal(expected, actual)
         end
@@ -223,7 +223,7 @@ describe GraphQL::InputObjectType do
 
   describe "coerce_result" do
     it "omits unspecified arguments" do
-      result = input_object.coerce_result(fatContent: 0.3)
+      result = input_object.coerce_result({fatContent: 0.3})
       assert_equal ["fatContent"], result.keys
       assert_equal 0.3, result["fatContent"]
     end

--- a/spec/graphql/int_type_spec.rb
+++ b/spec/graphql/int_type_spec.rb
@@ -4,13 +4,13 @@ require "spec_helper"
 describe GraphQL::INT_TYPE do
   describe "coerce_input" do
     it "accepts ints and floats" do
-      assert_equal 1, GraphQL::INT_TYPE.coerce_input(1)
-      assert_equal 6, GraphQL::INT_TYPE.coerce_input(6.1)
+      assert_equal 1, GraphQL::INT_TYPE.coerce_isolated_input(1)
+      assert_equal 6, GraphQL::INT_TYPE.coerce_isolated_input(6.1)
     end
 
     it "rejects other types" do
-      assert_equal nil, GraphQL::INT_TYPE.coerce_input("55")
-      assert_equal nil, GraphQL::INT_TYPE.coerce_input(true)
+      assert_equal nil, GraphQL::INT_TYPE.coerce_isolated_input("55")
+      assert_equal nil, GraphQL::INT_TYPE.coerce_isolated_input(true)
     end
   end
 end

--- a/spec/graphql/list_type_spec.rb
+++ b/spec/graphql/list_type_spec.rb
@@ -5,12 +5,12 @@ describe GraphQL::ListType do
   let(:float_list) { GraphQL::ListType.new(of_type: GraphQL::FLOAT_TYPE) }
 
   it "coerces elements in the list" do
-    assert_equal([1.0, 2.0, 3.0].inspect, float_list.coerce_input([1, 2, 3]).inspect)
+    assert_equal([1.0, 2.0, 3.0].inspect, float_list.coerce_isolated_input([1, 2, 3]).inspect)
   end
 
   describe "validate_input with bad input" do
     let(:bad_num) { "bad_num" }
-    let(:result) { float_list.validate_input([bad_num, 2.0, 3.0]) }
+    let(:result) { float_list.validate_isolated_input([bad_num, 2.0, 3.0]) }
 
     it "returns an invalid result" do
       assert(!result.valid?)
@@ -25,7 +25,7 @@ describe GraphQL::ListType do
     end
 
     it "has the correct explanation" do
-      expected = GraphQL::FLOAT_TYPE.validate_input(bad_num).problems[0]["explanation"]
+      expected = GraphQL::FLOAT_TYPE.validate_isolated_input(bad_num).problems[0]["explanation"]
       actual = result.problems[0]["explanation"]
       assert_equal(actual, expected)
     end

--- a/spec/graphql/list_type_spec.rb
+++ b/spec/graphql/list_type_spec.rb
@@ -10,7 +10,7 @@ describe GraphQL::ListType do
 
   describe "validate_input with bad input" do
     let(:bad_num) { "bad_num" }
-    let(:result) { float_list.validate_input([bad_num, 2.0, 3.0], PermissiveWarden) }
+    let(:result) { float_list.validate_input([bad_num, 2.0, 3.0]) }
 
     it "returns an invalid result" do
       assert(!result.valid?)
@@ -25,7 +25,7 @@ describe GraphQL::ListType do
     end
 
     it "has the correct explanation" do
-      expected = GraphQL::FLOAT_TYPE.validate_input(bad_num, PermissiveWarden).problems[0]["explanation"]
+      expected = GraphQL::FLOAT_TYPE.validate_input(bad_num).problems[0]["explanation"]
       actual = result.problems[0]["explanation"]
       assert_equal(actual, expected)
     end

--- a/spec/graphql/query/variables_spec.rb
+++ b/spec/graphql/query/variables_spec.rb
@@ -17,8 +17,10 @@ describe GraphQL::Query::Variables do
   let(:ast_variables) { GraphQL.parse(query_string).definitions.first.variables }
   let(:schema) { Dummy::Schema }
   let(:variables) { GraphQL::Query::Variables.new(
-    schema,
-    GraphQL::Schema::Warden.new(schema.default_mask, schema: schema, context: nil),
+    OpenStruct.new({
+      schema: schema,
+      warden: GraphQL::Schema::Warden.new(schema.default_mask, schema: schema, context: nil),
+    }),
     ast_variables,
     provided_variables)
   }
@@ -165,8 +167,10 @@ describe GraphQL::Query::Variables do
       let(:run_query) { schema.execute(query_string, variables: provided_variables) }
 
       let(:variables) { GraphQL::Query::Variables.new(
-        schema,
-        GraphQL::Schema::Warden.new(schema.default_mask, schema: schema, context: nil),
+        OpenStruct.new({
+          schema: schema,
+          warden: GraphQL::Schema::Warden.new(schema.default_mask, schema: schema, context: nil),
+        }),
         ast_variables,
         provided_variables)
       }

--- a/spec/graphql/scalar_type_spec.rb
+++ b/spec/graphql/scalar_type_spec.rb
@@ -5,8 +5,8 @@ describe GraphQL::ScalarType do
   let(:custom_scalar) {
     GraphQL::ScalarType.define do
       name "BigInt"
-      coerce_input ->(value) { value =~ /\d+/ ? Integer(value) : nil }
-      coerce_result ->(value) { value.to_s }
+      coerce_input ->(value, _ctx) { value =~ /\d+/ ? Integer(value) : nil }
+      coerce_result ->(value, _ctx) { value.to_s }
     end
   }
   let(:bignum) { 2 ** 128 }

--- a/spec/graphql/scalar_type_spec.rb
+++ b/spec/graphql/scalar_type_spec.rb
@@ -28,7 +28,7 @@ describe GraphQL::ScalarType do
   end
 
   describe "custom scalar errors" do
-    let(:result) { custom_scalar.validate_input("xyz", PermissiveWarden) }
+    let(:result) { custom_scalar.validate_input("xyz") }
 
     it "returns an invalid result" do
       assert !result.valid?
@@ -37,7 +37,7 @@ describe GraphQL::ScalarType do
   end
 
   describe "validate_input with good input" do
-    let(:result) { GraphQL::INT_TYPE.validate_input(150, PermissiveWarden) }
+    let(:result) { GraphQL::INT_TYPE.validate_input(150) }
 
     it "returns a valid result" do
       assert(result.valid?)
@@ -45,7 +45,7 @@ describe GraphQL::ScalarType do
   end
 
   describe "validate_input with bad input" do
-    let(:result) { GraphQL::INT_TYPE.validate_input("bad num", PermissiveWarden) }
+    let(:result) { GraphQL::INT_TYPE.validate_input("bad num") }
 
     it "returns an invalid result for bad input" do
       assert(!result.valid?)

--- a/spec/graphql/scalar_type_spec.rb
+++ b/spec/graphql/scalar_type_spec.rb
@@ -16,19 +16,19 @@ describe GraphQL::ScalarType do
   end
 
   it "coerces nil into nil" do
-    assert_equal(nil, custom_scalar.coerce_input(nil))
+    assert_equal(nil, custom_scalar.coerce_isolated_input(nil))
   end
 
   it "coerces input into objects" do
-    assert_equal(bignum, custom_scalar.coerce_input(bignum.to_s))
+    assert_equal(bignum, custom_scalar.coerce_isolated_input(bignum.to_s))
   end
 
   it "coerces result value for serialization" do
-    assert_equal(bignum.to_s, custom_scalar.coerce_result(bignum))
+    assert_equal(bignum.to_s, custom_scalar.coerce_isolated_result(bignum))
   end
 
   describe "custom scalar errors" do
-    let(:result) { custom_scalar.validate_input("xyz") }
+    let(:result) { custom_scalar.validate_isolated_input("xyz") }
 
     it "returns an invalid result" do
       assert !result.valid?
@@ -37,7 +37,7 @@ describe GraphQL::ScalarType do
   end
 
   describe "validate_input with good input" do
-    let(:result) { GraphQL::INT_TYPE.validate_input(150) }
+    let(:result) { GraphQL::INT_TYPE.validate_isolated_input(150) }
 
     it "returns a valid result" do
       assert(result.valid?)
@@ -45,7 +45,7 @@ describe GraphQL::ScalarType do
   end
 
   describe "validate_input with bad input" do
-    let(:result) { GraphQL::INT_TYPE.validate_input("bad num") }
+    let(:result) { GraphQL::INT_TYPE.validate_isolated_input("bad num") }
 
     it "returns an invalid result for bad input" do
       assert(!result.valid?)

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -352,8 +352,8 @@ type Root {
 
       built_schema = build_schema_and_compare_output(schema.chop)
       custom_scalar = built_schema.types["CustomScalar"]
-      assert_equal true, custom_scalar.valid_input?("anything", PermissiveWarden)
-      assert_equal true, custom_scalar.valid_input?(12345, PermissiveWarden)
+      assert_equal true, custom_scalar.valid_input?("anything")
+      assert_equal true, custom_scalar.valid_input?(12345)
     end
 
     it 'supports input object' do

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -352,8 +352,8 @@ type Root {
 
       built_schema = build_schema_and_compare_output(schema.chop)
       custom_scalar = built_schema.types["CustomScalar"]
-      assert_equal true, custom_scalar.valid_input?("anything")
-      assert_equal true, custom_scalar.valid_input?(12345)
+      assert_equal true, custom_scalar.valid_isolated_input?("anything")
+      assert_equal true, custom_scalar.valid_isolated_input?(12345)
     end
 
     it 'supports input object' do

--- a/spec/graphql/schema/loader_spec.rb
+++ b/spec/graphql/schema/loader_spec.rb
@@ -23,8 +23,8 @@ describe GraphQL::Schema::Loader do
 
     big_int_type = GraphQL::ScalarType.define do
       name "BigInt"
-      coerce_input ->(value) { value =~ /\d+/ ? Integer(value) : nil }
-      coerce_result ->(value) { value.to_s }
+      coerce_input ->(value, _ctx) { value =~ /\d+/ ? Integer(value) : nil }
+      coerce_result ->(value, _ctx) { value.to_s }
     end
 
     variant_input_type = GraphQL::InputObjectType.define do

--- a/spec/graphql/schema/loader_spec.rb
+++ b/spec/graphql/schema/loader_spec.rb
@@ -202,8 +202,8 @@ describe GraphQL::Schema::Loader do
 
     it "has no-op coerce functions" do
       custom_scalar = loaded_schema.types["BigInt"]
-      assert_equal true, custom_scalar.valid_input?("anything")
-      assert_equal true, custom_scalar.valid_input?(12345)
+      assert_equal true, custom_scalar.valid_isolated_input?("anything")
+      assert_equal true, custom_scalar.valid_isolated_input?(12345)
     end
 
     it "sets correct default values on custom scalar arguments" do

--- a/spec/graphql/schema/loader_spec.rb
+++ b/spec/graphql/schema/loader_spec.rb
@@ -202,8 +202,8 @@ describe GraphQL::Schema::Loader do
 
     it "has no-op coerce functions" do
       custom_scalar = loaded_schema.types["BigInt"]
-      assert_equal true, custom_scalar.valid_input?("anything", PermissiveWarden)
-      assert_equal true, custom_scalar.valid_input?(12345, PermissiveWarden)
+      assert_equal true, custom_scalar.valid_input?("anything")
+      assert_equal true, custom_scalar.valid_input?(12345)
     end
 
     it "sets correct default values on custom scalar arguments" do

--- a/spec/graphql/string_type_spec.rb
+++ b/spec/graphql/string_type_spec.rb
@@ -12,20 +12,20 @@ describe GraphQL::STRING_TYPE do
     it "requires string to be encoded as UTF-8" do
       binary_str = "\0\0\0foo\255\255\255".dup.force_encoding("BINARY")
       assert_raises(GraphQL::CoercionError) {
-        assert_equal nil, string_type.coerce_result(binary_str)
+        assert_equal nil, string_type.coerce_isolated_result(binary_str)
       }
     end
   end
 
   describe "coerce_input" do
     it "accepts strings" do
-      assert_equal "str", string_type.coerce_input("str")
+      assert_equal "str", string_type.coerce_isolated_input("str")
     end
 
     it "doesn't accept other types" do
-      assert_equal nil, string_type.coerce_input(100)
-      assert_equal nil, string_type.coerce_input(true)
-      assert_equal nil, string_type.coerce_input(0.999)
+      assert_equal nil, string_type.coerce_isolated_input(100)
+      assert_equal nil, string_type.coerce_isolated_input(true)
+      assert_equal nil, string_type.coerce_isolated_input(0.999)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,17 +27,6 @@ GraphQL::Field.accepts_definitions(metadata: assign_metadata_key)
 GraphQL::Argument.accepts_definitions(metadata: assign_metadata_key)
 GraphQL::EnumType::EnumValue.accepts_definitions(metadata: assign_metadata_key)
 
-# Can be used as a GraphQL::Schema::Warden for some purposes, but allows anything
-module PermissiveWarden
-  def self.arguments(input_obj)
-    input_obj.arguments.values
-  end
-
-  def self.enum_values(enum_type)
-    enum_type.values.values
-  end
-end
-
 # Can be used as a GraphQL::Schema::Warden for some purposes, but allows nothing
 module NothingWarden
   def self.enum_values(enum_type)


### PR DESCRIPTION
Pass ctx to scalar coerce functions, pass coercion errors to `Schema#type_error` handler 

__TODO__ 

- [x] Thread `ctx` through coercion functions 
- [x] Maintain `ctx`-less API for compatibility
- [x] Pass coerce errors to type_error handler 
- [x] Make `coerce_non_null_input` private (there are no hits on github)

~~In a later (non-patch) release, I'll mark the old `ctx`-less APIs as deprecated.~~ Doin' it now