### PR TITLE
Enforce EnumValue name uniqueness

### DIFF
--- a/lib/graphql/enum_type.rb
+++ b/lib/graphql/enum_type.rb
@@ -93,6 +93,10 @@ module GraphQL
 
     # @param enum_value [EnumValue] A value to add to this type's set of values
     def add_value(enum_value)
+      if @values_by_name.key?(enum_value.name)
+        raise "Enum value names must be unique. `#{enum_value.name}` already exists."
+      end
+
       @values_by_name[enum_value.name] = enum_value
     end
 

--- a/spec/graphql/enum_type_spec.rb
+++ b/spec/graphql/enum_type_spec.rb
@@ -110,4 +110,12 @@ describe GraphQL::EnumType do
       assert_equal(7, enum_2.values.size)
     end
   end
+
+  describe "validates enum value name uniqueness" do
+    it "raises an exception when adding a duplicate enum value name" do
+      assert_raises "Enum value names must be unique. `COW` already exists." do
+        enum.add_value(GraphQL::EnumType::EnumValue.define(name: "COW"))
+      end
+    end
+  end
 end


### PR DESCRIPTION
Raises an exception when trying to add a value that already exists with the same name.

From the [spec](https://facebook.github.io/graphql/#sec-Enum):

> There must be at least one and they must have unique names.

Two questions:

1. is this a good place for the validation or should it be done during schema validation?
2. is there a better existing exception to raise?