### PR TITLE
fix(spec): Update usage of Sequel in test schema

### DIFF
--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -164,7 +164,7 @@ module StarWars
       resolve ->(obj, args, ctx) {
         all_bases = SequelBase.where(faction_id: obj.id)
         if args[:nameIncludes]
-          all_bases = all_bases.where("name LIKE ?", "%#{args[:nameIncludes]}%")
+          all_bases = all_bases.where(Sequel.like(:name, "%#{args[:nameIncludes]}%"))
         end
         all_bases
       }


### PR DESCRIPTION
This change just follows what the error message says, upgrading to the newer syntax.

I encountered this error when working on #742, and it was a simple straight-forward fix.