### PR TITLE
More flexibility with query string / operation_name

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -27,7 +27,10 @@ module GraphQL
       end
     end
 
-    attr_reader :schema, :context, :root_value, :warden, :provided_variables, :operation_name
+    attr_reader :schema, :context, :root_value, :warden, :provided_variables
+
+    # @return [nil, String] The operation name provided by client or the one inferred from the document. Used to determine which operation to run.
+    attr_accessor :operation_name
 
     # @return [Boolean] if false, static validation is skipped (execution behavior for invalid queries is undefined)
     attr_accessor :validate

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -253,7 +253,8 @@ module GraphQL
       elsif parse_error
         # This will be handled later
       else
-        raise ArgumentError, "a query string or document is required"
+        parse_error = GraphQL::ExecutionError.new("No query string was present")
+        @context.add_error(parse_error)
       end
 
       # Trying to execute a document

--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -87,6 +87,17 @@ module GraphQL
         GraphQL::Execution::Execute::SKIP
       end
 
+      # Add error at query-level.
+      # @param error [GraphQL::ExecutionError] an execution error
+      # @return [void]
+      def add_error(error)
+        if !error.is_a?(ExecutionError)
+          raise TypeError, "expected error to be a ExecutionError, but was #{error.class}"
+        end
+        errors << error
+        nil
+      end
+
       class FieldResolutionContext
         extend GraphQL::Delegate
 

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -45,15 +45,15 @@ describe GraphQL::Query do
   let(:result) { query.result }
 
   describe "when passed no query string or document" do
-    it 'fails with an ArgumentError' do
-      assert_raises(ArgumentError) {
-        GraphQL::Query.new(
-          schema,
-          variables: query_variables,
-          operation_name: operation_name,
-          max_depth: max_depth,
-        ).result
-      }
+    it 'returns an error to the client' do
+      res = GraphQL::Query.new(
+        schema,
+        variables: query_variables,
+        operation_name: operation_name,
+        max_depth: max_depth,
+      ).result
+      assert_equal 1, res["errors"].length
+      assert_equal "No query string was present", res["errors"][0]["message"]
     end
 
     it 'can be assigned later' do

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -94,6 +94,21 @@ describe GraphQL::Query do
         assert_equal "q3", query.selected_operation_name
       end
     end
+
+    describe "assigning operation_name=" do
+      let(:query_string) { <<-GRAPHQL
+          query q3 { manchego: cheese(id: 3) { flavor } }
+          query q2 { gouda: cheese(id: 2) { flavor } }
+        GRAPHQL
+      }
+
+      it "runs the assigned name" do
+        query = GraphQL::Query.new(Dummy::Schema, query_string, operation_name: "q3")
+        query.operation_name = "q2"
+        res = query.result
+        assert_equal "Gouda", res["data"]["gouda"]["flavor"]
+      end
+    end
   end
 
   describe "when passed a document instance" do


### PR DESCRIPTION
- Allow operation_name to be assigned later 
- Don't `raise` if there's no operation name; return a client error instead
- Support query-level errors with `query.context.add_error(err)`