### PR TITLE
Add operation name for multiple operation queries.

### DIFF
--- a/lib/generators/graphql/templates/graphql_controller.erb
+++ b/lib/generators/graphql/templates/graphql_controller.erb
@@ -2,11 +2,12 @@ class GraphqlController < ApplicationController
   def execute
     variables = ensure_hash(params[:variables])
     query = params[:query]
+    operation_name = params[:operationName]
     context = {
       # Query context goes here, for example:
       # current_user: current_user,
     }
-    result = <%= schema_name %>.execute(query, variables: variables, context: context)
+    result = <%= schema_name %>.execute(query, variables: variables, context: context, operation_name: operation_name)
     render json: result
   end
 

--- a/spec/generators/graphql/install_generator_spec.rb
+++ b/spec/generators/graphql/install_generator_spec.rb
@@ -128,11 +128,12 @@ class GraphqlController < ApplicationController
   def execute
     variables = ensure_hash(params[:variables])
     query = params[:query]
+    operation_name = params[:operationName]
     context = {
       # Query context goes here, for example:
       # current_user: current_user,
     }
-    result = DummySchema.execute(query, variables: variables, context: context)
+    result = DummySchema.execute(query, variables: variables, context: context, operation_name: operation_name)
     render json: result
   end
 


### PR DESCRIPTION
For multi-operation queries, GraphQL Controller throws error on default executor template:

```json
{
  "errors": [
    {
      "message": "An operation name is required"
    }
  ]
}
```

In case of `operationName` sent by client in the query with multi-operation queries, pass `operation_name` to `execute` to avoid this error.

```graphql
# query
query getDiscounts {
  discounts {
    name
  }
}
query getEmployees {
  employees {
    first_name
  }
}
```

I'm sending this query with `operationName=getEmployees` and get the error above. Solved passing `operationName` to the `execute` method. This change may help others not to face this issue again.