### PR TITLE
Fix negative offset error in postgres with `last` argument

### DIFF
--- a/lib/graphql/relay/relation_connection.rb
+++ b/lib/graphql/relay/relation_connection.rb
@@ -68,7 +68,8 @@ module GraphQL
               items = items.offset(offset).limit(last)
             end
           else
-            offset = (relation_offset(items) || 0) + relation_count(items) - last
+            slice_count = relation_count(items)
+            offset = (relation_offset(items) || 0) + slice_count - [last, slice_count].min
             items = items.offset(offset).limit(last)
           end
         end

--- a/spec/graphql/relay/relation_connection_spec.rb
+++ b/spec/graphql/relay/relation_connection_spec.rb
@@ -293,6 +293,68 @@ describe GraphQL::Relay::RelationConnection do
     end
   end
 
+  describe "applying a max_page_size bigger than the results" do
+    let(:query_string) {%|
+      query getBases($first: Int, $after: String, $last: Int, $before: String){
+        empire {
+          bases: basesWithLargeMaxLimitRelation(first: $first, after: $after, last: $last, before: $before) {
+            ... basesConnection
+          }
+        }
+      }
+
+      fragment basesConnection on BaseConnection {
+        edges {
+          cursor
+          node {
+            name
+          }
+        },
+        pageInfo {
+          hasNextPage
+          hasPreviousPage
+          startCursor
+          endCursor
+        }
+      }
+      |}
+
+    it "applies to queries by `first`" do
+      result = star_wars_query(query_string, "first" => 100)
+      assert_equal(6, result["data"]["empire"]["bases"]["edges"].size)
+      assert_equal(false, result["data"]["empire"]["bases"]["pageInfo"]["hasNextPage"])
+
+      # Max page size is applied _without_ `first`, also
+      result = star_wars_query(query_string)
+      assert_equal(6, result["data"]["empire"]["bases"]["edges"].size)
+      assert_equal(false, result["data"]["empire"]["bases"]["pageInfo"]["hasNextPage"], "hasNextPage is false when first is not specified")
+    end
+
+    it "applies to queries by `last`" do
+      all_names = ["Yavin", "Echo Base", "Secret Hideout", "Death Star", "Shield Generator", "Headquarters"]
+
+      last_cursor = "Ng=="
+      result = star_wars_query(query_string, "last" => 100, "before" => last_cursor)
+      assert_equal(all_names[0..4], get_names(result))
+      assert_equal(false, result["data"]["empire"]["bases"]["pageInfo"]["hasPreviousPage"])
+
+      result = star_wars_query(query_string, "last" => 100)
+      assert_equal(all_names, get_names(result))
+      assert_equal(false, result["data"]["empire"]["bases"]["pageInfo"]["hasPreviousPage"])
+
+      result = star_wars_query(query_string, "before" => last_cursor)
+      assert_equal(all_names[0..4], get_names(result))
+      assert_equal(false, result["data"]["empire"]["bases"]["pageInfo"]["hasPreviousPage"], "hasPreviousPage is false when last is not specified")
+
+      fourth_cursor = "NA=="
+      result = star_wars_query(query_string, "last" => 100, "before" => fourth_cursor)
+      assert_equal(all_names[0..2], get_names(result))
+
+      result = star_wars_query(query_string, "before" => fourth_cursor)
+      assert_equal(all_names[0..2], get_names(result))
+    end
+  end
+
   describe "without a block" do
     let(:query_string) {%|
       {

--- a/spec/support/star_wars/data.rb
+++ b/spec/support/star_wars/data.rb
@@ -39,7 +39,7 @@ module StarWars
 
   ActiveRecord::Schema.define do
     self.verbose = false
-    create_table :bases do |t|
+    create_table :bases, force: true do |t|
       t.column :name, :string
       t.column :planet, :string
       t.column :faction_id, :integer

--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -167,6 +167,10 @@ module StarWars
       resolve ->(object, args, context) { Base.all.to_a }
     end
 
+    connection :basesWithLargeMaxLimitRelation, BaseType.connection_type, max_page_size: 1000 do
+      resolve ->(object, args, context) { Base.all }
+    end
+
     connection :basesAsSequelDataset, BaseConnectionWithTotalCountType, max_page_size: 1000 do
       argument :nameIncludes, types.String
       resolve ->(obj, args, ctx) {


### PR DESCRIPTION
_EDIT: mixed up less than / greater than_

A query where `last` is bigger than the # of sliced nodes causes the offset to be negative, which throws an error in Postgres.  Example of a problematic query:

```
query {
  users(last: 10) {  # PG will throw an error if there are less than 10 users
    edges {
      ...
    }
  }
}
```

This was not caught earlier because the tests all use a very small `max_page_size` of 2 or 3 against queries that return 6+ nodes so `relation_count(items) - last` was always positive.  I added tests that use a `max_page_size` of 1000.

Note that this will only catch the problem when the tests are run with `POSTGRESQL=true` since it is postgres that throws the error, not rails.  In sqlite, a negative offset is evaluated as 0 instead of throwing an error.