### PR TITLE
Function docs: update types usage

### DIFF
--- a/guides/schema/code_reuse.md
+++ b/guides/schema/code_reuse.md
@@ -54,7 +54,7 @@ Objects passed with the `function:` keyword must implement some field-related me
 ```ruby
 class MyFunc < GraphQL::Function
   # Define a member of `#arguments`, just like the DSL:
-  argument :id, GraphQL::ID_TYPE
+  argument :id, types.ID
 
   # Define documentation:
   description "My Custom function"
@@ -65,21 +65,11 @@ class MyFunc < GraphQL::Function
   type do
     name "MyFuncReturnType"
     # The returned object must implement these methods:
-    field :name, GraphQL::STRING_TYPE
-    field :count, GraphQL::INT_TYPE
+    field :name, types.String
+    field :count, types.Int
   end
 end
 ```
-
-#### Types
-
-Note that `types.` is _not_ available. Instead, you should reference GraphQL's built-in {{ "GraphQL::ScalarType" | api_doc }}s directly.
-
-To make lists and non-null types, you can use:
-
-- {{ "BaseType#to_list_type" | api_doc }} to make a list, eg `PostType.to_list_type`
-- {{ "BaseType#to_non_null_type" | api_doc }} to make a non-null type, eg `PostType.to_non_null_type`
-
 
 #### Function Inheritance
 

--- a/lib/generators/graphql/templates/function.erb
+++ b/lib/generators/graphql/templates/function.erb
@@ -9,7 +9,7 @@ class Functions::<%= name %> < GraphQL::Function
   # end
 
   # add arguments by type:
-  # argument :id, !GraphQL::ID_TYPE
+  # argument :id, !types.ID
 
   # Resolve function:
   def call(obj, args, ctx)

--- a/lib/graphql/function.rb
+++ b/lib/graphql/function.rb
@@ -18,7 +18,7 @@ module GraphQL
   #
   #     argument :id, GraphQL::ID_TYPE
   #
-  #     def resolve(obj, args, ctx)
+  #     def call(obj, args, ctx)
   #        @model.find(args.id)
   #     end
   #   end

--- a/spec/generators/graphql/function_generator_spec.rb
+++ b/spec/generators/graphql/function_generator_spec.rb
@@ -20,7 +20,7 @@ class Functions::FindRecord < GraphQL::Function
   # end
 
   # add arguments by type:
-  # argument :id, !GraphQL::ID_TYPE
+  # argument :id, !types.ID
 
   # Resolve function:
   def call(obj, args, ctx)


### PR DESCRIPTION
`types` is exposed in functions as of `1.5.6` (in https://github.com/rmosolgo/graphql-ruby/pull/654)

I figured the whole section on Types wasn't even needed anymore?