### PR TITLE
fix(RelationConnection) correctly count when ActiveRecord has already added an alias

### DIFF
--- a/lib/graphql/relay/relation_connection.rb
+++ b/lib/graphql/relay/relation_connection.rb
@@ -100,7 +100,12 @@ module GraphQL
 
       # If a relation contains a `.group` clause, a `.count` will return a Hash.
       def relation_count(relation)
-        count_or_hash = relation.count
+        count_or_hash = case relation
+        when ActiveRecord::Relation
+          relation.count(:all)
+        else # eg, Sequel::Dataset, don't mess up others
+          relation.count
+        end
         count_or_hash.is_a?(Integer) ? count_or_hash : count_or_hash.length
       end
 

--- a/spec/graphql/relay/relation_connection_spec.rb
+++ b/spec/graphql/relay/relation_connection_spec.rb
@@ -481,6 +481,14 @@ describe GraphQL::Relay::RelationConnection do
   end
 
   describe "for an ActiveRecord::Relation" do
+    describe "#has_next_page" do
+      it "handles joined, aliased relations" do
+        relation = StarWars::Base.select("id AS crazy_id")
+        connection = GraphQL::Relay::RelationConnection.new(relation, { first: 1 })
+        assert connection.has_next_page
+      end
+    end
+
     describe "#edge_nodes" do
       it "returns the nodes for the current page" do
         # Offset


### PR DESCRIPTION
Sometimes ActiveRecord gets a really tricky query, but then `.count` fails. So we have to specify `count(:all)` which overrides other selected fields and runs `COUNT(*)` instead.

TODO: 

- [x] Add a test for the fix