### PR TITLE
Add batch-loader as a gem for batching

### DIFF
--- a/guides/schema/lazy_execution.md
+++ b/guides/schema/lazy_execution.md
@@ -12,11 +12,6 @@ With lazy execution, you can optimize access to external services (such as datab
 - Connect it to your schema with {{ "GraphQL::Schema#lazy_resolve" | api_doc }}
 - In `resolve` functions, return instances of the lazy-loading class
 
-[`graphql-batch`](https://github.com/shopify/graphql-batch) provides a powerful, flexible toolkit for lazy resolution with GraphQL.
-
-[`dataloader`](https://github.com/sheerun/dataloader) is more general [`promise`](https://github.com/lgierth/promise.rb)-based utilify for batching queries within the same thread.
-
-
 Lazy resolution can be {% internal_link "instrumented","/fields/instrumentation" %}.
 
 ## Example: Batched Find
@@ -91,4 +86,10 @@ Now, calls to `author` will use batched database access. For example, this query
 
 Will only make one query to load the `author` values.
 
-The example above is simple and has some shortcomings. Consider the `graphql-batch` or `dataloader` gem for a robust solution to batched resolution.
+## Gems for batching
+
+The example above is simple and has some shortcomings. Consider the following gems for a robust solution to batched resolution:
+
+* [`graphql-batch`](https://github.com/shopify/graphql-batch) provides a powerful, flexible toolkit for lazy resolution with GraphQL.
+* [`dataloader`](https://github.com/sheerun/dataloader) is more general promise-based utility for batching queries within the same thread.
+* [`batch-loader`](https://github.com/exAspArk/batch-loader) works with any Ruby code including GraphQL, no extra dependencies or primitives.


### PR DESCRIPTION
Hey @rmosolgo!

I created a new gem called [batch-loader](https://github.com/exAspArk/batch-loader) which helps to avoid N+1 queries. I saw the repository was already starred by you 💛 

I'd like to add it to your list. In addition to the detailed description in [README](https://github.com/exAspArk/batch-loader) I also created a small presentation. I'm using the [slides](https://speakerdeck.com/exaspark/batching-the-powerful-way-to-solve-n-plus-1-queries-every-rubyist-should-know) to describe to my internal team why the gem was created and how it can be used even in existing legacy applications during the migration from REST APIs to GraphQL. Would be happy to receive your feedback :)

In the PR I moved the gems below your simple and very helpful example. I left them in FIFO order, but can also sort them alphabetically.