### PR TITLE
fix(Schema#query_execution_strategy) support custom strategy when running 1 query

### DIFF
--- a/lib/graphql/execution/multiplex.rb
+++ b/lib/graphql/execution/multiplex.rb
@@ -40,7 +40,27 @@ module GraphQL
           run_queries(schema, queries, *rest)
         end
 
+        # @param schema [GraphQL::Schema]
+        # @param queries [Array<GraphQL::Query>]
+        # @param context [Hash]
+        # @param max_complexity [Integer]
+        # @return [Array<Hash>] One result per query
         def run_queries(schema, queries, context: {}, max_complexity: nil)
+          has_custom_strategy = schema.query_execution_strategy || schema.mutation_execution_strategy || schema.subscription_execution_strategy
+          if has_custom_strategy
+            if queries.length == 1
+              return [run_one_legacy(schema, queries.first)]
+            else
+              raise "Multiplexing doesn't support custom execution strategies, run one query at a time instead"
+            end
+          else
+            run_as_multiplex(schema, queries, context: context, max_complexity: max_complexity)
+          end
+        end
+
+        private
+
+        def run_as_multiplex(schema, queries, context:, max_complexity:)
           query_instrumenters = schema.instrumenters[:query]
           multiplex_instrumenters = schema.instrumenters[:multiplex]
           multiplex = self.new(schema: schema, queries: queries, context: context)
@@ -79,8 +99,6 @@ module GraphQL
           end
           multiplex_instrumenters.reverse_each { |i| i.after_multiplex(multiplex) }
         end
-
-        private
 
         # @param query [GraphQL::Query]
         # @return [Hash] The initial result (may not be finished if there are lazy values)
@@ -127,6 +145,24 @@ module GraphQL
 
             result
           end
+        end
+
+        # use the old `query_execution_strategy` etc to run this query
+        def run_one_legacy(schema, query)
+          instrumenters = schema.instrumenters[:query]
+          instrumenters.each { |i| i.before_query(query) }
+          query.result = if !query.valid?
+            all_errors = query.validation_errors + query.analysis_errors + query.context.errors
+            if all_errors.any?
+              { "errors" => all_errors.map(&:to_h) }
+            else
+              nil
+            end
+          else
+            GraphQL::Query::Executor.new(query).result
+          end
+        ensure
+          instrumenters.reverse_each { |i| i.after_query(query) }
         end
       end
     end

--- a/lib/graphql/execution/multiplex.rb
+++ b/lib/graphql/execution/multiplex.rb
@@ -51,7 +51,7 @@ module GraphQL
             if queries.length == 1
               return [run_one_legacy(schema, queries.first)]
             else
-              raise "Multiplexing doesn't support custom execution strategies, run one query at a time instead"
+              raise ArgumentError, "Multiplexing doesn't support custom execution strategies, run one query at a time instead"
             end
           else
             run_as_multiplex(schema, queries, context: context, max_complexity: max_complexity)

--- a/lib/graphql/query/executor.rb
+++ b/lib/graphql/query/executor.rb
@@ -8,7 +8,6 @@ module GraphQL
       attr_reader :query
 
       def initialize(query)
-        warn("Executor is deprecated; use Schema#execute")
         @query = query
       end
 

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -98,7 +98,7 @@ module GraphQL
       GraphQL::Filter.new(except: default_mask)
     end
 
-    self.default_execution_strategy = GraphQL::Execution::Execute
+    self.default_execution_strategy = nil
 
     BUILT_IN_TYPES = Hash[[INT_TYPE, STRING_TYPE, FLOAT_TYPE, BOOLEAN_TYPE, ID_TYPE].map{ |type| [type.name, type] }]
     DIRECTIVES = [GraphQL::Directive::IncludeDirective, GraphQL::Directive::SkipDirective, GraphQL::Directive::DeprecatedDirective]

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -578,4 +578,18 @@ describe GraphQL::Query do
       assert_kind_of GraphQL::InternalRepresentation::Node, query.internal_representation.fragment_definitions["dairyFields"]
     end
   end
+
+  describe "query_execution_strategy" do
+    class DummyStrategy
+      def execute(ast_operation, root_type, query_object)
+        { "dummy" => true }
+      end
+    end
+
+    it "is used for running a query, if it's present and not the default" do
+      dummy_schema = schema.redefine(query_execution_strategy: DummyStrategy)
+      result = dummy_schema.execute(" { __typename }")
+      assert_equal({"data"=>{"dummy"=>true}}, result)
+    end
+  end
 end


### PR DESCRIPTION
Oops, adding Schema#multiplex bypassed this altogether!
