### PR TITLE
fix: remove usage of Rails' Array.wrap

### DIFF
--- a/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb
+++ b/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb
@@ -12,7 +12,13 @@ module GraphQL
         }
 
         context.visitor[GraphQL::Language::Nodes::Argument] << ->(node, parent) {
-          node_values = Array.wrap(node.value).select { |value| value.is_a? GraphQL::Language::Nodes::VariableIdentifier }
+          node_values = if node.value.is_a?(Array)
+            node.value
+          else
+            [node.value]
+          end
+          node_values = node_values.select { |value| value.is_a? GraphQL::Language::Nodes::VariableIdentifier }
+
           return if node_values.none?
 
           arguments = nil


### PR DESCRIPTION
Fixes https://github.com/rmosolgo/graphql-ruby/issues/839

It looks like active_support happens to be included in the tests, which is why
this succeeded in the first place. Nevertheless, we want to avoid this dependency!
Introduced in https://github.com/rmosolgo/graphql-ruby/pull/824