### PR TITLE
fix(Rewrite) root nodes have nil definition

### DIFF
--- a/lib/graphql/internal_representation/node.rb
+++ b/lib/graphql/internal_representation/node.rb
@@ -89,11 +89,14 @@ module GraphQL
       end
 
       def definition_name
-        @definition_name ||= definition.name
+        definition && definition.name
       end
 
       def definition
-        @definition ||= @query.get_field(@owner_type, @definitions.first.name)
+        @definition ||= begin
+          first_def = @definitions.first
+          first_def && @query.get_field(@owner_type, first_def.name)
+        end
       end
 
       def ast_node

--- a/spec/graphql/internal_representation/rewrite_spec.rb
+++ b/spec/graphql/internal_representation/rewrite_spec.rb
@@ -105,6 +105,7 @@ describe GraphQL::InternalRepresentation::Rewrite do
 
     it "groups selections by object types which they apply to" do
       doc = rewrite_result["getPlant"]
+      assert_equal nil, doc.definition
 
       plant_scoped_selection = doc.scoped_children[schema.types["Query"]]["plant"]
       assert_equal ["Fruit", "Nut", "Plant", "Tree"], plant_scoped_selection.scoped_children.keys.map(&:name).sort


### PR DESCRIPTION
Oops, `node.definition` raised on root nodes which broke some query analyzers.