### PR TITLE
Add UnionType#resolve_type for more ganular control in unions

### DIFF
--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -86,7 +86,7 @@ module GraphQL
 
     # Find out which possible type to use for `value`.
     # Returns self if there are no possible types (ie, not Union or Interface)
-    def resolve_type(value)
+    def resolve_type(value, ctx)
       self
     end
 

--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -210,7 +210,7 @@ module GraphQL
               )
             when GraphQL::TypeKinds::UNION, GraphQL::TypeKinds::INTERFACE
               query = field_ctx.query
-              resolved_type = query.resolve_type(value)
+              resolved_type = field_type.resolve_type(value, field_ctx)
               possible_types = query.possible_types(field_type)
 
               if !possible_types.include?(resolved_type)

--- a/lib/graphql/interface_type.rb
+++ b/lib/graphql/interface_type.rb
@@ -42,6 +42,10 @@ module GraphQL
       GraphQL::TypeKinds::INTERFACE
     end
 
+    def resolve_type(value, ctx)
+      ctx.query.resolve_type(value)
+    end
+
     # @return [GraphQL::Field] The defined field for `field_name`
     def get_field(field_name)
       fields[field_name]

--- a/spec/graphql/introspection/schema_type_spec.rb
+++ b/spec/graphql/introspection/schema_type_spec.rb
@@ -19,6 +19,8 @@ describe GraphQL::Introspection::SchemaType do
         "types" => Dummy::Schema.types.values.map { |t| t.name.nil? ? (p t; raise("no name for #{t}")) : {"name" => t.name} },
         "queryType"=>{
           "fields"=>[
+            {"name"=>"allAnimal"},
+            {"name"=>"allAnimalAsCow"},
             {"name"=>"allDairy"},
             {"name"=>"allEdible"},
             {"name"=>"cheese"},

--- a/spec/support/dummy/data.rb
+++ b/spec/support/dummy/data.rb
@@ -25,9 +25,13 @@ module Dummy
     milks: [MILKS[1]]
   )
 
-  COW = OpenStruct.new(
-    id: 1,
-    name: "Billy",
-    last_produced_dairy: MILKS[1]
-  )
+  Cow = Struct.new(:id, :name, :last_produced_dairy)
+  COWS = {
+    1 => Cow.new(1, "Billy", MILKS[1])
+  }
+
+  Goat = Struct.new(:id, :name, :last_produced_dairy)
+  GOATS = {
+    1 => Goat.new(1, "Gilly", MILKS[1]),
+  }
 end

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -152,7 +152,7 @@ module Dummy
 
   CowType = GraphQL::ObjectType.define do
     name "Cow"
-    description "A farm where milk is harvested and cheese is produced"
+    description "A bovine animal that produces milk"
     field :id, !types.ID
     field :name, types.String
     field :last_produced_dairy, DairyProductUnion
@@ -166,6 +166,29 @@ module Dummy
       type !GraphQL::STRING_TYPE
       resolve ->(t, a, c) { raise GraphQL::ExecutionError, "BOOM" }
     end
+  end
+
+  GoatType = GraphQL::ObjectType.define do
+    name "Goat"
+    description "An caprinae animal that produces milk"
+    field :id, !types.ID
+    field :name, types.String
+    field :last_produced_dairy, DairyProductUnion
+  end
+
+  AnimalUnion = GraphQL::UnionType.define do
+    name "Animal"
+    description "Species of living things"
+    possible_types [CowType, GoatType]
+  end
+
+  AnimalAsCowUnion = GraphQL::UnionType.define do
+    name "AnimalAsCow"
+    description "All animals go mooooo!"
+    possible_types [CowType]
+    resolve_type ->(obj, ctx) {
+      CowType
+    }
   end
 
   ResourceOrderType = GraphQL::InputObjectType.define {
@@ -271,7 +294,7 @@ module Dummy
     field :dairy, function: GetSingleton.new(type: DairyType, data: DAIRY)
     field :fromSource, &SourceFieldDefn
     field :favoriteEdible, FavoriteFieldDefn
-    field :cow, function: GetSingleton.new(type: CowType, data: COW)
+    field :cow, function: GetSingleton.new(type: CowType, data: COWS[1])
     field :searchDairy do
       description "Find dairy products matching a description"
       type !DairyProductUnion
@@ -285,6 +308,14 @@ module Dummy
         end
         products.first
       }
+    end
+
+    field :allAnimal, !types[AnimalUnion] do
+      resolve ->(obj, args, ctx) { COWS.values + GOATS.values }
+    end
+
+    field :allAnimalAsCow, !types[AnimalAsCowUnion] do
+      resolve ->(obj, args, ctx) { COWS.values + GOATS.values }
     end
 
     field :allDairy, types[DairyProductUnion] do


### PR DESCRIPTION
## Purpose
This feature allows a union type to resolve to more specific types when handling a value. This is useful when working with objects that may fit into multiple types. When executing the query
will call `resolve_type(value, field_ctx)` on either Unions or Interfaces.

Union type's call can be definable via `resolve_type ->(value, ctx) { }`. Interface type's call returns `ctx.query.resolve_type(value)` which is the default implementation for resolving both types.

### Tests:
- Added a new test that raises an error if a returned type is not within possible_types
- Added an implementation in the dummy schema, though I would consider altering this by adding a new type derived from MilkType (for example KefirType) in which it is re-casted as a MilkType - but this would alter a significant portion of other tests.

### Guides
- I have not updated any guides or documentation on the static site. If there are any I should do for this PR please advise.

```
831 tests, 4720 assertions, 0 failures, 0 errors, 0 skips
Running RuboCop...
Inspecting 340 files
....................................................................................................................................................................................................................................................................................................................................................

340 files inspected, no offenses detected
```

Edit:

Resolves #529