### PR TITLE
Fix fragment scoping, add InternalRepresentation::Print

### DIFF
--- a/lib/graphql/execution/typecast.rb
+++ b/lib/graphql/execution/typecast.rb
@@ -28,8 +28,8 @@ module GraphQL
               false
             end
           when GraphQL::UnionType
-            # A type is a subtype of that interface
-            # if the union includes that interface
+            # A type is a subtype of that union
+            # if the union includes that type
             parent_type.possible_types.include?(child_type)
           when GraphQL::ListType
             # A list type is a subtype of another list type

--- a/lib/graphql/internal_representation.rb
+++ b/lib/graphql/internal_representation.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "graphql/internal_representation/node"
+require "graphql/internal_representation/print"
 require "graphql/internal_representation/rewrite"
 require "graphql/internal_representation/scope"
 require "graphql/internal_representation/visit"

--- a/lib/graphql/internal_representation/node.rb
+++ b/lib/graphql/internal_representation/node.rb
@@ -19,6 +19,9 @@ module GraphQL
           if @scoped_children.any?
             all_object_types = Set.new
             scoped_children.each_key { |t| all_object_types.merge(@query.possible_types(t)) }
+            # Remove any scoped children which don't follow this return type
+            # (This can happen with fragment merging where lexical scope is lost)
+            all_object_types &= @query.possible_types(@return_type)
             all_object_types.each do |t|
               new_tc[t] = get_typed_children(t)
             end

--- a/lib/graphql/internal_representation/node.rb
+++ b/lib/graphql/internal_representation/node.rb
@@ -114,19 +114,23 @@ module GraphQL
 
       # Merge selections from `new_parent` into `self`.
       # Selections are merged in place, not copied.
-      def deep_merge_node(new_parent, merge_self: true)
+      def deep_merge_node(new_parent, scope: nil, merge_self: true)
         if merge_self
           @ast_nodes.concat(new_parent.ast_nodes)
           @definitions.concat(new_parent.definitions)
         end
+        scope ||= Scope.new(@query, @return_type)
         new_parent.scoped_children.each do |obj_type, new_fields|
-          prev_fields = @scoped_children[obj_type]
-          new_fields.each do |name, new_node|
-            prev_node = prev_fields[name]
-            if prev_node
-              prev_node.deep_merge_node(new_node)
-            else
-              prev_fields[name] = new_node
+          inner_scope = scope.enter(obj_type)
+          inner_scope.each do |scoped_type|
+            prev_fields = @scoped_children[scoped_type]
+            new_fields.each do |name, new_node|
+              prev_node = prev_fields[name]
+              if prev_node
+                prev_node.deep_merge_node(new_node)
+              else
+                prev_fields[name] = new_node
+              end
             end
           end
         end

--- a/lib/graphql/internal_representation/print.rb
+++ b/lib/graphql/internal_representation/print.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+module GraphQL
+  module InternalRepresentation
+    module Print
+      module_function
+
+      def print(schema, query_string)
+        query = GraphQL::Query.new(schema, query_string)
+        print_node(query.irep_selection)
+      end
+
+      def print_node(node, indent: 0)
+        padding = " " * indent
+        typed_children_padding = " " * (indent + 2)
+        query_str = "".dup
+
+        if !node.definition
+          op_node = node.ast_node
+          name = op_node.name ? " " + op_node.name : ""
+          op_type = op_node.operation_type
+          query_str << "#{op_type}#{name}"
+        elsif node.name == node.definition_name
+          query_str << "#{padding}#{node.name}"
+        else
+          query_str << "#{padding}#{node.name}: #{node.definition_name}"
+        end
+
+        if node.typed_children.any?
+          query_str << " {\n"
+          node.typed_children.each do |type, children|
+            query_str << "#{typed_children_padding}... on #{type.name} {\n"
+            children.each do |name, child|
+              query_str << print_node(child, indent: indent + 4)
+            end
+            query_str << "#{typed_children_padding}}\n"
+          end
+          query_str << "#{padding}}\n"
+        else
+          query_str << "\n"
+        end
+
+        query_str
+      end
+    end
+  end
+end

--- a/lib/graphql/internal_representation/print.rb
+++ b/lib/graphql/internal_representation/print.rb
@@ -19,10 +19,15 @@ module GraphQL
           name = op_node.name ? " " + op_node.name : ""
           op_type = op_node.operation_type
           query_str << "#{op_type}#{name}"
-        elsif node.name == node.definition_name
-          query_str << "#{padding}#{node.name}"
         else
-          query_str << "#{padding}#{node.name}: #{node.definition_name}"
+          if node.name == node.definition_name
+            query_str << "#{padding}#{node.name}"
+          else
+            query_str << "#{padding}#{node.name}: #{node.definition_name}"
+          end
+
+          args = node.ast_nodes.map { |n| n.arguments.map(&:to_query_string).join(",") }.uniq
+          query_str << args.map { |a| "(#{a})"}.join("|")
         end
 
         if node.typed_children.any?

--- a/lib/graphql/internal_representation/rewrite.rb
+++ b/lib/graphql/internal_representation/rewrite.rb
@@ -31,6 +31,8 @@ module GraphQL
         # Hash<Nodes::FragmentSpread => Set<InternalRepresentation::Node>>
         # A record of fragment spreads and the irep nodes that used them
         spread_parents = Hash.new { |h, k| h[k] = Set.new }
+        # Hash<Nodes::FragmentSpread => Scope>
+        spread_scopes = {}
         # Array<Set<InternalRepresentation::Node>>
         # The current point of the irep_tree during visitation
         nodes_stack = []
@@ -124,6 +126,7 @@ module GraphQL
           if skip_nodes.none? && !skip?(ast_node, query)
             # Register the irep nodes that depend on this AST node:
             spread_parents[ast_node].merge(nodes_stack.last)
+            spread_scopes[ast_node] = scopes_stack.last
           end
         }
 
@@ -139,8 +142,9 @@ module GraphQL
           if fragment_node
             spread_ast_nodes.each do |spread_ast_node|
               parent_nodes = spread_parents[spread_ast_node]
+              parent_scope = spread_scopes[spread_ast_node]
               parent_nodes.each do |parent_node|
-                parent_node.deep_merge_node(fragment_node, merge_self: false)
+                parent_node.deep_merge_node(fragment_node, scope: parent_scope, merge_self: false)
               end
             end
           end

--- a/spec/graphql/internal_representation/print_spec.rb
+++ b/spec/graphql/internal_representation/print_spec.rb
@@ -24,11 +24,11 @@ describe GraphQL::InternalRepresentation::Print do
       expected_plan = <<-GRAPHQL
 query {
   ... on Query {
-    cheese {
+    cheese(id: 1) {
       ... on Cheese {
-        flavor
-        o2: origin
-        o: origin
+        flavor()
+        o2: origin()
+        o: origin()
       }
     }
   }

--- a/spec/graphql/internal_representation/print_spec.rb
+++ b/spec/graphql/internal_representation/print_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::InternalRepresentation::Print do
+  describe "printing queries" do
+    let(:query_str) { <<-GRAPHQL
+    {
+      cheese(id: 1) {
+        flavor
+        ...EdibleFields
+        ... on Edible {
+          o2: origin
+        }
+      }
+    }
+
+    fragment EdibleFields on Edible {
+      o: origin
+    }
+    GRAPHQL
+  }
+    it "prints the rewritten query" do
+      query_plan = GraphQL::InternalRepresentation::Print.print(Dummy::Schema, query_str)
+      expected_plan = <<-GRAPHQL
+query {
+  ... on Query {
+    cheese {
+      ... on Cheese {
+        flavor
+        o2: origin
+        o: origin
+      }
+    }
+  }
+}
+      GRAPHQL
+
+      assert_equal expected_plan, query_plan
+    end
+  end
+end

--- a/spec/graphql/internal_representation/rewrite_spec.rb
+++ b/spec/graphql/internal_representation/rewrite_spec.rb
@@ -108,7 +108,7 @@ describe GraphQL::InternalRepresentation::Rewrite do
       assert_equal nil, doc.definition
 
       plant_scoped_selection = doc.scoped_children[schema.types["Query"]]["plant"]
-      assert_equal ["Fruit", "Nut", "Plant", "Tree"], plant_scoped_selection.scoped_children.keys.map(&:name).sort
+      assert_equal ["Fruit", "Nut", "Plant"], plant_scoped_selection.scoped_children.keys.map(&:name).sort
 
       plant_selection = doc.typed_children[schema.types["Query"]]["plant"]
       assert_equal ["Fruit", "Grain", "Nut", "Vegetable"], plant_selection.typed_children.keys.map(&:name).sort

--- a/spec/graphql/static_validation/rules/fields_will_merge_spec.rb
+++ b/spec/graphql/static_validation/rules/fields_will_merge_spec.rb
@@ -422,12 +422,20 @@ describe GraphQL::StaticValidation::FieldsWillMerge do
       {
         pet {
           ... on Dog {
-            name(surname: true)
+            ...X
           }
           ... on Cat {
-            name
+            ...Y
           }
         }
+      }
+
+      fragment X on Pet {
+        name(surname: true)
+      }
+
+      fragment Y on Pet {
+        name
       }
     |}
 
@@ -435,6 +443,7 @@ describe GraphQL::StaticValidation::FieldsWillMerge do
       assert_equal [], errors
     end
   end
+
   describe "return types must be unambiguous" do
     let(:schema) {
       GraphQL::Schema.from_definition(%|


### PR DESCRIPTION
Fixes #668 

And in the meantime added a debugging utility, `InternalRepresentation::Print.print(schema, query_str)`. It shows you `Rewrite`'s output which matches actual query execution. 