### PR TITLE
Fix: List of Input Objects

### DIFF
--- a/lib/graphql/list_type.rb
+++ b/lib/graphql/list_type.rb
@@ -69,13 +69,7 @@ module GraphQL
     end
 
     def ensure_array(value)
-      if value.is_a?(Array)
-        value
-      elsif value.respond_to?(:to_ary)
-        value.to_ary
-      else
-        [value]
-      end
+      value.is_a?(Array) ? value : [value]
     end
   end
 end

--- a/lib/graphql/list_type.rb
+++ b/lib/graphql/list_type.rb
@@ -69,7 +69,13 @@ module GraphQL
     end
 
     def ensure_array(value)
-      value.is_a?(Array) ? value : [value]
+      if value.is_a?(Array)
+        value
+      elsif value.respond_to?(:to_ary)
+        value.to_ary
+      else
+        [value]
+      end
     end
   end
 end

--- a/lib/graphql/list_type.rb
+++ b/lib/graphql/list_type.rb
@@ -46,19 +46,19 @@ module GraphQL
         warn_deprecated_coerce("coerce_isolated_result")
         ctx = GraphQL::Query::NullContext
       end
-      Array(value).map { |item| item.nil? ? nil : of_type.coerce_result(item, ctx) }
+      ensure_array(value).map { |item| item.nil? ? nil : of_type.coerce_result(item, ctx) }
     end
 
     private
 
     def coerce_non_null_input(value, ctx)
-      Array(value).map { |item| of_type.coerce_input(item, ctx) }
+      ensure_array(value).map { |item| of_type.coerce_input(item, ctx) }
     end
 
     def validate_non_null_input(value, ctx)
       result = GraphQL::Query::InputValidationResult.new
 
-      Array(value).each_with_index do |item, index|
+      ensure_array(value).each_with_index do |item, index|
         item_result = of_type.validate_input(item, ctx)
         if !item_result.valid?
           result.merge_result!(index, item_result)
@@ -66,6 +66,10 @@ module GraphQL
       end
 
       result
+    end
+
+    def ensure_array(value)
+      value.is_a?(Array) ? value : [value]
     end
   end
 end

--- a/spec/graphql/list_type_spec.rb
+++ b/spec/graphql/list_type_spec.rb
@@ -8,6 +8,10 @@ describe GraphQL::ListType do
     assert_equal([1.0, 2.0, 3.0].inspect, float_list.coerce_isolated_input([1, 2, 3]).inspect)
   end
 
+  it "converts items that are not lists into lists" do
+    assert_equal([1.0].inspect, float_list.coerce_isolated_input(1.0).inspect)
+  end
+
   describe "validate_input with bad input" do
     let(:bad_num) { "bad_num" }
     let(:result) { float_list.validate_isolated_input([bad_num, 2.0, 3.0]) }
@@ -28,6 +32,22 @@ describe GraphQL::ListType do
       expected = GraphQL::FLOAT_TYPE.validate_isolated_input(bad_num).problems[0]["explanation"]
       actual = result.problems[0]["explanation"]
       assert_equal(actual, expected)
+    end
+  end
+
+  describe "list of input objects" do
+    let(:input_object) do
+      GraphQL::InputObjectType.define do
+        name "SomeInputObjectType"
+        argument :float, !types.Float
+      end
+    end
+
+    let(:input_object_list) { input_object.to_list_type }
+
+    it "converts hashes into lists of hashes" do
+      hash = { 'float' => 1.0 }
+      assert_equal([hash].inspect, input_object_list.coerce_isolated_input(hash).map(&:to_h).inspect)
     end
   end
 end

--- a/spec/graphql/list_type_spec.rb
+++ b/spec/graphql/list_type_spec.rb
@@ -49,20 +49,5 @@ describe GraphQL::ListType do
       hash = { 'float' => 1.0 }
       assert_equal([hash].inspect, input_object_list.coerce_isolated_input(hash).map(&:to_h).inspect)
     end
-
-    it "supports array-like objects" do
-      array_like = Class.new do
-        def initialize(value)
-          @value = value
-        end
-
-        def to_ary
-          [@value]
-        end
-      end
-      
-      hash = { 'float' => 1.0 }
-      assert_equal([hash].inspect, input_object_list.coerce_isolated_input(array_like.new(hash)).map(&:to_h).inspect)
-    end
   end
 end

--- a/spec/graphql/list_type_spec.rb
+++ b/spec/graphql/list_type_spec.rb
@@ -49,5 +49,20 @@ describe GraphQL::ListType do
       hash = { 'float' => 1.0 }
       assert_equal([hash].inspect, input_object_list.coerce_isolated_input(hash).map(&:to_h).inspect)
     end
+
+    it "supports array-like objects" do
+      array_like = Class.new do
+        def initialize(value)
+          @value = value
+        end
+
+        def to_ary
+          [@value]
+        end
+      end
+      
+      hash = { 'float' => 1.0 }
+      assert_equal([hash].inspect, input_object_list.coerce_isolated_input(array_like.new(hash)).map(&:to_h).inspect)
+    end
   end
 end


### PR DESCRIPTION
According to the [GraphQL Spec](https://facebook.github.io/graphql/#sec-Lists):
> If the value passed as an input to a list type is not a list and not the null value, it should be coerced as though the input was a list of size one, where the value passed is the only item in the list. This is to allow inputs that accept a “var args” to declare their input type as a list; if only one argument is passed (a common case), the client can just pass that value rather than constructing the list.

As best I can tell, this should apply to both lists of scalars or lists of input objects. One of the recent refactors modified `GraphQL::ListType` so that instead of using `ensure_array(value)`, it would use `Array(value)`.

The problem is that when you pass a hash into the `Array` method, you get the equivalent of calling `to_a` on the hash:
```ruby
Array({ "hello" => "world" })
 => [["hello", "world"]] 
```
I'm guessing that the change was so that the user could pass in an array-like object, instead of an actual array, as inputs to list types. So I took a cue from [`Array#wrap`](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/array/wrap.rb#L37) and wrote a custom `ensure_array` method that will attempt to call `to_ary` on provided objects. 

This may not be the best fix, but maybe it's a good starting point.