### PR TITLE
Fix bug concerning `as` and `prepare` on arguments

### DIFF
--- a/lib/graphql/argument.rb
+++ b/lib/graphql/argument.rb
@@ -109,9 +109,10 @@ module GraphQL
       if default_value != NO_DEFAULT_VALUE
         argument.default_value = default_value
       end
-      argument.as = as
-      argument.prepare = prepare
-
+      as && argument.as = as
+      if prepare != DefaultPrepare
+        argument.prepare = prepare
+      end
 
       argument
     end

--- a/spec/graphql/argument_spec.rb
+++ b/spec/graphql/argument_spec.rb
@@ -56,6 +56,14 @@ describe GraphQL::Argument do
       arg_3 = arg_2.redefine { as :ff }
       assert_equal arg_3.expose_as, "ff"
     end
+
+    it "can be set in the passed block" do
+      argument = GraphQL::Argument.define do
+        name "arg"
+        as "arg_name"
+      end
+      assert_equal "arg_name", argument.as
+    end
   end
 
   describe "prepare" do
@@ -68,6 +76,15 @@ describe GraphQL::Argument do
     it "returns the value itself if no prepare proc is provided" do
       argument = GraphQL::Argument.define(name: :someNumber, type: GraphQL::INT_TYPE)
       assert_equal argument.prepare(1, nil), 1
+    end
+
+    it "can be set in the passed block" do
+      prepare_proc = Proc.new { |arg, ctx| arg + ctx[:val] }
+      argument = GraphQL::Argument.define do
+        name "arg"
+        prepare prepare_proc
+      end
+      assert_equal argument.prepare(1, {val: 1}), 2
     end
   end
 end


### PR DESCRIPTION
When using `as` and `prepare` in argument blocks, they were overwritten by
the default values:

```ruby
argument :fooBar, types.String do
  as :foo_bar # will be overwritten by the default value (nil)
end
```