### PR TITLE
Support skipping fields altogether from user code

### DIFF
--- a/lib/graphql/compatibility/execution_specification.rb
+++ b/lib/graphql/compatibility/execution_specification.rb
@@ -15,6 +15,7 @@ module GraphQL
     # - Typecasting
     # - Error handling (raise / return GraphQL::ExecutionError)
     # - Provides Irep & AST node to resolve fn
+    # - Skipping fields
     #
     # Some things are explicitly _not_ tested here, because they're handled
     # by other parts of the system:
@@ -95,6 +96,19 @@ module GraphQL
 
             res = execute_query(query_string)
             assert_equal ["SNCC"], res["data"]["node"]["organizations"].map { |o| o["name"] }
+          end
+
+          def test_it_skips_skipped_fields
+            query_str = <<-GRAPHQL
+            {
+              o3001: organization(id: "3001")  { name }
+              o2001: organization(id: "2001")  { name }
+            }
+            GRAPHQL
+
+            res = execute_query(query_str)
+            assert_equal ["o2001"], res["data"].keys
+            assert_equal false, res.key?("errors")
           end
 
           def test_it_propagates_nulls_to_field

--- a/lib/graphql/compatibility/execution_specification/specification_schema.rb
+++ b/lib/graphql/compatibility/execution_specification/specification_schema.rb
@@ -158,7 +158,12 @@ module GraphQL
             field :organization, !organization_type do
               argument :id, !types.ID
               resolve ->(obj, args, ctx) {
-                args[:id].start_with?("2") && obj[args[:id]]
+                if args[:id].start_with?("2")
+                  obj[args[:id]]
+                else
+                  # test context.skip
+                  ctx.skip
+                end
               }
             end
 

--- a/lib/graphql/compatibility/lazy_execution_specification.rb
+++ b/lib/graphql/compatibility/lazy_execution_specification.rb
@@ -180,6 +180,25 @@ module GraphQL
             ]
             assert_equal expected_log, log
           end
+
+          def test_it_skips_ctx_skip
+            query_string = <<-GRAPHQL
+            {
+              p0: push(value: 15) { value }
+              p1: push(value: 1) { value }
+              p2: push(value: 2) {
+                value
+                p3: push(value: 15) {
+                  value
+                }
+              }
+            }
+            GRAPHQL
+            pushes = []
+            res = self.class.lazy_schema.execute(query_string, context: {pushes: pushes})
+            assert_equal [[1,2]], pushes
+            assert_equal({"data"=>{"p1"=>{"value"=>1}, "p2"=>{"value"=>2}}}, res)
+          end
         end
       end
     end

--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -4,7 +4,10 @@ module GraphQL
     # A valid execution strategy
     # @api private
     class Execute
-      PROPAGATE_NULL = :__graphql_propagate_null__
+      # @api private
+      SKIP = Object.new
+      # @api private
+      PROPAGATE_NULL = Object.new
 
       def execute(ast_operation, root_type, query)
         result = resolve_selection(
@@ -34,6 +37,10 @@ module GraphQL
             object,
             query_ctx
           )
+
+          if field_result == SKIP
+            next
+          end
 
           if mutation
             GraphQL::Execution::Lazy.resolve(field_result)
@@ -138,6 +145,8 @@ module GraphQL
           else
             nil
           end
+        elsif value == SKIP
+          value
         else
           case field_type.kind
           when GraphQL::TypeKinds::SCALAR

--- a/lib/graphql/execution/field_result.rb
+++ b/lib/graphql/execution/field_result.rb
@@ -21,6 +21,7 @@ module GraphQL
       # If it is {Execute::PROPAGATE_NULL}, tell the owner to propagate null.
       # If the value is a {SelectionResult}, make a link with it, and if it's already null,
       # propagate the null as needed.
+      # If it's {Execute::Execution::SKIP}, remove this field result from its parent
       # @param new_value [Any] The GraphQL-ready value
       def value=(new_value)
         if new_value.is_a?(SelectionResult)
@@ -31,12 +32,15 @@ module GraphQL
           end
         end
 
-        if new_value == GraphQL::Execution::Execute::PROPAGATE_NULL
+        case new_value
+        when GraphQL::Execution::Execute::PROPAGATE_NULL
           if @type.kind.non_null?
             @owner.propagate_null
           else
             @value = nil
           end
+        when GraphQL::Execution::Execute::SKIP
+          @owner.delete(self)
         else
           @value = new_value
         end

--- a/lib/graphql/execution/selection_result.rb
+++ b/lib/graphql/execution/selection_result.rb
@@ -38,6 +38,11 @@ module GraphQL
         end
       end
 
+      # TODO this should delete by key, ya dummy
+      def delete(field_result)
+        @storage.delete_if { |k, v| v == field_result }
+      end
+
       # A field has been unexpectedly nullified.
       # Tell the owner {FieldResult} if it is present.
       # Record {#invalid_null} in case an owner is added later.

--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -71,6 +71,12 @@ module GraphQL
         )
       end
 
+      # Return this value to tell the runtime
+      # to exclude this field from the response altogether
+      def skip
+        GraphQL::Execution::Execute::SKIP
+      end
+
       class FieldResolutionContext
         extend Forwardable
 
@@ -84,7 +90,7 @@ module GraphQL
           @parent_type = parent_type
         end
 
-        def_delegators :@context, :[], :[]=, :spawn, :query, :schema, :warden, :errors, :execution_strategy, :strategy
+        def_delegators :@context, :[], :[]=, :spawn, :query, :schema, :warden, :errors, :execution_strategy, :strategy, :skip
 
         # @return [GraphQL::Language::Nodes::Field] The AST node for the currently-executing field
         def ast_node

--- a/lib/graphql/query/serial_execution/field_resolution.rb
+++ b/lib/graphql/query/serial_execution/field_resolution.rb
@@ -24,7 +24,11 @@ module GraphQL
         def result
           result_name = irep_node.name
           raw_value = get_raw_value
-          { result_name => get_finished_value(raw_value) }
+          if raw_value == GraphQL::Execution::Execute::SKIP
+            {}
+          else
+            { result_name => get_finished_value(raw_value) }
+          end
         end
 
         # GraphQL::Batch depends on this


### PR DESCRIPTION
This will help on subscriptions, where untriggered root fields will be skipped. I think it'll also help for `@defer`-like behavior where some fields should be entirely absent from the result, but we have to do the skip at runtime in order to have access to the backing `obj`.

__TODO:__

- Improve `SelectionResult#delete` to not be O(n). I'm feeling a lot of pain here in the parallel trees of `Context` and `Result` objects, I think they should be merged.
- Test for lists of scalars? Or this is unsupported for lists? (The whole list must be `ctx.skip`?)