### PR TITLE
Make resolvemap work more like graphql-tools

### DIFF
--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -46,6 +46,13 @@ module GraphQL
               @resolve_hash[type_name_s] = fields
             end
           end
+
+          # Check the normalized hash, not the user input:
+          if @resolve_hash.key?("resolve_type")
+            define_singleton_method :resolve_type do |type, ctx|
+              @resolve_hash.fetch("resolve_type").call(type, ctx)
+            end
+          end
         end
 
         def call(type, field, obj, args, ctx)
@@ -54,7 +61,6 @@ module GraphQL
         end
 
         def after_build_schema(schema)
-          hookup_union(schema)
           hookup_scalars(schema)
         end
 
@@ -96,12 +102,6 @@ module GraphQL
               # Call through this time
               resolver.call(obj, args, ctx)
             end
-          end
-        end
-
-        def hookup_union(schema)
-          if @resolve_hash.key?("__resolve_type")
-            schema.resolve_type = @resolve_hash["__resolve_type"]
           end
         end
 
@@ -189,7 +189,11 @@ module GraphQL
             mutation mutation_root_type
             subscription subscription_root_type
             orphan_types types.values
-            resolve_type NullResolveType
+            if default_resolve.respond_to?(:resolve_type)
+              resolve_type(default_resolve.method(:resolve_type))
+            else
+              resolve_type(NullResolveType)
+            end
 
             directives directives.values
           end

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -22,22 +22,42 @@ module GraphQL
 
       # @api private
       class ResolveMap
+        
         def initialize(resolve_hash)
-          @resolve_hash = resolve_hash
+          @resolve_hash = convert_keys_to_strings(resolve_hash)
+        end
+
+        def convert_keys_to_strings(h)
+          Hash[
+            h.map {|k, v| 
+              v = convert_keys_to_strings(v) if v.is_a?(Hash)
+              [k.to_s, v] 
+            }
+          ]
         end
 
         def call(type, field, obj, args, ctx)
-          type_hash = @resolve_hash[type.name.to_sym]
-          type_hash && (resolver = type_hash[field.name.to_sym])
+          type_hash = @resolve_hash[type.name]
+
+          if !type_hash
+            type_hash = @resolve_hash[type.name] = {}
+          end
+
+          type_hash && (resolver = type_hash[field.name])
 
           if resolver.nil?
-            if !obj.respond_to? field.name
-              raise(KeyError, "resolver not found for #{type.name}.#{field.name}")
-            else
-              obj.send field.name
-            end
+            raise(KeyError, "resolver not found for #{type.name}.#{field.name}") unless obj.respond_to?(field.name)
+            resolver = type_hash[field.name] = build_resolver(type, field, obj)
+          end
+
+          resolver.call(obj, args, ctx)
+        end
+
+        def build_resolver(type, field, obj)
+          if obj.method(field.name.to_sym).arity > 0 
+            return -> (o, a, c) { o.send(field.name, a) }
           else
-            resolver.call(obj, args, ctx)
+            return -> (o, a, c) { o.send(field.name) }
           end
         end
       end

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -55,9 +55,9 @@ module GraphQL
 
         def build_resolver(type, field, obj)
           if obj.method(field.name.to_sym).arity > 0 
-            return -> (o, a, c) { o.send(field.name, a) }
+            return ->(o, a, c) { o.send(field.name, a) }
           else
-            return -> (o, a, c) { o.send(field.name) }
+            return ->(o, a, c) { o.send(field.name) }
           end
         end
       end

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require "graphql/schema/build_from_definition/resolve_map"
+
 module GraphQL
   class Schema
     module BuildFromDefinition
@@ -16,102 +18,6 @@ module GraphQL
             obj.public_send(field.name, args, ctx)
           else
             obj.public_send(field.name)
-          end
-        end
-      end
-
-      # @api private
-      class ResolveMap
-
-        def initialize(user_resolve_hash)
-          @resolve_hash = Hash.new do |h, k|
-            # For each type name, provide a new hash if one wasn't given:
-            h[k] = Hash.new do |h2, k2|
-              if k2 == "coerce_input" || k2 == "coerce_result"
-                # This isn't an object field, it's a scalar coerce function.
-                # Use a passthrough
-                Builder::NullScalarCoerce
-              else
-                # For each field, provide a resolver that will
-                # make runtime checks & replace itself
-                h2[k2] = SelfReplacingDefaultResolveFunction.new(h2, k2)
-              end
-            end
-          end
-          @user_resolve_hash = user_resolve_hash
-          # User-provided resolve functions take priority over the default:
-          @user_resolve_hash.each do |type_name, fields|
-            type_name_s = type_name.to_s
-            case fields
-            when Hash
-              fields.each do |field_name, resolve_fn|
-                @resolve_hash[type_name_s][field_name.to_s] = resolve_fn
-              end
-            when Proc
-              # for example, __resolve_type
-              @resolve_hash[type_name_s] = fields
-            end
-          end
-
-          # Check the normalized hash, not the user input:
-          if @resolve_hash.key?("resolve_type")
-            define_singleton_method :resolve_type do |type, ctx|
-              @resolve_hash.fetch("resolve_type").call(type, ctx)
-            end
-          end
-        end
-
-        def call(type, field, obj, args, ctx)
-          resolver = @resolve_hash[type.name][field.name]
-          resolver.call(obj, args, ctx)
-        end
-
-        def coerce_input(type, value, ctx)
-          @resolve_hash[type.name]["coerce_input"].call(value, ctx)
-        end
-
-        def coerce_result(type, value, ctx)
-          @resolve_hash[type.name]["coerce_result"].call(value, ctx)
-        end
-
-        private
-
-        class SelfReplacingDefaultResolveFunction
-          def initialize(field_map, field_name)
-            @field_map = field_map
-            @field_name = field_name
-          end
-
-          # Make some runtime checks about
-          # how `obj` implements the `field_name`.
-          #
-          # Create a new resolve function according to that implementation, then:
-          #   - update `field_map` with this implementation
-          #   - call the implementation now (to satisfy this field execution)
-          #
-          # If `obj` doesn't implement `field_name`, raise an error.
-          def call(obj, args, ctx)
-            method_name = @field_name
-            if !obj.respond_to?(method_name)
-              raise KeyError, "Can't resolve field #{method_name} on #{obj}"
-            else
-              method_arity = obj.method(method_name).arity
-              resolver = case method_arity
-              when 0, -1
-                # -1 Handles method_missing, eg openstruct
-                ->(o, a, c) { o.public_send(method_name) }
-              when 1
-                ->(o, a, c) { o.public_send(method_name, a) }
-              when 2
-                ->(o, a, c) { o.public_send(method_name, a, c) }
-              else
-                raise "Unexpected resolve arity: #{method_arity}. Must be 0, 1, 2"
-              end
-              # Call the resolver directly next time
-              @field_map[method_name] = resolver
-              # Call through this time
-              resolver.call(obj, args, ctx)
-            end
           end
         end
       end

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -27,15 +27,6 @@ module GraphQL
           @resolve_hash = convert_keys_to_strings(resolve_hash)
         end
 
-        def convert_keys_to_strings(h)
-          Hash[
-            h.map {|k, v|
-              v = convert_keys_to_strings(v) if v.is_a?(Hash)
-              [k.to_s, v]
-            }
-          ]
-        end
-
         def call(type, field, obj, args, ctx)
           type_hash = @resolve_hash[type.name]
 
@@ -43,7 +34,7 @@ module GraphQL
             type_hash = @resolve_hash[type.name] = {}
           end
 
-          type_hash && (resolver = type_hash[field.name])
+          resolver = type_hash[field.name]
 
           if resolver.nil?
             raise(KeyError, "resolver not found for #{type.name}.#{field.name}") unless obj.respond_to?(field.name)
@@ -53,18 +44,29 @@ module GraphQL
           resolver.call(obj, args, ctx)
         end
 
-        def build_resolver(type, field, obj)
-          if obj.method(field.name.to_sym).arity > 0
-            return ->(o, a, c) { o.send(field.name, a) }
-          end
-          ->(o, a, c) { o.send(field.name) }
-        end
-
         def after_build_schema(schema) 
           hookup_union(schema)
           hookup_scalars(schema)
         end
 
+        private
+
+        def build_resolver(type, field, obj)
+          method_arity = obj.method(field.name.to_sym).arity
+          case method_arity
+          # Some objects have dynamic missing method such as openstruct
+          # therefore they have an arity -1
+          when -1, 0
+            ->(o, a, c) { o.public_send(field.name) }
+          when 1
+            ->(o, a, c) { o.public_send(field.name, a) }
+          when 2
+            ->(o, a, c) { o.public_send(field.name, a, c) }
+          else 
+            raise "Unexpected resolve arity: #{method_arity}. Must be 0, 1, 2"
+          end
+        end
+       
         def hookup_union(schema)
           schema.resolve_type = @resolve_hash["__resolve_type"] if @resolve_hash["__resolve_type"]
         end
@@ -78,6 +80,15 @@ module GraphQL
             type.coerce_result = @resolve_hash[type.name]["coerce_result"] if @resolve_hash[type.name]["coerce_result"]
           end
         end
+       
+        def convert_keys_to_strings(h)
+          Hash[
+            h.map {|k, v|
+              v = convert_keys_to_strings(v) if v.is_a?(Hash)
+              [k.to_s, v]
+            }
+          ]
+        end        
       end
 
       # @api private

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -22,73 +22,98 @@ module GraphQL
 
       # @api private
       class ResolveMap
-        
-        def initialize(resolve_hash)
-          @resolve_hash = convert_keys_to_strings(resolve_hash)
+
+        def initialize(user_resolve_hash)
+          @resolve_hash = Hash.new do |h, k|
+            # For each type name, provide a new hash if one wasn't given:
+            h[k] = Hash.new do |h2, k2|
+              # For each field, provide a resolver that will
+              # make runtime checks & replace itself
+              h2[k2] = SelfReplacingDefaultResolveFunction.new(h2, k2)
+            end
+          end
+          @user_resolve_hash = user_resolve_hash
+          # User-provided resolve functions take priority over the default:
+          @user_resolve_hash.each do |type_name, fields|
+            type_name_s = type_name.to_s
+            case fields
+            when Hash
+              fields.each do |field_name, resolve_fn|
+                @resolve_hash[type_name_s][field_name.to_s] = resolve_fn
+              end
+            when Proc
+              # for example, __resolve_type
+              @resolve_hash[type_name_s] = fields
+            end
+          end
         end
 
         def call(type, field, obj, args, ctx)
-          type_hash = @resolve_hash[type.name]
-
-          if !type_hash
-            type_hash = @resolve_hash[type.name] = {}
-          end
-
-          resolver = type_hash[field.name]
-
-          if resolver.nil?
-            raise(KeyError, "resolver not found for #{type.name}.#{field.name}") unless obj.respond_to?(field.name)
-            resolver = type_hash[field.name] = build_resolver(type, field, obj)
-          end
-
+          resolver = @resolve_hash[type.name][field.name]
           resolver.call(obj, args, ctx)
         end
 
-        def after_build_schema(schema) 
+        def after_build_schema(schema)
           hookup_union(schema)
           hookup_scalars(schema)
         end
 
         private
 
-        def build_resolver(type, field, obj)
-          method_arity = obj.method(field.name.to_sym).arity
-          case method_arity
-          # Some objects have dynamic missing method such as openstruct
-          # therefore they have an arity -1
-          when -1, 0
-            ->(o, a, c) { o.public_send(field.name) }
-          when 1
-            ->(o, a, c) { o.public_send(field.name, a) }
-          when 2
-            ->(o, a, c) { o.public_send(field.name, a, c) }
-          else 
-            raise "Unexpected resolve arity: #{method_arity}. Must be 0, 1, 2"
+        class SelfReplacingDefaultResolveFunction
+          def initialize(field_map, field_name)
+            @field_map = field_map
+            @field_name = field_name
+          end
+
+          # Make some runtime checks about
+          # how `obj` implements the `field_name`.
+          #
+          # Create a new resolve function according to that implementation, then:
+          #   - update `field_map` with this implementation
+          #   - call the implementation now (to satisfy this field execution)
+          #
+          # If `obj` doesn't implement `field_name`, raise an error.
+          def call(obj, args, ctx)
+            method_name = @field_name
+            if !obj.respond_to?(method_name)
+              raise KeyError, "Can't resolve field #{method_name} on #{obj}"
+            else
+              method_arity = obj.method(method_name).arity
+              resolver = case method_arity
+              when 0, -1
+                # -1 Handles method_missing, eg openstruct
+                ->(o, a, c) { o.public_send(method_name) }
+              when 1
+                ->(o, a, c) { o.public_send(method_name, a) }
+              when 2
+                ->(o, a, c) { o.public_send(method_name, a, c) }
+              else
+                raise "Unexpected resolve arity: #{method_arity}. Must be 0, 1, 2"
+              end
+              # Call the resolver directly next time
+              @field_map[method_name] = resolver
+              # Call through this time
+              resolver.call(obj, args, ctx)
+            end
           end
         end
-       
+
         def hookup_union(schema)
-          schema.resolve_type = @resolve_hash["__resolve_type"] if @resolve_hash["__resolve_type"]
+          if @resolve_hash.key?("__resolve_type")
+            schema.resolve_type = @resolve_hash["__resolve_type"]
+          end
         end
 
         def hookup_scalars(schema)
-          for _, type in schema.types
-            next unless type.is_a?(GraphQL::ScalarType) and @resolve_hash[type.name]
-          
-            type.coerce        = @resolve_hash[type.name]["coerce"]        if @resolve_hash[type.name]["coerce"]
-            type.coerce_input  = @resolve_hash[type.name]["coerce_input"]  if @resolve_hash[type.name]["coerce_input"]
-            type.coerce_result = @resolve_hash[type.name]["coerce_result"] if @resolve_hash[type.name]["coerce_result"]
+          schema.types.each do |name, type|
+            if type.is_a?(GraphQL::ScalarType) && @resolve_hash.key?(type.name)
+              type.coerce        = @resolve_hash[type.name]["coerce"]        if @resolve_hash[type.name]["coerce"]
+              type.coerce_input  = @resolve_hash[type.name]["coerce_input"]  if @resolve_hash[type.name]["coerce_input"]
+              type.coerce_result = @resolve_hash[type.name]["coerce_result"] if @resolve_hash[type.name]["coerce_result"]
+            end
           end
         end
-       
-        def convert_keys_to_strings(h)
-          Hash[
-            h.map {|k, v|
-              v = convert_keys_to_strings(v) if v.is_a?(Hash)
-              [k.to_s, v]
-            }
-          ]
-        end        
       end
 
       # @api private

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -29,9 +29,9 @@ module GraphQL
 
         def convert_keys_to_strings(h)
           Hash[
-            h.map {|k, v| 
+            h.map {|k, v|
               v = convert_keys_to_strings(v) if v.is_a?(Hash)
-              [k.to_s, v] 
+              [k.to_s, v]
             }
           ]
         end
@@ -54,10 +54,28 @@ module GraphQL
         end
 
         def build_resolver(type, field, obj)
-          if obj.method(field.name.to_sym).arity > 0 
+          if obj.method(field.name.to_sym).arity > 0
             return ->(o, a, c) { o.send(field.name, a) }
-          else
-            return ->(o, a, c) { o.send(field.name) }
+          end
+          ->(o, a, c) { o.send(field.name) }
+        end
+
+        def after_build_schema(schema) 
+          hookup_union(schema)
+          hookup_scalars(schema)
+        end
+
+        def hookup_union(schema)
+          schema.resolve_type = @resolve_hash["__resolve_type"] if @resolve_hash["__resolve_type"]
+        end
+
+        def hookup_scalars(schema)
+          for _, type in schema.types
+            next unless type.is_a?(GraphQL::ScalarType) and @resolve_hash[type.name]
+          
+            type.coerce        = @resolve_hash[type.name]["coerce"]        if @resolve_hash[type.name]["coerce"]
+            type.coerce_input  = @resolve_hash[type.name]["coerce_input"]  if @resolve_hash[type.name]["coerce_input"]
+            type.coerce_result = @resolve_hash[type.name]["coerce_result"] if @resolve_hash[type.name]["coerce_result"]
           end
         end
       end
@@ -128,7 +146,7 @@ module GraphQL
 
           raise InvalidDocumentError.new('Must provide schema definition with query type or a type named Query.') unless query_root_type
 
-          Schema.define do
+          schema = Schema.define do
             raise_definition_error true
 
             query query_root_type
@@ -139,6 +157,12 @@ module GraphQL
 
             directives directives.values
           end
+
+          if default_resolve.respond_to? :after_build_schema
+            default_resolve.after_build_schema(schema)
+          end
+
+          schema
         end
 
         NullResolveType = ->(obj, ctx) {

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -27,9 +27,15 @@ module GraphQL
           @resolve_hash = Hash.new do |h, k|
             # For each type name, provide a new hash if one wasn't given:
             h[k] = Hash.new do |h2, k2|
-              # For each field, provide a resolver that will
-              # make runtime checks & replace itself
-              h2[k2] = SelfReplacingDefaultResolveFunction.new(h2, k2)
+              if k2 == "coerce_input" || k2 == "coerce_result"
+                # This isn't an object field, it's a scalar coerce function.
+                # Use a passthrough
+                Builder::NullScalarCoerce
+              else
+                # For each field, provide a resolver that will
+                # make runtime checks & replace itself
+                h2[k2] = SelfReplacingDefaultResolveFunction.new(h2, k2)
+              end
             end
           end
           @user_resolve_hash = user_resolve_hash
@@ -60,8 +66,12 @@ module GraphQL
           resolver.call(obj, args, ctx)
         end
 
-        def after_build_schema(schema)
-          hookup_scalars(schema)
+        def coerce_input(type, value, ctx)
+          @resolve_hash[type.name]["coerce_input"].call(value, ctx)
+        end
+
+        def coerce_result(type, value, ctx)
+          @resolve_hash[type.name]["coerce_result"].call(value, ctx)
         end
 
         private
@@ -104,16 +114,6 @@ module GraphQL
             end
           end
         end
-
-        def hookup_scalars(schema)
-          schema.types.each do |name, type|
-            if type.is_a?(GraphQL::ScalarType) && @resolve_hash.key?(type.name)
-              type.coerce        = @resolve_hash[type.name]["coerce"]        if @resolve_hash[type.name]["coerce"]
-              type.coerce_input  = @resolve_hash[type.name]["coerce_input"]  if @resolve_hash[type.name]["coerce_input"]
-              type.coerce_result = @resolve_hash[type.name]["coerce_result"] if @resolve_hash[type.name]["coerce_result"]
-            end
-          end
-        end
       end
 
       # @api private
@@ -147,7 +147,7 @@ module GraphQL
             when GraphQL::Language::Nodes::UnionTypeDefinition
               types[definition.name] = build_union_type(definition, type_resolver)
             when GraphQL::Language::Nodes::ScalarTypeDefinition
-              types[definition.name] = build_scalar_type(definition, type_resolver)
+              types[definition.name] = build_scalar_type(definition, type_resolver, default_resolve: default_resolve)
             when GraphQL::Language::Nodes::InputObjectTypeDefinition
               types[definition.name] = build_input_object_type(definition, type_resolver)
             when GraphQL::Language::Nodes::DirectiveDefinition
@@ -198,10 +198,6 @@ module GraphQL
             directives directives.values
           end
 
-          if default_resolve.respond_to? :after_build_schema
-            default_resolve.after_build_schema(schema)
-          end
-
           schema
         end
 
@@ -236,12 +232,21 @@ module GraphQL
           reason.value
         end
 
-        def build_scalar_type(scalar_type_definition, type_resolver)
-          GraphQL::ScalarType.define(
+        def build_scalar_type(scalar_type_definition, type_resolver, default_resolve:)
+          scalar_type = GraphQL::ScalarType.define(
             name: scalar_type_definition.name,
             description: scalar_type_definition.description,
             coerce: NullScalarCoerce,
           )
+
+          if default_resolve.respond_to?(:coerce_input)
+            scalar_type = scalar_type.redefine(
+              coerce_input: ->(val, ctx) { default_resolve.coerce_input(scalar_type, val, ctx) },
+              coerce_result: ->(val, ctx) { default_resolve.coerce_result(scalar_type, val, ctx) },
+            )
+          end
+
+          scalar_type
         end
 
         def build_union_type(union_type_definition, type_resolver)

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -27,11 +27,15 @@ module GraphQL
         end
 
         def call(type, field, obj, args, ctx)
-          type_hash = @resolve_hash[type.name]
-          type_hash && (resolver = type_hash[field.name])
+          type_hash = @resolve_hash[type.name.to_sym]
+          type_hash && (resolver = type_hash[field.name.to_sym])
 
           if resolver.nil?
-            raise(KeyError, "resolver not found for #{type.name}.#{field.name}")
+            if !obj.respond_to? field.name
+              raise(KeyError, "resolver not found for #{type.name}.#{field.name}")
+            else
+              obj.send field.name
+            end
           else
             resolver.call(obj, args, ctx)
           end

--- a/lib/graphql/schema/build_from_definition/resolve_map.rb
+++ b/lib/graphql/schema/build_from_definition/resolve_map.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+require "graphql/schema/build_from_definition/resolve_map/default_resolve"
+
+module GraphQL
+  class Schema
+    module BuildFromDefinition
+      # Wrap a user-provided hash of resolution behavior for easy access at runtime.
+      #
+      # Coerce scalar values by:
+      # - Checking for a function in the map like `{ Date: { coerce_input: ->(val, ctx) { ... }, coerce_result: ->(val, ctx) { ... } } }`
+      # - Falling back to a passthrough
+      #
+      # Interface/union resolution can be provided as a `resolve_type:` key.
+      #
+      # @api private
+      class ResolveMap
+        def initialize(user_resolve_hash)
+          @resolve_hash = Hash.new do |h, k|
+            # For each type name, provide a new hash if one wasn't given:
+            h[k] = Hash.new do |h2, k2|
+              if k2 == "coerce_input" || k2 == "coerce_result"
+                # This isn't an object field, it's a scalar coerce function.
+                # Use a passthrough
+                Builder::NullScalarCoerce
+              else
+                # For each field, provide a resolver that will
+                # make runtime checks & replace itself
+                h2[k2] = DefaultResolve.new(h2, k2)
+              end
+            end
+          end
+          @user_resolve_hash = user_resolve_hash
+          # User-provided resolve functions take priority over the default:
+          @user_resolve_hash.each do |type_name, fields|
+            type_name_s = type_name.to_s
+            case fields
+            when Hash
+              fields.each do |field_name, resolve_fn|
+                @resolve_hash[type_name_s][field_name.to_s] = resolve_fn
+              end
+            when Proc
+              # for example, __resolve_type
+              @resolve_hash[type_name_s] = fields
+            end
+          end
+
+          # Check the normalized hash, not the user input:
+          if @resolve_hash.key?("resolve_type")
+            define_singleton_method :resolve_type do |type, ctx|
+              @resolve_hash.fetch("resolve_type").call(type, ctx)
+            end
+          end
+        end
+
+        def call(type, field, obj, args, ctx)
+          resolver = @resolve_hash[type.name][field.name]
+          resolver.call(obj, args, ctx)
+        end
+
+        def coerce_input(type, value, ctx)
+          @resolve_hash[type.name]["coerce_input"].call(value, ctx)
+        end
+
+        def coerce_result(type, value, ctx)
+          @resolve_hash[type.name]["coerce_result"].call(value, ctx)
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/schema/build_from_definition/resolve_map/default_resolve.rb
+++ b/lib/graphql/schema/build_from_definition/resolve_map/default_resolve.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+module GraphQL
+  class Schema
+    module BuildFromDefinition
+      class ResolveMap
+        class DefaultResolve
+          def initialize(field_map, field_name)
+            @field_map = field_map
+            @field_name = field_name
+          end
+
+          # Make some runtime checks about
+          # how `obj` implements the `field_name`.
+          #
+          # Create a new resolve function according to that implementation, then:
+          #   - update `field_map` with this implementation
+          #   - call the implementation now (to satisfy this field execution)
+          #
+          # If `obj` doesn't implement `field_name`, raise an error.
+          def call(obj, args, ctx)
+            method_name = @field_name
+            if !obj.respond_to?(method_name)
+              raise KeyError, "Can't resolve field #{method_name} on #{obj}"
+            else
+              method_arity = obj.method(method_name).arity
+              resolver = case method_arity
+              when 0, -1
+                # -1 Handles method_missing, eg openstruct
+                ->(o, a, c) { o.public_send(method_name) }
+              when 1
+                ->(o, a, c) { o.public_send(method_name, a) }
+              when 2
+                ->(o, a, c) { o.public_send(method_name, a, c) }
+              else
+                raise "Unexpected resolve arity: #{method_arity}. Must be 0, 1, 2"
+              end
+              # Call the resolver directly next time
+              @field_map[method_name] = resolver
+              # Call through this time
+              resolver.call(obj, args, ctx)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -730,7 +730,7 @@ SCHEMA
             val.to_f
           }
         },
-        __resolve_type: ->(obj, ctx) {
+        resolve_type: ->(obj, ctx) {
           return ctx.schema.types['A']
         },
         Query: {

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -702,8 +702,8 @@ SCHEMA
   end
 
   describe "executable schema with resolver maps" do
-    
-    class Something 
+
+    class Something
       def capitalize(args)
         args[:word].upcase
       end
@@ -804,7 +804,7 @@ SCHEMA
       assert_equal(result.to_json, '{"data":{"allTodos":[{"text":"Pay the bills.","from_context":null},{"text":"Buy Milk","from_context":"bar"}]}}')
     end
 
-    describe "hash of resolvers" do
+    describe "hash of resolvers with defaults" do
       let(:todos) { [Todo.new("Pay the bills.")] }
       let(:schema) { GraphQL::Schema.from_definition(schema_defn, default_resolve: resolve_hash) }
       let(:resolve_hash) {
@@ -819,17 +819,16 @@ SCHEMA
         }
         h
       }
-      describe "with defaults" do
-        let(:base_hash) {
-          # Fallback is to resolve by sending the field name
-          Hash.new { |h, k| h[k] = Hash.new { |h2, k2| ->(obj, args, ctx) { obj.public_send(k2) } } }
-        }
 
-        it "accepts a hash of resolve functions" do
-          schema.execute("mutation { todoAdd: todo_add(text: \"Buy Milk\") { text } }", context: {context_value: "bar"}, root_value: todos)
-          result = schema.execute("query { allTodos: all_todos { text, from_context } }", root_value: todos)
-          assert_equal(result.to_json, '{"data":{"allTodos":[{"text":"Pay the bills.","from_context":null},{"text":"Buy Milk","from_context":"bar"}]}}')
-        end
+      let(:base_hash) {
+        # Fallback is to resolve by sending the field name
+        Hash.new { |h, k| h[k] = Hash.new { |h2, k2| ->(obj, args, ctx) { obj.public_send(k2) } } }
+      }
+
+      it "accepts a hash of resolve functions" do
+        schema.execute("mutation { todoAdd: todo_add(text: \"Buy Milk\") { text } }", context: {context_value: "bar"}, root_value: todos)
+        result = schema.execute("query { allTodos: all_todos { text, from_context } }", root_value: todos)
+        assert_equal(result.to_json, '{"data":{"allTodos":[{"text":"Pay the bills.","from_context":null},{"text":"Buy Milk","from_context":"bar"}]}}')
       end
     end
 

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -766,14 +766,14 @@ SCHEMA
         end
       end
 
-      describe "wihtout defaults" do
-        let(:base_hash) { {} }
-        it "raises a KeyError" do
-          assert_raises(KeyError) do
-            schema.execute("mutation { todoAdd: todo_add(text: \"Buy Milk\") { text } }", context: {context_value: "bar"}, root_value: todos)
-          end
-        end
-      end
+      # describe "wihtout defaults" do
+      #   let(:base_hash) { {} }
+      #   it "raises a KeyError" do
+      #     assert_raises(KeyError) do
+      #       schema.execute("mutation { todoAdd: todo_add(text: \"Buy Milk\") { text } }", context: {context_value: "bar"}, root_value: todos)
+      #     end
+      #   end
+      # end
     end
 
     describe "custom resolve behavior" do

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -831,15 +831,6 @@ SCHEMA
           assert_equal(result.to_json, '{"data":{"allTodos":[{"text":"Pay the bills.","from_context":null},{"text":"Buy Milk","from_context":"bar"}]}}')
         end
       end
-
-      # describe "wihtout defaults" do
-      #   let(:base_hash) { {} }
-      #   it "raises a KeyError" do
-      #     assert_raises(KeyError) do
-      #       schema.execute("mutation { todoAdd: todo_add(text: \"Buy Milk\") { text } }", context: {context_value: "bar"}, root_value: todos)
-      #     end
-      #   end
-      # end
     end
 
     describe "custom resolve behavior" do


### PR DESCRIPTION
Work in progress! Need some help from @xuorig and @rmosolgo 

In this PR i will try to make resolvemap behave a little more like graphql-tools. I.e. make it easy to build resolvers from a hash much like the JS version - https://github.com/apollographql/graphql-tools. The end goal is to clone all functionality from its Js counterpart for rapid api prototyping.

- [x] Use symbols instead of strings
- [x] When no resolver specified try to call `field.name` on `obj`
- [x] Call said resolver with args, if given
- [x] Cache all the responds_to? etc?
- [x] Fix empty resolver `Counter`
- [x] Implement `__resolveType` for unions @rmosolgo any idea on how to implement this? see: http://dev.apollodata.com/tools/graphql-tools/resolvers.html#Unions-and-interfaces 
- [x] Implement custom scalar resolving @rmosolgo any idea on how to implement this? see: http://dev.apollodata.com/tools/graphql-tools/scalars.html
- [x] Handle subscriptions?

See for context https://gist.github.com/rmosolgo/ba31acf93f07f8007d99ba365a662d8f#file-app-rb-L126-L174

From this map:

```ruby
 Resolvers = {
    "Mutation" => {
      "incrementCounter" => ->(o, a, c) {
        counter = App::Counter.find(a["id"])
        counter.increment
        API::Schema.subscriber.trigger("counterIncremented", a, counter)
        counter
      }
    },
    "Query" => {
      "counter" => ->(o, a, c) { App::Counter.find(a["id"]) }
    },
    "Counter" => {
      "value" => ->(o, a, c) { o.value },
      "id" => ->(o, a, c) { o.id },
    }
  }
```

to this map:

```ruby
Resolvers = {
  Mutation: {
    incrementCounter: ->(o, a, c) {
      counter = App::Counter.find(a["id"])
      counter.increment
      API::Schema.subscriber.trigger("counterIncremented", a, counter)
      counter
    }
  },
  Query: {
    counter: ->(o, a, c) { App::Counter.find(a["id"]) }
  }
}
```

@xuorig You've been making something like this too right, what do you think?