### PR TITLE
fix(FieldsWillMerge) handle input objects properly

### DIFF
--- a/lib/graphql/static_validation/rules/fields_will_merge.rb
+++ b/lib/graphql/static_validation/rules/fields_will_merge.rb
@@ -19,10 +19,8 @@ module GraphQL
               n.arguments.reduce({}) do |memo, a|
                 arg_value = a.value
                 memo[a.name] = case arg_value
-                when GraphQL::Language::Nodes::VariableIdentifier
-                  "$#{arg_value.name}"
-                when GraphQL::Language::Nodes::Enum
-                  "#{arg_value.name}"
+                when GraphQL::Language::Nodes::AbstractNode
+                  arg_value.to_query_string
                 else
                   GraphQL::Language.serialize(arg_value)
                 end

--- a/spec/graphql/static_validation/rules/fields_will_merge_spec.rb
+++ b/spec/graphql/static_validation/rules/fields_will_merge_spec.rb
@@ -13,6 +13,10 @@ describe GraphQL::StaticValidation::FieldsWillMerge do
         toy: Toy
       }
 
+      type Mutation {
+        registerPet(params: PetParams): Pet
+      }
+
       enum PetCommand {
         SIT
         HEEL
@@ -23,6 +27,16 @@ describe GraphQL::StaticValidation::FieldsWillMerge do
       enum ToySize {
         SMALL
         LARGE
+      }
+
+      enum PetSpecies {
+        DOG
+        CAT
+      }
+
+      input PetParams {
+        name: String!
+        species: PetSpecies!
       }
 
       interface Pet {
@@ -76,6 +90,23 @@ describe GraphQL::StaticValidation::FieldsWillMerge do
         dog {
           name
           name
+        }
+      }
+    |}
+
+    it "passes rule" do
+      assert_equal [], errors
+    end
+  end
+
+  describe "identical fields with identical input objects" do
+    let(:query_string) {%|
+      mutation {
+        registerPet(params: { name: "Fido", species: DOG }) {
+          name
+        }
+        registerPet(params: { name: "Fido", species: DOG }) {
+          __typename
         }
       }
     |}


### PR DESCRIPTION
oops, the short whitelist of node classes here didn't include input objects. better to just use `to_query_string` since it's supported across the board!