### PR TITLE
Populate Field#function when defined from a function

### DIFF
--- a/lib/graphql/define/assign_object_field.rb
+++ b/lib/graphql/define/assign_object_field.rb
@@ -25,6 +25,7 @@ module GraphQL
             type: function.type,
             resolve: function,
             description: function.description,
+            function: function,
             deprecation_reason: function.deprecation_reason,
           )
         elsif field.is_a?(GraphQL::Field)

--- a/spec/graphql/relay/connection_field_spec.rb
+++ b/spec/graphql/relay/connection_field_spec.rb
@@ -11,6 +11,11 @@ describe GraphQL::Relay::ConnectionField do
     assert_equal ["tests"], test_type.fields.keys
   end
 
+  it "keeps a reference to the function" do
+    conn_field = StarWars::Faction.fields["shipsWithMaxPageSize"]
+    assert_instance_of StarWars::ShipsWithMaxPageSize, conn_field.function
+  end
+
   it "leaves the original field untouched" do
     test_type = nil
 


### PR DESCRIPTION
Oops, the accessor was there but I don't think it was ever assigned

Fixes #669 