### PR TITLE
fix(Multiplex) correctly check for any overridden execution strategy

### DIFF
--- a/lib/graphql/execution/multiplex.rb
+++ b/lib/graphql/execution/multiplex.rb
@@ -46,8 +46,7 @@ module GraphQL
         # @param max_complexity [Integer]
         # @return [Array<Hash>] One result per query
         def run_queries(schema, queries, context: {}, max_complexity: nil)
-          has_custom_strategy = schema.query_execution_strategy || schema.mutation_execution_strategy || schema.subscription_execution_strategy
-          if has_custom_strategy
+          if has_custom_strategy?(schema)
             if queries.length == 1
               return [run_one_legacy(schema, queries.first)]
             else
@@ -163,6 +162,12 @@ module GraphQL
           end
         ensure
           instrumenters.reverse_each { |i| i.after_query(query) }
+        end
+
+        def has_custom_strategy?(schema)
+          schema.query_execution_strategy != GraphQL::Execution::Execute ||
+            schema.mutation_execution_strategy != GraphQL::Execution::Execute ||
+            schema.subscription_execution_strategy != GraphQL::Execution::Execute
         end
       end
     end

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -98,7 +98,7 @@ module GraphQL
       GraphQL::Filter.new(except: default_mask)
     end
 
-    self.default_execution_strategy = nil
+    self.default_execution_strategy = GraphQL::Execution::Execute
 
     BUILT_IN_TYPES = Hash[[INT_TYPE, STRING_TYPE, FLOAT_TYPE, BOOLEAN_TYPE, ID_TYPE].map{ |type| [type.name, type] }]
     DIRECTIVES = [GraphQL::Directive::IncludeDirective, GraphQL::Directive::SkipDirective, GraphQL::Directive::DeprecatedDirective]

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -609,6 +609,9 @@ describe GraphQL::Query do
     it "is used for running a query, if it's present and not the default" do
       result = custom_execution_schema.execute(" { __typename }")
       assert_equal({"data"=>{"dummy"=>true}}, result)
+
+      result = custom_execution_schema.execute(" mutation { __typename } ")
+      assert_equal({"data"=>{"__typename" => "Mutation"}}, result)
     end
 
     it "can't run a multiplex" do


### PR DESCRIPTION
Oops, if you overrode _one_ strategy but not _all_ of them, you'd get `undefined method "new" for NilClass`

cc @swalkinshaw 