### PR TITLE
Prevent name error when ActiveRecord not exists.

### DIFF
--- a/lib/graphql/relay/relation_connection.rb
+++ b/lib/graphql/relay/relation_connection.rb
@@ -83,19 +83,17 @@ module GraphQL
       end
 
       def relation_offset(relation)
-        case relation
-        when ActiveRecord::Relation
+        if relation.respond_to?(:offset_value)
           relation.offset_value
-        when Sequel::Dataset
+        else
           relation.opts[:offset]
         end
       end
 
       def relation_limit(relation)
-        case relation
-        when ActiveRecord::Relation
+        if relation.respond_to?(:limit_value)
           relation.limit_value
-        when Sequel::Dataset
+        else
           relation.opts[:limit]
         end
       end


### PR DESCRIPTION
The error was NameError: uninitialized constant ActiveRecord.