### PR TITLE
Prepare arguments for nested input types

### DIFF
--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -89,7 +89,8 @@ module GraphQL
         field_value = value[input_key]
 
         if value.key?(input_key)
-          input_values[input_key] = input_field_defn.type.coerce_input(field_value, ctx)
+          coerced_value = input_field_defn.type.coerce_input(field_value, ctx)
+          input_values[input_key] = input_field_defn.prepare(coerced_value, ctx)
         elsif input_field_defn.default_value?
           input_values[input_key] = input_field_defn.default_value
         end

--- a/spec/graphql/query/arguments_spec.rb
+++ b/spec/graphql/query/arguments_spec.rb
@@ -272,7 +272,7 @@ describe GraphQL::Query::Arguments do
       GraphQL::Schema.define(query: query)
     }
 
-    it "returns prepared arguemnt value for nested input type" do
+    it "returns prepared argument value for nested input type" do
       schema.execute("query prepareTest($arg: TestInput2 = {b: {a: 2}}){ prepareTest(a: $arg) }")
 
       args = arg_values[0].values[0]

--- a/spec/graphql/query/arguments_spec.rb
+++ b/spec/graphql/query/arguments_spec.rb
@@ -241,4 +241,42 @@ describe GraphQL::Query::Arguments do
       assert_equal({"d" => nil, "b" => 2}, test_defaults.to_h)
     end
   end
+
+  describe "prepare" do
+    let(:arg_values) { [] }
+    let(:schema) {
+      arg_values_array = arg_values
+      test_input_1 = GraphQL::InputObjectType.define do
+        name "TestInput1"
+        argument :a, types.Int, prepare: ->(value, ctx) do
+          value * 10
+        end
+      end
+
+      test_input_2 = GraphQL::InputObjectType.define do
+        name "TestInput2"
+        argument :b, !test_input_1, as: :inputObject
+      end
+
+      query = GraphQL::ObjectType.define do
+        name "Query"
+        field :prepareTest, types.Int do
+          argument :a, test_input_2
+          resolve ->(obj, args, ctx) {
+            arg_values_array << args
+            1
+          }
+        end
+      end
+
+      GraphQL::Schema.define(query: query)
+    }
+
+    it "returns prepared arguemnt value for nested input type" do
+      schema.execute("query prepareTest($arg: TestInput2 = {b: {a: 2}}){ prepareTest(a: $arg) }")
+
+      args = arg_values[0].values[0]
+      assert_equal 2 * 10, args['inputObject']['a']
+    end
+  end
 end


### PR DESCRIPTION
When using `prepare` in a nested input type, the provided block wasn't called. This PR fixes it. 