### PR TITLE
`connection?` is not properly set when parsing the IDL

### DIFF
--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -280,6 +280,9 @@ module GraphQL
               resolve: ->(obj, args, ctx) { default_resolve.call(field, obj, args, ctx) },
               deprecation_reason: build_deprecation_reason(field_definition.directives),
             )
+
+            type_name = resolve_type_name(field_definition.type)
+            field.connection = type_name.end_with?("Connection")
             [field_definition.name, field]
           end
         end
@@ -293,6 +296,15 @@ module GraphQL
             raise InvalidDocumentError.new("Type \"#{ast_node.name}\" not found in document.")
           end
           type
+        end
+
+        def resolve_type_name(type)
+          case type
+          when GraphQL::Language::Nodes::TypeName
+            return type.name
+          else
+            resolve_type_name(type.of_type)
+          end
         end
       end
 

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -206,6 +206,85 @@ type Hello {
       build_schema_and_compare_output(schema.chop)
     end
 
+    it 'properly understands connections' do
+      schema = <<-SCHEMA
+schema {
+  query: Type
+}
+
+type Organization {
+  email: String
+}
+
+# The connection type for Organization.
+type OrganizationConnection {
+  # A list of edges.
+  edges: [OrganizationEdge]
+
+  # A list of nodes.
+  nodes: [Organization]
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # Identifies the total count of items in the connection.
+  totalCount: Int!
+}
+
+# An edge in a connection.
+type OrganizationEdge {
+  # A cursor for use in pagination.
+  cursor: String!
+
+  # The item at the end of the edge.
+  node: Organization
+}
+
+# Information about pagination in a connection.
+type PageInfo {
+  # When paginating forwards, the cursor to continue.
+  endCursor: String
+
+  # When paginating forwards, are there more items?
+  hasNextPage: Boolean!
+
+  # When paginating backwards, are there more items?
+  hasPreviousPage: Boolean!
+
+  # When paginating backwards, the cursor to continue.
+  startCursor: String
+}
+
+type Type {
+  name: String
+  organization(
+    # The login of the organization to find.
+    login: String!
+  ): Organization
+
+  # A list of organizations the user belongs to.
+  organizations(
+    # Returns the elements in the list that come after the specified global ID.
+    after: String
+
+    # Returns the elements in the list that come before the specified global ID.
+    before: String
+
+    # Returns the first _n_ elements from the list.
+    first: Int
+
+    # Returns the last _n_ elements from the list.
+    last: Int
+  ): OrganizationConnection!
+}
+      SCHEMA
+
+      built_schema = build_schema_and_compare_output(schema.chop)
+      obj = built_schema.types["Type"]
+      refute obj.fields["organization"].connection?
+      assert obj.fields["organizations"].connection?
+    end
+
     it 'supports simple type with multiple arguments' do
       schema = <<-SCHEMA
 schema {


### PR DESCRIPTION
When using ` GraphQL::Schema.from_definition`, it seems that `connection?` is always `false`. I've added a failing test, but have yet to find a root cause.