### PR TITLE
Backtrace improvements

### DIFF
--- a/lib/graphql/backtrace/inspect_result.rb
+++ b/lib/graphql/backtrace/inspect_result.rb
@@ -43,7 +43,7 @@ module GraphQL
         when GraphQL::Execution::Lazy
           "(unresolved)"
         else
-          obj.inspect
+          "#{obj.inspect}"
         end
       end
     end

--- a/lib/graphql/backtrace/table.rb
+++ b/lib/graphql/backtrace/table.rb
@@ -87,7 +87,7 @@ module GraphQL
           rows << [
             "#{position}",
             "#{field_name}#{field_alias ? " as #{field_alias}" : ""}",
-            ctx.object.inspect,
+            "#{ctx.object.inspect}",
             ctx.irep_node.arguments.to_h.inspect,
             Backtrace::InspectResult.inspect(top && @override_value ? @override_value : ctx.value),
           ]
@@ -107,7 +107,7 @@ module GraphQL
           rows << [
             "#{position}",
             "#{op_type}#{op_name ? " #{op_name}" : ""}",
-            query.root_value.inspect,
+            "#{query.root_value.inspect}",
             query.variables.to_h.inspect,
             Backtrace::InspectResult.inspect(query.context.value),
           ]

--- a/lib/graphql/relay/base_connection.rb
+++ b/lib/graphql/relay/base_connection.rb
@@ -140,6 +140,10 @@ module GraphQL
         raise NotImplementedError, "must return a cursor for this object/connection pair"
       end
 
+      def inspect
+        "#<GraphQL::Relay::Connection @parent=#{@parent.inspect} @arguments=#{@arguments.to_h.inspect}>"
+      end
+
       private
 
       # Return a sanitized `arguments[arg_name]` (don't allow negatives)

--- a/lib/graphql/relay/edge.rb
+++ b/lib/graphql/relay/edge.rb
@@ -4,7 +4,7 @@ module GraphQL
     # Mostly an internal concern.
     #
     # Wraps an object as a `node`, and exposes a connection-specific `cursor`.
-    class Edge < GraphQL::ObjectType
+    class Edge
       attr_reader :node, :connection
       def initialize(node, connection)
         @node = node
@@ -17,6 +17,10 @@ module GraphQL
 
       def parent
         @parent ||= connection.parent
+      end
+
+      def inspect
+        "#<GraphQL::Relay::Edge (#{parent.inspect} => #{node.inspect})>"
       end
     end
   end

--- a/spec/graphql/backtrace_spec.rb
+++ b/spec/graphql/backtrace_spec.rb
@@ -157,14 +157,14 @@ describe GraphQL::Backtrace do
 
     it "always stringifies the #inspect response" do
       err = assert_raises(GraphQL::Backtrace::TracedError) {
-        schema.execute("query { nilInspect { raiseField(message: \"💥\") } }")
+        schema.execute("query { nilInspect { raiseField(message: \"pop!\") } }")
       }
 
       rendered_table = [
-        'Loc  | Field            | Object | Arguments        | Result',
-        '1:22 | Thing.raiseField |        | {"message"=>"💥"} | #<RuntimeError: This is broken: 💥>',
-        '1:9  | Query.nilInspect | nil    | {}               | {}',
-        '1:1  | query            | nil    | {}               | {}',
+        'Loc  | Field            | Object | Arguments           | Result',
+        '1:22 | Thing.raiseField |        | {"message"=>"pop!"} | #<RuntimeError: This is broken: pop!>',
+        '1:9  | Query.nilInspect | nil    | {}                  | {}',
+        '1:1  | query            | nil    | {}                  | {}',
       ].join("\n")
 
       assert_includes(err.message, rendered_table)

--- a/spec/graphql/relay/base_connection_spec.rb
+++ b/spec/graphql/relay/base_connection_spec.rb
@@ -49,6 +49,17 @@ describe GraphQL::Relay::BaseConnection do
     end
   end
 
+  describe "#inspect" do
+    it "inspects nicely" do
+      args = {
+        first: 1,
+        last: -1,
+      }
+      conn = GraphQL::Relay::BaseConnection.new([], args, context: context)
+      assert_equal "#<GraphQL::Relay::Connection @parent=nil @arguments={:first=>1, :last=>-1}>", conn.inspect
+    end
+  end
+
   describe "#encode / #decode" do
     module ReverseEncoder
       module_function

--- a/spec/graphql/relay/edge_spec.rb
+++ b/spec/graphql/relay/edge_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::Relay::Edge do
+  it "inspects nicely" do
+    connection = OpenStruct.new(parent: "Parent")
+    edge = GraphQL::Relay::Edge.new("Node", connection)
+    assert_equal '#<GraphQL::Relay::Edge ("Parent" => "Node")>', edge.inspect
+  end
+end


### PR DESCRIPTION
Took a serious look at hooking this up with github, found issues 😬  

Also I took a quick look at performance. First, I ran the query benchmark in this gem source: 

<p><details>
<summary>Before</summary>
<pre>
~/code/graphql-ruby $ be rake bench:query
Warming up --------------------------------------
               query     2.000  i/100ms
Calculating -------------------------------------
               query     24.588  (± 8.1%) i/s -    124.000  in   5.068650s
~/code/graphql-ruby $ be rake bench:query
Warming up --------------------------------------
               query     2.000  i/100ms
Calculating -------------------------------------
               query^[[A     25.837  (± 3.9%) i/s -    130.000  in   5.042497s
~/code/graphql-ruby $ be rake bench:query
Warming up --------------------------------------
               query     2.000  i/100ms
Calculating -------------------------------------
               query     25.613  (± 3.9%) i/s -    128.000  in   5.007024s
</pre>
</details></p>

Then added `GraphQL::Backtrace.enable` and re-ran them.

<p><details>
<summary>After</summary>
<pre>
~/code/graphql-ruby $ be rake bench:query
Warming up --------------------------------------
               query     2.000  i/100ms
Calculating -------------------------------------
               query     23.588  (± 4.2%) i/s -    118.000  in   5.015849s
~/code/graphql-ruby $ be rake bench:query
Warming up --------------------------------------
               query     2.000  i/100ms
Calculating -------------------------------------
               query     24.182  (± 8.3%) i/s -    122.000  in   5.066458s
~/code/graphql-ruby $ be rake bench:query
Warming up --------------------------------------
               query     2.000  i/100ms
Calculating -------------------------------------
               query     24.481  (± 8.2%) i/s -    122.000  in   5.002452s
~/code/graphql-ruby $ be rake bench:query
Warming up --------------------------------------
               query     2.000  i/100ms
Calculating -------------------------------------
               query     23.631  (± 4.2%) i/s -    118.000  in   5.008995s
</pre>
</details>
</p>

So, it's about  

<p><details>
<summary>5% slower</summary>
<pre>
irb(main):002:0> avg_before = (24.588 +  25.837 + 25.613) / 3
=> 25.346
irb(main):003:0> avg_after = (23.588 + 24.182 + 24.481 + 23.631) / 4
=> 23.9705
irb(main):004:0> avg_after / avg_before
=> 0.9457310818275073
</pre>
</details></p>

This overhead is not too bad; it would be nice to turn it off-and-on at query level, so if you have a buggy query someplace, you can watch that one in particular.