### PR TITLE
feat(Query::Result) add a first-class result object

### DIFF
--- a/lib/graphql/execution/multiplex.rb
+++ b/lib/graphql/execution/multiplex.rb
@@ -77,6 +77,8 @@ module GraphQL
           results.each_with_index.map do |data_result, idx|
             query = queries[idx]
             finish_query(data_result, query)
+            # Get the Query::Result, not the Hash
+            query.result
           end
         end
 
@@ -109,7 +111,7 @@ module GraphQL
         # @return [Hash] final result of this query, including all values and errors
         def finish_query(data_result, query)
           # Assign the result so that it can be accessed in instrumentation
-          query.result = if data_result.equal?(NO_OPERATION)
+          query.result_values = if data_result.equal?(NO_OPERATION)
             if !query.valid?
               { "errors" => query.static_errors.map(&:to_h) }
             else
@@ -129,7 +131,7 @@ module GraphQL
 
         # use the old `query_execution_strategy` etc to run this query
         def run_one_legacy(schema, query)
-          query.result = if !query.valid?
+          query.result_values = if !query.valid?
             all_errors = query.validation_errors + query.analysis_errors + query.context.errors
             if all_errors.any?
               { "errors" => all_errors.map(&:to_h) }

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -5,6 +5,7 @@ require "graphql/query/context"
 require "graphql/query/executor"
 require "graphql/query/literal_input"
 require "graphql/query/null_context"
+require "graphql/query/result"
 require "graphql/query/serial_execution"
 require "graphql/query/variables"
 require "graphql/query/input_validation_result"
@@ -98,17 +99,17 @@ module GraphQL
       @max_depth = max_depth || schema.max_depth
       @max_complexity = max_complexity || schema.max_complexity
 
-      @result = nil
+      @result_values = nil
       @executed = false
     end
 
     # @api private
-    def result=(result_hash)
+    def result_values=(result_hash)
       if @executed
         raise "Invariant: Can't reassign result"
       else
         @executed = true
-        @result = result_hash
+        @result_values = result_hash
       end
     end
 
@@ -128,7 +129,7 @@ module GraphQL
           Execution::Multiplex.run_queries(@schema, [self])
         }
       end
-      @result
+      @result ||= Query::Result.new(query: self, values: @result_values)
     end
 
     def static_errors

--- a/lib/graphql/query/result.rb
+++ b/lib/graphql/query/result.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module GraphQL
+  class Query
+    # A result from {Schema#execute}.
+    # It provides the requested data and
+    # access to the {Query} and {Query::Context}.
+    class Result
+      extend GraphQL::Delegate
+
+      def initialize(query:, values:)
+        @query = query
+        @to_h = values
+      end
+
+      # @return [GraphQL::Query] The query that was executed
+      attr_reader :query
+
+      # @return [Hash] The resulting hash of "data" and/or "errors"
+      attr_reader :to_h
+
+      def_delegators :@query, :context, :mutation?, :query?
+
+      def_delegators :@to_h, :[], :keys, :values
+
+      # Delegate any hash-like method to the underlying hash.
+      def method_missing(method_name, *args, &block)
+        if @to_h.respond_to?(method_name)
+          @to_h.public_send(method_name, *args, &block)
+        else
+          super
+        end
+      end
+
+      def respond_to_missing?(method_name, include_private = false)
+        @to_h.respond_to?(method_name) || super
+      end
+
+      def inspect
+        "#<GraphQL::Query::Result @query=... @to_h=#{@to_h} >"
+      end
+
+      def ==(other)
+        if other.is_a?(Hash)
+          @to_h == other
+        else
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/query/result.rb
+++ b/lib/graphql/query/result.rb
@@ -21,7 +21,7 @@ module GraphQL
 
       def_delegators :@query, :context, :mutation?, :query?
 
-      def_delegators :@to_h, :[], :keys, :values
+      def_delegators :@to_h, :[], :keys, :values, :to_json, :as_json
 
       # Delegate any hash-like method to the underlying hash.
       def method_missing(method_name, *args, &block)
@@ -40,9 +40,20 @@ module GraphQL
         "#<GraphQL::Query::Result @query=... @to_h=#{@to_h} >"
       end
 
+      # A result is equal to another object when:
+      #
+      # - The other object is a Hash whose value matches `result.to_h`
+      # - The other object is a Result whose value matches `result.to_h`
+      #
+      # (The query is ignored for comparing result equality.)
+      #
+      # @return [Boolean]
       def ==(other)
-        if other.is_a?(Hash)
+        case other
+        when Hash
           @to_h == other
+        when Query::Result
+          @to_h == other.to_h
         else
           super
         end

--- a/spec/graphql/query/result_spec.rb
+++ b/spec/graphql/query/result_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::Query::Result do
+  let(:query_string) { '{ __type(name: "Cheese") { name } }' }
+  let(:schema) { Dummy::Schema }
+  let(:result) { schema.execute(query_string, context: { a: :b }) }
+
+  it "exposes hash-like methods" do
+    assert_equal "Cheese", result["data"]["__type"]["name"]
+    refute result.key?("errors")
+    assert_equal ["data"], result.keys
+  end
+
+  it "is equal with hashes" do
+    hash_result = {"data" => { "__type" => { "name" => "Cheese" } } }
+    assert_equal hash_result, result
+  end
+
+  it "tells the kind of operation" do
+    assert result.query?
+    refute result.mutation?
+  end
+
+  it "exposes the context" do
+    assert_instance_of GraphQL::Query::Context, result.context
+    assert_equal({a: :b}, result.context.to_h)
+  end
+end


### PR DESCRIPTION
Sometimes you need query-related data, but `Schema#execute` returns a hash. You can work around this using `Query#result`, but then you can't do multiplexing. So, let's attach query data to the `Query::Result`.

Specifically, I need this for subscriptions: after running a query, we should open a channel for updates if `result.query.subscription?` 

