### PR TITLE
Fix `property:` on mutation return_fields`

### DIFF
--- a/lib/graphql/relay/mutation.rb
+++ b/lib/graphql/relay/mutation.rb
@@ -211,7 +211,10 @@ module GraphQL
 
         def self.define_subclass(mutation_defn)
           subclass = Class.new(self) do
-            attr_accessor(*mutation_defn.return_type.all_fields.map(&:name))
+            mutation_result_methods = mutation_defn.return_type.all_fields.map do |f|
+              f.property || f.name
+            end
+            attr_accessor(*mutation_result_methods)
             self.mutation = mutation_defn
           end
           subclass

--- a/lib/graphql/relay/mutation.rb
+++ b/lib/graphql/relay/mutation.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
+require "graphql/relay/mutation/instrumentation"
+require "graphql/relay/mutation/resolve"
+require "graphql/relay/mutation/result"
+
 module GraphQL
   module Relay
     # Define a Relay mutation:
@@ -178,9 +182,7 @@ module GraphQL
       end
 
       def result_class
-        @result_class ||= begin
-          Result.define_subclass(self)
-        end
+        @result_class ||= Result.define_subclass(self)
       end
 
       private
@@ -191,87 +193,6 @@ module GraphQL
           callable.arity
         else
           callable.method(:call).arity
-        end
-      end
-
-      # Use this when the mutation's return type was generated from `return_field`s.
-      # It delegates field lookups to the hash returned from `resolve`.
-      class Result
-        attr_reader :client_mutation_id
-        def initialize(client_mutation_id:, result:)
-          @client_mutation_id = client_mutation_id
-          result && result.each do |key, value|
-            self.public_send("#{key}=", value)
-          end
-        end
-
-        class << self
-          attr_accessor :mutation
-        end
-
-        def self.define_subclass(mutation_defn)
-          subclass = Class.new(self) do
-            mutation_result_methods = mutation_defn.return_type.all_fields.map do |f|
-              f.property || f.name
-            end
-            attr_accessor(*mutation_result_methods)
-            self.mutation = mutation_defn
-          end
-          subclass
-        end
-      end
-
-      module MutationInstrumentation
-        def self.instrument(type, field)
-          if field.mutation
-            new_resolve = MutationResolve.new(field.mutation, field.resolve_proc)
-            new_lazy_resolve = MutationResolve.new(field.mutation, field.lazy_resolve_proc)
-            field.redefine(resolve: new_resolve, lazy_resolve: new_lazy_resolve)
-          else
-            field
-          end
-        end
-      end
-
-      class MutationResolve
-        def initialize(mutation, resolve)
-          @mutation = mutation
-          @resolve = resolve
-          @wrap_result = mutation.has_generated_return_type?
-        end
-
-        def call(obj, args, ctx)
-          begin
-            mutation_result = @resolve.call(obj, args[:input], ctx)
-          rescue GraphQL::ExecutionError => err
-            mutation_result = err
-          end
-
-          if ctx.schema.lazy?(mutation_result)
-            mutation_result
-          else
-            build_result(mutation_result, args, ctx)
-          end
-        end
-
-        private
-
-        def build_result(mutation_result, args, ctx)
-          if mutation_result.is_a?(GraphQL::ExecutionError)
-            ctx.add_error(mutation_result)
-            mutation_result = nil
-          end
-
-          if @wrap_result
-            if mutation_result && !mutation_result.is_a?(Hash)
-              raise StandardError, "Expected `#{mutation_result}` to be a Hash."\
-                " Return a hash when using `return_field` or specify a custom `return_type`."
-            end
-
-            @mutation.result_class.new(client_mutation_id: args[:input][:clientMutationId], result: mutation_result)
-          else
-            mutation_result
-          end
         end
       end
     end

--- a/lib/graphql/relay/mutation/instrumentation.rb
+++ b/lib/graphql/relay/mutation/instrumentation.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+module GraphQL
+  module Relay
+    class Mutation
+      # @api private
+      module Instrumentation
+        # Modify mutation `return_field` resolves by wrapping the returned object
+        # in a {Mutation::Result}.
+        #
+        # By using an instrumention, we can apply our wrapper _last_,
+        # giving users access to the original resolve function in earlier instrumentation.
+        def self.instrument(type, field)
+          if field.mutation
+            new_resolve = Mutation::Resolve.new(field.mutation, field.resolve_proc)
+            new_lazy_resolve = Mutation::Resolve.new(field.mutation, field.lazy_resolve_proc)
+            field.redefine(resolve: new_resolve, lazy_resolve: new_lazy_resolve)
+          else
+            field
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/relay/mutation/resolve.rb
+++ b/lib/graphql/relay/mutation/resolve.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+module GraphQL
+  module Relay
+    class Mutation
+      # Wrap a user-provided resolve function,
+      # wrapping the returned value in a {Mutation::Result}.
+      # Also, pass the `clientMutationId` to that result object.
+      # @api private
+      class Resolve
+        def initialize(mutation, resolve)
+          @mutation = mutation
+          @resolve = resolve
+          @wrap_result = mutation.has_generated_return_type?
+        end
+
+        def call(obj, args, ctx)
+          begin
+            mutation_result = @resolve.call(obj, args[:input], ctx)
+          rescue GraphQL::ExecutionError => err
+            mutation_result = err
+          end
+
+          if ctx.schema.lazy?(mutation_result)
+            mutation_result
+          else
+            build_result(mutation_result, args, ctx)
+          end
+        end
+
+        private
+
+        def build_result(mutation_result, args, ctx)
+          if mutation_result.is_a?(GraphQL::ExecutionError)
+            ctx.add_error(mutation_result)
+            mutation_result = nil
+          end
+
+          if @wrap_result
+            if mutation_result && !mutation_result.is_a?(Hash)
+              raise StandardError, "Expected `#{mutation_result}` to be a Hash."\
+                " Return a hash when using `return_field` or specify a custom `return_type`."
+            end
+
+            @mutation.result_class.new(client_mutation_id: args[:input][:clientMutationId], result: mutation_result)
+          else
+            mutation_result
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/relay/mutation/result.rb
+++ b/lib/graphql/relay/mutation/result.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+module GraphQL
+  module Relay
+    class Mutation
+      # Use this when the mutation's return type was generated from `return_field`s.
+      # It delegates field lookups to the hash returned from `resolve`.
+      # @api private
+      class Result
+        attr_reader :client_mutation_id
+        def initialize(client_mutation_id:, result:)
+          @client_mutation_id = client_mutation_id
+          result && result.each do |key, value|
+            self.public_send("#{key}=", value)
+          end
+        end
+
+        class << self
+          attr_accessor :mutation
+        end
+
+        # Build a subclass whose instances have a method
+        # for each of `mutation_defn`'s `return_field`s
+        # @param mutation_defn [GraphQL::Relay::Mutation]
+        # @return [Class]
+        def self.define_subclass(mutation_defn)
+          subclass = Class.new(self) do
+            mutation_result_methods = mutation_defn.return_type.all_fields.map do |f|
+              f.property || f.name
+            end
+            attr_accessor(*mutation_result_methods)
+            self.mutation = mutation_defn
+          end
+          subclass
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -445,7 +445,7 @@ module GraphQL
     def build_instrumented_field_map
       all_instrumenters = @instrumenters[:field] + [
         GraphQL::Relay::ConnectionInstrumentation,
-        GraphQL::Relay::Mutation::MutationInstrumentation,
+        GraphQL::Relay::Mutation::Instrumentation,
       ]
       @instrumented_field_map = InstrumentedFieldMap.new(self, all_instrumenters)
     end

--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -183,7 +183,7 @@ module StarWars
     # Result may have access to these fields:
     return_field :shipEdge, Ship.edge_type
     return_field :faction, Faction
-    return_field :aliasedFaction, Faction, property: :faction
+    return_field :aliasedFaction, Faction, property: :aliased_faction
 
     # Here's the mutation operation:
     resolve ->(root_obj, inputs, ctx) {
@@ -217,7 +217,8 @@ module StarWars
         ship_edge = GraphQL::Relay::Edge.new(ship, ships_connection)
         result = {
           shipEdge: ship_edge,
-          faction: faction
+          faction: faction,
+          aliased_faction: faction,
         }
         if args["shipName"] == "Slave II"
           LazyWrapper.new(result)


### PR DESCRIPTION
Add an accessor to the derived result object based on `property`, not `field.name`.

Closes #686 