### PR TITLE
Improve pretty print debugging of ListType and NonNullType

### DIFF
--- a/lib/graphql/list_type.rb
+++ b/lib/graphql/list_type.rb
@@ -39,6 +39,7 @@ module GraphQL
     def to_s
       "[#{of_type.to_s}]"
     end
+    alias_method :inspect, :to_s
 
     def coerce_result(value, ctx = nil)
       if ctx.nil?

--- a/lib/graphql/non_null_type.rb
+++ b/lib/graphql/non_null_type.rb
@@ -61,5 +61,6 @@ module GraphQL
     def to_s
       "#{of_type.to_s}!"
     end
+    alias_method :inspect, :to_s
   end
 end


### PR DESCRIPTION
Its bugged me that `p GraphQL::STRING_TYPE` gives a nice `String` output while `p !types.String` just prints *nothing* for a strange reason.

It looks like these subclasses forgot to realias the `inspect` method. `p !types.String` now outputs `String!`. 😎 