### PR TITLE
Update arguments.md

### DIFF
--- a/guides/fields/arguments.md
+++ b/guides/fields/arguments.md
@@ -36,7 +36,7 @@ argument :category, !types.String
 Use `default_value: value` to provide a default value for the argument if not supplied in the query.
 
 ```ruby
-argument :category, !types.String, default_value: "Programming"
+argument :category, types.String, default_value: "Programming"
 ```
 
 Use `as: :alternateName` to use a different key from within your resolvers while


### PR DESCRIPTION
Fix smalltypo in docs

current would throw: 
GraphQL::Schema::InvalidTypeError (Query is invalid: field "foo" argument "category" Variable id of type "String!" is required and will not use the default value. Perhaps you meant to use type "String".)