### PR TITLE
Update graphql-batch usage in generators

### DIFF
--- a/lib/generators/graphql/templates/schema.erb
+++ b/lib/generators/graphql/templates/schema.erb
@@ -29,6 +29,5 @@
   }
 <% end %><% if options[:batch] %>
   # GraphQL::Batch setup:
-  lazy_resolve(Promise, :sync)
-  instrument(:query, GraphQL::Batch::Setup)
+  use GraphQL::Batch
 <% end %>end

--- a/spec/generators/graphql/install_generator_spec.rb
+++ b/spec/generators/graphql/install_generator_spec.rb
@@ -178,8 +178,7 @@ DummySchema = GraphQL::Schema.define do
   }
 
   # GraphQL::Batch setup:
-  lazy_resolve(Promise, :sync)
-  instrument(:query, GraphQL::Batch::Setup)
+  use GraphQL::Batch
 end
 RUBY
 end


### PR DESCRIPTION
`v0.3.2` includes the `use` functionality

Not sure if the `# GraphQL::Batch setup:` comment is still needed or not?