### PR TITLE
WIP: Improved mutation generator

### DIFF
--- a/lib/generators/graphql/core.rb
+++ b/lib/generators/graphql/core.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require 'rails/generators/base'
+
+module Graphql
+  module Generators
+    module Core
+      def insert_root_type(type, name)
+        log :add_root_type, type
+        sentinel = /GraphQL\:\:Schema\.define do\s*\n/m
+
+        in_root do
+          inject_into_file schema_file_path, "  #{type}(Types::#{name})\n", after: sentinel, verbose: false, force: false
+        end
+      end
+
+      def create_mutation_root_type
+        create_dir("app/graphql/mutations")
+        template("mutation_type.erb", "app/graphql/types/mutation_type.rb", { skip: true })
+        insert_root_type('mutation', 'MutationType')
+      end
+
+      def schema_file_path
+        "app/graphql/#{schema_name.underscore}.rb"
+      end
+
+      def create_dir(dir)
+        empty_directory(dir)
+        if !options[:skip_keeps]
+          create_file("#{dir}/.keep")
+        end
+      end
+
+      private
+
+      def schema_name
+        @schema_name ||= begin
+          if options[:schema]
+            options[:schema]
+          else
+            require File.expand_path("config/application", destination_root)
+            "#{Rails.application.class.parent_name}Schema"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/graphql/install_generator.rb
+++ b/lib/generators/graphql/install_generator.rb
@@ -105,9 +105,22 @@ RUBY
             route(GRAPHIQL_ROUTE)
           end
         end
+
+        if gemfile_modified?
+          say "Gemfile has been modified, make sure you `bundle install`"
+        end
       end
 
       private
+
+      def gemfile_modified?
+        @gemfile_modified
+      end
+
+      def gem(*args)
+        @gemfile_modified = true
+        super(*args)
+      end
 
       def create_dir(dir)
         empty_directory(dir)

--- a/lib/generators/graphql/install_generator.rb
+++ b/lib/generators/graphql/install_generator.rb
@@ -98,7 +98,12 @@ RUBY
           say("  You may wish to use GraphiQL.app for development: https://github.com/skevy/graphiql-app")
         elsif !options[:skip_graphiql]
           gem("graphiql-rails", group: :development)
-          route(GRAPHIQL_ROUTE)
+
+          # This is a little cheat just to get cleaner shell output:
+          log :route, 'graphiql-rails'
+          shell.mute do
+            route(GRAPHIQL_ROUTE)
+          end
         end
       end
 

--- a/lib/generators/graphql/install_generator.rb
+++ b/lib/generators/graphql/install_generator.rb
@@ -68,6 +68,11 @@ module Graphql
         default: false,
         desc: "Include GraphQL::Batch installation"
 
+      # These two options are taken from Rails' own generators'
+      class_option :api,
+        type: :boolean,
+        desc: "Preconfigure smaller stack for API only apps"
+
 
       GRAPHIQL_ROUTE = <<-RUBY
 if Rails.env.development?
@@ -83,14 +88,17 @@ RUBY
         template("graphql_controller.erb", "app/controllers/graphql_controller.rb")
         route('post "/graphql", to: "graphql#execute"')
 
-        if !options[:skip_graphiql]
-          gem("graphiql-rails", group: :development)
-          route(GRAPHIQL_ROUTE)
-        end
-
         if options[:batch]
           gem("graphql-batch")
           create_dir("app/graphql/loaders")
+        end
+
+        if options.api?
+          say("Skipped graphiql, as this rails project is API only")
+          say("  You may wish to use GraphiQL.app for development: https://github.com/skevy/graphiql-app")
+        elsif !options[:skip_graphiql]
+          gem("graphiql-rails", group: :development)
+          route(GRAPHIQL_ROUTE)
         end
       end
 

--- a/lib/generators/graphql/install_generator.rb
+++ b/lib/generators/graphql/install_generator.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'rails/generators/base'
+require_relative 'core'
 
 module Graphql
   module Generators
@@ -40,6 +41,8 @@ module Graphql
     #
     # Use `--no-graphiql` to skip `graphiql-rails` installation.
     class InstallGenerator < Rails::Generators::Base
+      include Core
+
       desc "Install GraphQL folder structure and boilerplate code"
       source_root File.expand_path('../templates', __FILE__)
 
@@ -81,10 +84,17 @@ if Rails.env.development?
 RUBY
 
       def create_folder_structure
-        create_dir("app/graphql/mutations")
         create_dir("app/graphql/types")
+        template("schema.erb", schema_file_path)
+
+        # Note: Yuo can't have a schema without the query type, otherwise introspection breaks
         template("query_type.erb", "app/graphql/types/query_type.rb")
-        template("schema.erb", "app/graphql/#{schema_name.underscore}.rb")
+        insert_root_type('query', 'QueryType')
+
+        unless no? 'Create root mutation type? Y/n'
+          create_mutation_root_type
+        end
+
         template("graphql_controller.erb", "app/controllers/graphql_controller.rb")
         route('post "/graphql", to: "graphql#execute"')
 
@@ -120,24 +130,6 @@ RUBY
       def gem(*args)
         @gemfile_modified = true
         super(*args)
-      end
-
-      def create_dir(dir)
-        empty_directory(dir)
-        if !options[:skip_keeps]
-          create_file("#{dir}/.keep")
-        end
-      end
-
-      def schema_name
-        @schema_name ||= begin
-          if options[:schema]
-            options[:schema]
-          else
-            require File.expand_path("config/application", destination_root)
-            "#{Rails.application.class.parent_name}Schema"
-          end
-        end
       end
     end
   end

--- a/lib/generators/graphql/templates/mutation.erb
+++ b/lib/generators/graphql/templates/mutation.erb
@@ -1,5 +1,5 @@
-Mutations::<%= name %> = GraphQL::Relay::Mutation.define do
-  name "<%= name %>"
+Mutations::<%= mutation_name %> = GraphQL::Relay::Mutation.define do
+  name "<%= field_name %>"
   # TODO: define return fields
   # return_field :post, Types::PostType
 

--- a/lib/generators/graphql/templates/mutation_type.erb
+++ b/lib/generators/graphql/templates/mutation_type.erb
@@ -1,0 +1,5 @@
+Types::MutationType = GraphQL::ObjectType.define do
+  name "Mutation"
+
+  # TODO: Add Mutations as fields
+end

--- a/lib/generators/graphql/templates/schema.erb
+++ b/lib/generators/graphql/templates/schema.erb
@@ -1,5 +1,4 @@
 <%= schema_name %> = GraphQL::Schema.define do
-  query(Types::QueryType)
 <% if options[:relay] %>
   # Relay Object Identification:
 

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,8 @@ $ bundle install
 $ rails generate graphql:install
 ```
 
+After this, you may need to run `bundle install` again, as by default graphiql-rails is added on installation.
+
 Or, see ["Getting Started"](https://rmosolgo.github.io/graphql-ruby/).
 
 ## Upgrade

--- a/spec/generators/graphql/install_generator_spec.rb
+++ b/spec/generators/graphql/install_generator_spec.rb
@@ -93,6 +93,18 @@ RUBY
     assert_file "app/graphql/dummy_schema.rb", EXPECTED_RELAY_BATCH_SCHEMA
   end
 
+  test "it doesn't install graphiql when API Only" do
+    run_generator(['--api'])
+
+    assert_file "Gemfile" do |contents|
+      refute_includes contents, "graphiql-rails"
+    end
+
+    assert_file "config/routes.rb" do |contents|
+      refute_includes contents, "GraphiQL::Rails"
+    end
+  end
+
   test "it can skip keeps, skip graphiql and customize schema name" do
     run_generator(["--skip-keeps", "--skip-graphiql", "--schema=CustomSchema"])
     assert_no_file "app/graphql/types/.keep"


### PR DESCRIPTION
Currently a work in progress for #769 

There is a pretty major change here, in that I'm no longer using NamedBase for the mutation generator. Considering that if you're to do: `rails g graphql:mutation createUser` you get the wrong output.

Now if you do:

```
rails g graphql:mutation createUser
rails g graphql:mutation CreateUser
rails g graphql:mutation Create_User
rails g graphql:mutation create_user
```

All will now result in the exact same mutation being created. The field added to the root will be the lower-camelcase of the NAME, the module will be upper-camelcase of the NAME, and the file name will be lower-underscore-case of the NAME. This makes the output more reliable a predictable.

p.s., don't look at the code to NamedBase, it's confusing because it's so messy. A lot of the rails generator code seem to be just randomly dumped all over the place with no actual design.

I'm still not happy with this 100%, especially my "core" module, but I did need somewhere to start to put common functions used between each generator.

When you initially do `rails g graphql:install`, if you choose not to setup mutations, then when you do the first `rails g graphql:mutation NAME`, it'll automatically setup the mutation root type for you, add it to the schema, and add all the correct structure.

Additionally, it'll automatically add the field to the mutation root type, so following the examples above, you'd get this:

```rb
# MutationType.rb
Types::MutationType = GraphQL::ObjectType.define do
  name "Mutation"

  field :createUser, Mutations::CreateUser.field
end
```

If you choose to create mutations on install, then this file will initially look like:

```rb
# MutationType.rb
Types::MutationType = GraphQL::ObjectType.define do
  name "Mutation"

  # TODO: Add Mutations as fields
end
```

The code for `rails g graphql:mutation` is smart enough to remove that line.