### PR TITLE
Resolves RuboCop namespace warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,19 +28,19 @@ Metrics/ParameterLists:
 Style/ClassAndModuleChildren:
   EnforcedStyle: nested
 
-Style/EmptyLineBetweenDefs:
+Layout/EmptyLineBetweenDefs:
   AllowAdjacentOneLineDefs: true
 
 Style/FrozenStringLiteralComment:
   Enabled: true
 
-Style/IndentationWidth:
+Layout/IndentationWidth:
   Width: 2
 
 Style/LambdaCall:
   EnforcedStyle: call
 
-Style/LeadingCommentSpace:
+Layout/LeadingCommentSpace:
   Enabled: true
 
 Style/MethodName:
@@ -50,5 +50,5 @@ Style/WordArray:
   EnforcedStyle: brackets
 
 # ->(...) { ... }
-Style/SpaceInLambdaLiteral:
+Layout/SpaceInLambdaLiteral:
   Enabled: true # Default is "require_no_space"


### PR DESCRIPTION
When running Rubocop you'll get these warnings:
```
.../src/graphql-ruby/.rubocop.yml: Style/EmptyLineBetweenDefs has the wrong namespace - should be Layout
.../src/graphql-ruby/.rubocop.yml: Style/IndentationWidth has the wrong namespace - should be Layout
.../src/graphql-ruby/.rubocop.yml: Style/LeadingCommentSpace has the wrong namespace - should be Layout
.../src/graphql-ruby/.rubocop.yml: Style/SpaceInLambdaLiteral has the wrong namespace - should be Layout
```
This PR fixes the namespace and resolves the warnings.
