### PR TITLE
fix(Execute) use .is_a?(Skip) instead of ==(Skip) to avoid touching user code

### DIFF
--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -4,8 +4,14 @@ module GraphQL
     # A valid execution strategy
     # @api private
     class Execute
+
       # @api private
-      SKIP = Object.new
+      class Skip; end
+
+      # Just a singleton for implementing {Query::Context#skip}
+      # @api private
+      SKIP = Skip.new
+
       # @api private
       PROPAGATE_NULL = Object.new
 
@@ -40,7 +46,7 @@ module GraphQL
               query_ctx
             )
 
-            if field_result == SKIP
+            if field_result.is_a?(Skip)
               next
             end
 
@@ -147,7 +153,7 @@ module GraphQL
             else
               nil
             end
-          elsif value == SKIP
+          elsif value.is_a?(Skip)
             value
           else
             case field_type.kind

--- a/spec/support/dummy/data.rb
+++ b/spec/support/dummy/data.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 require 'ostruct'
 module Dummy
-  Cheese = Struct.new(:id, :flavor, :origin, :fat_content, :source)
+  Cheese = Struct.new(:id, :flavor, :origin, :fat_content, :source) do
+    def ==(other)
+      # This is buggy on purpose -- it shouldn't be called during execution.
+      other.id == id
+    end
+  end
+
   CHEESES = {
     1 => Cheese.new(1, "Brie", "France", 0.19, 1),
     2 => Cheese.new(2, "Gouda", "Netherlands", 0.3, 1),


### PR DESCRIPTION
This is to support cases when `#==(other)` doesn't support comparison with arbitrary objects.

Sure, it should be fixed in application code, but I also want to reduce the burden for people who are upgrading. It's a nasty surprise to find this issue!