### PR TITLE
fix(Lazy) resolve cousin fields in the same pass

### DIFF
--- a/lib/graphql/compatibility/lazy_execution_specification.rb
+++ b/lib/graphql/compatibility/lazy_execution_specification.rb
@@ -24,11 +24,17 @@ module GraphQL
               p2: push(value: 2) {
                 push(value: 3) {
                   value
+                  push(value: 21) {
+                    value
+                  }
                 }
               }
               p3: push(value: 4) {
                 push(value: 5) {
                   value
+                  push(value: 22) {
+                    value
+                  }
                 }
               }
             }
@@ -37,14 +43,15 @@ module GraphQL
 
             expected_data = {
               "p1"=>{"value"=>1},
-              "p2"=>{"push"=>{"value"=>3}},
-              "p3"=>{"push"=>{"value"=>5}},
+              "p2"=>{"push"=>{"value"=>3, "push"=>{"value"=>21}}},
+              "p3"=>{"push"=>{"value"=>5, "push"=>{"value"=>22}}},
             }
             assert_equal expected_data, res["data"]
 
             expected_pushes = [
               [1,2,4], # first level
               [3,5], # second level
+              [21, 22],
             ]
             assert_equal expected_pushes, pushes
           end

--- a/lib/graphql/execution/field_result.rb
+++ b/lib/graphql/execution/field_result.rb
@@ -47,7 +47,7 @@ module GraphQL
       end
 
       def inspect
-        "#<FieldResult #{value.inspect} (#{field.type})>"
+        "#<FieldResult #{value.inspect} (#{@type})>"
       end
     end
   end

--- a/lib/graphql/execution/lazy/resolve.rb
+++ b/lib/graphql/execution/lazy/resolve.rb
@@ -36,14 +36,12 @@ module GraphQL
             Lazy::NullResult
           else
             Lazy.new {
-              next_values = []
               acc.each_with_index { |field_result, idx|
-                lazy = field_result.value
-                inner_v = lazy.value
+                inner_v = field_result.value.value
                 field_result.value = inner_v
-                next_values << inner_v
+                acc[idx] = inner_v
               }
-              resolve_in_place(next_values)
+              resolve_in_place(acc)
             }
           end
         end
@@ -84,9 +82,9 @@ module GraphQL
           when Lazy
             deep_sync(val.value)
           when Array
-            val.each { |v| deep_sync(v) }
+            val.each { |v| deep_sync(v.value) }
           when Hash
-            val.each { |k, v| deep_sync(v) }
+            val.each { |k, v| deep_sync(v.value) }
           end
         end
       end

--- a/spec/graphql/execution/lazy_spec.rb
+++ b/spec/graphql/execution/lazy_spec.rb
@@ -19,6 +19,9 @@ describe GraphQL::Execution::Lazy do
             value
             nestedSum(value: 1) {
               value
+              nestedSum(value: -50) {
+                value
+              }
             }
           }
         }
@@ -28,6 +31,9 @@ describe GraphQL::Execution::Lazy do
             value
             nestedSum(value: 2) {
               value
+              nestedSum(value: -50) {
+                value
+              }
             }
           }
         }
@@ -41,8 +47,20 @@ describe GraphQL::Execution::Lazy do
       |
 
       expected_data = {
-        "a"=>{"value"=>14, "nestedSum"=>{"value"=>46, "nestedSum"=>{"value"=>95}}},
-        "b"=>{"value"=>14, "nestedSum"=>{"value"=>46, "nestedSum"=>{"value"=>95}}},
+        "a"=>{"value"=>14, "nestedSum"=>{
+          "value"=>46,
+          "nestedSum"=>{
+            "value"=>95,
+            "nestedSum"=>{"value"=>90}
+          }
+        }},
+        "b"=>{"value"=>14, "nestedSum"=>{
+          "value"=>46,
+          "nestedSum"=>{
+            "value"=>95,
+            "nestedSum"=>{"value"=>90}
+          }
+        }},
         "c"=>[
           {"nestedSum"=>{"value"=>14}},
           {"nestedSum"=>{"value"=>14}}

--- a/spec/graphql/execution/lazy_spec.rb
+++ b/spec/graphql/execution/lazy_spec.rb
@@ -17,12 +17,18 @@ describe GraphQL::Execution::Lazy do
           value
           nestedSum(value: 7) {
             value
+            nestedSum(value: 1) {
+              value
+            }
           }
         }
         b: nestedSum(value: 2) {
           value
           nestedSum(value: 11) {
             value
+            nestedSum(value: 2) {
+              value
+            }
           }
         }
 
@@ -35,9 +41,12 @@ describe GraphQL::Execution::Lazy do
       |
 
       expected_data = {
-        "a"=>{"value"=>14, "nestedSum"=>{"value"=>46}},
-        "b"=>{"value"=>14, "nestedSum"=>{"value"=>46}},
-        "c"=>[{"nestedSum"=>{"value"=>14}}, {"nestedSum"=>{"value"=>14}}],
+        "a"=>{"value"=>14, "nestedSum"=>{"value"=>46, "nestedSum"=>{"value"=>95}}},
+        "b"=>{"value"=>14, "nestedSum"=>{"value"=>46, "nestedSum"=>{"value"=>95}}},
+        "c"=>[
+          {"nestedSum"=>{"value"=>14}},
+          {"nestedSum"=>{"value"=>14}}
+        ],
       }
 
       assert_equal expected_data, res["data"]


### PR DESCRIPTION
This issue was identified in https://github.com/Shopify/graphql-batch/pull/58. 

graphql-ruby's implementation of batching missed a feature of graphql-batch's implementation. Consider a query like this: 

```
field1 {
  field {
    batchMe 
  }
}

field2 {
  field {
    batchMe 
  }
}
```

Previously, these fields were not properly batched. 

Now, "cousin" fields (that is, children of siblings) are batched to any level.