### PR TITLE
Fix selected operation name when there are no selections in a query

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -161,7 +161,10 @@ module GraphQL
     end
 
     def irep_selection
-      @selection ||= internal_representation.operation_definitions[selected_operation.name]
+      @selection ||= begin
+        return nil unless selected_operation
+        internal_representation.operation_definitions[selected_operation.name]
+      end
     end
 
     # Node-level cache for calculating arguments. Used during execution and query analysis.

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -44,6 +44,7 @@ module GraphQL
 
     # @return [String, nil] The name of the operation to run (may be inferred)
     def selected_operation_name
+      return nil unless selected_operation
       selected_operation.name
     end
 

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -633,6 +633,18 @@ describe GraphQL::Query do
     end
   end
 
+  describe '#irep_selection' do
+    it "returns the irep for the selected operation" do
+      assert_kind_of GraphQL::InternalRepresentation::Node, query.irep_selection
+      assert_equal 'getFlavor', query.irep_selection.name
+    end
+
+    it "returns nil when there is no selected operation" do
+      query = GraphQL::Query.new(schema, '# Only a comment')
+      assert_equal nil, query.irep_selection
+    end
+  end
+
   describe "query_execution_strategy" do
     let(:custom_execution_schema) {
       schema.redefine do

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -68,7 +68,7 @@ describe GraphQL::Query do
     end
   end
 
-  describe "operation_name" do
+  describe "#operation_name" do
     describe "when provided" do
       let(:query_string) { <<-GRAPHQL
         query q1 { cheese(id: 1) { flavor } }
@@ -79,7 +79,6 @@ describe GraphQL::Query do
 
       it "returns the provided name" do
         assert_equal "q2", query.operation_name
-        assert_equal "q2", query.selected_operation_name
       end
     end
 
@@ -91,7 +90,44 @@ describe GraphQL::Query do
 
       it "returns nil" do
         assert_equal nil, query.operation_name
-        assert_equal "q3", query.selected_operation_name
+      end
+    end
+
+    describe "#selected_operation_name" do
+      describe "when an operation isprovided" do
+        let(:query_string) { <<-GRAPHQL
+          query q1 { cheese(id: 1) { flavor } }
+          query q2 { cheese(id: 2) { flavor } }
+        GRAPHQL
+        }
+        let(:operation_name) { "q2" }
+
+        it "returns the provided name" do
+          assert_equal "q2", query.selected_operation_name
+        end
+      end
+
+      describe "when operation is inferred" do
+        let(:query_string) { <<-GRAPHQL
+          query q3 { cheese(id: 3) { flavor } }
+        GRAPHQL
+        }
+
+        it "returns the inferred operation name" do
+          assert_equal "q3", query.selected_operation_name
+        end
+      end
+
+      describe "when there are no operations" do
+        let(:query_string) { <<-GRAPHQL
+          # Only Comments
+          # In this Query
+        GRAPHQL
+        }
+
+        it "returns the inferred operation name" do
+          assert_equal nil, query.selected_operation_name
+        end
       end
     end
 


### PR DESCRIPTION
Noticed Query would 💥 in two places when a query with no operations is executed, for example a query with only comments.