### PR TITLE
improve error handling in argument prepare procs

### DIFF
--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -76,8 +76,8 @@ module GraphQL
             selection: selection,
           )
 
-          arguments = query.arguments_for(selection, field)
           raw_value = begin
+            arguments = query.arguments_for(selection, field)
             query_ctx.schema.middleware.invoke([parent_type, object, field, arguments, field_ctx])
           rescue GraphQL::ExecutionError => err
             err
@@ -116,7 +116,7 @@ module GraphQL
 
           case raw_value
           when GraphQL::ExecutionError
-            raw_value.ast_node = field_ctx.ast_node
+            raw_value.ast_node ||= field_ctx.ast_node
             raw_value.path = field_ctx.path
             query.context.errors.push(raw_value)
           when Array

--- a/spec/graphql/query/literal_input_spec.rb
+++ b/spec/graphql/query/literal_input_spec.rb
@@ -5,8 +5,8 @@ describe GraphQL::Query::LiteralInput do
   describe ".from_arguments" do
     describe "arguments are prepared" do
       let(:schema) {
-        query = GraphQL::ObjectType.define do
-          name "Query"
+        type = GraphQL::ObjectType.define do
+          name "SomeType"
 
           field :addToArgumentValue do
             type !types.Int
@@ -35,40 +35,56 @@ describe GraphQL::Query::LiteralInput do
           end
         end
 
+        query = GraphQL::ObjectType.define do
+          name "Query"
+
+          field :top, type, resolve: ->(_, _, _) { true }
+        end
+
         GraphQL::Schema.define(query: query)
       }
 
       it "prepares values from query literals" do
-        result = schema.execute("{ addToArgumentValue(value: 1) }", context: { val: 1 })
-        assert_equal(result["data"]["addToArgumentValue"], 2)
+        result = schema.execute("{ top { addToArgumentValue(value: 1) } }", context: { val: 1 })
+        assert_equal(result["data"]["top"]["addToArgumentValue"], 2)
       end
 
       it "prepares default values" do
-        result = schema.execute("{ addToArgumentValue }", context: { val: 4 })
-        assert_equal(7, result["data"]["addToArgumentValue"])
+        result = schema.execute("{ top { addToArgumentValue } }", context: { val: 4 })
+        assert_equal(7, result["data"]["top"]["addToArgumentValue"])
       end
 
       it "raises an execution error if the default value is bad" do
-        result = schema.execute("{ fieldWithArgumentThatIsBadByDefault }", context: { })
-        assert_equal(result["errors"], [{"message" => "Always bad"}])
+        result = schema.execute("{ top { fieldWithArgumentThatIsBadByDefault } }", context: { })
+        assert_equal(result["data"], {
+          "top"=>{
+            "fieldWithArgumentThatIsBadByDefault"=>nil}
+        })
+        assert_equal(result["errors"], [
+          {"message"=>"Always bad",
+           "locations"=>[{"line"=>1, "column"=>9}],
+           "path"=>["top", "fieldWithArgumentThatIsBadByDefault"]}
+        ])
       end
 
       it "prepares values from variables" do
-        result = schema.execute("query ($value: Int!) { addToArgumentValue(value: $value) }", variables: { "value" => 1}, context: { val: 2 } )
-        assert_equal(result["data"]["addToArgumentValue"], 3)
+        result = schema.execute("query ($value: Int!) { top { addToArgumentValue(value: $value) } }", variables: { "value" => 1}, context: { val: 2 } )
+        assert_equal(result["data"]["top"]["addToArgumentValue"], 3)
       end
 
       it "prepares values correctly if called multiple times with different arguments" do
-        result = schema.execute("{ first: addToArgumentValue(value: 1) second: addToArgumentValue(value: 2) }", context: { val: 3 })
-        assert_equal(result["data"]["first"], 4)
-        assert_equal(result["data"]["second"], 5)
+        result = schema.execute("{ top { first: addToArgumentValue(value: 1) second: addToArgumentValue(value: 2) } }", context: { val: 3 })
+        assert_equal(result["data"]["top"]["first"], 4)
+        assert_equal(result["data"]["top"]["second"], 5)
       end
 
       it "adds message to errors key if an ExecutionError is returned from the prepare function" do
-        result = schema.execute("{ addToArgumentValue(value: 999) }")
+        result = schema.execute("{ top { addToArgumentValue(value: 999) } }")
+        assert_equal(result["data"]["top"], nil)
         assert_equal(result["errors"][0]["message"], "Can't return more than 3 digits")
         assert_equal(result["errors"][0]["locations"][0]["line"], 1)
-        assert_equal(result["errors"][0]["locations"][0]["column"], 22)
+        assert_equal(result["errors"][0]["locations"][0]["column"], 28)
+        assert_equal(result["errors"][0]["path"], ["top", "addToArgumentValue"])
       end
     end
   end


### PR DESCRIPTION
This change fixes #798, but also improves the error and data results from synchronous queries.  Specifically, errors that happen during argument preparation get path info now, and also less of the result is nil'ed out.