### PR TITLE
Support custom coercion error messages for scalars

### DIFF
--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -99,6 +99,7 @@ require "graphql/schema/loader"
 require "graphql/schema/printer"
 
 require "graphql/analysis_error"
+require "graphql/coercion_error"
 require "graphql/runtime_type_error"
 require "graphql/invalid_null_error"
 require "graphql/invalid_name_error"

--- a/lib/graphql/coercion_error.rb
+++ b/lib/graphql/coercion_error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+module GraphQL
+  class CoercionError < GraphQL::Error
+  end
+end

--- a/lib/graphql/scalar_type.rb
+++ b/lib/graphql/scalar_type.rb
@@ -34,6 +34,30 @@ module GraphQL
   #     coerce_result ->(value, ctx) { value.to_f }
   #   end
   #
+  #
+  # You can customize the error message for invalid input values by raising a `GraphQL::CoercionError` within `coerce_input`:
+  #
+  # @example raising a custom error message
+  #   TimeType = GraphQL::ScalarType.define do
+  #     name "Time"
+  #     description "Time since epoch in seconds"
+  #
+  #     coerce_input ->(value, ctx) do
+  #       begin
+  #         Time.at(Float(value))
+  #       rescue ArgumentError
+  #         raise GraphQL::CoercionError, "cannot coerce `#{value.inspect}` to Float"
+  #       end
+  #     end
+  #
+  #     coerce_result ->(value, ctx) { value.to_f }
+  #   end
+  #
+  # This will result in the message of the `GraphQL::CoercionError` being used in the error response:
+  #
+  # @example custom error response
+  # {"message"=>"cannot coerce `"2"` to Float", "locations"=>[{"line"=>3, "column"=>9}], "fields"=>["arg"]}
+  #
   class ScalarType < GraphQL::BaseType
     accepts_definitions :coerce, :coerce_input, :coerce_result
     ensure_defined :coerce_non_null_input, :coerce_result

--- a/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb
+++ b/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb
@@ -6,10 +6,15 @@ module GraphQL
         return if node.value.is_a?(GraphQL::Language::Nodes::VariableIdentifier)
         arg_defn = defn.arguments[node.name]
         return unless arg_defn
-        if !context.valid_literal?(node.value, arg_defn.type)
-          kind_of_node = node_type(parent)
-          error_arg_name = parent_name(parent, defn)
-          context.errors << message("Argument '#{node.name}' on #{kind_of_node} '#{error_arg_name}' has an invalid value. Expected type '#{arg_defn.type}'.", parent, context: context)
+
+        begin
+          if !context.valid_literal?(node.value, arg_defn.type)
+            kind_of_node = node_type(parent)
+            error_arg_name = parent_name(parent, defn)
+            context.errors << message("Argument '#{node.name}' on #{kind_of_node} '#{error_arg_name}' has an invalid value. Expected type '#{arg_defn.type}'.", parent, context: context)
+          end
+        rescue GraphQL::CoercionError => err
+          context.errors << message(err.message, parent, context: context)
         end
       end
     end

--- a/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb
+++ b/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb
@@ -8,14 +8,20 @@ module GraphQL
         return unless arg_defn
 
         begin
-          if !context.valid_literal?(node.value, arg_defn.type)
-            kind_of_node = node_type(parent)
-            error_arg_name = parent_name(parent, defn)
-            context.errors << message("Argument '#{node.name}' on #{kind_of_node} '#{error_arg_name}' has an invalid value. Expected type '#{arg_defn.type}'.", parent, context: context)
-          end
+          valid = context.valid_literal?(node.value, arg_defn.type)
         rescue GraphQL::CoercionError => err
-          context.errors << message(err.message, parent, context: context)
+          error_message = err.message
         end
+
+        return if valid
+
+        error_message ||= begin
+          kind_of_node = node_type(parent)
+          error_arg_name = parent_name(parent, defn)
+          "Argument '#{node.name}' on #{kind_of_node} '#{error_arg_name}' has an invalid value. Expected type '#{arg_defn.type}'."
+        end
+
+        context.errors << message(error_message, parent, context: context)
       end
     end
   end

--- a/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
+++ b/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
@@ -219,4 +219,54 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
       })
     end
   end
+
+  describe "custom error messages" do
+    let(:schema) {
+      TimeType = GraphQL::ScalarType.define do
+        name "Time"
+        description "Time since epoch in seconds"
+
+        coerce_input ->(value, ctx) do
+          begin
+            Time.at(Float(value))
+          rescue ArgumentError
+            raise GraphQL::CoercionError, 'cannot coerce to Float'
+          end
+        end
+
+        coerce_result ->(value, ctx) { value.to_f }
+      end
+
+      QueryType = GraphQL::ObjectType.define do
+        name "Query"
+        description "The query root of this schema"
+
+        field :time do
+          type TimeType
+          argument :value, !TimeType
+          resolve ->(obj, args, ctx) { args[:value] }
+        end
+      end
+
+      GraphQL::Schema.define do
+        query QueryType
+      end
+    }
+
+    let(:query_string) {%|
+      query {
+        time(value: "a")
+      }
+    |}
+
+    it "sets error message from a CoercionError if raised" do
+      assert_equal 1, errors.length
+
+      assert_includes errors, {
+        "message"=> "cannot coerce to Float",
+        "locations"=>[{"line"=>3, "column"=>9}],
+        "fields"=>["query", "time", "value"]
+      }
+    end
+  end
 end


### PR DESCRIPTION
Closes #981

Error messages for invalid scalar input values were statically set during validation.

This allows for a scalar to raise a `GraphQL::CoercionError` within `coerce_input` and its error message will be used in the error response.