### PR TITLE
Support .erb files in Schema.from_definition

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -444,13 +444,19 @@ module GraphQL
       GraphQL::Schema::Loader.load(introspection_result)
     end
 
-    # Create schema from an IDL schema.
-    # @param definition_string [String] A schema definition string
+    # Create schema from an IDL schema or file containing an IDL definition.
+    # @param definition_or_path [String] A schema definition string, or a path to a file containing the definition
     # @param default_resolve [<#call(type, field, obj, args, ctx)>] A callable for handling field resolution
     # @param parser [Object] An object for handling definition string parsing (must respond to `parse`)
     # @return [GraphQL::Schema] the schema described by `document`
-    def self.from_definition(string, default_resolve: BuildFromDefinition::DefaultResolve, parser: BuildFromDefinition::DefaultParser)
-      GraphQL::Schema::BuildFromDefinition.from_definition(string, default_resolve: default_resolve, parser: parser)
+    def self.from_definition(definition_or_path, default_resolve: BuildFromDefinition::DefaultResolve, parser: BuildFromDefinition::DefaultParser)
+      # If the file ends in `.graphql`, treat it like a filepath
+      definition = if definition_or_path.end_with?(".graphql")
+        File.read(definition_or_path)
+      else
+        definition_or_path
+      end
+      GraphQL::Schema::BuildFromDefinition.from_definition(definition, default_resolve: default_resolve, parser: parser)
     end
 
     # Error that is raised when [#Schema#from_definition] is passed an invalid schema definition string.

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -449,6 +449,7 @@ module GraphQL
     # @param definition_or_path [String] A schema definition string, or a path to a file containing the definition
     # @param default_resolve [<#call(type, field, obj, args, ctx)>] A callable for handling field resolution
     # @param parser [Object] An object for handling definition string parsing (must respond to `parse`)
+    # @param helpers [Module] Extra helper methods for rendering ERB
     # @return [GraphQL::Schema] the schema described by `document`
     def self.from_definition(definition_or_path, helpers: nil, default_resolve: BuildFromDefinition::DefaultResolve, parser: BuildFromDefinition::DefaultParser)
       # If the file ends in `.graphql`, treat it like a filepath

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -450,7 +450,7 @@ module GraphQL
     # @param default_resolve [<#call(type, field, obj, args, ctx)>] A callable for handling field resolution
     # @param parser [Object] An object for handling definition string parsing (must respond to `parse`)
     # @param helpers [Module] Extra helper methods for rendering ERB
-    # @return [GraphQL::Schema] the schema described by `document`
+    # @return [GraphQL::Schema] the schema described by `definition_or_path`
     def self.from_definition(definition_or_path, helpers: nil, default_resolve: BuildFromDefinition::DefaultResolve, parser: BuildFromDefinition::DefaultParser)
       # If the file ends in `.graphql`, treat it like a filepath
       definition = if definition_or_path.end_with?(".graphql")

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -10,6 +10,7 @@ require "graphql/schema/null_mask"
 require "graphql/schema/possible_types"
 require "graphql/schema/rescue_middleware"
 require "graphql/schema/reduce_types"
+require "graphql/schema/template"
 require "graphql/schema/timeout_middleware"
 require "graphql/schema/type_expression"
 require "graphql/schema/type_map"
@@ -453,6 +454,9 @@ module GraphQL
       # If the file ends in `.graphql`, treat it like a filepath
       definition = if definition_or_path.end_with?(".graphql")
         File.read(definition_or_path)
+      elsif definition_or_path.end_with?(".erb")
+        erb_template = File.read(definition_or_path)
+        GraphQL::Schema::Template.run(erb_template)
       else
         definition_or_path
       end

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -450,13 +450,13 @@ module GraphQL
     # @param default_resolve [<#call(type, field, obj, args, ctx)>] A callable for handling field resolution
     # @param parser [Object] An object for handling definition string parsing (must respond to `parse`)
     # @return [GraphQL::Schema] the schema described by `document`
-    def self.from_definition(definition_or_path, default_resolve: BuildFromDefinition::DefaultResolve, parser: BuildFromDefinition::DefaultParser)
+    def self.from_definition(definition_or_path, helpers: nil, default_resolve: BuildFromDefinition::DefaultResolve, parser: BuildFromDefinition::DefaultParser)
       # If the file ends in `.graphql`, treat it like a filepath
       definition = if definition_or_path.end_with?(".graphql")
         File.read(definition_or_path)
       elsif definition_or_path.end_with?(".erb")
         erb_template = File.read(definition_or_path)
-        GraphQL::Schema::Template.run(erb_template)
+        GraphQL::Schema::Template.run(erb_template, helpers: helpers)
       else
         definition_or_path
       end

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -286,7 +286,12 @@ module GraphQL
 
         def resolve_type(types, ast_node)
           type = GraphQL::Schema::TypeExpression.build_type(types, ast_node)
-          raise InvalidDocumentError.new("Type \"#{ast_node.name}\" not found in document.") unless type
+          if type.nil?
+            while ast_node.respond_to?(:of_type)
+              ast_node = ast_node.of_type
+            end
+            raise InvalidDocumentError.new("Type \"#{ast_node.name}\" not found in document.")
+          end
           type
         end
       end

--- a/lib/graphql/schema/template.rb
+++ b/lib/graphql/schema/template.rb
@@ -2,16 +2,23 @@
 
 module GraphQL
   class Schema
+    # @see {Schema.from_definition} for loading GraphQL schema from GraphQL IDL
+    # @see {Template::Helpers} for ERB definition helpers
+    # @api private
     class Template
       # @param erb_template [String]
+      # @param helpers [Module] extra helper methods for ERB template
       # @return [String] Reified GraphQL
       def self.run(erb_template, helpers: nil)
         template_class = self
-        if helpers
-          template_class = Class.new(template_class) {
+        template_class = Class.new(template_class) {
+          # Include built-in helpers
+          include Helpers
+          # Include user-provided helpers
+          if helpers
             include helpers
-          }
-        end
+          end
+        }
         template_class.new(erb_template).run
       end
 
@@ -21,37 +28,85 @@ module GraphQL
         @result = ""
       end
 
-      # @return [String] Rendered ERB
-      def run
-        ERB.new(@erb_template, 0, "", "@result").result(binding)
-        @result
-      end
-
-      def connection(type_name)
-        conn = type("#{type_name}Connection", edges: "[#{type_name}Edge!]!", pageInfo: "PageInfo!")
-        edge = type("#{type_name}Edge", cursor: "ID!", node: "#{type_name}!")
-        conn + "\n" + edge
-      end
-
-      def connects(fields)
-        graphql = fields.map do |name, type|
-          "#{name}(after: ID, before: ID, first: Int, last: Int): #{type}Connection!"
+      module Helpers
+        # @return [String] Rendered ERB
+        def run
+          ERB.new(@erb_template, 0, "", "@result").result(binding)
+          @result
         end
-        graphql.join("\n  ")
-      end
 
-      PAGE_INFO = "type PageInfo {\n  endCursor\n  }"
-      def page_info
-        type("PageInfo", {startCursor: "ID!", endCursor: "ID!", hasNextPage: "Boolean!", hasPreviousPage: "Boolean!"})
-      end
+        # Define a default-configuration Relay connection type for `type_name`
+        # @param type_name [String]
+        # @return [String] GraphQL IDL for a connection type
+        def connection_type(type_name)
+          conn = type("#{type_name}Connection", edges: "[#{type_name}Edge!]!", pageInfo: "PageInfo!")
+          edge = type("#{type_name}Edge", cursor: "ID!", node: "#{type_name}!")
+          conn + "\n" + edge
+        end
 
-      def type(name, fields)
-        field_defns = fields
-          .map { |name, returns| "\n  #{name}: #{returns}"}
-          .sort
-          .join
+        # Generate GraphQL definition for `name => return_type_name` pairs.
+        #
+        # @example Generate a connection of posts
+        #   <%= connection_field(posts: :Posts) %>
+        #   # => "posts(after: ID, before: ID, first: Int, last: Int): PostsConnection"
+        #
+        # @param fields [Hash<[String, Symbol] => [String, Symbol]]
+        # @return [String] GraphQL IDL definition for connection fields
+        def connection_field(fields)
+          graphql = fields.map do |name, type|
+            field(name, {after: :ID, before: :ID, first: :Int, last: :Int}, "#{type}Connection!")
+          end
+          graphql.join("\n  ")
+        end
 
-        "type #{name} {#{field_defns}\n}\n"
+        # @return [String] GraphQL code for Relay's `PageInfo` type
+        def page_info
+          @page_info ||= type("PageInfo", {startCursor: "ID!", endCursor: "ID!", hasNextPage: "Boolean!", hasPreviousPage: "Boolean!"})
+        end
+
+        # Generate code for a GraphQL object type named `name`
+        # with fields described by `fields`
+        #
+        # @see {#field} for field options
+        # @param name [String]
+        # @param field [Hash<String, Symbol => String, Symbol, Array(Hash, [String, Symbol])>]
+        # @return [String] GraphQL code for described type
+        def type(name, fields)
+          field_defns = fields
+            .map { |name, returns|
+              field_code = case returns
+              when Array
+                # Support name: [args, return_type]
+                field(name, returns[0], returns[1])
+              when String, Symbol
+                field(name, returns)
+              else
+                raise "Unexpected field description: #{name} => #{returns}"
+              end
+              "\n  #{field_code}"
+            }
+            .sort
+            .join
+
+          "type #{name} {#{field_defns}\n}\n"
+        end
+
+        # @param field_name [String]
+        # @param arguments [Hash<String, Symbol => String, Symbol>]
+        # @param return_type_name [String]
+        # @return [String] GraphQL IDL code for this field
+        def field(field_name, arguments = {}, return_type_name)
+          arg_string = if arguments.any?
+            str = arguments
+              .sort_by { |name, type| name.to_s }
+              .map { |name, type| "#{name}: #{type}" }
+              .join(",")
+            "(#{str})"
+          else
+            ""
+          end
+          "#{field_name}#{arg_string}: #{return_type_name}"
+        end
       end
     end
   end

--- a/lib/graphql/schema/template.rb
+++ b/lib/graphql/schema/template.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module GraphQL
+  class Schema
+    class Template
+      # @param erb_template [String]
+      # @return [String] Reified GraphQL
+      def self.run(erb_template, helpers: nil)
+        template_class = self
+        if helpers
+          template_class = Class.new(template_class) {
+            include helpers
+          }
+        end
+        template_class.new(erb_template).run
+      end
+
+      # @param erb_template [String] GraphQL with embedded Ruby
+      def initialize(erb_template)
+        @erb_template = erb_template
+        @result = ""
+      end
+
+      # @return [String] Rendered ERB
+      def run
+        ERB.new(@erb_template, 0, "", "@result").result(binding)
+        @result
+      end
+
+      def connection(type_name)
+        conn = type("#{type_name}Connection", edges: "[#{type_name}Edge!]!", pageInfo: "PageInfo!")
+        edge = type("#{type_name}Edge", cursor: "ID!", node: "#{type_name}!")
+        conn + "\n" + edge
+      end
+
+      def connects(fields)
+        graphql = fields.map do |name, type|
+          "#{name}(after: ID, before: ID, first: Int, last: Int): #{type}Connection!"
+        end
+        graphql.join("\n  ")
+      end
+
+      PAGE_INFO = "type PageInfo {\n  endCursor\n  }"
+      def page_info
+        type("PageInfo", {startCursor: "ID!", endCursor: "ID!", hasNextPage: "Boolean!", hasPreviousPage: "Boolean!"})
+      end
+
+      def type(name, fields)
+        field_defns = fields
+          .map { |name, returns| "\n  #{name}: #{returns}"}
+          .sort
+          .join
+
+        "type #{name} {#{field_defns}\n}\n"
+      end
+    end
+  end
+end

--- a/spec/graphql/schema/template_spec.rb
+++ b/spec/graphql/schema/template_spec.rb
@@ -8,7 +8,7 @@ describe GraphQL::Schema::Template do
 
   module CustomHelpers
     def search_field(name:, result:)
-      "#{name}(search: String): #{result}Connection"
+      field(name, {search: "String"}, "#{result}Connection")
     end
   end
 
@@ -19,9 +19,17 @@ describe GraphQL::Schema::Template do
   end
 
   it "runs built-in helpers" do
-    template = "<%= connection('Pizza') %>"
+    template = "<%= connection_type('Pizza') %>"
     res = run_template(template)
     expected = "type PizzaConnection {\n  edges: [PizzaEdge!]!\n  pageInfo: PageInfo!\n}\n\ntype PizzaEdge {\n  cursor: ID!\n  node: Pizza!\n}\n"
+    assert_equal expected, res
+
+    query_type = %|<%= type "Query", {
+      card: [{name: :String}, :Card],
+      expansion: [{symbol: "String!"}, :Expansion],
+    } %>|
+    res = run_template(query_type)
+    expected = "type Query {\n  card(name: String): Card\n  expansion(symbol: String!): Expansion\n}\n"
     assert_equal expected, res
   end
 

--- a/spec/graphql/schema/template_spec.rb
+++ b/spec/graphql/schema/template_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::Schema::Template do
+  def run_template(erb, helpers: nil)
+    GraphQL::Schema::Template.run(erb, helpers: helpers)
+  end
+
+  module CustomHelpers
+    def search_field(name:, result:)
+      "#{name}(search: String): #{result}Connection"
+    end
+  end
+
+  it "renders the template" do
+    template = 'type User { name: <%= "Str" + "ing" %>! }'
+    res = run_template(template)
+    assert_equal "type User { name: String! }", res
+  end
+
+  it "runs built-in helpers" do
+    template = "<%= connection('Pizza') %>"
+    res = run_template(template)
+    expected = "type PizzaConnection {\n  edges: [PizzaEdge!]!\n  pageInfo: PageInfo!\n}\n\ntype PizzaEdge {\n  cursor: ID!\n  node: Pizza!\n}\n"
+    assert_equal expected, res
+  end
+
+  it "runs a custom helper module too" do
+    template = "<% res = 'Book' %><%= search_field(name: 'books', result: res) %>"
+    res = run_template(template, helpers: CustomHelpers)
+    expected = "books(search: String): BookConnection"
+    assert_equal expected, res
+  end
+end

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -168,6 +168,13 @@ type Query {
       built_schema = GraphQL::Schema.from_definition(schema)
       assert_equal schema.chop, GraphQL::Schema::Printer.print_schema(built_schema)
     end
+
+    it "builds from a file" do
+      schema = GraphQL::Schema.from_definition("spec/support/magic_cards/schema.graphql")
+      assert_instance_of GraphQL::Schema, schema
+      expected_types =  ["Card", "Color", "Expansion", "Printing"]
+      assert_equal expected_types, (expected_types & schema.types.keys)
+    end
   end
 
   describe ".from_introspection" do

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -175,6 +175,14 @@ type Query {
       expected_types =  ["Card", "Color", "Expansion", "Printing"]
       assert_equal expected_types, (expected_types & schema.types.keys)
     end
+
+    it "builds from an ERB file" do
+      schema = GraphQL::Schema.from_definition("spec/support/magic_cards/schema.graphql.erb")
+      assert_instance_of GraphQL::Schema, schema
+      expected_types =  ["Card", "Color", "Expansion", "Printing", "PrintingConnection", "PrintingEdge", "PageInfo"]
+      assert_equal expected_types, (expected_types & schema.types.keys)
+      assert_equal "PrintingConnection!", schema.get_field("Card", "printings").type.to_s
+    end
   end
 
   describe ".from_introspection" do

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -176,8 +176,21 @@ type Query {
       assert_equal expected_types, (expected_types & schema.types.keys)
     end
 
+    module ErbHelpers
+      def colors
+        [
+          "RED",
+          "GREEN",
+          "BLACK",
+          "BLUE",
+          "WHITE",
+          "COLORLESS",
+        ].map { |c| "\n  #{c}" }.join
+      end
+    end
+
     it "builds from an ERB file" do
-      schema = GraphQL::Schema.from_definition("spec/support/magic_cards/schema.graphql.erb")
+      schema = GraphQL::Schema.from_definition("spec/support/magic_cards/schema.graphql.erb", helpers: ErbHelpers)
       assert_instance_of GraphQL::Schema, schema
       expected_types =  ["Card", "Color", "Expansion", "Printing", "PrintingConnection", "PrintingEdge", "PageInfo"]
       assert_equal expected_types, (expected_types & schema.types.keys)

--- a/spec/support/magic_cards/schema.graphql
+++ b/spec/support/magic_cards/schema.graphql
@@ -1,0 +1,33 @@
+type Card {
+  name: String!
+  printings: [Printing!]!
+  expansions: [Expansion!]!
+  colors: [Color!]!
+  convertedManaCost: Int!
+}
+
+type Expansion {
+  name: String!
+  symbol: String!
+  printings: [Printing!]!
+  cards: [Card!]!
+}
+
+type Printing {
+  card: Card!
+  expansion: Expansion!
+}
+
+enum Color {
+  RED
+  GREEN
+  BLACK
+  BLUE
+  WHITE
+  COLORLESS
+}
+
+type Query {
+  card(name: String!): Card
+  expansion(symbol: String!): Expansion
+}

--- a/spec/support/magic_cards/schema.graphql.erb
+++ b/spec/support/magic_cards/schema.graphql.erb
@@ -19,12 +19,7 @@ type Printing {
 }
 
 enum Color {
-  RED
-  GREEN
-  BLACK
-  BLUE
-  WHITE
-  COLORLESS
+  <%= colors %>
 }
 
 <%= connection("Printing") %>

--- a/spec/support/magic_cards/schema.graphql.erb
+++ b/spec/support/magic_cards/schema.graphql.erb
@@ -1,0 +1,36 @@
+type Card {
+  name: String!
+  <%= connects(printings: "Printing") %>
+  expansions: [Expansion!]!
+  colors: [Color!]!
+  convertedManaCost: Int!
+}
+
+type Expansion {
+  name: String!
+  symbol: String!
+  printings: [Printing!]!
+  cards: [Card!]!
+}
+
+type Printing {
+  card: Card!
+  expansion: Expansion!
+}
+
+enum Color {
+  RED
+  GREEN
+  BLACK
+  BLUE
+  WHITE
+  COLORLESS
+}
+
+<%= connection("Printing") %>
+<%= page_info %>
+
+type Query {
+  card(name: String!): Card
+  expansion(symbol: String!): Expansion
+}

--- a/spec/support/magic_cards/schema.graphql.erb
+++ b/spec/support/magic_cards/schema.graphql.erb
@@ -1,6 +1,6 @@
 type Card {
   name: String!
-  <%= connects(printings: "Printing") %>
+  <%= connection_field(printings: "Printing") %>
   expansions: [Expansion!]!
   colors: [Color!]!
   convertedManaCost: Int!
@@ -22,10 +22,10 @@ enum Color {
   <%= colors %>
 }
 
-<%= connection("Printing") %>
+<%= connection_type("Printing") %>
 <%= page_info %>
 
-type Query {
-  card(name: String!): Card
-  expansion(symbol: String!): Expansion
-}
+<%= type "Query", {
+  card: [{name: :String}, :Card],
+  expansion: [{symbol: "String!"}, :Expansion],
+} %>


### PR DESCRIPTION
If we start using `.graphql` files as the source of truth, it would be nice to have a way to reduce boilerplate code. 

Here's a crazy idea: use ERB as a preprocessor. It's familiar to Ruby devs and the processing model is fairly simple: the ERB has to output valid GraphQL code, just like an ERB template in Rails has to output valid HTML. 

We can include some built-in helpers (I've added a few, can you think of others?) as well as a way to take a module of user-provided methods to mix in at runtime (the `helpers:` option). 

Is this worth a try?

```ruby 
# Load a schema from definition:
MySchema = GraphQL::Schema.from_definition("schema.graphql.erb")
```