### PR TITLE
Fix ArrayConnection and RelationConnection issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Bug fixes
 
+## 1.5.13 (11 May 2017)
+
+- Fix raising `ExecutionError` inside mutation resolve functions (it nullifies the field) #722
+
 ## 1.5.12 (9 May 2017)
 
 - Fix returning `nil` from connection resolve functions (now they become `null`) #719

--- a/lib/graphql/relay/array_connection.rb
+++ b/lib/graphql/relay/array_connection.rb
@@ -7,14 +7,6 @@ module GraphQL
         encode(idx.to_s)
       end
 
-      def has_next_page
-        !!(first && sliced_nodes.count > first)
-      end
-
-      def has_previous_page
-        !!(last && sliced_nodes.count > last)
-      end
-
       private
 
       def first

--- a/lib/graphql/relay/relation_connection.rb
+++ b/lib/graphql/relay/relation_connection.rb
@@ -68,8 +68,8 @@ module GraphQL
               items = items.offset(offset).limit(last)
             end
           else
-            # TODO: I don't think #last works quite the same way in Sequel vs ActiveRecord
-            items = items.last(last)
+            offset = (relation_offset(items) || 0) + relation_count(items) - last
+            items = items.offset(offset).limit(last)
           end
         end
 

--- a/lib/graphql/relay/relation_connection.rb
+++ b/lib/graphql/relay/relation_connection.rb
@@ -17,8 +17,6 @@ module GraphQL
             offset += offset_from_cursor(after)
           elsif before
             offset += offset_from_cursor(before) - 1 - sliced_nodes_count
-          else
-
           end
 
           encode(offset.to_s)

--- a/lib/graphql/version.rb
+++ b/lib/graphql/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module GraphQL
-  VERSION = "1.5.12"
+  VERSION = "1.5.13"
 end

--- a/spec/graphql/relay/array_connection_spec.rb
+++ b/spec/graphql/relay/array_connection_spec.rb
@@ -89,6 +89,27 @@ describe GraphQL::Relay::ArrayConnection do
       assert_equal(false, result["data"]["rebels"]["ships"]["pageInfo"]["hasPreviousPage"])
     end
 
+    it 'works with before and after specified together' do
+      result = star_wars_query(query_string, "first" => 1)
+      assert_equal(["X-Wing"], get_names(result))
+
+      first_cursor = get_last_cursor(result)
+
+      # There is no records between before and after if they point to the same cursor
+      result = star_wars_query(query_string, "before" => first_cursor, "after" => first_cursor, "last" => 2)
+      assert_equal([], get_names(result))
+
+      result = star_wars_query(query_string, "after" => first_cursor, "first" => 2)
+      assert_equal(["Y-Wing", "A-Wing"], get_names(result))
+
+      # After the last result, find the next 2:
+      second_cursor = get_last_cursor(result)
+
+      # There is only 2 results between the cursors
+      result = star_wars_query(query_string, "after" => first_cursor, "before" => second_cursor, "first" => 5)
+      assert_equal(["Y-Wing", "A-Wing"], get_names(result))
+    end
+
     it 'handles cursors beyond the bounds of the array' do
       overreaching_cursor = Base64.strict_encode64("100")
       result = star_wars_query(query_string, "after" => overreaching_cursor, "first" => 2)
@@ -157,13 +178,13 @@ describe GraphQL::Relay::ArrayConnection do
 
       it "applies to queries by `last`" do
         last_cursor = "Ng=="
-        second_to_last_two_names = ["Death Star", "Shield Generator"]
+
         result = star_wars_query(query_string, "last" => 100, "before" => last_cursor)
-        assert_equal(second_to_last_two_names, get_names(result))
+        assert_equal(["Death Star", "Shield Generator"], get_names(result))
         assert_equal(true, get_page_info(result)["hasPreviousPage"])
 
         result = star_wars_query(query_string, "before" => last_cursor)
-        assert_equal(second_to_last_two_names, get_names(result))
+        assert_equal(["Yavin", "Echo Base"], get_names(result))
         assert_equal(false, get_page_info(result)["hasPreviousPage"], "hasPreviousPage is false when last is not specified")
 
         third_cursor = "Mw=="

--- a/spec/graphql/relay/page_info_spec.rb
+++ b/spec/graphql/relay/page_info_spec.rb
@@ -75,8 +75,8 @@ describe GraphQL::Relay::PageInfo do
       result = star_wars_query(query_string, "last" => 1, "first" => 1, "before" => cursor_of_last_base)
       assert_equal(true, get_page_info(result)["hasNextPage"])
       assert_equal(true, get_page_info(result)["hasPreviousPage"])
-      assert_equal("Mg==", get_page_info(result)["startCursor"])
-      assert_equal("Mg==", get_page_info(result)["endCursor"])
+      assert_equal("MQ==", get_page_info(result)["startCursor"])
+      assert_equal("MQ==", get_page_info(result)["endCursor"])
     end
 
     it "startCursor and endCursor are the cursors of the first and last edge" do

--- a/spec/graphql/relay/relation_connection_spec.rb
+++ b/spec/graphql/relay/relation_connection_spec.rb
@@ -120,7 +120,7 @@ describe GraphQL::Relay::RelationConnection do
       second_cursor = get_last_cursor(result)
 
       result = star_wars_query(query_string, "after" => first_cursor, "before" => second_cursor, "first" => 3)
-      assert_equal(["Headquarters"], get_names(result))
+      assert_equal([], get_names(result))
     end
 
     it 'handles cursors beyond the bounds of the array' do


### PR DESCRIPTION
Fix the ArrayConnection to work as described in the Relay Connection spec.

* Both `before` and `after` can be specified now.
* Both `first` and `last` can be specified now. Note that doing so is discouraged and the result is confusing.

This also fixes an issue where `max_page_size` in combination with `before` and no `last` would return results from the end of the list instead of from the beginning.