### PR TITLE
Raise when both query string and document are provided to Query

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -78,6 +78,10 @@ module GraphQL
       @query_string = query_string || query
       @document = document
 
+      if @query_string && @document
+        raise ArgumentError, "Query should only be provided a query string or a document, not both."
+      end
+
       # A two-layer cache of type resolution:
       # { abstract_type => { value => resolved_type } }
       @resolved_types_cache = Hash.new do |h1, k1|

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -45,11 +45,21 @@ describe GraphQL::Query do
   let(:result) { query.result }
 
   describe "when passed both a query string and a document" do
-    it "returns an error to the client" do
+    it "returns an error to the client when query kwarg is used" do
       assert_raises ArgumentError do
         GraphQL::Query.new(
           schema,
           query: "{ fromSource(source: COW) { id } }",
+          document: document
+        )
+      end
+    end
+
+    it "returns an error to the client" do
+      assert_raises ArgumentError do
+        GraphQL::Query.new(
+          schema,
+          "{ fromSource(source: COW) { id } }",
           document: document
         )
       end

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -44,6 +44,18 @@ describe GraphQL::Query do
   )}
   let(:result) { query.result }
 
+  describe "when passed both a query string and a document" do
+    it "returns an error to the client" do
+      assert_raises ArgumentError do
+        GraphQL::Query.new(
+          schema,
+          query: "{ fromSource(source: COW) { id } }",
+          document: document
+        )
+      end
+    end
+  end
+
   describe "when passed no query string or document" do
     it 'returns an error to the client' do
       res = GraphQL::Query.new(


### PR DESCRIPTION
As reported in https://github.com/rmosolgo/graphql-ruby/issues/956

This PR does the quick fix to avoid the inconsistency in `GraphQL::Query` at runtime to avoid breaking changes.