### PR TITLE
feat(InterfaceType) add type-level resolve_type support

### DIFF
--- a/lib/graphql/backwards_compatibility.rb
+++ b/lib/graphql/backwards_compatibility.rb
@@ -18,7 +18,11 @@ module GraphQL
         callable
       when from
         # It has the old arity, so wrap it with an arity converter
-        warn("#{name} with #{from} arguments is deprecated, it now accepts #{to} arguments")
+        message ="#{name} with #{from} arguments is deprecated, it now accepts #{to} arguments, see:"
+        backtrace = caller(0, 20)
+        # Find the first line in the trace that isn't library internals:
+        user_line = backtrace.find {|l| l !~ /lib\/graphql/ }
+        warn(message + "\n" + user_line + "\n")
         wrapper = last ? LastArgumentsWrapper : FirstArgumentsWrapper
         wrapper.new(callable, from)
       else

--- a/lib/graphql/compatibility/execution_specification/counter_schema.rb
+++ b/lib/graphql/compatibility/execution_specification/counter_schema.rb
@@ -40,7 +40,7 @@ module GraphQL
 
           schema = GraphQL::Schema.define(
             query: query_type,
-            resolve_type: ->(o, c) { o == :counter ? counter_type : nil },
+            resolve_type: ->(t, o, c) { o == :counter ? counter_type : nil },
             orphan_types: [alt_counter_type, counter_type],
             query_execution_strategy: execution_strategy,
           )

--- a/lib/graphql/compatibility/execution_specification/specification_schema.rb
+++ b/lib/graphql/compatibility/execution_specification/specification_schema.rb
@@ -178,7 +178,7 @@ module GraphQL
             query_execution_strategy execution_strategy
             query query_type
 
-            resolve_type ->(obj, ctx) {
+            resolve_type ->(type, obj, ctx) {
               if obj.respond_to?(:birthdate)
                 person_type
               elsif obj.respond_to?(:leader_id)

--- a/lib/graphql/interface_type.rb
+++ b/lib/graphql/interface_type.rb
@@ -23,14 +23,15 @@ module GraphQL
   #   end
   #
   class InterfaceType < GraphQL::BaseType
-    accepts_definitions :fields, field: GraphQL::Define::AssignObjectField
+    accepts_definitions :fields, :resolve_type, field: GraphQL::Define::AssignObjectField
 
-    attr_accessor :fields
-    ensure_defined :fields
+    attr_accessor :fields, :resolve_type_proc
+    ensure_defined :fields, :resolve_type_proc, :resolve_type
 
     def initialize
       super
       @fields = {}
+      @resolve_type_proc = nil
     end
 
     def initialize_copy(other)
@@ -43,7 +44,11 @@ module GraphQL
     end
 
     def resolve_type(value, ctx)
-      ctx.query.resolve_type(value)
+      ctx.query.resolve_type(self, value)
+    end
+
+    def resolve_type=(resolve_type_callable)
+      @resolve_type_proc = resolve_type_callable
     end
 
     # @return [GraphQL::Field] The defined field for `field_name`

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -74,7 +74,13 @@ module GraphQL
       @query_string = query_string || query
       @document = document
 
-      @resolved_types_cache = Hash.new { |h, k| h[k] = @schema.resolve_type(k, @context) }
+      # A two-layer cache of type resolution:
+      # { abstract_type => { value => resolved_type } }
+      @resolved_types_cache = Hash.new do |h1, k1|
+        h1[k1] = Hash.new do |h2, k2|
+          h2[k2] = @schema.resolve_type(k1, k2, @context)
+        end
+      end
 
       @arguments_cache = ArgumentsCache.build(self)
 
@@ -184,11 +190,17 @@ module GraphQL
 
     def_delegators :warden, :get_type, :get_field, :possible_types, :root_type_for_operation
 
+    # @param abstract_type [GraphQL::UnionType, GraphQL::InterfaceType]
     # @param value [Object] Any runtime value
     # @return [GraphQL::ObjectType, nil] The runtime type of `value` from {Schema#resolve_type}
     # @see {#possible_types} to apply filtering from `only` / `except`
-    def resolve_type(value)
-      @resolved_types_cache[value]
+    def resolve_type(abstract_type, value = :__undefined__)
+      if value.is_a?(Symbol) && value == :__undefined__
+        # Old method signature
+        value = abstract_type
+        abstract_type = nil
+      end
+      @resolved_types_cache[abstract_type][value]
     end
 
     def mutation?

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -110,7 +110,7 @@ module GraphQL
           schema
         end
 
-        NullResolveType = ->(obj, ctx) {
+        NullResolveType = ->(type, obj, ctx) {
           raise(NotImplementedError, "Generated Schema cannot use Interface or Union types for execution.")
         }
 

--- a/lib/graphql/schema/build_from_definition/resolve_map.rb
+++ b/lib/graphql/schema/build_from_definition/resolve_map.rb
@@ -46,8 +46,8 @@ module GraphQL
 
           # Check the normalized hash, not the user input:
           if @resolve_hash.key?("resolve_type")
-            define_singleton_method :resolve_type do |type, ctx|
-              @resolve_hash.fetch("resolve_type").call(type, ctx)
+            define_singleton_method :resolve_type do |type, obj, ctx|
+              @resolve_hash.fetch("resolve_type").call(type, obj, ctx)
             end
           end
         end

--- a/lib/graphql/schema/loader.rb
+++ b/lib/graphql/schema/loader.rb
@@ -33,7 +33,7 @@ module GraphQL
         Schema.define(**kargs, raise_definition_error: true)
       end
 
-      NullResolveType = ->(obj, ctx) {
+      NullResolveType = ->(type, obj, ctx) {
         raise(NotImplementedError, "This schema was loaded from string, so it can't resolve types for objects")
       }
 

--- a/lib/graphql/union_type.rb
+++ b/lib/graphql/union_type.rb
@@ -25,7 +25,9 @@ module GraphQL
   #
   class UnionType < GraphQL::BaseType
     accepts_definitions :possible_types, :resolve_type
-    ensure_defined :possible_types
+    ensure_defined :possible_types, :resolve_type, :resolve_type_proc
+
+    attr_accessor :resolve_type_proc
 
     def initialize
       super
@@ -66,16 +68,7 @@ module GraphQL
     end
 
     def resolve_type(value, ctx)
-      if !@resolve_type_proc.nil?
-        resolved_type = @resolve_type_proc.call(value, ctx)
-        if !include?(resolved_type)
-          raise(NotImplementedError, "Unrecognized possible type kind: #{resolved_type}")
-        end
-
-        return resolved_type
-      end
-
-      ctx.query.resolve_type(value)
+      ctx.query.resolve_type(self, value)
     end
 
     def resolve_type=(new_resolve_type_proc)
@@ -84,6 +77,6 @@ module GraphQL
 
     protected
 
-    attr_reader :dirty_possible_types, :resolve_type_proc
+    attr_reader :dirty_possible_types
   end
 end

--- a/spec/graphql/analysis/query_complexity_spec.rb
+++ b/spec/graphql/analysis/query_complexity_spec.rb
@@ -260,7 +260,7 @@ describe GraphQL::Analysis::QueryComplexity do
       GraphQL::Schema.define(
         query: query_type,
         orphan_types: [double_complexity_type],
-        resolve_type: :pass
+        resolve_type: ->(a,b,c) { :pass }
       )
     }
     let(:query_string) {%|

--- a/spec/graphql/introspection/schema_type_spec.rb
+++ b/spec/graphql/introspection/schema_type_spec.rb
@@ -23,6 +23,7 @@ describe GraphQL::Introspection::SchemaType do
             {"name"=>"allAnimalAsCow"},
             {"name"=>"allDairy"},
             {"name"=>"allEdible"},
+            {"name"=>"allEdibleAsMilk"},
             {"name"=>"cheese"},
             {"name"=>"cow"},
             {"name"=>"dairy"},

--- a/spec/graphql/introspection/type_type_spec.rb
+++ b/spec/graphql/introspection/type_type_spec.rb
@@ -41,6 +41,7 @@ describe GraphQL::Introspection::TypeType do
       "milkType"=>{
         "interfaces"=>[
           {"name"=>"Edible"},
+          {"name"=>"EdibleAsMilk"},
           {"name"=>"AnimalProduct"},
           {"name"=>"LocalProduct"},
         ],

--- a/spec/graphql/object_type_spec.rb
+++ b/spec/graphql/object_type_spec.rb
@@ -17,7 +17,12 @@ describe GraphQL::ObjectType do
 
   describe "interfaces" do
     it "may have interfaces" do
-      assert_equal([Dummy::EdibleInterface, Dummy::AnimalProductInterface, Dummy::LocalProductInterface], type.interfaces)
+      assert_equal([
+        Dummy::EdibleInterface,
+        Dummy::EdibleAsMilkInterface,
+        Dummy::AnimalProductInterface,
+        Dummy::LocalProductInterface
+      ], type.interfaces)
     end
 
     it "raises if the interfaces arent an array" do
@@ -129,8 +134,8 @@ describe GraphQL::ObjectType do
 
       type_2.fields["nonsense"] = GraphQL::Field.define(name: "nonsense", type: type)
 
-      assert_equal 3, type.interfaces.size
-      assert_equal 4, type_2.interfaces.size
+      assert_equal 4, type.interfaces.size
+      assert_equal 5, type_2.interfaces.size
       assert_equal 8, type.fields.size
       assert_equal 9, type_2.fields.size
     end

--- a/spec/graphql/query/executor_spec.rb
+++ b/spec/graphql/query/executor_spec.rb
@@ -119,7 +119,7 @@ describe GraphQL::Query::Executor do
         end
       end
 
-      GraphQL::Schema.define(query: DummyQueryType, mutation: Dummy::DairyAppMutationType, resolve_type: :pass, id_from_object: :pass)
+      GraphQL::Schema.define(query: DummyQueryType, mutation: Dummy::DairyAppMutationType, resolve_type: ->(a,b,c) { :pass }, id_from_object: :pass)
     }
     let(:variables) { nil }
     let(:query_string) { %|

--- a/spec/graphql/query/serial_execution/value_resolution_spec.rb
+++ b/spec/graphql/query/serial_execution/value_resolution_spec.rb
@@ -45,7 +45,7 @@ describe GraphQL::Query::SerialExecution::ValueResolution do
     GraphQL::Schema.define do
       query(query_root)
       orphan_types [some_object]
-      resolve_type ->(obj, ctx) do
+      resolve_type ->(type, obj, ctx) do
         if obj.is_a?(Symbol)
           other_object
         else

--- a/spec/graphql/relay/mutation_spec.rb
+++ b/spec/graphql/relay/mutation_spec.rb
@@ -258,7 +258,7 @@ describe GraphQL::Relay::Mutation do
 
       GraphQL::Schema.define do
         mutation(mutation_root)
-        resolve_type ->(obj, ctx) { "not really used" }
+        resolve_type NO_OP_RESOLVE_TYPE
       end
     }
 

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -735,7 +735,7 @@ SCHEMA
             val.to_f
           }
         },
-        resolve_type: ->(obj, ctx) {
+        resolve_type: ->(type, obj, ctx) {
           return ctx.schema.types['A']
         },
         Query: {

--- a/spec/graphql/schema/loader_spec.rb
+++ b/spec/graphql/schema/loader_spec.rb
@@ -125,7 +125,7 @@ describe GraphQL::Schema::Loader do
       query: query_root,
       mutation: mutation_root,
       orphan_types: [audio_type, video_type],
-      resolve_type: :pass,
+      resolve_type: ->(a,b,c) { :pass },
     )
   }
 

--- a/spec/graphql/schema/printer_spec.rb
+++ b/spec/graphql/schema/printer_spec.rb
@@ -123,7 +123,7 @@ describe GraphQL::Schema::Printer do
       query: query_root,
       mutation: mutation_root,
       subscription: subscription_root,
-      resolve_type: :pass,
+      resolve_type: ->(a,b,c) { :pass },
       orphan_types: [media_union_type]
     )
   }

--- a/spec/graphql/schema/traversal_spec.rb
+++ b/spec/graphql/schema/traversal_spec.rb
@@ -14,6 +14,7 @@ describe GraphQL::Schema::Traversal do
       "Float" => GraphQL::FLOAT_TYPE,
       "String" => GraphQL::STRING_TYPE,
       "Edible" => Dummy::EdibleInterface,
+      "EdibleAsMilk" => Dummy::EdibleAsMilkInterface,
       "DairyAnimal" => Dummy::DairyAnimalEnum,
       "Int" => GraphQL::INT_TYPE,
       "AnimalProduct" => Dummy::AnimalProductInterface,

--- a/spec/graphql/schema/warden_spec.rb
+++ b/spec/graphql/schema/warden_spec.rb
@@ -120,7 +120,7 @@ module MaskHelpers
     query QueryType
     mutation MutationType
     subscription MutationType
-    resolve_type ->(obj, ctx) { PhonemeType }
+    resolve_type ->(type, obj, ctx) { PhonemeType }
     instrument :query, FilterInstrumentation
   end
 

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -99,7 +99,7 @@ describe GraphQL::Schema do
         assert_raises(NotImplementedError) {
           GraphQL::Schema.define do
             query(query_type)
-            resolve_type ->(obj, ctx) { :whatever }
+            resolve_type NO_OP_RESOLVE_TYPE
           end
         }
       end
@@ -125,7 +125,7 @@ describe GraphQL::Schema do
         assert_raises(NotImplementedError) {
           GraphQL::Schema.define do
             query(query_type)
-            resolve_type ->(obj, ctx) { :whatever }
+            resolve_type NO_OP_RESOLVE_TYPE
           end
         }
       end

--- a/spec/graphql/union_type_spec.rb
+++ b/spec/graphql/union_type_spec.rb
@@ -27,13 +27,14 @@ describe GraphQL::UnionType do
   end
 
   it '#resolve_type raises error if resolved type is not in possible_types' do
-    assert_raises(NotImplementedError) {
-      test_str = 'Hello world'
-      union.resolve_type = ->(value, ctx) {
-        "This is not the types you are looking for"
-      }
+    test_str = 'Hello world'
+    union.resolve_type = ->(value, ctx) {
+      "This is not the types you are looking for"
+    }
+    fake_ctx = OpenStruct.new(query: GraphQL::Query.new(Dummy::Schema, ""))
 
-      union.resolve_type(test_str, nil)
+    assert_raises(RuntimeError) {
+      union.resolve_type(test_str, fake_ctx)
     }
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,11 @@ module NothingWarden
   end
 end
 
+# Use this when a schema requires a `resolve_type` hook
+# but you know it won't be called
+NO_OP_RESOLVE_TYPE = ->(type, obj, ctx) {
+  raise "this should never be called"
+}
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 

--- a/spec/support/dummy/data.rb
+++ b/spec/support/dummy/data.rb
@@ -8,7 +8,7 @@ module Dummy
     end
 
     # Alias for when this is treated as milk in EdibleAsMilkInterface
-    def fatContent
+    def fatContent # rubocop:disable Style/MethodName
       fat_content
     end
   end

--- a/spec/support/dummy/data.rb
+++ b/spec/support/dummy/data.rb
@@ -6,6 +6,11 @@ module Dummy
       # This is buggy on purpose -- it shouldn't be called during execution.
       other.id == id
     end
+
+    # Alias for when this is treated as milk in EdibleAsMilkInterface
+    def fatContent
+      fat_content
+    end
   end
 
   CHEESES = {

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -24,9 +24,6 @@ module Dummy
   EdibleAsMilkInterface = EdibleInterface.redefine do
     name "EdibleAsMilk"
     description "Milk :+1:"
-    field :fatContent, !types.Float, "Percentage which is fat"
-    field :origin, !types.String, "Place the edible comes from"
-    field :selfAsEdible, EdibleInterface, resolve: ->(o, a, c) { o }
     resolve_type ->(obj, ctx) { MilkType }
   end
 
@@ -57,7 +54,7 @@ module Dummy
     name "Cheese"
     class_names ["Cheese"]
     description "Cultured dairy product"
-    interfaces [EdibleInterface, AnimalProductInterface, LocalProductInterface]
+    interfaces [EdibleInterface, EdibleAsMilkInterface, AnimalProductInterface, LocalProductInterface]
 
     # Can have (name, type, desc)
     field :id, !types.Int, "Unique identifier"
@@ -105,7 +102,7 @@ module Dummy
   MilkType = GraphQL::ObjectType.define do
     name "Milk"
     description "Dairy beverage"
-    interfaces [EdibleInterface, AnimalProductInterface, LocalProductInterface]
+    interfaces [EdibleInterface, EdibleAsMilkInterface, AnimalProductInterface, LocalProductInterface]
     field :id, !types.ID
     field :source, !DairyAnimalEnum, "Animal which produced this milk", hash_key: :source
     field :origin, !types.String, "Place the milk comes from"

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -21,6 +21,15 @@ module Dummy
     field :selfAsEdible, EdibleInterface, resolve: ->(o, a, c) { o }
   end
 
+  EdibleAsMilkInterface = EdibleInterface.redefine do
+    name "EdibleAsMilk"
+    description "Milk :+1:"
+    field :fatContent, !types.Float, "Percentage which is fat"
+    field :origin, !types.String, "Place the edible comes from"
+    field :selfAsEdible, EdibleInterface, resolve: ->(o, a, c) { o }
+    resolve_type ->(obj, ctx) { MilkType }
+  end
+
   AnimalProductInterface = GraphQL::InterfaceType.define do
     name "AnimalProduct"
     description "Comes from an animal, no joke"
@@ -328,6 +337,10 @@ module Dummy
     end
 
     field :allEdible, types[EdibleInterface] do
+      resolve ->(obj, args, ctx) { CHEESES.values + MILKS.values }
+    end
+
+    field :allEdibleAsMilk, types[EdibleAsMilkInterface] do
       resolve ->(obj, args, ctx) { CHEESES.values + MILKS.values }
     end
 

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -419,7 +419,7 @@ module Dummy
 
     rescue_from(NoSuchDairyError) { |err| err.message  }
 
-    resolve_type ->(obj, ctx) {
+    resolve_type ->(type, obj, ctx) {
       Schema.types[obj.class.name.split("::").last]
     }
   end

--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -362,7 +362,7 @@ module StarWars
     mutation(MutationType)
     default_max_page_size 3
 
-    resolve_type ->(object, ctx) {
+    resolve_type ->(type, object, ctx) {
       if object == :test_error
         :not_a_type
       elsif object.is_a?(Base)


### PR DESCRIPTION
This is the interface equivalent of #829 

Also, it changes the signature of `Schema#resolve_type`, so you should migrate code from: 

```ruby
MySchema = GraphQL::Schema.define do 
  resolve_type ->(obj, ctx) { ... }
end 
```

to: 

```ruby
MySchema = GraphQL::Schema.define do 
  resolve_type ->(type, obj, ctx) { ... }
  #                ^ add this first param
end 
```