### PR TITLE
[Masking] Hide types when no members of that type are visible

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -528,8 +528,8 @@ module GraphQL
       @instrumented_field_map = InstrumentedFieldMap.new(self, all_instrumenters)
     end
 
-    # A map of Type => Array<Field>
-    # for a given type, returns the fields of that type.
+    # A map of Type => Array<Field|Argument>
+    # for a given type, returns the fields or arguments of that type.
     def build_type_references_map
       @type_references_map = GraphQL::Schema::TypeReferencesMap.from_fields(
         @instrumented_field_map.all_fields
@@ -537,11 +537,8 @@ module GraphQL
     end
 
     def build_types_map
-      @types = GraphQL::Schema::ReduceTypes.reduce(all_types)
-    end
-
-    def all_types
-      (orphan_types + [query, mutation, subscription, GraphQL::Introspection::SchemaType]).compact
+      all_types = orphan_types + [query, mutation, subscription, GraphQL::Introspection::SchemaType]
+      @types = GraphQL::Schema::ReduceTypes.reduce(all_types.compact)
     end
 
     def with_definition_error_check

--- a/lib/graphql/schema/instrumented_field_map.rb
+++ b/lib/graphql/schema/instrumented_field_map.rb
@@ -35,6 +35,10 @@ module GraphQL
       def get_all(type_name)
         @storage[type_name]
       end
+
+      def all_fields
+        @storage.values.map(&:values).flatten
+      end
     end
   end
 end

--- a/lib/graphql/schema/type_references_map.rb
+++ b/lib/graphql/schema/type_references_map.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module GraphQL
+  class Schema
+    module TypeReferencesMap
+      # @param types [Array<GraphQL::Field>] fields of a schema
+      # @return { GraphQL::BaseType => Array<Field|Argument> }
+      def self.from_fields(fields)
+        map = Hash.new { |h, k| h[k] = [] }
+        fields.reduce(map) do |type_references, field|
+          type_references[field.type.unwrap.to_s] << field
+
+          field.arguments.each_value do |argument|
+            type_references[argument.type.unwrap.to_s] << argument
+          end
+
+          type_references
+        end
+      end
+    end
+  end
+end

--- a/spec/graphql/schema/type_references_map_spec.rb
+++ b/spec/graphql/schema/type_references_map_spec.rb
@@ -15,10 +15,13 @@ describe GraphQL::Schema::TypeReferencesMap do
   it "it builds a map from a list of fields" do
     result = GraphQL::Schema::TypeReferencesMap.from_fields(fields)
     expected = {
-      "String!" => [Dummy::CheeseType.fields["flavor"]],
-      "ID!" => [Dummy::DairyType.fields["id"], Dummy::CowType.fields["id"]],
-      "String" => [Dummy::CowType.fields["name"]],
-      "Cheese" => [Dummy::CheeseType.fields["similarCheese"]]
+      "String" => [Dummy::CheeseType.fields["flavor"], Dummy::CowType.fields["name"]],
+      "ID" => [Dummy::DairyType.fields["id"], Dummy::CowType.fields["id"]],
+      "Cheese" => [Dummy::CheeseType.fields["similarCheese"]],
+      "DairyAnimal" => [
+        Dummy::CheeseType.fields["similarCheese"].arguments["source"],
+        Dummy::CheeseType.fields["similarCheese"].arguments["nullableSource"]
+      ]
     }
     assert_equal expected, result
   end

--- a/spec/graphql/schema/type_references_map_spec.rb
+++ b/spec/graphql/schema/type_references_map_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::Schema::TypeReferencesMap do
+  let(:fields) {
+    [
+      Dummy::CheeseType.fields["flavor"],
+      Dummy::DairyType.fields["id"],
+      Dummy::CowType.fields["name"],
+      Dummy::CowType.fields["id"],
+      Dummy::CheeseType.fields["similarCheese"]
+    ]
+  }
+
+  it "it builds a map from a list of fields" do
+    result = GraphQL::Schema::TypeReferencesMap.from_fields(fields)
+    expected = {
+      "String!" => [Dummy::CheeseType.fields["flavor"]],
+      "ID!" => [Dummy::DairyType.fields["id"], Dummy::CowType.fields["id"]],
+      "String" => [Dummy::CowType.fields["name"]],
+      "Cheese" => [Dummy::CheeseType.fields["similarCheese"]]
+    }
+    assert_equal expected, result
+  end
+end


### PR DESCRIPTION
Currently, object types and input types that are not queryable because fields or arguments of that type are hidden still show up in the introspection.

That is because the warden does not make that check in `get_type`.

This PR attempts to solve this in an efficient way by building an inverse mapping of `Type => Array<Field|Argument>` at schema build time. This means by looking up a type you get an array of schema members *of* that type.

The warden can then verify that if an object is "referenced" by fields, there must be at least one that is visible to show that type.

@rmosolgo I'd still like to add more tests to this PR but would love to get your opinion on this approach!
