### PR TITLE
fix(Execute) if a lazy returns an invalid null, stop running its siblings

### DIFF
--- a/lib/graphql/compatibility/lazy_execution_specification.rb
+++ b/lib/graphql/compatibility/lazy_execution_specification.rb
@@ -66,9 +66,9 @@ module GraphQL
             |
             res = self.class.lazy_schema.execute(query_str, context: {pushes: []})
             assert_equal nil, res["data"]
-            assert_equal 2, res["errors"].length
+            # The first fail causes the second field to never resolve
+            assert_equal 1, res["errors"].length
             assert_equal ["push", "push", "fail1", "value"], res["errors"][0]["path"]
-            assert_equal ["push", "push", "fail2", "value"], res["errors"][1]["path"]
           end
 
           def test_it_resolves_mutation_values_eagerly

--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -109,6 +109,9 @@ module GraphQL
         end
 
         def continue_resolve_field(owner, selection, parent_type, field, raw_value, field_ctx)
+          if owner.invalid_null?
+            return
+          end
           query = field_ctx.query
 
           case raw_value

--- a/spec/graphql/execution/multiplex_spec.rb
+++ b/spec/graphql/execution/multiplex_spec.rb
@@ -64,6 +64,10 @@ describe GraphQL::Execution::Multiplex do
           nestedSum(value: 13) {
             value
           }
+          # This field will never get executed
+          ns2: nestedSum(value: 13) {
+            value
+          }
         }
       }
     }" }


### PR DESCRIPTION
This behavior of eager execution was not properly implemented in lazy execution