### PR TITLE
Avoid ActionController::InvalidAuthenticityToken

### DIFF
--- a/lib/generators/graphql/templates/graphql_controller.erb
+++ b/lib/generators/graphql/templates/graphql_controller.erb
@@ -1,4 +1,6 @@
 class GraphqlController < ApplicationController
+  protect_from_forgery
+                                               
   def execute
     variables = ensure_hash(params[:variables])
     query = params[:query]


### PR DESCRIPTION
Setting `protect_from_forgery` to avoid authenticity token exceptions on a vanilla GraphQL controller.