### PR TITLE
feat(Query#operation_name) return selected operation name

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -27,7 +27,7 @@ module GraphQL
       end
     end
 
-    attr_reader :schema, :document, :context, :fragments, :operations, :root_value, :query_string, :warden, :provided_variables
+    attr_reader :schema, :document, :context, :fragments, :operations, :root_value, :query_string, :warden, :provided_variables, :operation_name
 
     # Prepare query `query_string` on `schema`
     # @param schema [GraphQL::Schema]
@@ -83,13 +83,17 @@ module GraphQL
       @ast_variables = []
       @mutation = false
       operation_name_error = nil
+      @operation_name = nil
+
       if @operations.any?
-        @selected_operation = find_operation(@operations, operation_name)
-        if @selected_operation.nil?
+        selected_operation = find_operation(@operations, operation_name)
+        if selected_operation.nil?
           operation_name_error = GraphQL::Query::OperationNameMissingError.new(operation_name)
         else
-          @ast_variables = @selected_operation.variables
-          @mutation = @selected_operation.operation_type == "mutation"
+          @operation_name = selected_operation.name
+          @ast_variables = selected_operation.variables
+          @mutation = selected_operation.operation_type == "mutation"
+          @selected_operation = selected_operation
         end
       end
 

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -57,6 +57,32 @@ describe GraphQL::Query do
     end
   end
 
+  describe "operation_name" do
+    describe "when provided" do
+      let(:query_string) { <<-GRAPHQL
+        query q1 { cheese(id: 1) { flavor } }
+        query q2 { cheese(id: 2) { flavor } }
+      GRAPHQL
+      }
+      let(:operation_name) { "q2" }
+
+      it "returns the provided name" do
+        assert_equal "q2", query.operation_name
+      end
+    end
+
+    describe "when inferred" do
+      let(:query_string) { <<-GRAPHQL
+        query q3 { cheese(id: 3) { flavor } }
+      GRAPHQL
+      }
+
+      it "returns the inferred name" do
+        assert_equal "q3", query.operation_name
+      end
+    end
+  end
+
   describe "when passed a document instance" do
     let(:query) { GraphQL::Query.new(
       schema,


### PR DESCRIPTION
This'll be nice for subscriptions where we'll need to re-run the query. It's basically a shortcut to `selected_operation.operation_name`, but you don't have to check whether selected_operation is nil.