### PR TITLE
BuildFromDefinition: add parser option

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -399,9 +399,10 @@ module GraphQL
     # Create schema from an IDL schema.
     # @param definition_string [String] A schema definition string
     # @param default_resolve [<#call(type, field, obj, args, ctx)>] A callable for handling field resolution
+    # @param parser [Object] An object for handling definition string parsing (must respond to `parse`)
     # @return [GraphQL::Schema] the schema described by `document`
-    def self.from_definition(string, default_resolve: BuildFromDefinition::DefaultResolve)
-      GraphQL::Schema::BuildFromDefinition.from_definition(string, default_resolve: default_resolve)
+    def self.from_definition(string, default_resolve: BuildFromDefinition::DefaultResolve, parser: BuildFromDefinition::DefaultParser)
+      GraphQL::Schema::BuildFromDefinition.from_definition(string, default_resolve: default_resolve, parser: parser)
     end
 
     # Error that is raised when [#Schema#from_definition] is passed an invalid schema definition string.

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -3,11 +3,14 @@ module GraphQL
   class Schema
     module BuildFromDefinition
       class << self
-        def from_definition(definition_string, default_resolve:)
-          document = GraphQL::parse(definition_string)
+        def from_definition(definition_string, default_resolve:, parser: DefaultParser)
+          document = parser.parse(definition_string)
           Builder.build(document, default_resolve: default_resolve)
         end
       end
+
+      # @api private
+      DefaultParser = GraphQL::Language::Parser
 
       # @api private
       module DefaultResolve

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -813,5 +813,21 @@ SCHEMA
         assert_equal(result.to_json, '{"data":{"allTodos":[{"text":"Pay the bills.","from_context":null},{"text":"Buy Milk","from_context":"bar"}]}}')
       end
     end
+
+    describe "custom parser behavior" do
+      module BadParser
+        ParseError = Class.new(StandardError)
+
+        def self.parse(string)
+          raise ParseError
+        end
+      end
+
+      it 'accepts a parser callable' do
+        assert_raises(BadParser::ParseError) do
+          GraphQL::Schema.from_definition(schema_defn, parser: BadParser)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds a callable `parser` option to `from_definition`.

The main use case for changing the default `GraphQL.parse` is if you're using `graphql-libgraphqlparser-ruby`. That gem overrides `GraphQL.parse` which does not support parsing an IDL string.

The workaround for this would be to pass in a callable that uses `GraphQL.parse_without_libgraphqlparser`.