### PR TITLE
fix(Query#mutation? Query#query?) fix op-type methods to load AST

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -188,7 +188,11 @@ module GraphQL
     end
 
     def mutation?
-      @mutation
+      with_prepared_ast { @mutation }
+    end
+
+    def query?
+      with_prepared_ast { @query }
     end
 
     # @return [void]
@@ -260,6 +264,7 @@ module GraphQL
           end
           @ast_variables = @selected_operation.variables
           @mutation = @selected_operation.operation_type == "mutation"
+          @query = @selected_operation.operation_type == "query"
         end
       end
 

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -500,6 +500,24 @@ describe GraphQL::Query do
     end
   end
 
+  describe "#mutation?" do
+    let(:query_string) { <<-GRAPHQL
+    query Q { __typename }
+    mutation M { pushValue(value: 1) }
+    GRAPHQL
+    }
+
+    it "returns true if the selected operation is a mutation" do
+      query_query = GraphQL::Query.new(schema, query_string, operation_name: "Q")
+      assert_equal false, query_query.mutation?
+      assert_equal true, query_query.query?
+
+      mutation_query = GraphQL::Query.new(schema, query_string, operation_name: "M")
+      assert_equal true, mutation_query.mutation?
+      assert_equal false, mutation_query.query?
+    end
+  end
+
   describe 'NullValue type arguments' do
     let(:schema_definition) {
       <<-GRAPHQL


### PR DESCRIPTION
Since adding lazy AST preparation, I missed a couple of attributes which depend on the AST.

So this ensures that it's been prepared before trying to check it.