### PR TITLE
refactor(js-client) rename to graphql-ruby-client

### DIFF
--- a/guides/operation_store/authentication.md
+++ b/guides/operation_store/authentication.md
@@ -22,4 +22,4 @@ The Authorization header takes the form:
 "GraphQL::Pro #{client_name} #{hmac}"
 ```
 
-[`graphql-pro-js`](http://github.com/rmosolgo/graphql-pro-js) adds this header to outgoing requests by using the provided `--client` and `--secret` values.
+[`graphql-ruby-client`](http://github.com/rmosolgo/graphql-ruby-client) adds this header to outgoing requests by using the provided `--client` and `--secret` values.

--- a/guides/operation_store/client_workflow.md
+++ b/guides/operation_store/client_workflow.md
@@ -14,7 +14,7 @@ To use persisted queries with your client application, you must:
 - [Sync operations](#syncing) from the client to the server
 - [Send `params[:operationId]`](#client-usage) from the client app
 
-This documentation also touches on [`graphql-pro-js`](https://github.com/rmosolgo/graphql-pro-js), a JavaScript client library for using `OperationStore`.
+This documentation also touches on [`graphql-ruby-client`](https://github.com/rmosolgo/graphql-ruby-client), a JavaScript client library for using `OperationStore`.
 
 ### Add a Client
 
@@ -30,7 +30,7 @@ A default `secret` is provided for you, but you can also enter your own. The `se
 
 Once a client is registered, it can push queries to the server via {% internal_link "the Sync API","/operation_store/getting_started#add-routes" %}.
 
-The easiest way to sync is with `graphql-pro sync`, a command-line tool written in JavaScript: [`graphql-pro-js`](https://github.com/rmosolgo/graphql-pro-js).
+The easiest way to sync is with `graphql-pro sync`, a command-line tool written in JavaScript: [`graphql-ruby-client`](https://github.com/rmosolgo/graphql-ruby-client).
 
 In short, it:
 
@@ -43,15 +43,15 @@ For example:
 
 {{ "/operation_store/sync_example.png" | link_to_img:"OperationStore client sync" }}
 
-See the readme for [Relay support](https://github.com/rmosolgo/graphql-pro-js#use-with-relay), [Apollo Client support](https://github.com/rmosolgo/graphql-pro-js#use-with-apollo-client), and [plain JS usage](https://github.com/rmosolgo/graphql-pro-js#use-with-plain-javascript).
+See the readme for [Relay support](https://github.com/rmosolgo/graphql-ruby-client#use-with-relay), [Apollo Client support](https://github.com/rmosolgo/graphql-ruby-client#use-with-apollo-client), and [plain JS usage](https://github.com/rmosolgo/graphql-ruby-client#use-with-plain-javascript).
 
 
 
-For help syncing in another language, you can take inspiration from the [JavaScript implementation](https://github.com/rmosolgo/graphql-pro-js), {% open_an_issue "Implementing operation sync in another language" %}, or email `support@graphql.pro`.
+For help syncing in another language, you can take inspiration from the [JavaScript implementation](https://github.com/rmosolgo/graphql-ruby-client), {% open_an_issue "Implementing operation sync in another language" %}, or email `support@graphql.pro`.
 
 ### Client Usage
 
-`graphql-pro-js` generates [Apollo middleware](https://github.com/rmosolgo/graphql-pro-js#use-with-apollo-client) and a [Relay helper function](https://github.com/rmosolgo/graphql-pro-js#use-with-relay) to get started quickly.
+`graphql-ruby-client` generates [Apollo middleware](https://github.com/rmosolgo/graphql-ruby-client#use-with-apollo-client) and a [Relay helper function](https://github.com/rmosolgo/graphql-ruby-client#use-with-relay) to get started quickly.
 
 To run stored operations from another client, send a param called `operationId` which is composed of:
 


### PR DESCRIPTION
I'm going to add subscription client implementations to this JS project, so I want to rename it to be more general