### PR TITLE
plural nodes is not correct here

### DIFF
--- a/guides/relay/object_identification.md
+++ b/guides/relay/object_identification.md
@@ -134,7 +134,7 @@ Both of these fields may be customized using the usual definition block:
 QueryType = GraphQL::ObjectType.define do
   name "Query"
 
-  field :nodes, (GraphQL::Relay::Node.field do
+  field :node, (GraphQL::Relay::Node.field do
     resolve ->(_, args, _) { # your own custom logic here }
   end)
 


### PR DESCRIPTION
I assume `nodes` here is a typo otherwise it should define `GraphQL::Relay::Node.plural_field`.