### PR TITLE
Fix 774: cannot increase max complexity at query time

### DIFF
--- a/lib/graphql/execution/multiplex.rb
+++ b/lib/graphql/execution/multiplex.rb
@@ -35,17 +35,18 @@ module GraphQL
       end
 
       class << self
-        def run_all(schema, query_options, *args, **kwargs)
+        def run_all(schema, query_options, *args)
           queries = query_options.map { |opts| GraphQL::Query.new(schema, nil, opts) }
-          run_queries(schema, queries, *args, **kwargs)
+          run_queries(schema, queries, *args)
         end
 
         # @param schema [GraphQL::Schema]
         # @param queries [Array<GraphQL::Query>]
         # @param context [Hash]
-        # @param max_complexity [Integer]
+        # @param max_complexity [Integer, nil]
         # @return [Array<Hash>] One result per query
-        def run_queries(schema, queries, context: {}, max_complexity: nil)
+        def run_queries(schema, queries, context: {}, max_complexity: schema.max_complexity)
+
           if has_custom_strategy?(schema)
             if queries.length != 1
               raise ArgumentError, "Multiplexing doesn't support custom execution strategies, run one query at a time instead"
@@ -161,7 +162,7 @@ module GraphQL
           end
 
           multiplex_analyzers = schema.multiplex_analyzers
-          if max_complexity ||= schema.max_complexity
+          if max_complexity
             multiplex_analyzers += [GraphQL::Analysis::MaxQueryComplexity.new(max_complexity)]
           end
 

--- a/lib/graphql/execution/multiplex.rb
+++ b/lib/graphql/execution/multiplex.rb
@@ -35,9 +35,9 @@ module GraphQL
       end
 
       class << self
-        def run_all(schema, query_options, context: {}, max_complexity: nil)
+        def run_all(schema, query_options, *args, **kwargs)
           queries = query_options.map { |opts| GraphQL::Query.new(schema, nil, opts) }
-          run_queries(schema, queries, context: context, max_complexity: max_complexity)
+          run_queries(schema, queries, *args, **kwargs)
         end
 
         # @param schema [GraphQL::Schema]

--- a/lib/graphql/execution/multiplex.rb
+++ b/lib/graphql/execution/multiplex.rb
@@ -35,9 +35,9 @@ module GraphQL
       end
 
       class << self
-        def run_all(schema, query_options, *rest, max_complexity: nil)
+        def run_all(schema, query_options, context: {}, max_complexity: nil)
           queries = query_options.map { |opts| GraphQL::Query.new(schema, nil, opts) }
-          run_queries(schema, queries, *rest, max_complexity: max_complexity)
+          run_queries(schema, queries, context: context, max_complexity: max_complexity)
         end
 
         # @param schema [GraphQL::Schema]

--- a/lib/graphql/execution/multiplex.rb
+++ b/lib/graphql/execution/multiplex.rb
@@ -161,7 +161,7 @@ module GraphQL
           end
 
           multiplex_analyzers = schema.multiplex_analyzers
-          if max_complexity ||= schema.max_complexity
+          if max_complexity
             multiplex_analyzers += [GraphQL::Analysis::MaxQueryComplexity.new(max_complexity)]
           end
 

--- a/lib/graphql/execution/multiplex.rb
+++ b/lib/graphql/execution/multiplex.rb
@@ -35,9 +35,9 @@ module GraphQL
       end
 
       class << self
-        def run_all(schema, query_options, *rest)
+        def run_all(schema, query_options, *rest, max_complexity: nil)
           queries = query_options.map { |opts| GraphQL::Query.new(schema, nil, opts) }
-          run_queries(schema, queries, *rest)
+          run_queries(schema, queries, *rest, max_complexity: max_complexity)
         end
 
         # @param schema [GraphQL::Schema]
@@ -161,7 +161,7 @@ module GraphQL
           end
 
           multiplex_analyzers = schema.multiplex_analyzers
-          if max_complexity
+          if max_complexity ||= schema.max_complexity
             multiplex_analyzers += [GraphQL::Analysis::MaxQueryComplexity.new(max_complexity)]
           end
 

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -222,12 +222,11 @@ module GraphQL
     # Execute a query on itself. Raises an error if the schema definition is invalid.
     # @see {Query#initialize} for arguments.
     # @return [Hash] query result, ready to be serialized as JSON
-    def execute(query_str = nil, max_complexity: nil, **kwargs)
+    def execute(query_str = nil, **kwargs)
       if query_str
         kwargs[:query] = query_str
-        kwargs[:max_complexity] = max_complexity
       end
-      all_results = multiplex([kwargs], max_complexity: max_complexity)
+      all_results = multiplex([kwargs], max_complexity: kwargs[:max_complexity])
       all_results[0]
     end
 
@@ -249,9 +248,9 @@ module GraphQL
     # @param queries [Array<Hash>] Keyword arguments for each query
     # @param context [Hash] Multiplex-level context
     # @return [Array<Hash>] One result for each query in the input
-    def multiplex(*args, max_complexity: nil, context: {})
+    def multiplex(*args, **kwargs)
       with_definition_error_check {
-        GraphQL::Execution::Multiplex.run_all(self, *args, context: context, max_complexity: max_complexity)
+        GraphQL::Execution::Multiplex.run_all(self, *args, **kwargs)
       }
     end
 

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -249,9 +249,9 @@ module GraphQL
     # @param queries [Array<Hash>] Keyword arguments for each query
     # @param context [Hash] Multiplex-level context
     # @return [Array<Hash>] One result for each query in the input
-    def multiplex(*args, max_complexity: nil)
+    def multiplex(*args, max_complexity: nil, context: {})
       with_definition_error_check {
-        GraphQL::Execution::Multiplex.run_all(self, *args, max_complexity: max_complexity)
+        GraphQL::Execution::Multiplex.run_all(self, *args, context: context, max_complexity: max_complexity)
       }
     end
 

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -226,7 +226,8 @@ module GraphQL
       if query_str
         kwargs[:query] = query_str
       end
-      all_results = multiplex([kwargs], max_complexity: kwargs[:max_complexity])
+      # Since we're running one query, don't run a multiplex-level complexity analyzer
+      all_results = multiplex([kwargs], max_complexity: nil)
       all_results[0]
     end
 
@@ -248,9 +249,9 @@ module GraphQL
     # @param queries [Array<Hash>] Keyword arguments for each query
     # @param context [Hash] Multiplex-level context
     # @return [Array<Hash>] One result for each query in the input
-    def multiplex(*args, **kwargs)
+    def multiplex(queries, **kwargs)
       with_definition_error_check {
-        GraphQL::Execution::Multiplex.run_all(self, *args, **kwargs)
+        GraphQL::Execution::Multiplex.run_all(self, queries, **kwargs)
       }
     end
 

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -222,11 +222,12 @@ module GraphQL
     # Execute a query on itself. Raises an error if the schema definition is invalid.
     # @see {Query#initialize} for arguments.
     # @return [Hash] query result, ready to be serialized as JSON
-    def execute(query_str = nil, **kwargs)
+    def execute(query_str = nil, max_complexity: nil, **kwargs)
       if query_str
         kwargs[:query] = query_str
+        kwargs[:max_complexity] = max_complexity
       end
-      all_results = multiplex([kwargs])
+      all_results = multiplex([kwargs], max_complexity: max_complexity)
       all_results[0]
     end
 
@@ -248,9 +249,9 @@ module GraphQL
     # @param queries [Array<Hash>] Keyword arguments for each query
     # @param context [Hash] Multiplex-level context
     # @return [Array<Hash>] One result for each query in the input
-    def multiplex(*args)
+    def multiplex(*args, max_complexity: nil)
       with_definition_error_check {
-        GraphQL::Execution::Multiplex.run_all(self, *args)
+        GraphQL::Execution::Multiplex.run_all(self, *args, max_complexity: max_complexity)
       }
     end
 

--- a/spec/graphql/analysis/max_query_complexity_spec.rb
+++ b/spec/graphql/analysis/max_query_complexity_spec.rb
@@ -50,7 +50,7 @@ describe GraphQL::Analysis::MaxQueryComplexity do
     end
   end
 
-  describe "when complexity is overriden at query-level" do
+  describe "when max_complexity is decreased at query-level" do
     before do
       Dummy::Schema.max_complexity = 100
     end
@@ -58,6 +58,17 @@ describe GraphQL::Analysis::MaxQueryComplexity do
 
     it "is applied" do
       assert_equal "Query has complexity of 10, which exceeds max complexity of 7", result["errors"][0]["message"]
+    end
+  end
+
+  describe "when max_complexity is increased at query-level" do
+    before do
+      Dummy::Schema.max_complexity = 1
+    end
+    let(:result) { Dummy::Schema.execute(query_string, max_complexity: 10) }
+
+    it "doesn't error" do
+      assert_equal nil, result["errors"]
     end
   end
 


### PR DESCRIPTION
#774 

I cherry picked the failing test from #804 


Much to my surprise it appears the analyzer in the test was being run twice! If I understand things correctly, there's an analyzer being run for the query itself (analyzer no. 1) and an analyzer being run for the collection of all queries -- the multiplex -- (analyzer no. 2). It was this second analyzer that was causing the failure described in #774, as it could not be overridden by providing arguments to `execute`, and so would always default to the schema defined `max_complexity`. 

The analyzer no. 2, the one for the multiplex, gets added here: https://github.com/rmosolgo/graphql-ruby/blob/master/lib/graphql/execution/multiplex.rb#L165

So, yes. A lot of figuring out, very little actual code changes :smile: . The issue is fixed by passing `max_complexity` all the way down from `execute` to `run_queries`.