### PR TITLE
fix(Argument.accepts_definitions) accept custom keywords

### DIFF
--- a/lib/graphql/argument.rb
+++ b/lib/graphql/argument.rb
@@ -96,11 +96,11 @@ module GraphQL
 
     NO_DEFAULT_VALUE = Object.new
     # @api private
-    def self.from_dsl(name, type = nil, description = nil, default_value: NO_DEFAULT_VALUE, as: nil, prepare: DefaultPrepare, &block)
+    def self.from_dsl(name, type = nil, description = nil, default_value: NO_DEFAULT_VALUE, as: nil, prepare: DefaultPrepare, **kwargs, &block)
       argument = if block_given?
         GraphQL::Argument.define(&block)
       else
-        GraphQL::Argument.new
+        GraphQL::Argument.define(**kwargs)
       end
 
       argument.name = name.to_s

--- a/lib/graphql/define.rb
+++ b/lib/graphql/define.rb
@@ -7,6 +7,7 @@ require "graphql/define/assign_mutation_function"
 require "graphql/define/assign_object_field"
 require "graphql/define/defined_object_proxy"
 require "graphql/define/instance_definable"
+require "graphql/define/no_definition_error"
 require "graphql/define/non_null_with_bang"
 require "graphql/define/type_definer"
 

--- a/lib/graphql/define/defined_object_proxy.rb
+++ b/lib/graphql/define/defined_object_proxy.rb
@@ -38,7 +38,7 @@ module GraphQL
           definition.call(@target, *args, &block)
         else
           msg = "#{@target.class.name} can't define '#{name}'"
-          raise NoMethodError, msg, caller
+          raise NoDefinitionError, msg, caller
         end
       end
 

--- a/lib/graphql/define/no_definition_error.rb
+++ b/lib/graphql/define/no_definition_error.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+module GraphQL
+  module Define
+    class NoDefinitionError < GraphQL::Error
+    end
+  end
+end

--- a/spec/graphql/argument_spec.rb
+++ b/spec/graphql/argument_spec.rb
@@ -19,6 +19,18 @@ describe GraphQL::Argument do
     assert_includes err.message, expected_error
   end
 
+  it "accepts custom keywords" do
+    type = GraphQL::ObjectType.define do
+      name "Something"
+      field :something, types.String do
+        argument "flagged", types.Int, metadata_flag: :flag_1
+      end
+    end
+
+    arg = type.fields["something"].arguments["flagged"]
+    assert_equal true, arg.metadata[:flag_1]
+  end
+
   it "accepts proc type" do
     argument = GraphQL::Argument.define(name: :favoriteFood, type: -> { GraphQL::STRING_TYPE })
     assert_equal GraphQL::STRING_TYPE, argument.type

--- a/spec/graphql/define/assign_argument_spec.rb
+++ b/spec/graphql/define/assign_argument_spec.rb
@@ -24,17 +24,17 @@ describe GraphQL::Define::AssignArgument do
   end
 
   it "passing unknown keyword arguments will raise" do
-    err = assert_raises ArgumentError do
+    err = assert_raises GraphQL::Define::NoDefinitionError do
       define_argument(:a, GraphQL::STRING_TYPE, blah: nil)
     end
 
-    assert_equal 'unknown keyword: blah', err.message
+    assert_equal "GraphQL::Argument can't define 'blah'", err.message
 
-    err = assert_raises ArgumentError do
+    err = assert_raises GraphQL::Define::NoDefinitionError do
       define_argument(:a, GraphQL::STRING_TYPE, blah: nil, blah2: nil)
     end
 
-    assert_equal 'unknown keywords: blah, blah2', err.message
+    assert_equal "GraphQL::Argument can't define 'blah'", err.message
   end
 
   def define_argument(*args)

--- a/spec/graphql/define/instance_definable_spec.rb
+++ b/spec/graphql/define/instance_definable_spec.rb
@@ -185,7 +185,7 @@ describe GraphQL::Define::InstanceDefinable do
 
   describe "typos" do
     it "provides the right class name, method name and line number" do
-      err = assert_raises(NoMethodError) {
+      err = assert_raises(GraphQL::Define::NoDefinitionError) {
         beet = Garden::Vegetable.define {
           name "Beet"
           nonsense :Blah

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,9 +24,11 @@ Minitest.backtrace_filter = Minitest::BacktraceFilter.new
 
 # This is for convenient access to metadata in test definitions
 assign_metadata_key = ->(target, key, value) { target.metadata[key] = value }
+assign_metadata_flag = -> (target, flag) { target.metadata[flag] = true }
 GraphQL::BaseType.accepts_definitions(metadata: assign_metadata_key)
 GraphQL::Field.accepts_definitions(metadata: assign_metadata_key)
 GraphQL::Argument.accepts_definitions(metadata: assign_metadata_key)
+GraphQL::Argument.accepts_definitions(metadata_flag: assign_metadata_flag)
 GraphQL::EnumType::EnumValue.accepts_definitions(metadata: assign_metadata_key)
 
 # Can be used as a GraphQL::Schema::Warden for some purposes, but allows nothing

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,7 @@ Minitest.backtrace_filter = Minitest::BacktraceFilter.new
 
 # This is for convenient access to metadata in test definitions
 assign_metadata_key = ->(target, key, value) { target.metadata[key] = value }
-assign_metadata_flag = -> (target, flag) { target.metadata[flag] = true }
+assign_metadata_flag = ->(target, flag) { target.metadata[flag] = true }
 GraphQL::BaseType.accepts_definitions(metadata: assign_metadata_key)
 GraphQL::Field.accepts_definitions(metadata: assign_metadata_key)
 GraphQL::Argument.accepts_definitions(metadata: assign_metadata_key)


### PR DESCRIPTION
Oops, custom definitions were not accepted as keywords, only with a block! Now, custom definitions can also be passed as keywords.