### PR TITLE
fix(Query validate: false) support skipping validation to live on the wild side

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -29,6 +29,9 @@ module GraphQL
 
     attr_reader :schema, :context, :root_value, :warden, :provided_variables, :operation_name
 
+    # @return [Boolean] if false, static validation is skipped (execution behavior for invalid queries is undefined)
+    attr_accessor :validate
+
     attr_accessor :query_string
 
     # @return [GraphQL::Language::Nodes::Document]
@@ -59,6 +62,7 @@ module GraphQL
       @root_value = root_value
       @fragments = nil
       @operations = nil
+      @validate = validate
 
       @analysis_errors = []
       if variables.is_a?(String)
@@ -270,6 +274,7 @@ module GraphQL
 
       @validation_pipeline = GraphQL::Query::ValidationPipeline.new(
         query: self,
+        validate: @validate,
         parse_error: parse_error,
         operation_name_error: operation_name_error,
         max_depth: @max_depth,

--- a/lib/graphql/query/validation_pipeline.rb
+++ b/lib/graphql/query/validation_pipeline.rb
@@ -14,10 +14,11 @@ module GraphQL
     #
     # @api private
     class ValidationPipeline
-      def initialize(query:, parse_error:, operation_name_error:, max_depth:, max_complexity:)
+      def initialize(query:, validate:, parse_error:, operation_name_error:, max_depth:, max_complexity:)
         @validation_errors = []
         @analysis_errors = []
         @internal_representation = nil
+        @validate = validate
         @parse_error = parse_error
         @operation_name_error = operation_name_error
         @query = query
@@ -76,7 +77,7 @@ module GraphQL
         elsif @operation_name_error
           @validation_errors << @operation_name_error
         else
-          validation_result = @schema.static_validator.validate(@query)
+          validation_result = @schema.static_validator.validate(@query, validate: @validate)
           @validation_errors.concat(validation_result[:errors])
           @internal_representation = validation_result[:irep]
 

--- a/lib/graphql/static_validation/validator.rb
+++ b/lib/graphql/static_validation/validator.rb
@@ -21,14 +21,18 @@ module GraphQL
       # Validate `query` against the schema. Returns an array of message hashes.
       # @param query [GraphQL::Query]
       # @return [Array<Hash>]
-      def validate(query)
+      def validate(query, validate: true)
         context = GraphQL::StaticValidation::ValidationContext.new(query)
         rewrite = GraphQL::InternalRepresentation::Rewrite.new
 
         # Put this first so its enters and exits are always called
         rewrite.validate(context)
-        @rules.each do |rules|
-          rules.new.validate(context)
+
+        # If the caller opted out of validation, don't attach these
+        if validate
+          @rules.each do |rules|
+            rules.new.validate(context)
+          end
         end
 
         context.visitor.visit

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -518,6 +518,27 @@ describe GraphQL::Query do
     end
   end
 
+  describe "validate: false" do
+    it "doesn't validate the query" do
+      invalid_query_string = "{ nonExistantField }"
+      # Can assign attribute
+      query = GraphQL::Query.new(schema, invalid_query_string)
+      query.validate = false
+      assert_equal true, query.valid?
+      assert_equal 0, query.static_errors.length
+
+      # Can pass keyword argument
+      query = GraphQL::Query.new(schema, invalid_query_string, validate: false)
+      assert_equal true, query.valid?
+      assert_equal 0, query.static_errors.length
+
+      # Can pass `true`
+      query = GraphQL::Query.new(schema, invalid_query_string, validate: true)
+      assert_equal false, query.valid?
+      assert_equal 1, query.static_errors.length
+    end
+  end
+
   describe 'NullValue type arguments' do
     let(:schema_definition) {
       <<-GRAPHQL

--- a/spec/graphql/static_validation/validator_spec.rb
+++ b/spec/graphql/static_validation/validator_spec.rb
@@ -4,7 +4,8 @@ require "spec_helper"
 describe GraphQL::StaticValidation::Validator do
   let(:validator) { GraphQL::StaticValidation::Validator.new(schema: Dummy::Schema) }
   let(:query) { GraphQL::Query.new(Dummy::Schema, query_string) }
-  let(:errors) { validator.validate(query)[:errors].map(&:to_h) }
+  let(:validate) { true }
+  let(:errors) { validator.validate(query, validate: validate)[:errors].map(&:to_h) }
 
 
   describe "validation order" do
@@ -29,6 +30,14 @@ describe GraphQL::StaticValidation::Validator do
       it "handles args on invalid fields" do
         # nonsenseField, nonsenseArg, bogusField, bogusArg, undefinedVar
         assert_equal(5, errors.length)
+      end
+
+      describe "when validate: false" do
+        let(:validate) { false }
+
+        it "skips validation" do
+          assert_equal 0, errors.length
+        end
       end
     end
 


### PR DESCRIPTION
You can save a few ms if you know for sure that your query is valid (eg, static queries which were validated in development/test, as with github/graphql-client)

If you run an invalid, lots of safeguards are thrown out the window:

- Fields which should be hidden by `only:`/`except:` may be visible 
- Runtime errors will probably happen 

The validation step involves a full visit to the AST, we can't skip that because we have to do a rewrite to InternalRepresentation. Soon, I will refactor that step to be static, so you can run it at build-time and never parse/visit the AST again :) 