### PR TITLE
Argument conflict on nested interface type fragments

### DIFF
--- a/spec/graphql/static_validation/rules/fields_will_merge_spec.rb
+++ b/spec/graphql/static_validation/rules/fields_will_merge_spec.rb
@@ -422,12 +422,20 @@ describe GraphQL::StaticValidation::FieldsWillMerge do
       {
         pet {
           ... on Dog {
-            name(surname: true)
+            ...X
           }
           ... on Cat {
-            name
+            ...Y
           }
         }
+      }
+
+      fragment X on Pet {
+        name(surname: true)
+      }
+
+      fragment Y on Pet {
+        name
       }
     |}
 
@@ -435,6 +443,7 @@ describe GraphQL::StaticValidation::FieldsWillMerge do
       assert_equal [], errors
     end
   end
+
   describe "return types must be unambiguous" do
     let(:schema) {
       GraphQL::Schema.from_definition(%|


### PR DESCRIPTION
I ran into an issue where fetching the same field with different arguments for different types using different fragments that used the same interface would fail with a validation error. (That's a really long winded sentence!)

I think the issue is a bit hard to describe, so I modified one of the existing test cases to reproduce the failure I was running into. I'm not even sure whether this is allowed by the GraphQL specification or not, and I couldn't find anything in the spec. It definitely feels like this should just work. 😆 

This is similar to https://github.com/rmosolgo/graphql-ruby/issues/418.