### PR TITLE
Fix Sequel::Error when limit is 0

### DIFF
--- a/lib/graphql/relay/relation_connection.rb
+++ b/lib/graphql/relay/relation_connection.rb
@@ -121,15 +121,24 @@ module GraphQL
 
         if before && after
           if offset_from_cursor(after) < offset_from_cursor(before)
-            @sliced_nodes = @sliced_nodes.limit(offset_from_cursor(before) - offset_from_cursor(after) - 1)
+            @sliced_nodes = limit_nodes(@sliced_nodes,  offset_from_cursor(before) - offset_from_cursor(after) - 1)
           else
-            @sliced_nodes = @sliced_nodes.limit(0)
+            @sliced_nodes = limit_nodes(@sliced_nodes, 0)
           end
+
         elsif before
-          @sliced_nodes = @sliced_nodes.limit(offset_from_cursor(before) - 1)
+          @sliced_nodes = limit_nodes(@sliced_nodes, offset_from_cursor(before) - 1)
         end
 
         @sliced_nodes
+      end
+
+      def limit_nodes(sliced_nodes, limit)
+        if limit > 0 || defined?(ActiveRecord::Relation) && sliced_nodes.is_a?(ActiveRecord::Relation)
+          sliced_nodes.limit(limit)
+        else
+          sliced_nodes.where(false)
+        end
       end
 
       def sliced_nodes_count

--- a/spec/graphql/relay/relation_connection_spec.rb
+++ b/spec/graphql/relay/relation_connection_spec.rb
@@ -123,11 +123,18 @@ describe GraphQL::Relay::RelationConnection do
       assert_equal([], get_names(result))
     end
 
-    it 'handles cursors beyond the bounds of the array' do
+    it 'handles cursors above the bounds of the array' do
       overreaching_cursor = Base64.strict_encode64("100")
       result = star_wars_query(query_string, "after" => overreaching_cursor, "first" => 2)
       assert_equal([], get_names(result))
     end
+
+    it 'handles cursors below the bounds of the array' do
+      underreaching_cursor = Base64.strict_encode64("1")
+      result = star_wars_query(query_string, "before" => underreaching_cursor, "first" => 2)
+      assert_equal([], get_names(result))
+    end
+
 
     it 'handles grouped connections with only last argument' do
       grouped_conn_query = <<-GRAPHQL
@@ -439,6 +446,18 @@ describe GraphQL::Relay::RelationConnection do
         result = star_wars_query(query_string, "before" => last_cursor, "last" => 10)
         assert_equal(["Death Star", "Shield Generator"], get_names(result))
 
+      end
+
+      it 'handles cursors above the bounds of the array' do
+        overreaching_cursor = Base64.strict_encode64("100")
+        result = star_wars_query(query_string, "after" => overreaching_cursor, "first" => 2)
+        assert_equal([], get_names(result))
+      end
+
+      it 'handles cursors below the bounds of the array' do
+        underreaching_cursor = Base64.strict_encode64("1")
+        result = star_wars_query(query_string, "before" => underreaching_cursor, "first" => 2)
+        assert_equal([], get_names(result))
       end
 
       it "applies custom arguments" do


### PR DESCRIPTION
Sequel, contrarily to ActiveRecord, does not support `limit(0)` queries
and raises a `Sequel::Error` instead.

To fix this, we need to deal with this differently by using `where(false)`
instead when we are attempting to perform a query for zero rows in Sequel.

Fixes #887 