### PR TITLE
Add more information in UnresolvedTypeError message

### DIFF
--- a/lib/graphql/unresolved_type_error.rb
+++ b/lib/graphql/unresolved_type_error.rb
@@ -24,7 +24,10 @@ module GraphQL
       @parent_type = parent_type
       @resolved_type = resolved_type
       @possible_types = possible_types
-      message = %|The value from "#{field.name}" on "#{parent_type}" could not be resolved to "#{field.type}". (Received: #{resolved_type.inspect}, Expected: [#{possible_types.map(&:inspect).join(", ")}])|
+      message = "The value from \"#{field.name}\" on \"#{parent_type}\" could not be resolved to \"#{field.type}\". " \
+        "(Received: `#{resolved_type.inspect}`, Expected: [#{possible_types.map(&:inspect).join(", ")}]) " \
+        "Make sure you have defined a `type_from_object` proc on your schema and that value `#{value.inspect}` " \
+        "gets resolved to a valid type."
       super(message)
     end
   end

--- a/spec/graphql/query/serial_execution/value_resolution_spec.rb
+++ b/spec/graphql/query/serial_execution/value_resolution_spec.rb
@@ -35,7 +35,7 @@ describe GraphQL::Query::SerialExecution::ValueResolution do
         resolve ->(obj, args, ctx) { (args["today"] + 1) % 7 }
       end
       field :resolvesToNilInterface, interface do
-        resolve ->(obj, args, ctx) { Object.new }
+        resolve ->(obj, args, ctx) { 1337 }
       end
       field :resolvesToWrongTypeInterface, interface do
         resolve ->(obj, args, ctx) { :something }
@@ -86,7 +86,10 @@ describe GraphQL::Query::SerialExecution::ValueResolution do
 
       it "raises an error" do
         err = assert_raises(GraphQL::UnresolvedTypeError) { result }
-        expected_message = %|The value from "resolvesToNilInterface" on "Query" could not be resolved to "SomeInterface". (Received: nil, Expected: [SomeObject])|
+        expected_message = "The value from \"resolvesToNilInterface\" on \"Query\" could not be resolved to \"SomeInterface\". " \
+          "(Received: `nil`, Expected: [SomeObject]) " \
+          "Make sure you have defined a `type_from_object` proc on your schema and that value `1337` " \
+          "gets resolved to a valid type."
         assert_equal expected_message, err.message
       end
     end
@@ -100,7 +103,10 @@ describe GraphQL::Query::SerialExecution::ValueResolution do
 
       it "raises an error" do
         err = assert_raises(GraphQL::UnresolvedTypeError) { result }
-        expected_message = %|The value from "resolvesToWrongTypeInterface" on "Query" could not be resolved to "SomeInterface". (Received: OtherObject, Expected: [SomeObject])|
+        expected_message = "The value from \"resolvesToWrongTypeInterface\" on \"Query\" could not be resolved to \"SomeInterface\". " \
+          "(Received: `OtherObject`, Expected: [SomeObject]) " \
+          "Make sure you have defined a `type_from_object` proc on your schema and that value `:something` " \
+          "gets resolved to a valid type."
         assert_equal expected_message, err.message
       end
     end


### PR DESCRIPTION
Adds a bit more information on how to fix an `UnresolvedTypeError` by hinting to `type_from_object` and displaying the value trying to be resolved to a type.

I've seen confusion from teammates trying to implement Interfaces and unions and we've added similar errors, thought it might be useful here too 🤷‍♂️ 