### PR TITLE
Implement "default_max_page_size"

### DIFF
--- a/guides/relay/connections.md
+++ b/guides/relay/connections.md
@@ -57,6 +57,14 @@ You can limit the number of results with `max_page_size:`:
 connection :featured_comments, CommentType.connection_type, max_page_size: 50
 ```
 
+In addition, you can set a global default for all connection that do not specify a `max_page_size`:
+
+```ruby
+MySchema = GraphQL::Schema.define do
+  default_max_page_size 100
+end
+```
+
 ## Connection types
 
 You can customize a connection type with `.define_connection`:

--- a/lib/graphql/relay/base_connection.rb
+++ b/lib/graphql/relay/base_connection.rb
@@ -57,13 +57,13 @@ module GraphQL
       # @param parent [Object] The object which this collection belongs to
       # @param context [GraphQL::Query::Context] The context from the field being resolved
       def initialize(nodes, arguments, field: nil, max_page_size: nil, parent: nil, context: nil)
+        @context = context
         @nodes = nodes
         @arguments = arguments
-        @max_page_size = max_page_size
         @field = field
         @parent = parent
-        @context = context
         @encoder = context ? @context.schema.cursor_encoder : GraphQL::Schema::Base64Encoder
+        @max_page_size = max_page_size.nil? && context ? @context.schema.default_max_page_size : max_page_size
       end
 
       def encode(data)

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -55,7 +55,7 @@ module GraphQL
     accepts_definitions \
       :query, :mutation, :subscription,
       :query_execution_strategy, :mutation_execution_strategy, :subscription_execution_strategy,
-      :max_depth, :max_complexity,
+      :max_depth, :max_complexity, :default_max_page_size,
       :orphan_types, :resolve_type, :type_error, :parse_error,
       :raise_definition_error,
       :object_from_id, :id_from_object,
@@ -77,7 +77,7 @@ module GraphQL
     attr_accessor \
       :query, :mutation, :subscription,
       :query_execution_strategy, :mutation_execution_strategy, :subscription_execution_strategy,
-      :max_depth, :max_complexity,
+      :max_depth, :max_complexity, :default_max_page_size,
       :orphan_types, :directives,
       :query_analyzers, :multiplex_analyzers, :instrumenters, :lazy_methods,
       :cursor_encoder,

--- a/spec/graphql/relay/array_connection_spec.rb
+++ b/spec/graphql/relay/array_connection_spec.rb
@@ -187,12 +187,12 @@ describe GraphQL::Relay::ArrayConnection do
         assert_equal(["Yavin", "Echo Base"], get_names(result))
         assert_equal(false, get_page_info(result)["hasPreviousPage"], "hasPreviousPage is false when last is not specified")
 
-        fourth_cursor = "Mw=="
+        third_cursor = "Mw=="
         first_and_second_names = ["Yavin", "Echo Base"]
-        result = star_wars_query(query_string, "last" => 100, "before" => fourth_cursor)
+        result = star_wars_query(query_string, "last" => 100, "before" => third_cursor)
         assert_equal(first_and_second_names, get_names(result))
 
-        result = star_wars_query(query_string, "before" => fourth_cursor)
+        result = star_wars_query(query_string, "before" => third_cursor)
         assert_equal(first_and_second_names, get_names(result))
       end
     end

--- a/spec/graphql/relay/array_connection_spec.rb
+++ b/spec/graphql/relay/array_connection_spec.rb
@@ -187,13 +187,73 @@ describe GraphQL::Relay::ArrayConnection do
         assert_equal(["Yavin", "Echo Base"], get_names(result))
         assert_equal(false, get_page_info(result)["hasPreviousPage"], "hasPreviousPage is false when last is not specified")
 
-        third_cursor = "Mw=="
+        fourth_cursor = "Mw=="
         first_and_second_names = ["Yavin", "Echo Base"]
-        result = star_wars_query(query_string, "last" => 100, "before" => third_cursor)
+        result = star_wars_query(query_string, "last" => 100, "before" => fourth_cursor)
         assert_equal(first_and_second_names, get_names(result))
 
-        result = star_wars_query(query_string, "before" => third_cursor)
+        result = star_wars_query(query_string, "before" => fourth_cursor)
         assert_equal(first_and_second_names, get_names(result))
+      end
+    end
+
+    describe "applying default_max_page_size" do
+      def get_names(result)
+        result["data"]["rebels"]["bases"]["edges"].map { |e| e["node"]["name"] }
+      end
+
+      def get_page_info(result)
+        result["data"]["rebels"]["bases"]["pageInfo"]
+      end
+
+      let(:query_string) {%|
+        query getShips($first: Int, $after: String, $last: Int, $before: String){
+          rebels {
+            bases: basesWithDefaultMaxLimitArray(first: $first, after: $after, last: $last, before: $before) {
+              edges {
+                cursor
+                node {
+                  name
+                }
+              }
+              pageInfo {
+                hasNextPage
+                hasPreviousPage
+              }
+            }
+          }
+        }
+      |}
+
+      it "applies to queries by `first`" do
+        result = star_wars_query(query_string, "first" => 100)
+        assert_equal(["Yavin", "Echo Base", "Secret Hideout"], get_names(result))
+        assert_equal(true, get_page_info(result)["hasNextPage"])
+
+        # Max page size is applied _without_ `first`, also
+        result = star_wars_query(query_string)
+        assert_equal(["Yavin", "Echo Base", "Secret Hideout"], get_names(result))
+        assert_equal(false, get_page_info(result)["hasNextPage"], "hasNextPage is false when first is not specified")
+      end
+
+      it "applies to queries by `last`" do
+        last_cursor = "Ng=="
+
+        result = star_wars_query(query_string, "last" => 100, "before" => last_cursor)
+        assert_equal(["Secret Hideout", "Death Star", "Shield Generator"], get_names(result))
+        assert_equal(true, get_page_info(result)["hasPreviousPage"])
+
+        result = star_wars_query(query_string, "before" => last_cursor)
+        assert_equal(["Yavin", "Echo Base", "Secret Hideout"], get_names(result))
+        assert_equal(false, get_page_info(result)["hasPreviousPage"], "hasPreviousPage is false when last is not specified")
+
+        fourth_cursor = "NA=="
+        first_second_and_third_names = ["Yavin", "Echo Base", "Secret Hideout"]
+        result = star_wars_query(query_string, "last" => 100, "before" => fourth_cursor)
+        assert_equal(first_second_and_third_names, get_names(result))
+
+        result = star_wars_query(query_string, "before" => fourth_cursor)
+        assert_equal(first_second_and_third_names, get_names(result))
       end
     end
   end

--- a/spec/graphql/relay/relation_connection_spec.rb
+++ b/spec/graphql/relay/relation_connection_spec.rb
@@ -206,7 +206,7 @@ describe GraphQL::Relay::RelationConnection do
 
       it "applies to queries by `last`" do
         second_to_last_two_names = ["Death Star", "Shield Generator"]
-        first_second_and_third_names = ["Yavin", "Echo Base"]
+        first_and_second_names = ["Yavin", "Echo Base"]
 
         last_cursor = "Ng=="
         result = star_wars_query(query_string, "last" => 100, "before" => last_cursor)
@@ -214,15 +214,15 @@ describe GraphQL::Relay::RelationConnection do
         assert_equal(true, result["data"]["empire"]["bases"]["pageInfo"]["hasPreviousPage"])
 
         result = star_wars_query(query_string, "before" => last_cursor)
-        assert_equal(first_second_and_third_names, get_names(result))
+        assert_equal(first_and_second_names, get_names(result))
         assert_equal(false, result["data"]["empire"]["bases"]["pageInfo"]["hasPreviousPage"], "hasPreviousPage is false when last is not specified")
 
         third_cursor = "Mw=="
         result = star_wars_query(query_string, "last" => 100, "before" => third_cursor)
-        assert_equal(first_second_and_third_names, get_names(result))
+        assert_equal(first_and_second_names, get_names(result))
 
         result = star_wars_query(query_string, "before" => third_cursor)
-        assert_equal(first_second_and_third_names, get_names(result))
+        assert_equal(first_and_second_names, get_names(result))
       end
     end
 

--- a/spec/graphql/relay/relation_connection_spec.rb
+++ b/spec/graphql/relay/relation_connection_spec.rb
@@ -206,7 +206,7 @@ describe GraphQL::Relay::RelationConnection do
 
       it "applies to queries by `last`" do
         second_to_last_two_names = ["Death Star", "Shield Generator"]
-        first_and_second_names = ["Yavin", "Echo Base"]
+        first_second_and_third_names = ["Yavin", "Echo Base"]
 
         last_cursor = "Ng=="
         result = star_wars_query(query_string, "last" => 100, "before" => last_cursor)
@@ -214,15 +214,74 @@ describe GraphQL::Relay::RelationConnection do
         assert_equal(true, result["data"]["empire"]["bases"]["pageInfo"]["hasPreviousPage"])
 
         result = star_wars_query(query_string, "before" => last_cursor)
-        assert_equal(first_and_second_names, get_names(result))
+        assert_equal(first_second_and_third_names, get_names(result))
         assert_equal(false, result["data"]["empire"]["bases"]["pageInfo"]["hasPreviousPage"], "hasPreviousPage is false when last is not specified")
 
         third_cursor = "Mw=="
         result = star_wars_query(query_string, "last" => 100, "before" => third_cursor)
-        assert_equal(first_and_second_names, get_names(result))
+        assert_equal(first_second_and_third_names, get_names(result))
 
         result = star_wars_query(query_string, "before" => third_cursor)
-        assert_equal(first_and_second_names, get_names(result))
+        assert_equal(first_second_and_third_names, get_names(result))
+      end
+    end
+
+    describe "applying default_max_page_size" do
+      let(:query_string) {%|
+        query getBases($first: Int, $after: String, $last: Int, $before: String){
+          empire {
+            bases: basesWithDefaultMaxLimitRelation(first: $first, after: $after, last: $last, before: $before) {
+              ... basesConnection
+            }
+          }
+        }
+
+        fragment basesConnection on BaseConnection {
+          edges {
+            cursor
+            node {
+              name
+            }
+          },
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
+            startCursor
+            endCursor
+          }
+        }
+        |}
+
+      it "applies to queries by `first`" do
+        result = star_wars_query(query_string, "first" => 100)
+        assert_equal(3, result["data"]["empire"]["bases"]["edges"].size)
+        assert_equal(true, result["data"]["empire"]["bases"]["pageInfo"]["hasNextPage"])
+
+        # Max page size is applied _without_ `first`, also
+        result = star_wars_query(query_string)
+        assert_equal(3, result["data"]["empire"]["bases"]["edges"].size)
+        assert_equal(false, result["data"]["empire"]["bases"]["pageInfo"]["hasNextPage"], "hasNextPage is false when first is not specified")
+      end
+
+      it "applies to queries by `last`" do
+        second_to_last_three_names = ["Secret Hideout", "Death Star", "Shield Generator"]
+        first_second_and_third_names = ["Yavin", "Echo Base", "Secret Hideout"]
+
+        last_cursor = "Ng=="
+        result = star_wars_query(query_string, "last" => 100, "before" => last_cursor)
+        assert_equal(second_to_last_three_names, get_names(result))
+        assert_equal(true, result["data"]["empire"]["bases"]["pageInfo"]["hasPreviousPage"])
+
+        result = star_wars_query(query_string, "before" => last_cursor)
+        assert_equal(first_second_and_third_names, get_names(result))
+        assert_equal(false, result["data"]["empire"]["bases"]["pageInfo"]["hasPreviousPage"], "hasPreviousPage is false when last is not specified")
+
+        fourth_cursor = "NA=="
+        result = star_wars_query(query_string, "last" => 100, "before" => fourth_cursor)
+        assert_equal(first_second_and_third_names, get_names(result))
+
+        result = star_wars_query(query_string, "before" => fourth_cursor)
+        assert_equal(first_second_and_third_names, get_names(result))
       end
     end
   end

--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -96,7 +96,7 @@ module StarWars
 
     field :id, !types.ID, resolve: GraphQL::Relay::GlobalIdResolve.new(type: Faction)
     field :name, types.String
-    connection :ships, ShipConnectionWithParentType do
+    connection :ships, ShipConnectionWithParentType, max_page_size: 1000 do
       resolve ->(obj, args, ctx) {
         all_ships = obj.ships.map {|ship_id| StarWars::DATA["Ship"][ship_id] }
         if args[:nameIncludes]
@@ -340,7 +340,7 @@ module StarWars
   Schema = GraphQL::Schema.define do
     query(QueryType)
     mutation(MutationType)
-    default_max_page_size 100
+    default_max_page_size 3
 
     resolve_type ->(object, ctx) {
       if object == :test_error

--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -159,7 +159,15 @@ module StarWars
       resolve ->(object, args, context) { Base.all.to_a }
     end
 
-    connection :basesAsSequelDataset, BaseConnectionWithTotalCountType do
+    connection :basesWithDefaultMaxLimitRelation, BaseType.connection_type do
+      resolve ->(object, args, context) { Base.all }
+    end
+
+    connection :basesWithDefaultMaxLimitArray, BaseType.connection_type do
+      resolve ->(object, args, context) { Base.all.to_a }
+    end
+
+    connection :basesAsSequelDataset, BaseConnectionWithTotalCountType, max_page_size: 1000 do
       argument :nameIncludes, types.String
       resolve ->(obj, args, ctx) {
         all_bases = SequelBase.where(faction_id: obj.id)
@@ -332,6 +340,7 @@ module StarWars
   Schema = GraphQL::Schema.define do
     query(QueryType)
     mutation(MutationType)
+    default_max_page_size 100
 
     resolve_type ->(object, ctx) {
       if object == :test_error


### PR DESCRIPTION
https://github.com/rmosolgo/graphql-ruby/issues/751

Usage:

```ruby
MySchema = GraphQL::Schema.define do
  # ...
  default_max_page_size 100
  # ...
end
```

For any relation where `max_page_size` is not defined, or if it is `nil`, the `default_max_page_size` will be used instead.

Also, partially for my own benefit, here's the complete list of bases in order:

| Name | Cursor |
| -----|-------|
| Yavin      | MQ==       |
| Echo Base | Mg== |
| Secret Hideout | Mw== |
| Death Star | NA== |
| Shield Generator | NQ== |
| Headquarters | Ng== |

(Yavin being the first base, Headquarters being the last).
