### PR TITLE
Fix #961 Expose typename in persisted query sync

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.snap linguist-generated
+*.lock linguist-generated

--- a/guides/javascript_client/sync.md
+++ b/guides/javascript_client/sync.md
@@ -41,6 +41,7 @@ option | description
 `--client` | Client ID ({% internal_link "created on server", "/operation_store/client_workflow" %})
 `--secret` | Client Secret ({% internal_link "created on server", "/operation_store/client_workflow" %})
 `--outfile` | Destination for generated JS code
+`--add-typename` | Add `__typename` to all selection sets (for use with Apollo Client)
 
 You can see these and a few others with `graphql-ruby-client sync --help`.
 

--- a/javascript_client/__tests__/__snapshots__/syncTest.js.snap
+++ b/javascript_client/__tests__/__snapshots__/syncTest.js.snap
@@ -1,0 +1,289 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`sync operations Input files Merges fragments and operations across files 1`] = `
+Array [
+  Object {
+    "alias": "5f0da489cf508a7c65ff5fa144e50545",
+    "body": "fragment Frag1 on Query {
+  moreStuff
+}
+
+query GetStuff {
+  ...Frag1
+}
+",
+    "name": "GetStuff",
+  },
+  Object {
+    "alias": "c944b08d15eb94cf93dd124b7d664b62",
+    "body": "fragment Frag1 on Query {
+  moreStuff
+}
+
+fragment Frag2 on Query {
+  ...Frag3
+}
+
+fragment Frag3 on Query {
+  evenMoreStuff
+}
+
+query GetStuff2 {
+  stuff
+  ...Frag1
+  ...Frag2
+}
+",
+    "name": "GetStuff2",
+  },
+  Object {
+    "alias": "fc215a466a3ea309fe493e8f7cb206f2",
+    "body": "fragment Frag2 on Query {
+  ...Frag3
+}
+
+fragment Frag3 on Query {
+  evenMoreStuff
+}
+
+fragment Frag4 on Query {
+  evenMoreStuff {
+    stuffInside
+  }
+}
+
+query GetStuff3 {
+  stuff {
+    withStuffInside
+  }
+  ...Frag2
+  ...Frag4
+}
+",
+    "name": "GetStuff3",
+  },
+]
+`;
+
+exports[`sync operations Input files Uses mode: file to process each file separately 1`] = `
+Array [
+  Object {
+    "alias": "26c44bfe42872860da112b6177355bfa",
+    "body": "fragment Frag1 on Query {
+  moreStuff
+}
+",
+    "name": null,
+  },
+  Object {
+    "alias": "7de9e7bf1d6ea1f527de07a25983086c",
+    "body": "fragment Frag2 on Query {
+  ...Frag3
+}
+",
+    "name": null,
+  },
+  Object {
+    "alias": "8bc9b9922a7fbb66f4ac6c58d5d5c357",
+    "body": "fragment Frag3 on Query {
+  evenMoreStuff
+}
+",
+    "name": null,
+  },
+  Object {
+    "alias": "bfc521a5ade5ff6f17bdf9352c86c850",
+    "body": "fragment Frag4 on Query {
+  evenMoreStuff {
+    stuffInside
+  }
+}
+",
+    "name": null,
+  },
+  Object {
+    "alias": "0a6add7303775e2487f2c2235ecb1c80",
+    "body": "query GetStuff {
+  ...Frag1
+}
+",
+    "name": "GetStuff",
+  },
+  Object {
+    "alias": "2f26b770ded2a04279bc4bf824ca54ac",
+    "body": "query GetStuff2 {
+  stuff
+  ...Frag1
+  ...Frag2
+}
+",
+    "name": "GetStuff2",
+  },
+  Object {
+    "alias": "1b8da77aabef67ee54df7e5acfd75893",
+    "body": "query GetStuff3 {
+  stuff {
+    withStuffInside
+  }
+  ...Frag2
+  ...Frag4
+}
+",
+    "name": "GetStuff3",
+  },
+]
+`;
+
+exports[`sync operations Logging Can be quieted with quiet: true 1`] = `Array []`;
+
+exports[`sync operations Logging Logs progress 1`] = `
+Array [
+  Array [
+    "Syncing 3 operations to [1mbogus[0m...",
+  ],
+  Array [
+    "Generating client module in [1mOperationStoreClient.js[0m...",
+  ],
+  Array [
+    "[32m✓ Done![0m",
+  ],
+]
+`;
+
+exports[`sync operations Printing the result prints failure 1`] = `
+Array [
+  Array [
+    "Syncing 3 operations to [1mhttp://example.com/stored_operations/sync[0m...",
+  ],
+  Array [
+    "  [2m0 added[0m",
+  ],
+  Array [
+    "  [2m0 not modified[0m",
+  ],
+  Array [
+    "  [31m1 failed[0m",
+  ],
+]
+`;
+
+exports[`sync operations Printing the result prints failure 2`] = `
+Array [
+  Array [
+    "Sync failed, errors:",
+  ],
+  Array [
+    "  GetStuff:",
+  ],
+  Array [
+    "    [31m✘[0m something",
+  ],
+]
+`;
+
+exports[`sync operations Printing the result prints success 1`] = `
+Array [
+  Array [
+    "Syncing 3 operations to [1mhttp://example.com/stored_operations/sync[0m...",
+  ],
+]
+`;
+
+exports[`sync operations Printing the result prints success 2`] = `
+Array [
+  Array [
+    "  [32m1 added[0m",
+  ],
+  Array [
+    "  [0m2 not modified[0m",
+  ],
+  Array [
+    "  [2m0 failed[0m",
+  ],
+  Array [
+    "Generating client module in [1mOperationStoreClient.js[0m...",
+  ],
+  Array [
+    "[32m✓ Done![0m",
+  ],
+]
+`;
+
+exports[`sync operations Printing the result prints success 3`] = `Array []`;
+
+exports[`sync operations Relay support Uses Relay output 1`] = `
+Array [
+  Object {
+    "alias": "353e010cb78d082b29cb63ee7e9027b3",
+    "body": "query AppFeedQuery {
+  feed(type: NEW, limit: 5) {
+    ...Feed
+  }
+}
+
+fragment Feed on Entry {
+  repository {
+    owner {
+      login
+    }
+    name
+  }
+  ...FeedEntry
+}
+
+fragment FeedEntry on Entry {
+  repository {
+    owner {
+      login
+    }
+    name
+    stargazers_count
+  }
+  postedBy {
+    login
+  }
+}
+",
+    "name": "AppFeedQuery",
+  },
+]
+`;
+
+exports[`sync operations custom file processing options Adds .graphql to the glob if needed 1`] = `
+Array [
+  Object {
+    "alias": "f7f65309043352183e905e1396e51078",
+    "body": "query GetStuff {
+  stuff
+}
+",
+    "name": "GetStuff",
+  },
+]
+`;
+
+exports[`sync operations custom file processing options Adds .graphql to the glob if needed 2`] = `
+Array [
+  Object {
+    "alias": "f7f65309043352183e905e1396e51078",
+    "body": "query GetStuff {
+  stuff
+}
+",
+    "name": "GetStuff",
+  },
+]
+`;
+
+exports[`sync operations custom file processing options Uses a custom hash function if provided 1`] = `
+Array [
+  Object {
+    "alias": "GETSTUFF",
+    "body": "query GetStuff {
+  stuff
+}
+",
+    "name": "GetStuff",
+  },
+]
+`;

--- a/javascript_client/__tests__/__snapshots__/syncTest.js.snap
+++ b/javascript_client/__tests__/__snapshots__/syncTest.js.snap
@@ -62,6 +62,33 @@ query GetStuff3 {
 ",
     "name": "GetStuff3",
   },
+  Object {
+    "alias": "919af8f80d8848a9b9b6176e457f8e45",
+    "body": "query GetStuffIsolated {
+  ...FragIsolated
+  things {
+    existHere
+  }
+}
+
+fragment FragIsolated on Query {
+  evenMoreStuff {
+    stuffInside
+  }
+}
+",
+    "name": "GetStuffIsolated",
+  },
+  Object {
+    "alias": "d5dfe825034aeda06e2639935d8b107d",
+    "body": "query GetStuffIsolated2 {
+  things {
+    existHere
+  }
+}
+",
+    "name": "GetStuffIsolated2",
+  },
 ]
 `;
 
@@ -131,6 +158,33 @@ Array [
 ",
     "name": "GetStuff3",
   },
+  Object {
+    "alias": "919af8f80d8848a9b9b6176e457f8e45",
+    "body": "query GetStuffIsolated {
+  ...FragIsolated
+  things {
+    existHere
+  }
+}
+
+fragment FragIsolated on Query {
+  evenMoreStuff {
+    stuffInside
+  }
+}
+",
+    "name": "GetStuffIsolated",
+  },
+  Object {
+    "alias": "d5dfe825034aeda06e2639935d8b107d",
+    "body": "query GetStuffIsolated2 {
+  things {
+    existHere
+  }
+}
+",
+    "name": "GetStuffIsolated2",
+  },
 ]
 `;
 
@@ -139,7 +193,7 @@ exports[`sync operations Logging Can be quieted with quiet: true 1`] = `Array []
 exports[`sync operations Logging Logs progress 1`] = `
 Array [
   Array [
-    "Syncing 3 operations to [1mbogus[0m...",
+    "Syncing 5 operations to [1mbogus[0m...",
   ],
   Array [
     "Generating client module in [1mOperationStoreClient.js[0m...",
@@ -153,7 +207,7 @@ Array [
 exports[`sync operations Printing the result prints failure 1`] = `
 Array [
   Array [
-    "Syncing 3 operations to [1mhttp://example.com/stored_operations/sync[0m...",
+    "Syncing 5 operations to [1mhttp://example.com/stored_operations/sync[0m...",
   ],
   Array [
     "  [2m0 added[0m",
@@ -184,7 +238,7 @@ Array [
 exports[`sync operations Printing the result prints success 1`] = `
 Array [
   Array [
-    "Syncing 3 operations to [1mhttp://example.com/stored_operations/sync[0m...",
+    "Syncing 5 operations to [1mhttp://example.com/stored_operations/sync[0m...",
   ],
 ]
 `;

--- a/javascript_client/__tests__/project/frag_4.graphql
+++ b/javascript_client/__tests__/project/frag_4.graphql
@@ -1,0 +1,5 @@
+fragment Frag4 on Query {
+  evenMoreStuff {
+    stuffInside
+  }
+}

--- a/javascript_client/__tests__/project/op_3.graphql
+++ b/javascript_client/__tests__/project/op_3.graphql
@@ -1,0 +1,7 @@
+query GetStuff3 {
+  stuff {
+    withStuffInside
+  }
+  ...Frag2
+  ...Frag4
+}

--- a/javascript_client/__tests__/project/op_isolated_1.graphql
+++ b/javascript_client/__tests__/project/op_isolated_1.graphql
@@ -1,0 +1,12 @@
+query GetStuffIsolated {
+  ...FragIsolated
+  things {
+    existHere
+  }
+}
+
+fragment FragIsolated on Query {
+  evenMoreStuff {
+    stuffInside
+  }
+}

--- a/javascript_client/__tests__/project/op_isolated_2.graphql
+++ b/javascript_client/__tests__/project/op_isolated_2.graphql
@@ -1,0 +1,6 @@
+query GetStuffIsolated2 {
+  things {
+    existHere
+  }
+}
+

--- a/javascript_client/__tests__/syncTest.js
+++ b/javascript_client/__tests__/syncTest.js
@@ -44,21 +44,13 @@ describe("sync operations", () => {
       }
       sync(options)
 
-      // Digest::MD5.hexdigest("query GetStuff {\n  stuff\n}\n")
-      // => "f7f65309043352183e905e1396e51078"
-      var expectedOperations = [
-        {
-          alias: "f7f65309043352183e905e1396e51078",
-          name: "GetStuff",
-          body: "query GetStuff {\n  stuff\n}\n",
-        }
-      ]
-      expect(payload.operations).toEqual(expectedOperations)
+      expect(payload.operations).toMatchSnapshot()
 
       options.glob += "**/*.graphql"
       sync(options)
+
       // Get the same result, even when the glob already has a file extension
-      expect(payload.operations).toEqual(expectedOperations)
+      expect(payload.operations).toMatchSnapshot()
     })
 
     it("Uses a custom hash function if provided", () => {
@@ -76,15 +68,7 @@ describe("sync operations", () => {
       }
       sync(options)
 
-      expectedOperations = [
-        {
-          "body": "query GetStuff {\n  stuff\n}\n",
-          "alias": "GETSTUFF",
-          "name": "GetStuff",
-        },
-      ]
-
-      expect(payload.operations).toEqual(expectedOperations)
+      expect(payload.operations).toMatchSnapshot()
     })
   })
 
@@ -100,15 +84,7 @@ describe("sync operations", () => {
       }
       sync(options)
 
-      expectedOperations = [
-        {
-          "body": "query AppFeedQuery {\n  feed(type: NEW, limit: 5) {\n    ...Feed\n  }\n}\n\nfragment Feed on Entry {\n  repository {\n    owner {\n      login\n    }\n    name\n  }\n  ...FeedEntry\n}\n\nfragment FeedEntry on Entry {\n  repository {\n    owner {\n      login\n    }\n    name\n    stargazers_count\n  }\n  postedBy {\n    login\n  }\n}\n",
-          "name": "AppFeedQuery",
-          "alias": "353e010cb78d082b29cb63ee7e9027b3",
-        },
-      ]
-
-      expect(payload.operations).toEqual(expectedOperations)
+      expect(payload.operations).toMatchSnapshot()
     })
   })
 
@@ -125,15 +101,7 @@ describe("sync operations", () => {
       }
       sync(options)
 
-      expectedAliases = [
-        "5f0da489cf508a7c65ff5fa144e50545",
-        "c944b08d15eb94cf93dd124b7d664b62",
-      ]
-
-      expectedNames = ["GetStuff", "GetStuff2"]
-
-      expect(payload.operations.map((op) => op.name)).toEqual(expectedNames)
-      expect(payload.operations.map((op) => op.alias)).toEqual(expectedAliases)
+      expect(payload.operations).toMatchSnapshot()
     })
 
     it("Uses mode: file to process each file separately", () => {
@@ -148,19 +116,7 @@ describe("sync operations", () => {
       }
       sync(options)
 
-      // One alias per file, different than above
-      expectedAliases = [
-        "26c44bfe42872860da112b6177355bfa",
-        "7de9e7bf1d6ea1f527de07a25983086c",
-        "8bc9b9922a7fbb66f4ac6c58d5d5c357",
-        "0a6add7303775e2487f2c2235ecb1c80",
-        "2f26b770ded2a04279bc4bf824ca54ac",
-      ]
-
-      expectedNames = [null, null, null, "GetStuff", "GetStuff2"]
-
-      expect(payload.operations.map((op) => op.name)).toEqual(expectedNames)
-      expect(payload.operations.map((op) => op.alias)).toEqual(expectedAliases)
+      expect(payload.operations).toMatchSnapshot()
     })
   })
 
@@ -213,13 +169,7 @@ describe("sync operations", () => {
       }
       sync(options)
 
-      var expectedCalls = [
-        ["Syncing 2 operations to " + logger.bright("bogus") + "..."],
-        ["Generating client module in " + logger.bright("OperationStoreClient.js") + "..."],
-        [logger.green("✓ Done!")],
-      ]
-
-      expect(spy.mock.calls).toEqual(expectedCalls)
+      expect(spy.mock.calls).toMatchSnapshot()
     })
 
     it("Can be quieted with quiet: true", () => {
@@ -234,8 +184,7 @@ describe("sync operations", () => {
       }
       sync(options)
 
-      var expectedCalls = []
-      expect(spy.mock.calls).toEqual(expectedCalls)
+      expect(spy.mock.calls).toMatchSnapshot()
     })
   })
 
@@ -265,21 +214,8 @@ describe("sync operations", () => {
       var syncPromise = sync(options)
 
       return syncPromise.then(() => {
-
-        var expectedLogCalls = [
-          ["Syncing 2 operations to " + logger.bright("http://example.com/stored_operations/sync") + "..."],
-          ["  " + logger.dim("0 added")],
-          ["  " + logger.dim("0 not modified")],
-          ["  " + logger.red("1 failed")]
-        ]
-
-        var expectedErrorCalls = [
-          ["Sync failed, errors:"],
-          ["  GetStuff:"],
-          ["    " + logger.red("✘") + " something"],
-        ]
-        expect(spyConsoleLog.mock.calls).toEqual(expectedLogCalls)
-        expect(spyConsoleError.mock.calls).toEqual(expectedErrorCalls)
+        expect(spyConsoleLog.mock.calls).toMatchSnapshot()
+        expect(spyConsoleError.mock.calls).toMatchSnapshot()
         jest.clearAllMocks();
       })
     })
@@ -304,23 +240,12 @@ describe("sync operations", () => {
 
       var syncPromise = sync(options)
 
-      var expectedLogCalls = [
-        ["Syncing 2 operations to " + logger.bright("http://example.com/stored_operations/sync") + "..."],
-      ]
-      expect(spyConsoleLog.mock.calls).toEqual(expectedLogCalls)
+      expect(spyConsoleLog.mock.calls).toMatchSnapshot()
       jest.clearAllMocks();
 
       return syncPromise.then(() => {
-        var expectedLogCalls = [
-          ["  " + logger.green("1 added")],
-          ["  " + logger.reset("2 not modified")],
-          ["  " + logger.dim("0 failed")],
-          ["Generating client module in " + logger.bright("OperationStoreClient.js") + "..."],
-          [logger.green("✓ Done!")],
-        ]
-        var expectedErrorCalls = []
-        expect(spyConsoleLog.mock.calls).toEqual(expectedLogCalls)
-        expect(spyConsoleError.mock.calls).toEqual(expectedErrorCalls)
+        expect(spyConsoleLog.mock.calls).toMatchSnapshot()
+        expect(spyConsoleError.mock.calls).toMatchSnapshot()
         jest.clearAllMocks();
       })
     })

--- a/javascript_client/cli.js
+++ b/javascript_client/cli.js
@@ -10,7 +10,7 @@ if (argv.help || argv.h) {
 
 required arguments:
   --url=<endpoint-url>    URL where data should be POSTed
-  --client=<client-name>  Idetifier for this client application
+  --client=<client-name>  Identifier for this client application
 
 optional arguments:
   --path=<path>                   Path to .graphql files (default is "./**/*.graphql")

--- a/javascript_client/cli.js
+++ b/javascript_client/cli.js
@@ -24,6 +24,7 @@ optional arguments:
                                   By default, this flag is set to:
                                     - "relay" if "__generated__" in the path
                                     - otherwise, "project"
+  --add-typename                  Automatically adds the "__typename" field to your queries
   --quiet                         Suppress status logging
   --help                          Print this message
 `)
@@ -41,6 +42,7 @@ optional arguments:
       outfile: argv.outfile,
       secret: argv.secret,
       mode: argv.mode,
+      addTypename: argv["add-typename"],
       quiet: argv.hasOwnProperty("quiet"),
     })
 

--- a/javascript_client/sync/__tests__/__snapshots__/prepareIsolatedFilesTest.js.snap
+++ b/javascript_client/sync/__tests__/__snapshots__/prepareIsolatedFilesTest.js.snap
@@ -1,0 +1,68 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`builds out single operations 1`] = `
+Array [
+  Object {
+    "alias": null,
+    "body": "query GetStuffIsolated {
+  ...FragIsolated
+  things {
+    existHere
+  }
+}
+
+fragment FragIsolated on Query {
+  evenMoreStuff {
+    stuffInside
+  }
+}
+",
+    "name": "GetStuffIsolated",
+  },
+  Object {
+    "alias": null,
+    "body": "query GetStuffIsolated2 {
+  things {
+    existHere
+  }
+}
+",
+    "name": "GetStuffIsolated2",
+  },
+]
+`;
+
+exports[`with --add-typename builds out single operations with __typename fields 1`] = `
+Array [
+  Object {
+    "alias": null,
+    "body": "query GetStuffIsolated {
+  ...FragIsolated
+  things {
+    existHere
+    __typename
+  }
+}
+
+fragment FragIsolated on Query {
+  evenMoreStuff {
+    stuffInside
+    __typename
+  }
+}
+",
+    "name": "GetStuffIsolated",
+  },
+  Object {
+    "alias": null,
+    "body": "query GetStuffIsolated2 {
+  things {
+    existHere
+    __typename
+  }
+}
+",
+    "name": "GetStuffIsolated2",
+  },
+]
+`;

--- a/javascript_client/sync/__tests__/__snapshots__/prepareProjectTest.js.snap
+++ b/javascript_client/sync/__tests__/__snapshots__/prepareProjectTest.js.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`merging a project builds out separate operations 1`] = `
+Array [
+  Object {
+    "alias": null,
+    "body": "query GetStuff2 {
+  stuff
+  ...Frag1
+  ...Frag2
+}
+
+fragment Frag1 on Query {
+  moreStuff
+}
+
+fragment Frag2 on Query {
+  ...Frag3
+}
+
+fragment Frag3 on Query {
+  evenMoreStuff
+}
+",
+    "name": "GetStuff2",
+  },
+  Object {
+    "alias": null,
+    "body": "query GetStuff {
+  ...Frag1
+}
+
+fragment Frag1 on Query {
+  moreStuff
+}
+",
+    "name": "GetStuff",
+  },
+]
+`;

--- a/javascript_client/sync/__tests__/__snapshots__/prepareProjectTest.js.snap
+++ b/javascript_client/sync/__tests__/__snapshots__/prepareProjectTest.js.snap
@@ -38,3 +38,36 @@ fragment Frag1 on Query {
   },
 ]
 `;
+
+exports[`merging a project with --add-typename builds out operation with __typename fields 1`] = `
+Array [
+  Object {
+    "alias": null,
+    "body": "query GetStuff3 {
+  stuff {
+    withStuffInside
+    __typename
+  }
+  ...Frag2
+  ...Frag4
+}
+
+fragment Frag2 on Query {
+  ...Frag3
+}
+
+fragment Frag3 on Query {
+  evenMoreStuff
+}
+
+fragment Frag4 on Query {
+  evenMoreStuff {
+    stuffInside
+    __typename
+  }
+}
+",
+    "name": "GetStuff3",
+  },
+]
+`;

--- a/javascript_client/sync/__tests__/prepareIsolatedFilesTest.js
+++ b/javascript_client/sync/__tests__/prepareIsolatedFilesTest.js
@@ -1,0 +1,21 @@
+var prepareIsolatedFiles = require("../prepareIsolatedFiles")
+
+it("builds out single operations", () => {
+  var filenames = [
+    "./__tests__/project/op_isolated_1.graphql",
+    "./__tests__/project/op_isolated_2.graphql",
+  ]
+  var ops = prepareIsolatedFiles(filenames, false)
+  expect(ops).toMatchSnapshot()
+})
+
+describe("with --add-typename", () => {
+  it("builds out single operations with __typename fields", () => {
+    var filenames = [
+      "./__tests__/project/op_isolated_1.graphql",
+      "./__tests__/project/op_isolated_2.graphql",
+    ]
+    var ops = prepareIsolatedFiles(filenames, true)
+    expect(ops).toMatchSnapshot()
+  })
+})

--- a/javascript_client/sync/__tests__/prepareProjectTest.js
+++ b/javascript_client/sync/__tests__/prepareProjectTest.js
@@ -13,6 +13,19 @@ describe("merging a project", () => {
     expect(ops).toMatchSnapshot()
   })
 
+  describe("with --add-typename", () => {
+    it("builds out operation with __typename fields", () => {
+      var filenames = [
+        "./__tests__/project/op_3.graphql",
+        "./__tests__/project/frag_2.graphql",
+        "./__tests__/project/frag_3.graphql",
+        "./__tests__/project/frag_4.graphql",
+      ]
+      var ops = prepareProject(filenames, true)
+      expect(ops).toMatchSnapshot()
+    })
+  })
+
   it("blows up on duplicate names", () => {
     var filenames = [
       "./__tests__/documents/doc1.graphql",

--- a/javascript_client/sync/__tests__/prepareProjectTest.js
+++ b/javascript_client/sync/__tests__/prepareProjectTest.js
@@ -9,21 +9,8 @@ describe("merging a project", () => {
       "./__tests__/project/frag_2.graphql",
       "./__tests__/project/frag_3.graphql",
     ]
-    var ops = prepareProject(filenames)
-
-    var expectedOps = [
-      {
-        body: 'query GetStuff2 {\n  stuff\n  ...Frag1\n  ...Frag2\n}\n\nfragment Frag1 on Query {\n  moreStuff\n}\n\nfragment Frag2 on Query {\n  ...Frag3\n}\n\nfragment Frag3 on Query {\n  evenMoreStuff\n}\n',
-        name: 'GetStuff2',
-        alias: null,
-      },
-      {
-        body: 'query GetStuff {\n  ...Frag1\n}\n\nfragment Frag1 on Query {\n  moreStuff\n}\n',
-        name: 'GetStuff',
-        alias: null,
-      }
-    ]
-    expect(ops).toEqual(expectedOps)
+    var ops = prepareProject(filenames, false)
+    expect(ops).toMatchSnapshot()
   })
 
   it("blows up on duplicate names", () => {

--- a/javascript_client/sync/addTypenameToSelectionSet.js
+++ b/javascript_client/sync/addTypenameToSelectionSet.js
@@ -1,0 +1,40 @@
+// This file/concept was borrowed from https://github.com/apollographql/apollo-client/blob/fec6457746b1cb63c759f128349e66499328ae43/src/queries/queryTransform.ts#L22-L56
+
+const TYPENAME_FIELD = {
+  kind: "Field",
+  name: {
+    kind: "Name",
+    value: "__typename",
+  },
+}
+
+function addTypenameToSelectionSet(selectionSet, isRoot) {
+  if (selectionSet.selections) {
+    if (!isRoot) {
+      const alreadyHasThisField = selectionSet.selections.some(function(selection) {
+        return (
+          selection.kind === "Field" && selection.name.value === "__typename"
+        )
+      })
+
+      if (!alreadyHasThisField) {
+        selectionSet.selections.push(TYPENAME_FIELD);
+      }
+    }
+
+    selectionSet.selections.forEach(function(selection) {
+      // Must not add __typename if we're inside an introspection query
+      if (selection.kind === "Field") {
+        if (selection.name.value.lastIndexOf("__", 0) !== 0 && selection.selectionSet) {
+          addTypenameToSelectionSet(selection.selectionSet, false);
+        }
+      } else if (selection.kind === "InlineFragment") {
+        if (selection.selectionSet) {
+          addTypenameToSelectionSet(selection.selectionSet, false);
+        }
+      }
+    })
+  }
+}
+
+module.exports = addTypenameToSelectionSet

--- a/javascript_client/sync/index.js
+++ b/javascript_client/sync/index.js
@@ -19,6 +19,7 @@ var fs = require("fs")
  * @param {String} options.secret - HMAC-SHA256 key which must match the server secret (default is no encryption)
  * @param {String} options.url - Target URL for sending prepared queries
  * @param {String} options.mode - If `"file"`, treat each file separately. If `"project"`, concatenate all files and extract each operation. If `"relay"`, treat it as relay-compiler output
+ * @param {Boolean} options.addTypename - Indicates if the "__typename" field are automatically added to your queries
  * @param {String} options.outfile - Where the generated code should be written
  * @param {String} options.client - the Client ID that these operations belong to
  * @param {Function} options.send - A function for sending the payload to the server, with the signature `options.send(payload)`. (Default is an HTTP `POST` request)
@@ -54,8 +55,6 @@ function sync(options) {
   }
 
   var clientName = options.client
-
-
   if (!clientName) {
     throw new Error("Client name must be provided for sync")
   }
@@ -78,7 +77,7 @@ function sync(options) {
     if (filesMode === "file") {
       payload.operations = prepareIsolatedFiles(filenames)
     } else if (filesMode === "project") {
-      payload.operations = prepareProject(filenames)
+      payload.operations = prepareProject(filenames, options.addTypename)
     } else {
       throw new Error("Unexpected mode: " + filesMode)
     }

--- a/javascript_client/sync/index.js
+++ b/javascript_client/sync/index.js
@@ -75,7 +75,7 @@ function sync(options) {
     payload.operations = prepareRelay(filenames)
   } else {
     if (filesMode === "file") {
-      payload.operations = prepareIsolatedFiles(filenames)
+      payload.operations = prepareIsolatedFiles(filenames, options.addTypename)
     } else if (filesMode === "project") {
       payload.operations = prepareProject(filenames, options.addTypename)
     } else {


### PR DESCRIPTION
This should fix #961, by adding a new `--add-typename` option on the `graphql-ruby-client` CLI.

We're taking advantage of the work that [apollo-client](https://github.com/apollographql/apollo-client/blob/fec6457746b1cb63c759f128349e66499328ae43/src/queries/queryTransform.ts#L22-L56) has for adding the typenames to a GraphQL AST.

I've added this approach to both the project and isolated approaches.

I've refactored the isolated approach to take advantage of the visitor approach with `graphql`.

I've added and refactored tests in `graphql-ruby-client` to take advantage of [jest's snapshot testing](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

-----

Side note, I haven't actually done a _full end-to-end_ test on my application yet as I was waiting for #959 (which has since been fixed).

Let me know if there is anything you want me to change, or expand on. 