### PR TITLE
Add default mutation field

### DIFF
--- a/lib/generators/graphql/templates/mutation_type.erb
+++ b/lib/generators/graphql/templates/mutation_type.erb
@@ -1,7 +1,7 @@
 Types::MutationType = GraphQL::ObjectType.define do
   name "Mutation"
 
-  # TODO: Add Mutations as fields
+  # TODO: Remove me
   field :testField, types.String do
     description "An example field added by the generator"
     resolve ->(obj, args, ctx) {

--- a/lib/generators/graphql/templates/mutation_type.erb
+++ b/lib/generators/graphql/templates/mutation_type.erb
@@ -2,4 +2,10 @@ Types::MutationType = GraphQL::ObjectType.define do
   name "Mutation"
 
   # TODO: Add Mutations as fields
+  field :testField, types.String do
+    description "An example field added by the generator"
+    resolve ->(obj, args, ctx) {
+      "Hello World!"
+    }
+  end
 end


### PR DESCRIPTION
This PR fixes the following issue:

**Issue**

1. rails new graphql-app
2. cd 
2. add the `gem 'graphql'` to the `Gemfile`
3. bundle update
4. rails db:create
5. rails db:migrate
6. open http://localhost:3000
7. The following issue appears in the right side of the `GraphiQL` browser:

```
invariant@http://localhost:3000/assets/graphiql/rails/graphiql-0.11.2.self-c0b0dd0bd735a2c1f549e8d44e329b9a8b227cfffca61119d2e71d3f38740b4d.js?body=1:24809:20
defineFieldMap@http://localhost:3000/assets/graphiql/rails/graphiql-0.11.2.self-c0b0dd0bd735a2c1f549e8d44e329b9a8b227cfffca61119d2e71d3f38740b4d.js?body=1:28078:27
getFields@http://localhost:3000/assets/graphiql/rails/graphiql-0.11.2.self-c0b0dd0bd735a2c1f549e8d44e329b9a8b227cfffca61119d2e71d3f38740b4d.js?body=1:28035:58
typeMapReducer@http://localhost:3000/assets/graphiql/rails/graphiql-0.11.2.self-c0b0dd0bd735a2c1f549e8d44e329b9a8b227cfffca61119d2e71d3f38740b4d.js?body=1:29752:34
reduce@[native code]
GraphQLSchema@http://localhost:3000/assets/graphiql/rails/graphiql-0.11.2.self-c0b0dd0bd735a2c1f549e8d44e329b9a8b227cfffca61119d2e71d3f38740b4d.js?body=1:29641:40
buildClientSchema@http://localhost:3000/assets/graphiql/rails/graphiql-0.11.2.self-c0b0dd0bd735a2c1f549e8d44e329b9a8b227cfffca61119d2e71d3f38740b4d.js?body=1:31049:35
http://localhost:3000/assets/graphiql/rails/graphiql-0.11.2.self-c0b0dd0bd735a2c1f549e8d44e329b9a8b227cfffca61119d2e71d3f38740b4d.js?body=1:2131:55
promiseReactionJob@[native code]
```

**Fix**

1. Update the `lib/generators/graphql/templates/mutation_type.erb` file to have a default field.
