### PR TITLE
Fix unnecessary `hasNextPage` COUNT() query

### DIFF
--- a/lib/graphql/relay/relation_connection.rb
+++ b/lib/graphql/relay/relation_connection.rb
@@ -24,11 +24,11 @@ module GraphQL
       end
 
       def has_next_page
-        !!(first && sliced_nodes_count > first)
+        !!(first && paged_nodes_length >= first && sliced_nodes_count > first)
       end
 
       def has_previous_page
-        !!(last && sliced_nodes_count > last)
+        !!(last && paged_nodes_length >= last && sliced_nodes_count > last)
       end
 
       def first
@@ -155,6 +155,14 @@ module GraphQL
       def paged_nodes_array
         return @paged_nodes_array if defined?(@paged_nodes_array)
         @paged_nodes_array = paged_nodes.to_a
+      end
+
+      def paged_nodes_length
+        if paged_nodes.respond_to?(:length)
+          paged_nodes.length
+        else
+          paged_nodes_array.length
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #899 

## Change

This PR changes `has_next_page` to first check the length of `paged_nodes` to see if its less than the number of entities requested through `first` to avoid a separate COUNT query when know from the `paged_nodes` query that there is no next page.

The only negative performance impact is that in the rare case `hasNextPage` is called without `edges` the full paged nodes query will be run instead of just a COUNT query.

## Notes

In a future optimization, we could possibly request `last + 1` nodes and avoid the COUNT(*) query altogether. 


  