### PR TITLE
fix(ConnectionResolve) preserve parent when nodes is a lazy object

### DIFF
--- a/lib/graphql/relay/connection_instrumentation.rb
+++ b/lib/graphql/relay/connection_instrumentation.rb
@@ -32,8 +32,8 @@ module GraphQL
           connection_arguments = DEFAULT_ARGUMENTS.merge(field.arguments)
           original_resolve = field.resolve_proc
           original_lazy_resolve = field.lazy_resolve_proc
-          connection_resolve = GraphQL::Relay::ConnectionResolve.new(field, original_resolve)
-          connection_lazy_resolve = GraphQL::Relay::ConnectionResolve.new(field, original_lazy_resolve)
+          connection_resolve = GraphQL::Relay::ConnectionResolve.new(field, original_resolve, lazy: false)
+          connection_lazy_resolve = GraphQL::Relay::ConnectionResolve.new(field, original_lazy_resolve, lazy: true)
           field.redefine(
             resolve: connection_resolve,
             lazy_resolve: connection_lazy_resolve,

--- a/lib/graphql/relay/connection_resolve.rb
+++ b/lib/graphql/relay/connection_resolve.rb
@@ -2,21 +2,33 @@
 module GraphQL
   module Relay
     class ConnectionResolve
-      def initialize(field, underlying_resolve)
+      def initialize(field, underlying_resolve, lazy:)
         @field = field
         @underlying_resolve = underlying_resolve
         @max_page_size = field.connection_max_page_size
+        @lazy = lazy
       end
 
       def call(obj, args, ctx)
+        if @lazy && obj.is_a?(LazyNodesWrapper)
+          parent = obj.parent
+          obj = obj.lazy_object
+        else
+          parent = obj
+        end
+
         nodes = @underlying_resolve.call(obj, args, ctx)
 
         if nodes.nil?
           nil
         elsif ctx.schema.lazy?(nodes)
-          nodes
+          if !@lazy
+            LazyNodesWrapper.new(obj, nodes)
+          else
+            nodes
+          end
         else
-          build_connection(nodes, args, obj, ctx)
+          build_connection(nodes, args, parent, ctx)
         end
       end
 
@@ -31,6 +43,16 @@ module GraphQL
           connection_class.new(nodes, args, field: @field, max_page_size: @max_page_size, parent: parent, context: ctx)
         end
       end
+
+      # A container for the proper `parent` of connection nodes.
+      # Without this wrapper, the lazy object _itself_ is passed into `build_connection`
+      # and it becomes the parent, which is wrong.
+      #
+      # We can get away with it because we know that this instrumentation will be applied last.
+      # That means its code after `underlying_resolve` will be _last_ on the way in.
+      # And, its code before `underlying_resolve` will be _first_ during lazy resolution.
+      # @api private
+      LazyNodesWrapper = Struct.new(:parent, :lazy_object)
     end
   end
 end

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -111,6 +111,7 @@ module GraphQL
       @parse_error_proc = DefaultParseError
       @instrumenters = Hash.new { |h, k| h[k] = [] }
       @lazy_methods = GraphQL::Execution::Lazy::LazyMethodMap.new
+      @lazy_methods.set(GraphQL::Relay::ConnectionResolve::LazyNodesWrapper, :never_called)
       @cursor_encoder = Base64Encoder
       # Default to the built-in execution strategy:
       @query_execution_strategy = self.class.default_execution_strategy

--- a/spec/graphql/relay/connection_resolve_spec.rb
+++ b/spec/graphql/relay/connection_resolve_spec.rb
@@ -11,6 +11,7 @@ describe GraphQL::Relay::ConnectionResolve do
               name
             }
           }
+          parentClassName
         }
       }
     }
@@ -40,6 +41,15 @@ describe GraphQL::Relay::ConnectionResolve do
       result = star_wars_query(query_string, { "name" => "raisedError"})
       assert_equal 1, result["errors"].length
       assert_equal "error raised from within connection", result["errors"][0]["message"]
+    end
+  end
+
+
+  describe "when a lazy object is returned" do
+    it "returns the items with the correct parent" do
+      result = star_wars_query(query_string, { "name" => "lazyObject"})
+      assert_equal 5, result["data"]["rebels"]["ships"]["edges"].length
+      assert_equal "StarWars::FactionRecord", result["data"]["rebels"]["ships"]["parentClassName"]
     end
   end
 

--- a/spec/support/star_wars/data.rb
+++ b/spec/support/star_wars/data.rb
@@ -55,7 +55,18 @@ module StarWars
   class SequelBase < Sequel::Model(:bases)
   end
 
-  rebels  = OpenStruct.new({
+  class FactionRecord
+    attr_reader :id, :name, :ships, :bases, :basesClone
+    def initialize(id:, name:, ships:, bases:, basesClone:)
+      @id = id
+      @name = name
+      @ships = ships
+      @bases = bases
+      @basesClone = basesClone
+    end
+  end
+
+  rebels  = FactionRecord.new({
     id: '1',
     name: 'Alliance to Restore the Republic',
     ships:  ['1', '2', '3', '4', '5'],
@@ -64,7 +75,7 @@ module StarWars
   })
 
 
-  empire = OpenStruct.new({
+  empire = FactionRecord.new({
     id: '2',
     name: 'Galactic Empire',
     ships: ['6', '7', '8'],


### PR DESCRIPTION
Oops, `Connection#parent` was broken when you used a `GraphQL::Batch::Promise` as the connection's `nodes`. 

This meant that if you try to use the parent object's `counter_cache` to implement a `totalCount` field, you're gonna have a bad time.