### PR TITLE
Faster CI?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,12 @@ env:
 before_install:
   - gem update --system --no-doc
   - gem install bundler
-
+addons:
+  apt:
+    packages:
+      - haveged
 rvm:
-- 2.1.0 # Lowest version officially supported by that gem
-- 2.2.7
-- 2.3.4
+- 2.1.0 # Lowest version officially supported by the gem
 - 2.4.1
 - jruby-9.1.9.0
 
@@ -37,12 +38,6 @@ matrix:
     rvm: 2.4.1
 
   exclude:
-  - rvm: 2.4.1
-    gemfile: gemfiles/rails_3.2.gemfile
-  - rvm: 2.4.1
-    gemfile: gemfiles/rails_4.1.gemfile
-  - rvm: 2.4.1
-    gemfile: gemfiles/rails_4.2.gemfile
   - rvm: 2.1.0
     gemfile: gemfiles/rails_5.0.gemfile # Rails 5 requires Ruby 2.2.2+
   - rvm: jruby-9.1.9.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ gemfile:
 - gemfiles/rails_5.1.gemfile
 
 matrix:
+  fast_finish: true
   include:
   - env: DATABASE=POSTGRESQL
     gemfile: Gemfile


### PR DESCRIPTION
Builds [used to take 5 mins](https://travis-ci.org/rmosolgo/graphql-ruby/builds/252937570) but now they take [25 mins](https://travis-ci.org/rmosolgo/graphql-ruby/builds/252852853). Looking back through history, I don't see any smoking guns for where the jump came from. It looks like they just slowly crept up! 

But looking at the current build matrix, I got two ideas: 

- Use [travis's suggestion](https://docs.travis-ci.com/user/languages/ruby/#JRuby%3A-Installation-takes-a-long-time-on-Standard-and-Trusty-environments) for faster jruby installation 
- Stop testing ruby 2.2 & ruby 2.3 (is there any reason to test those since we already have 2.1 and 2.4?)