### PR TITLE
Mention dataloader as other batching solution

### DIFF
--- a/guides/schema/lazy_execution.md
+++ b/guides/schema/lazy_execution.md
@@ -14,6 +14,8 @@ With lazy execution, you can optimize access to external services (such as datab
 
 [`graphql-batch`](https://github.com/shopify/graphql-batch) provides a powerful, flexible toolkit for lazy resolution with GraphQL.
 
+[`dataloader`](https://github.com/sheerun/dataloader) is more general [`promise`](https://github.com/lgierth/promise.rb)-based utilify for batching queries within the same thread.
+
 
 Lazy resolution can be [instrumented]({{ site.baseurl }}/fields/instrumentation).
 
@@ -89,4 +91,4 @@ Now, calls to `author` will use batched database access. For example, this query
 
 Will only make one query to load the `author` values.
 
-The example above is simple and has some shortcomings. Consider the `graphql-batch` gem for a robust solution to batched resolution.
+The example above is simple and has some shortcomings. Consider the `graphql-batch` or `dataloader` gem for a robust solution to batched resolution.


### PR DESCRIPTION
Disclaimer: I'm an author.

[facebook/dataloader](https://github.com/facebook/dataloader) accepted my solution as alternative implementation of their library, so I though I could add it here as well.

Dataloader tries to mimic facebook/dataloader api as best as possible. In contrast to `batch-graphql` it offers more general solution that can be used even without graphql-ruby. The loaders created with `dataloader` also compose better as their return type is A+ [promise](https://github.com/lgierth/promise.rb).

EDIT: Link for better access:
https://github.com/sheerun/dataloader