### PR TITLE
Transcode string results to UTF-8 when possible

### DIFF
--- a/lib/graphql/string_encoding_error.rb
+++ b/lib/graphql/string_encoding_error.rb
@@ -4,7 +4,7 @@ module GraphQL
     attr_reader :string
     def initialize(str)
       @string = str
-      super("String \"#{str}\" was encoded as #{str.encoding}! GraphQL requires UTF-8 encoding.")
+      super("String \"#{str}\" was encoded as #{str.encoding}! GraphQL requires an encoding compatible with UTF-8.")
     end
   end
 end

--- a/lib/graphql/string_type.rb
+++ b/lib/graphql/string_type.rb
@@ -4,10 +4,10 @@ GraphQL::STRING_TYPE = GraphQL::ScalarType.define do
   description "Represents textual data as UTF-8 character sequences. This type is most often used by GraphQL to represent free-form human-readable text."
 
   coerce_result ->(value, ctx) {
-    str = value.to_s
-    if str.encoding == Encoding::US_ASCII || str.encoding == Encoding::UTF_8
-      str
-    else
+    begin
+      str = value.to_s
+      str.encoding == Encoding::UTF_8 ? str : str.encode(Encoding::UTF_8)
+    rescue EncodingError
       err = GraphQL::StringEncodingError.new(str)
       ctx.schema.type_error(err, ctx)
     end


### PR DESCRIPTION
Fixes an issue where strings such as "f2f962bd-2216-4c00-a8b0-8f9c71818285"
encoded as ASCII-8BIT would raise GraphQL::StringEncodingError when they
could be easily transcoded.

Strings containing code points that cannot be mapped to UTF-8 will still
raise GraphQL::StringEncodingError.