### PR TITLE
refactor(Query::Arguments) remove intermediary StaticArguments class

### DIFF
--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -96,7 +96,7 @@ module GraphQL
         end
       end
 
-      arguments_class.instantiate_arguments(input_values)
+      arguments_class.new(input_values)
     end
 
     # @api private

--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -1,48 +1,6 @@
 # frozen_string_literal: true
 module GraphQL
   class Query
-    class StaticArguments
-      attr_reader :argument_definitions
-
-      def initialize(argument_definitions:)
-        @argument_definitions = argument_definitions
-      end
-
-      def instantiate_arguments(values)
-        arg_class.new(values, argument_definitions: argument_definitions)
-      end
-
-      private
-
-      def arg_class
-        @arg_class ||= begin
-          klass = Class.new(GraphQL::Query::Arguments).instance_exec(self) do |static_arguments|
-            static_arguments.argument_definitions.each do |_arg_name, arg_definition|
-              expose_as = arg_definition.expose_as.to_s
-
-              # Don't define a helper method if it would override something.
-              if instance_methods.include?(expose_as)
-                warn(
-                  "Unable to define a helper for argument with name '#{expose_as}' "\
-                  "as this is a reserved name. If you're using an argument such as "\
-                  "`argument #{expose_as}`, consider renaming this argument.`"
-                )
-                next
-              end
-
-              define_method(expose_as) do
-                self[expose_as]
-              end
-            end
-
-            self
-          end
-
-          klass
-        end
-      end
-    end
-
     # Read-only access to values, normalizing all keys to strings
     #
     # {Arguments} recursively wraps the input in {Arguments} instances.
@@ -50,8 +8,32 @@ module GraphQL
       extend GraphQL::Delegate
 
       def self.construct_arguments_class(argument_owner)
-        arguments_class = GraphQL::Query::StaticArguments.new(argument_definitions: argument_owner.arguments)
-        argument_owner.arguments_class = arguments_class
+        argument_definitions = argument_owner.arguments
+        argument_owner.arguments_class = Class.new(self) do
+          self.argument_definitions = argument_definitions
+
+          def initialize(values)
+            super(values, argument_definitions: self.class.argument_definitions)
+          end
+
+          argument_definitions.each do |_arg_name, arg_definition|
+            expose_as = arg_definition.expose_as.to_s
+
+            # Don't define a helper method if it would override something.
+            if instance_methods.include?(expose_as)
+              warn(
+                "Unable to define a helper for argument with name '#{expose_as}' "\
+                "as this is a reserved name. If you're using an argument such as "\
+                "`argument #{expose_as}`, consider renaming this argument.`"
+              )
+              next
+            end
+
+            define_method(expose_as) do
+              self[expose_as]
+            end
+          end
+        end
       end
 
       def initialize(values, argument_definitions:)
@@ -105,6 +87,10 @@ module GraphQL
 
       NO_ARGS = self.new({}, argument_definitions: [])
 
+      class << self
+        attr_accessor :argument_definitions
+      end
+
       private
 
       class ArgumentValue
@@ -129,7 +115,7 @@ module GraphQL
             wrap_value(value, arg_defn_type.of_type)
           when GraphQL::InputObjectType
             if value.is_a?(Hash)
-              self.class.new(value, argument_definitions: arg_defn_type.arguments)
+              arg_defn_type.arguments_class.new(value)
             else
               value
             end

--- a/lib/graphql/query/literal_input.rb
+++ b/lib/graphql/query/literal_input.rb
@@ -105,7 +105,7 @@ module GraphQL
           end
         end
 
-        argument_owner.arguments_class.instantiate_arguments(values_hash)
+        argument_owner.arguments_class.new(values_hash)
       end
     end
   end

--- a/spec/graphql/query/arguments_spec.rb
+++ b/spec/graphql/query/arguments_spec.rb
@@ -90,13 +90,15 @@ describe GraphQL::Query::Arguments do
         argument :b, test_input_type
         argument :c, types.Int # will be a hash
       end
+      GraphQL::Query::Arguments.construct_arguments_class(test_input_type)
+      test_input_type
     }
     it "wraps input objects, but not other hashes" do
       args = GraphQL::Query::Arguments.new(
         {a: 1, b: {a: 2}, c: {a: 3}},
         argument_definitions: input_type.arguments
       )
-      assert_instance_of GraphQL::Query::Arguments, args["b"]
+      assert_kind_of GraphQL::Query::Arguments, args["b"]
       assert_instance_of Hash, args["c"]
     end
   end
@@ -304,7 +306,7 @@ describe GraphQL::Query::Arguments do
       assert_equal nil, input_object.arguments_class
 
       GraphQL::Query::Arguments.construct_arguments_class(input_object)
-      args = input_object.arguments_class.instantiate_arguments({foo: 3, bar: -90})
+      args = input_object.arguments_class.new({foo: 3, bar: -90})
 
       assert_equal 3, args.foo
       assert_equal -90, args.bar


### PR DESCRIPTION
Oops, I realized I left one race condition in this code, `@args_class ||=`. So I refactored to build the class eagerly instead of lazily. (In fact, I didn't experience a bug from this, but I noticed it while chasing something unrelated.)