### PR TITLE
fix(variables) Fix error when InputObjectType receives array as provided value

### DIFF
--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -105,22 +105,35 @@ module GraphQL
       warden = ctx.warden
       result = GraphQL::Query::InputValidationResult.new
 
+      # Handle arrays specifically
+      # .to_h will handle key value arrays [["a", 1]]
+      # but will raise when array is not in the good format
+      if input.is_a?(Array)
+        begin
+          # Actual coerce array to hash so it does not crash
+          # with string keys.
+          input = input.to_h
+        rescue
+          result.add_problem(INVALID_OBJECT_MESSAGE % { object: JSON.generate(input, quirks_mode: true) })
+        end
+      end
+
       # We're not actually _using_ the coerced result, we're just
       # using these methods to make sure that the object will
       # behave like a hash below, when we call `each` on it.
       begin
-        input = input.to_h
+        input.to_h
       rescue
         begin
           # Handle ActionController::Parameters:
-          input = input.to_unsafe_h
+          input.to_unsafe_h
         rescue
           # We're not sure it'll act like a hash, so reject it:
           result.add_problem(INVALID_OBJECT_MESSAGE % { object: JSON.generate(input, quirks_mode: true) })
-          return result
         end
       end
 
+      return result unless result.valid?
 
       visible_arguments_map = warden.arguments(self).reduce({}) { |m, f| m[f.name] = f; m}
 

--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -105,17 +105,9 @@ module GraphQL
       warden = ctx.warden
       result = GraphQL::Query::InputValidationResult.new
 
-      # Handle arrays specifically
-      # .to_h will handle key value arrays [["a", 1]]
-      # but will raise when array is not in the good format
       if input.is_a?(Array)
-        begin
-          # Actual coerce array to hash so it does not crash
-          # with string keys.
-          input = input.to_h
-        rescue
-          result.add_problem(INVALID_OBJECT_MESSAGE % { object: JSON.generate(input, quirks_mode: true) })
-        end
+        result.add_problem(INVALID_OBJECT_MESSAGE % { object: JSON.generate(input, quirks_mode: true) })
+        return result
       end
 
       # We're not actually _using_ the coerced result, we're just
@@ -130,10 +122,9 @@ module GraphQL
         rescue
           # We're not sure it'll act like a hash, so reject it:
           result.add_problem(INVALID_OBJECT_MESSAGE % { object: JSON.generate(input, quirks_mode: true) })
+          return result
         end
       end
-
-      return result unless result.valid?
 
       visible_arguments_map = warden.arguments(self).reduce({}) { |m, f| m[f.name] = f; m}
 

--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -109,11 +109,11 @@ module GraphQL
       # using these methods to make sure that the object will
       # behave like a hash below, when we call `each` on it.
       begin
-        input.to_h
+        input = input.to_h
       rescue
         begin
           # Handle ActionController::Parameters:
-          input.to_unsafe_h
+          input = input.to_unsafe_h
         rescue
           # We're not sure it'll act like a hash, so reject it:
           result.add_problem(INVALID_OBJECT_MESSAGE % { object: JSON.generate(input, quirks_mode: true) })

--- a/spec/graphql/query/variables_spec.rb
+++ b/spec/graphql/query/variables_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "spec_helper"
-require "pry"
 
 describe GraphQL::Query::Variables do
   let(:query_string) {%|


### PR DESCRIPTION
Gem would crash when an InputObject variable was provided an array as a value:

```
gems/graphql-1.6.3/lib/graphql/input_object_type.rb:136[]	
gems/graphql-1.6.3/lib/graphql/input_object_type.rb:136block in validate_non_null_input	
gems/graphql-1.6.3/lib/graphql/input_object_type.rb:135each	
gems/graphql-1.6.3/lib/graphql/input_object_type.rb:135map	
gems/graphql-1.6.3/lib/graphql/input_object_type.rb:135validate_non_null_input
```

### Cause

https://github.com/rmosolgo/graphql-ruby/blob/master/lib/graphql/input_object_type.rb#L108-L122

The Input Object class validates that the provided value responds to `to_h` or `to_unsafe_h` (Parameters). However, `Array` does respond to `to_h`, but `array["string"]` would cause the error to happen.

### Possible Fix

Instead of checking for `to_h`. This PR assigns the value of the provided value to `value.to_h`. I'm not 100% sure it's the right approach but it at least handles arrays and `ActionController::Parameters`.

Can anybody think of when this could fail?
