### PR TITLE
Document usage of default_value for field argument

### DIFF
--- a/guides/fields/arguments.md
+++ b/guides/fields/arguments.md
@@ -33,6 +33,11 @@ Use `!` to mark an argument as _required_:
 argument :category, !types.String
 ```
 
+Use `default_value: value` to provide a default value for the argument if not supplied in the query.
+```ruby
+argument :category, !types.String, default_value: "Programming"
+```
+
 Use `as: :alternateName` to use a different key from within your resolvers while
 exposing another key to clients.
 


### PR DESCRIPTION
I was looking for the DSL syntax to add a default value for a field argument and couldn't find it in the docs. This patch adds a quick usage example to the [field arguments docs](http://graphql-ruby.org/fields/arguments.html).
