### PR TITLE
BackwardsCompatibility arity check: support Method

### DIFF
--- a/lib/graphql/backwards_compatibility.rb
+++ b/lib/graphql/backwards_compatibility.rb
@@ -25,7 +25,7 @@ module GraphQL
 
     def get_arity(callable)
       case callable
-      when Proc
+      when Method, Proc
         callable.arity
       else
         callable.method(:call).arity

--- a/lib/graphql/schema/middleware_chain.rb
+++ b/lib/graphql/schema/middleware_chain.rb
@@ -66,20 +66,11 @@ module GraphQL
       end
 
       def wrap(callable)
-        if get_arity(callable) == 6
+        if BackwardsCompatibility.get_arity(callable) == 6
           warn("Middleware that takes a next_middleware parameter is deprecated (#{callable.inspect}); instead, accept a block and use yield.")
           MiddlewareWrapper.new(callable)
         else
           callable
-        end
-      end
-
-      def get_arity(callable)
-        case callable
-        when Proc, Method
-          callable.arity
-        else
-          callable.method(:call).arity
         end
       end
     end


### PR DESCRIPTION
* Adds support fo `Method` to `get_arity`.
* Updates MiddlewaChain to use `BackwardsCompatibility.get_arity`