### PR TITLE
Existing argument def

### DIFF
--- a/lib/graphql/argument.rb
+++ b/lib/graphql/argument.rb
@@ -96,7 +96,11 @@ module GraphQL
 
     NO_DEFAULT_VALUE = Object.new
     # @api private
-    def self.from_dsl(name, type = nil, description = nil, default_value: NO_DEFAULT_VALUE, as: nil, prepare: DefaultPrepare, **kwargs, &block)
+    def self.from_dsl(name, type_or_argument = nil, description = nil, default_value: NO_DEFAULT_VALUE, as: nil, prepare: DefaultPrepare, **kwargs, &block)
+      if type_or_argument.is_a?(GraphQL::Argument)
+        return type_or_argument.redefine(name: name.to_s)
+      end
+
       argument = if block_given?
         GraphQL::Argument.define(&block)
       else
@@ -104,7 +108,7 @@ module GraphQL
       end
 
       argument.name = name.to_s
-      type && argument.type = type
+      type_or_argument && argument.type = type_or_argument
       description && argument.description = description
       if default_value != NO_DEFAULT_VALUE
         argument.default_value = default_value

--- a/spec/graphql/argument_spec.rb
+++ b/spec/graphql/argument_spec.rb
@@ -19,6 +19,34 @@ describe GraphQL::Argument do
     assert_includes err.message, expected_error
   end
 
+  describe ".from_dsl" do
+    it "accepts an existing argument" do
+      existing = GraphQL::Argument.define do
+        name "bar"
+        type GraphQL::STRING_TYPE
+      end
+
+      arg = GraphQL::Argument.from_dsl(:foo, existing)
+
+      assert_equal "foo", arg.name
+      assert_equal GraphQL::STRING_TYPE, arg.type
+    end
+
+    it "creates an argument from dsl arguments" do
+      arg = GraphQL::Argument.from_dsl(
+        :foo,
+        GraphQL::STRING_TYPE,
+        "A Description",
+        default_value: "Bar"
+      )
+
+      assert_equal "foo", arg.name
+      assert_equal GraphQL::STRING_TYPE, arg.type
+      assert_equal "A Description", arg.description
+      assert_equal "Bar", arg.default_value
+    end
+  end
+
   it "accepts custom keywords" do
     type = GraphQL::ObjectType.define do
       name "Something"

--- a/spec/graphql/define/assign_argument_spec.rb
+++ b/spec/graphql/define/assign_argument_spec.rb
@@ -37,6 +37,18 @@ describe GraphQL::Define::AssignArgument do
     assert_equal "GraphQL::Argument can't define 'blah'", err.message
   end
 
+  it "accepts an existing argument" do
+    existing = GraphQL::Argument.define do
+      name "bar"
+      type GraphQL::STRING_TYPE
+    end
+
+    arg = define_argument(:foo, existing)
+
+    assert_equal "foo", arg.name
+    assert_equal GraphQL::STRING_TYPE, arg.type
+  end
+
   def define_argument(*args)
     type = GraphQL::ObjectType.define do
       field :a, types.String do


### PR DESCRIPTION
https://github.com/rmosolgo/graphql-ruby/issues/933

Allows defining an argument from an existing argument a bit like it's already possible with fields.