### PR TITLE
fix(Query#operation_name) return provided value, add #selected_operation_name

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -27,7 +27,7 @@ module GraphQL
       end
     end
 
-    attr_reader :schema, :context, :root_value, :warden, :provided_variables
+    attr_reader :schema, :context, :root_value, :warden, :provided_variables, :operation_name
 
     attr_accessor :query_string
 
@@ -37,8 +37,8 @@ module GraphQL
     end
 
     # @return [String, nil] The name of the operation to run (may be inferred)
-    def operation_name
-      with_prepared_ast { @operation_name }
+    def selected_operation_name
+      selected_operation.name
     end
 
     # Prepare query `query_string` on `schema`

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -79,6 +79,7 @@ describe GraphQL::Query do
 
       it "returns the provided name" do
         assert_equal "q2", query.operation_name
+        assert_equal "q2", query.selected_operation_name
       end
     end
 
@@ -88,8 +89,9 @@ describe GraphQL::Query do
       GRAPHQL
       }
 
-      it "returns the inferred name" do
-        assert_equal "q3", query.operation_name
+      it "returns nil" do
+        assert_equal nil, query.operation_name
+        assert_equal "q3", query.selected_operation_name
       end
     end
   end


### PR DESCRIPTION


Oops, #707 and #710 didn't play nicely together. If you checked for `#operation_name`
but query string wasn't present yet, it would raise an error.

Instead, return the user-provided value as `#operation_name` and return
the inferred value as `#selected_operation_name`.