### PR TITLE
fix(Traversal) don't apply instrumentation to Query.__type

### DIFF
--- a/lib/graphql/schema/traversal.rb
+++ b/lib/graphql/schema/traversal.rb
@@ -104,10 +104,13 @@ module GraphQL
       end
 
       def visit_field_on_type(type_defn, field_defn, dynamic_field: false)
-        instrumented_field_defn = @field_instrumenters.reduce(field_defn) do |defn, inst|
-          inst.instrument(type_defn, defn)
-        end
-        if !dynamic_field
+        if dynamic_field
+          # Don't apply instrumentation to dynamic fields since they're shared constants
+          instrumented_field_defn = field_defn
+        else
+          instrumented_field_defn = @field_instrumenters.reduce(field_defn) do |defn, inst|
+            inst.instrument(type_defn, defn)
+          end
           @instrumented_field_map[type_defn.name][instrumented_field_defn.name] = instrumented_field_defn
         end
         @type_reference_map[instrumented_field_defn.type.unwrap.name] << instrumented_field_defn

--- a/spec/graphql/introspection/type_by_name_field_spec.rb
+++ b/spec/graphql/introspection/type_by_name_field_spec.rb
@@ -2,38 +2,37 @@
 require "spec_helper"
 
 describe GraphQL::Introspection::TypeByNameField do
-    describe "after instrumentation" do
-      # Just make sure it returns a new object, not the original field
-      class DupInstrumenter
-        def self.instrument(t, f)
-          f.redefine {
-            resolve ->(o, a, c) { :no_op }
-          }
-        end
-      end
-
-      class ArgAnalyzer
-        def call(_, _, node)
-          if node.ast_node.is_a?(GraphQL::Language::Nodes::Field)
-            node.arguments
-          end
-        end
-      end
-
-      let(:instrumented_schema) {
-        # This was probably assigned earlier in the test suite, but to simulate an application, clear it.
-        GraphQL::Introspection::TypeByNameField.arguments_class = nil
-
-        Dummy::Schema.redefine {
-          instrument(:field, DupInstrumenter)
-          query_analyzer(ArgAnalyzer.new)
+  describe "after instrumentation" do
+    # Just make sure it returns a new object, not the original field
+    class DupInstrumenter
+      def self.instrument(t, f)
+        f.redefine {
+          resolve ->(o, a, c) { :no_op }
         }
-      }
-
-      it "still works with __type" do
-        res = instrumented_schema.execute("{ __type(name: \"X\") { name } }")
-        assert_equal({"data"=>{"__type"=>nil}}, res)
       end
     end
 
+    class ArgAnalyzer
+      def call(_, _, node)
+        if node.ast_node.is_a?(GraphQL::Language::Nodes::Field)
+          node.arguments
+        end
+      end
+    end
+
+    let(:instrumented_schema) {
+      # This was probably assigned earlier in the test suite, but to simulate an application, clear it.
+      GraphQL::Introspection::TypeByNameField.arguments_class = nil
+
+      Dummy::Schema.redefine {
+        instrument(:field, DupInstrumenter)
+        query_analyzer(ArgAnalyzer.new)
+      }
+    }
+
+    it "still works with __type" do
+      res = instrumented_schema.execute("{ __type(name: \"X\") { name } }")
+      assert_equal({"data"=>{"__type"=>nil}}, res)
+    end
+  end
 end

--- a/spec/graphql/introspection/type_by_name_field_spec.rb
+++ b/spec/graphql/introspection/type_by_name_field_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::Introspection::TypeByNameField do
+    describe "after instrumentation" do
+      # Just make sure it returns a new object, not the original field
+      class DupInstrumenter
+        def self.instrument(t, f)
+          f.redefine {
+            resolve ->(o, a, c) { :no_op }
+          }
+        end
+      end
+
+      class ArgAnalyzer
+        def call(_, _, node)
+          if node.ast_node.is_a?(GraphQL::Language::Nodes::Field)
+            node.arguments
+          end
+        end
+      end
+
+      let(:instrumented_schema) {
+        # This was probably assigned earlier in the test suite, but to simulate an application, clear it.
+        GraphQL::Introspection::TypeByNameField.arguments_class = nil
+
+        Dummy::Schema.redefine {
+          instrument(:field, DupInstrumenter)
+          query_analyzer(ArgAnalyzer.new)
+        }
+      }
+
+      it "still works with __type" do
+        res = instrumented_schema.execute("{ __type(name: \"X\") { name } }")
+        assert_equal({"data"=>{"__type"=>nil}}, res)
+      end
+    end
+
+end


### PR DESCRIPTION
What a beast, if an instrumentation copied `__type`, it would not get an arguments class, resulting in a runtime error, no method on `nil`. I didn't update the traversal code properly in working on this feature!