### PR TITLE
feat(Schema.from_definition) support loading schema from file path

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -462,13 +462,19 @@ module GraphQL
       GraphQL::Schema::Loader.load(introspection_result)
     end
 
-    # Create schema from an IDL schema.
-    # @param definition_string [String] A schema definition string
+    # Create schema from an IDL schema or file containing an IDL definition.
+    # @param definition_or_path [String] A schema definition string, or a path to a file containing the definition
     # @param default_resolve [<#call(type, field, obj, args, ctx)>] A callable for handling field resolution
     # @param parser [Object] An object for handling definition string parsing (must respond to `parse`)
     # @return [GraphQL::Schema] the schema described by `document`
-    def self.from_definition(string, default_resolve: BuildFromDefinition::DefaultResolve, parser: BuildFromDefinition::DefaultParser)
-      GraphQL::Schema::BuildFromDefinition.from_definition(string, default_resolve: default_resolve, parser: parser)
+    def self.from_definition(definition_or_path, default_resolve: BuildFromDefinition::DefaultResolve, parser: BuildFromDefinition::DefaultParser)
+      # If the file ends in `.graphql`, treat it like a filepath
+      definition = if definition_or_path.end_with?(".graphql")
+        File.read(definition_or_path)
+      else
+        definition_or_path
+      end
+      GraphQL::Schema::BuildFromDefinition.from_definition(definition, default_resolve: default_resolve, parser: parser)
     end
 
     # Error that is raised when [#Schema#from_definition] is passed an invalid schema definition string.

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -286,7 +286,12 @@ module GraphQL
 
         def resolve_type(types, ast_node)
           type = GraphQL::Schema::TypeExpression.build_type(types, ast_node)
-          raise InvalidDocumentError.new("Type \"#{ast_node.name}\" not found in document.") unless type
+          if type.nil?
+            while ast_node.respond_to?(:of_type)
+              ast_node = ast_node.of_type
+            end
+            raise InvalidDocumentError.new("Type \"#{ast_node.name}\" not found in document.")
+          end
           type
         end
       end

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -168,6 +168,13 @@ type Query {
       built_schema = GraphQL::Schema.from_definition(schema)
       assert_equal schema.chop, GraphQL::Schema::Printer.print_schema(built_schema)
     end
+
+    it "builds from a file" do
+      schema = GraphQL::Schema.from_definition("spec/support/magic_cards/schema.graphql")
+      assert_instance_of GraphQL::Schema, schema
+      expected_types =  ["Card", "Color", "Expansion", "Printing"]
+      assert_equal expected_types, (expected_types & schema.types.keys)
+    end
   end
 
   describe ".from_introspection" do

--- a/spec/support/magic_cards/schema.graphql
+++ b/spec/support/magic_cards/schema.graphql
@@ -1,0 +1,33 @@
+type Card {
+  name: String!
+  printings: [Printing!]!
+  expansions: [Expansion!]!
+  colors: [Color!]!
+  convertedManaCost: Int!
+}
+
+type Expansion {
+  name: String!
+  symbol: String!
+  printings: [Printing!]!
+  cards: [Card!]!
+}
+
+type Printing {
+  card: Card!
+  expansion: Expansion!
+}
+
+enum Color {
+  RED
+  GREEN
+  BLACK
+  BLUE
+  WHITE
+  COLORLESS
+}
+
+type Query {
+  card(name: String!): Card
+  expansion(symbol: String!): Expansion
+}


### PR DESCRIPTION
Support a `.graphql` filepath in `Schema.from_definition`, cherry-picked from #810 