### PR TITLE
Add some details to hasNextPage/hasPreviousPage descriptions.

### DIFF
--- a/lib/graphql/relay/page_info.rb
+++ b/lib/graphql/relay/page_info.rb
@@ -5,10 +5,10 @@ module GraphQL
     PageInfo = GraphQL::ObjectType.define do
       name("PageInfo")
       description("Information about pagination in a connection.")
-      field :hasNextPage, !types.Boolean, "Indicates if there are more pages to fetch (only meaningful if `first` argument is present)", property: :has_next_page
-      field :hasPreviousPage, !types.Boolean, "Indicates if there are any pages prior to the current page (only meaningful if `last` argument is present)", property: :has_previous_page
-      field :startCursor, types.String, "When paginating backwards, the cursor to continue", property: :start_cursor
-      field :endCursor, types.String, "When paginating forwards, the cursor to continue", property: :end_cursor
+      field :hasNextPage, !types.Boolean, "When paginating forwards, are there more items?", property: :has_next_page
+      field :hasPreviousPage, !types.Boolean, "When paginating backwards, are there more items?", property: :has_previous_page
+      field :startCursor, types.String, "When paginating backwards, the cursor to continue.", property: :start_cursor
+      field :endCursor, types.String, "When paginating forwards, the cursor to continue.", property: :end_cursor
       default_relay true
     end
   end

--- a/lib/graphql/relay/page_info.rb
+++ b/lib/graphql/relay/page_info.rb
@@ -5,8 +5,8 @@ module GraphQL
     PageInfo = GraphQL::ObjectType.define do
       name("PageInfo")
       description("Information about pagination in a connection.")
-      field :hasNextPage, !types.Boolean, "Indicates if there are more pages to fetch", property: :has_next_page
-      field :hasPreviousPage, !types.Boolean, "Indicates if there are any pages prior to the current page", property: :has_previous_page
+      field :hasNextPage, !types.Boolean, "Indicates if there are more pages to fetch (only meaningful if `first` argument is present)", property: :has_next_page
+      field :hasPreviousPage, !types.Boolean, "Indicates if there are any pages prior to the current page (only meaningful if `last` argument is present)", property: :has_previous_page
       field :startCursor, types.String, "When paginating backwards, the cursor to continue", property: :start_cursor
       field :endCursor, types.String, "When paginating forwards, the cursor to continue", property: :end_cursor
       default_relay true


### PR DESCRIPTION
According to the [Relay spec](https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo.Fields), the `hasNextPage` and `hasPreviousPage` fields in PageInfo require `first` or `last` arguments to be meaningful:

> hasPreviousPage is only meaningful when last is included, as it is always false otherwise. hasNextPage is only meaningful when first is included, as it is always false otherwise. When both first and last are included, both of the fields are set according to the above algorithms, but their meaning as it relates to pagination becomes unclear. This is among the reasons that pagination with both first and last is discouraged.

(NB this was decided [for performance purposes](https://github.com/graphql/graphql-relay-js/issues/58#issuecomment-169542843))

Since this can cause some [confusion](https://github.com/graphql/graphql-relay-js/issues/58#issuecomment-169542843) from getting a meaningless `false` value back, I propose we mention this in these fields' descriptions.