### PR TITLE
Define a default `nil` @edge_class

### DIFF
--- a/lib/graphql/field.rb
+++ b/lib/graphql/field.rb
@@ -205,6 +205,7 @@ module GraphQL
       @relay_node_field = false
       @connection = false
       @connection_max_page_size = nil
+      @edge_class = nil
     end
 
     def initialize_copy(other)


### PR DESCRIPTION
If warnings are turned on when parsing an IDL, the following errors are spat out:

```
/Users/gjtorikian/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/graphql-1.6.7/lib/graphql/field.rb:194: warning: instance variable @edge_class not initialized
/Users/gjtorikian/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/graphql-1.6.7/lib/graphql/field.rb:194: warning: instance variable @edge_class not initialized
/Users/gjtorikian/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/graphql-1.6.7/lib/graphql/field.rb:194: warning: instance variable @edge_class not initialized
/Users/gjtorikian/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/graphql-1.6.7/lib/graphql/field.rb:194: warning: instance variable @edge_class not initialized
/Users/gjtorikian/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/graphql-1.6.7/lib/graphql/field.rb:194: warning: instance variable @edge_class not initialized
/Users/gjtorikian/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/graphql-1.6.7/lib/graphql/field.rb:194: warning: instance variable @edge_class not initialized
/Users/gjtorikian/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/graphql-1.6.7/lib/graphql/field.rb:194: warning: instance variable @edge_class not initialized
/Users/gjtorikian/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/graphql-1.6.7/lib/graphql/field.rb:194: warning: instance variable @edge_class not initialized
/Users/gjtorikian/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/graphql-1.6.7/lib/graphql/field.rb:194: warning: instance variable @edge_class not initialized
/Users/gjtorikian/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/graphql-1.6.7/lib/graphql/field.rb:194: warning: instance variable @edge_class not initialized
/Users/gjtorikian/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/graphql-1.6.7/lib/graphql/field.rb:194: warning: instance variable @edge_class not initialized
```

This PR just sets `edge_class` to `nil` by default. 