### PR TITLE
Fix bug when connection is nil

### DIFF
--- a/lib/graphql/relay/connection_resolve.rb
+++ b/lib/graphql/relay/connection_resolve.rb
@@ -10,7 +10,10 @@ module GraphQL
 
       def call(obj, args, ctx)
         nodes = @underlying_resolve.call(obj, args, ctx)
-        if ctx.schema.lazy?(nodes)
+
+        if nodes.nil?
+          nil
+        elsif ctx.schema.lazy?(nodes)
           nodes
         else
           build_connection(nodes, args, obj, ctx)

--- a/spec/graphql/relay/connection_resolve_spec.rb
+++ b/spec/graphql/relay/connection_resolve_spec.rb
@@ -2,44 +2,52 @@
 require "spec_helper"
 
 describe GraphQL::Relay::ConnectionResolve do
-  describe "when an execution error is returned" do
-    let(:query_string) { <<-GRAPHQL
-      query getError($error: String!){
-        rebels {
-          ships(nameIncludes: $error) {
-            edges {
-              node {
-                name
-              }
+  let(:query_string) { <<-GRAPHQL
+    query getShips($name: String!){
+      rebels {
+        ships(nameIncludes: $name) {
+          edges {
+            node {
+              name
             }
           }
         }
       }
-    GRAPHQL
     }
+    GRAPHQL
+  }
 
+  describe "when an execution error is returned" do
     it "adds an error" do
-      result = star_wars_query(query_string, { "error" => "error"})
+      result = star_wars_query(query_string, { "name" => "error"})
       assert_equal 1, result["errors"].length
       assert_equal "error from within connection", result["errors"][0]["message"]
     end
 
     it "adds an error for a lazy error" do
-      result = star_wars_query(query_string, { "error" => "lazyError"})
+      result = star_wars_query(query_string, { "name" => "lazyError"})
       assert_equal 1, result["errors"].length
       assert_equal "lazy error from within connection", result["errors"][0]["message"]
     end
 
     it "adds an error for a lazy raised error" do
-      result = star_wars_query(query_string, { "error" => "lazyRaisedError"})
+      result = star_wars_query(query_string, { "name" => "lazyRaisedError"})
       assert_equal 1, result["errors"].length
       assert_equal "lazy raised error from within connection", result["errors"][0]["message"]
     end
 
     it "adds an error for a raised error" do
-      result = star_wars_query(query_string, { "error" => "raisedError"})
+      result = star_wars_query(query_string, { "name" => "raisedError"})
       assert_equal 1, result["errors"].length
       assert_equal "error raised from within connection", result["errors"][0]["message"]
+    end
+  end
+
+  describe "when nil is returned" do
+    it "becomes null" do
+      result = star_wars_query(query_string, { "name" => "null" })
+      conn = result["data"]["rebels"]["ships"]
+      assert_equal nil, conn
     end
   end
 end

--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -102,6 +102,8 @@ module StarWars
             all_ships = LazyWrapper.new { GraphQL::ExecutionError.new("lazy error from within connection") }
           when "lazyRaisedError"
             all_ships = LazyWrapper.new { raise GraphQL::ExecutionError.new("lazy raised error from within connection") }
+          when "null"
+            all_ships = nil
           else
             all_ships = all_ships.select { |ship| ship.name.include?(args[:nameIncludes])}
           end


### PR DESCRIPTION
Fixes a problem if you have a field resolver that returns `nil` for a connection.

Otherwise, you get this error: 
```
RuntimeError:
  No connection implementation to wrap NilClass ()
```