### PR TITLE
Fix bundler source URL for pro

### DIFF
--- a/guides/pro/installation.md
+++ b/guides/pro/installation.md
@@ -11,7 +11,7 @@ bundle config gems.graphql.pro #{YOUR_CREDENTIALS}
 Then, you can add `graphql-pro` to your Gemfile, which a custom `source`:
 
 ```ruby
-source "gems.graphql.pro" do
+source "https://gems.graphql.pro" do
   gem "graphql-pro"
 end
 ```


### PR DESCRIPTION
Trying to use the old shorthand version of Gem sources results in the following error on recent Bundler versions:

```
[!] There was an error parsing `Gemfile`: The source must be an absolute URI. For example:
source 'https://rubygems.org'. Bundler cannot continue.

 #  from Gemfile:5
 #  -------------------------------------------
 >  source "gems.graphql.pro" do
 #    gem "graphql-pro"
 #  -------------------------------------------
```