### PR TITLE
refactor(Relay::Mutation) returning/raising an error makes the result null

### DIFF
--- a/lib/graphql/relay/mutation/instrumentation.rb
+++ b/lib/graphql/relay/mutation/instrumentation.rb
@@ -11,8 +11,8 @@ module GraphQL
         # giving users access to the original resolve function in earlier instrumentation.
         def self.instrument(type, field)
           if field.mutation
-            new_resolve = Mutation::Resolve.new(field.mutation, field.resolve_proc, eager: true)
-            new_lazy_resolve = Mutation::Resolve.new(field.mutation, field.lazy_resolve_proc, eager: false)
+            new_resolve = Mutation::Resolve.new(field.mutation, field.resolve_proc)
+            new_lazy_resolve = Mutation::Resolve.new(field.mutation, field.lazy_resolve_proc)
             field.redefine(resolve: new_resolve, lazy_resolve: new_lazy_resolve)
           else
             field

--- a/spec/graphql/relay/mutation_spec.rb
+++ b/spec/graphql/relay/mutation_spec.rb
@@ -282,11 +282,7 @@ describe GraphQL::Relay::Mutation do
 
       expected = {
         "data" => {
-          "introduceShip" => {
-            "clientMutationId" => "5678",
-            "shipEdge" => nil,
-            "faction" => nil,
-          }
+          "introduceShip" => nil,
         },
         "errors" => [
           {
@@ -305,11 +301,7 @@ describe GraphQL::Relay::Mutation do
 
       expected = {
         "data" => {
-          "introduceShip" => {
-            "clientMutationId" => "5678",
-            "shipEdge" => nil,
-            "faction" => nil,
-          }
+          "introduceShip" => nil,
         },
         "errors" => [
           {


### PR DESCRIPTION
When a mutation's `resolve` raises or returns a `GraphQL::ExecutionError`, we should nullify the _whole_ object, not just the `return_field`s. 

See the diff of `mutation_spec.rb` to see how the nullability is different. In short, `clientMutationId` will _not_ be present if the mutation has an error. This is inline with Facebook's approach: https://github.com/facebook/relay/issues/360

This was fixed for one case in #722 but other cases should be brought into alignment.

Fixes #723 