### PR TITLE
feat(Context#namespace) add isolated storage to context, use it for TimeoutMiddleware

### DIFF
--- a/spec/graphql/query/context_spec.rb
+++ b/spec/graphql/query/context_spec.rb
@@ -75,8 +75,10 @@ describe GraphQL::Query::Context do
   describe "empty values" do
     let(:context) { GraphQL::Query::Context.new(query: OpenStruct.new(schema: schema), values: nil) }
 
-    it "returns nil for any key" do
+    it "returns returns nil and reports key? => false" do
       assert_equal(nil, context[:some_key])
+      assert_equal(false, context.key?(:some_key))
+      assert_raises(KeyError) { context.fetch(:some_key) }
     end
   end
 
@@ -87,6 +89,17 @@ describe GraphQL::Query::Context do
       assert_equal(nil, context[:some_key])
       context[:some_key] = "wow!"
       assert_equal("wow!", context[:some_key])
+    end
+
+    describe "namespaces" do
+      let(:context) { GraphQL::Query::Context.new(query: OpenStruct.new(schema: schema), values: {a: 1}) }
+
+      it "doesn't conflict with base values" do
+        ns = context.namespace(:stuff)
+        ns[:b] = 2
+        assert_equal({a: 1}, context.to_h)
+        assert_equal({b: 2}, context.namespace(:stuff))
+      end
     end
   end
 


### PR DESCRIPTION
Subscriptions do some query-level bookkeeping and I can simplify the integration between layers by using `context`. However, part of subscription management is dumping & loading `context` as needed. This can become very brittle when your `context` has "other peoples'" values in it. (That is, libraries, instrumentation, middleware, whatever, may have added values to your context hash.)

So, this PR introduces namespaced storage on context: a `Hash<Object => Hash>` where libraries, instrumentation, etc can pick a namespace and store values there in a way that's transparent to user code. There's no code to avoid naming conflicts, but an easy way to ensure nobody is using your namespace is to use the class or module as the key 😆 

As a bonus, this PR throws in better checks for context storage: `key?`, `fetch` and `to_h`. (Extra nifty for serializing your context.)

Initially suggested in #438 