### PR TITLE
fix(Argument#prepare) guides to reflect 1.6.0 changes

### DIFF
--- a/guides/fields/arguments.md
+++ b/guides/fields/arguments.md
@@ -49,7 +49,7 @@ Provide a `prepare` function to modify or validate the value of an argument befo
 
 ```ruby
 field :posts, types[PostType] do
-  argument :startDate, types.String, prepare: ->(startDate) {
+  argument :startDate, types.String, prepare: ->(startDate, ctx) {
     # return the prepared argument or GraphQL::ExecutionError.new("msg")
     # to halt the execution of the field and add "msg" to the `errors` key.
   }


### PR DESCRIPTION
As per https://github.com/rmosolgo/graphql-ruby/pull/730, Argument prepare functions receive the context as a second argument. This PR updates the guides to reflect this change.