### PR TITLE
Support Operation and Fragment definitions of the same name

### DIFF
--- a/spec/graphql/query/executor_spec.rb
+++ b/spec/graphql/query/executor_spec.rb
@@ -58,6 +58,27 @@ describe GraphQL::Query::Executor do
     end
   end
 
+  describe "operation and fragment defintions of the same name" do
+    let(:query_string) { %|
+      query Cheese { cheese(id: 1) { ...Cheese } }
+      query MoreCheese { cheese(id: 2) { ...Cheese } }
+      fragment Cheese on Cheese { flavor }
+    |}
+
+    let(:operation_name) { "Cheese" }
+
+    it "runs the named operation" do
+      expected = {
+        "data" => {
+          "cheese" => {
+            "flavor" => "Brie"
+          }
+        }
+      }
+      assert_equal(expected, result)
+    end
+  end
+
 
   describe "execution order" do
     let(:query_string) {%|


### PR DESCRIPTION
As per @rmosolgo's wise comment on https://github.com/rmosolgo/graphql-ruby/pull/701#discussion_r114229506.

It turns out operations and fragment names live in separate namespaces. An operation can share a fragments name. I tested and confirmed on the reference implementation (graphql-js) and it does indeed work.