### PR TITLE
Camelize type name

### DIFF
--- a/lib/generators/graphql/type_generator.rb
+++ b/lib/generators/graphql/type_generator.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 require 'rails/generators/base'
 require 'graphql'
+require 'active_support'
+require 'active_support/core_ext/string/inflections'
 
 module Graphql
   module Generators
@@ -39,10 +41,10 @@ module Graphql
             when "Int", "Float", "Boolean", "String", "ID"
               "types.#{type_expression}"
             else
-              "Types::#{type_expression}Type"
+              "Types::#{type_expression.camelize}Type"
             end
           when :graphql
-            type_expression
+            type_expression.camelize
           else
             raise "Unexpected normalize mode: #{mode}"
           end

--- a/spec/generators/graphql/object_generator_spec.rb
+++ b/spec/generators/graphql/object_generator_spec.rb
@@ -30,6 +30,15 @@ RUBY
     end
   end
 
+  test "it generates classifed file" do
+    run_generator(["page"])
+    assert_file "app/graphql/types/page_type.rb", <<-RUBY
+Types::PageType = GraphQL::ObjectType.define do
+  name "Page"
+end
+RUBY
+  end
+
   test "it makes Relay nodes" do
     run_generator(["Page", "--node"])
     assert_file "app/graphql/types/page_type.rb", <<-RUBY


### PR DESCRIPTION
Thank you for this great gem!

I think it is better to care lower case same as Rails' generator.

For example, `bin/rails g model foo` will generate:

```
class Foo < ApplicationRecord
end
```