### PR TITLE
fix(Relay::Connection) properly skip connections when ctx.skip

### DIFF
--- a/lib/graphql/compatibility/execution_specification.rb
+++ b/lib/graphql/compatibility/execution_specification.rb
@@ -418,6 +418,16 @@ module GraphQL
             assert_equal false, res.key?("errors")
             assert_equal [SpecificationSchema::BOGUS_NODE, SpecificationSchema::BOGUS_NODE], log
           end
+
+          def test_it_skips_connections
+            query_type = GraphQL::ObjectType.define do
+              name "Query"
+              connection :skipped, types[query_type], resolve: ->(o,a,c) { c.skip }
+            end
+            schema = GraphQL::Schema.define(query: query_type)
+            res = schema.execute("{ skipped { __typename } }")
+            assert_equal({"data" => nil}, res)
+          end
         end
       end
     end

--- a/lib/graphql/relay/connection_resolve.rb
+++ b/lib/graphql/relay/connection_resolve.rb
@@ -27,6 +27,8 @@ module GraphQL
           else
             nodes
           end
+        elsif nodes.is_a?(GraphQL::Execution::Execute::Skip)
+          nodes
         else
           build_connection(nodes, args, parent, ctx)
         end


### PR DESCRIPTION
oops, this is used in implementing GitHub's `rateLimit(dryRun: true)`, but we discovered this bug.