### PR TITLE
Thread-safe, per-query tracers

### DIFF
--- a/guides/queries/backtrace_annotations.md
+++ b/guides/queries/backtrace_annotations.md
@@ -28,12 +28,13 @@ The backtrace contains some execution data:
 
 ## Wrapping Errors
 
-You can wrap unhandled errors with a GraphQL error with `GraphQL::Backtrace`. To enable this feature, use `.enable`, for example:
+You can wrap unhandled errors with a GraphQL error with `GraphQL::Backtrace`.
+
+To enable this feature for a query, add `backtrace: true` to your `context`, for example:
 
 ```ruby
-# Start error wrapping,
-# NOTE: This is **NOT** threadsafe, so don't switch it off and on while the app is running.
-GraphQL::Backtrace.enable
+# Wrap this query with backtrace annotation
+MySchema.execute(query_string, context: { backtrace: true })
 ```
 
 Now, any unhandled errors will be wrapped by `GraphQL::Backtrace::TracedError`, which prints out the GraphQL backtrace, too. For example:
@@ -61,11 +62,4 @@ Loc  | Field                         | Object     | Arguments           | Result
 3:13 | Thing.raiseField as boomError | :something | {"message"=>"Boom"} | #<RuntimeError: This is broken: Boom>
 2:11 | Query.field1                  | "Root"     | {}                  | {}
 1:9  | query                         | "Root"     | {"msg"=>"Boom"}     | {}
-```
-
-Later, you can disable this with `.disable`:
-
-```ruby
-# End backtrace annotations
-GraphQL::Backtrace.disable
 ```

--- a/guides/queries/backtrace_annotations.md
+++ b/guides/queries/backtrace_annotations.md
@@ -37,6 +37,15 @@ To enable this feature for a query, add `backtrace: true` to your `context`, for
 MySchema.execute(query_string, context: { backtrace: true })
 ```
 
+Or, to _always_ wrap backtraces, add it to your schema definition with `use`, for example:
+
+```ruby
+MySchema = GraphQL::Schema.define do
+  # Always wrap backtraces with GraphQL annotation
+  use GraphQL::Backtrace
+end
+```
+
 Now, any unhandled errors will be wrapped by `GraphQL::Backtrace::TracedError`, which prints out the GraphQL backtrace, too. For example:
 
 ```

--- a/guides/queries/tracing.md
+++ b/guides/queries/tracing.md
@@ -14,7 +14,7 @@ A tracer must implement `.trace`, for example:
 
 ```ruby
 class MyCustomTracer
-  def trace(key, data)
+  def self.trace(key, data)
     # do stuff with key & data
     yield
   end
@@ -27,13 +27,21 @@ end
 - `data`: a hash of metadata about the event
 - `&block`: the event itself, it must be `yield`ed and the value must be returned
 
-To install a tracer, use `GraphQL::Tracing.install`:
+To run a tracer for every query, add it to the schema with `tracer`:
 
 ```ruby
-GraphQL::Tracing.install(MyCustomTracer.new)
+# Run `MyCustomTracer` for all queries
+MySchema = GraphQL::Schema.define do
+  tracer(MyCustomTracer)
+end
 ```
 
-To uninstall, use `GraphQL::Tracing.install(nil)`.
+Or, to run a tracer for one query only, add it to `context:` as `tracers: [...]`, for example:
+
+```ruby
+# Run `MyCustomTracer` for this query
+MySchema.execute(..., context: { tracers: [MyCustomTracer]})
+```
 
 For a full list of events, see the {{ "GraphQL::Tracing" | api_doc }} API docs.
 
@@ -45,7 +53,7 @@ To enable it, install the tracer:
 
 ```ruby
 # Send execution events to ActiveSupport::Notifications
-GraphQL::Tracing.install(
-  GraphQL::Tracing::ActiveSupportNotificationsTracing
-)
+MySchema = GraphQL::Schema.define do
+  tracer GraphQL::Tracing::ActiveSupportNotificationsTracing
+end
 ```

--- a/guides/queries/tracing.md
+++ b/guides/queries/tracing.md
@@ -27,7 +27,7 @@ end
 - `data`: a hash of metadata about the event
 - `&block`: the event itself, it must be `yield`ed and the value must be returned
 
-To run a tracer for every query, add it to the schema with `tracer`:
+To run a tracer for __every query__, add it to the schema with `tracer`:
 
 ```ruby
 # Run `MyCustomTracer` for all queries
@@ -36,7 +36,7 @@ MySchema = GraphQL::Schema.define do
 end
 ```
 
-Or, to run a tracer for one query only, add it to `context:` as `tracers: [...]`, for example:
+Or, to run a tracer for __one query only__, add it to `context:` as `tracers: [...]`, for example:
 
 ```ruby
 # Run `MyCustomTracer` for this query

--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -35,8 +35,8 @@ module GraphQL
   # Turn a query string or schema definition into an AST
   # @param graphql_string [String] a GraphQL query string or schema definition
   # @return [GraphQL::Language::Nodes::Document]
-  def self.parse(graphql_string)
-    parse_with_racc(graphql_string)
+  def self.parse(graphql_string, tracer: GraphQL::Tracing::NullTracer)
+    parse_with_racc(graphql_string, tracer: tracer)
   end
 
   # Read the contents of `filename` and parse them as GraphQL
@@ -47,8 +47,8 @@ module GraphQL
     parse_with_racc(content, filename: filename)
   end
 
-  def self.parse_with_racc(string, filename: nil)
-    GraphQL::Language::Parser.parse(string, filename: filename)
+  def self.parse_with_racc(string, filename: nil, tracer: GraphQL::Tracing::NullTracer)
+    GraphQL::Language::Parser.parse(string, filename: filename, tracer: tracer)
   end
 
   # @return [Array<GraphQL::Language::Token>]
@@ -92,6 +92,7 @@ require "graphql/name_validator"
 require "graphql/introspection"
 require "graphql/language"
 require "graphql/analysis"
+require "graphql/tracing"
 require "graphql/execution"
 require "graphql/relay"
 require "graphql/schema"
@@ -113,5 +114,4 @@ require "graphql/function"
 require "graphql/filter"
 require "graphql/subscriptions"
 require "graphql/parse_error"
-require "graphql/tracing"
 require "graphql/backtrace"

--- a/lib/graphql/analysis/analyze_query.rb
+++ b/lib/graphql/analysis/analyze_query.rb
@@ -5,7 +5,7 @@ module GraphQL
 
     # @return [void]
     def analyze_multiplex(multiplex, analyzers)
-      GraphQL::Tracing.trace("analyze_multiplex", { multiplex: multiplex }) do
+      multiplex.trace("analyze_multiplex", { multiplex: multiplex }) do
         reducer_states = analyzers.map { |r| ReducerState.new(r, multiplex) }
         query_results = multiplex.queries.map do |query|
           if query.valid?
@@ -37,7 +37,7 @@ module GraphQL
     # @param analyzers [Array<#call>] Objects that respond to `#call(memo, visit_type, irep_node)`
     # @return [Array<Any>] Results from those analyzers
     def analyze_query(query, analyzers, multiplex_states: [])
-      GraphQL::Tracing.trace("analyze_query", { query: query }) do
+      query.trace("analyze_query", { query: query }) do
         reducer_states = analyzers.map { |r| ReducerState.new(r, query) } + multiplex_states
 
         irep = query.internal_representation

--- a/lib/graphql/backtrace.rb
+++ b/lib/graphql/backtrace.rb
@@ -24,6 +24,7 @@ module GraphQL
     def_delegators :to_a, :each, :[]
 
     def self.enable
+      warn("GraphQL::Backtrace.enable is deprecated, add `use GraphQL::Backtrace` to your schema definition instead.")
       GraphQL::Tracing.install(Backtrace::Tracer)
       nil
     end

--- a/lib/graphql/backtrace.rb
+++ b/lib/graphql/backtrace.rb
@@ -33,6 +33,10 @@ module GraphQL
       nil
     end
 
+    def self.use(schema_defn)
+      schema_defn.tracer(self::Tracer)
+    end
+
     def initialize(context, value: nil)
       @table = Table.new(context, value: value)
     end

--- a/lib/graphql/execution/lazy/resolve.rb
+++ b/lib/graphql/execution/lazy/resolve.rb
@@ -37,7 +37,7 @@ module GraphQL
           else
             Lazy.new {
               acc.each_with_index { |ctx, idx|
-                acc[idx] = GraphQL::Tracing.trace("execute_field_lazy", { context: ctx }) do
+                acc[idx] = ctx.trace("execute_field_lazy", { context: ctx }) do
                   ctx.value.value
                 end
               }

--- a/lib/graphql/execution/multiplex.rb
+++ b/lib/graphql/execution/multiplex.rb
@@ -35,7 +35,11 @@ module GraphQL
         @queries = queries
         @context = context
         # TODO remove support for global tracers
-        @tracers = schema.tracers + GraphQL::Tracing.tracers + context.fetch(:tracers, [])
+        @tracers = schema.tracers + GraphQL::Tracing.tracers + (context[:tracers] || [])
+        # Support `context: {backtrace: true}`
+        if context[:backtrace] && !@tracers.include?(GraphQL::Backtrace::Tracer)
+          @tracers << GraphQL::Backtrace::Tracer
+        end
       end
 
       class << self

--- a/lib/graphql/language/parser.rb
+++ b/lib/graphql/language/parser.rb
@@ -14,19 +14,20 @@ module GraphQL
 
 module_eval(<<'...end parser.y/module_eval...', 'parser.y', 356)
 
-def initialize(query_string, filename:)
+def initialize(query_string, filename:, tracer: Tracing::NullTracer)
   @query_string = query_string
   @filename = filename
+  @tracer = tracer
 end
 
 def parse_document
   @document ||= begin
     # Break the string into tokens
-    GraphQL::Tracing.trace("lex", {query_string: @query_string}) do
+    @tracer.trace("lex", {query_string: @query_string}) do
       @tokens ||= GraphQL.scan(@query_string)
     end
     # From the tokens, build an AST
-    GraphQL::Tracing.trace("parse", {query_string: @query_string}) do
+    @tracer.trace("parse", {query_string: @query_string}) do
       if @tokens.none?
         make_node(:Document, definitions: [], filename: @filename)
       else
@@ -36,8 +37,8 @@ def parse_document
   end
 end
 
-def self.parse(query_string, filename: nil)
-  self.new(query_string, filename: filename).parse_document
+def self.parse(query_string, filename: nil, tracer: GraphQL::Tracing::NullTracer)
+  self.new(query_string, filename: filename, tracer: tracer).parse_document
 end
 
 private

--- a/lib/graphql/language/parser.y
+++ b/lib/graphql/language/parser.y
@@ -354,19 +354,20 @@ end
 
 ---- inner ----
 
-def initialize(query_string, filename:)
+def initialize(query_string, filename:, tracer: Tracing::NullTracer)
   @query_string = query_string
   @filename = filename
+  @tracer = tracer
 end
 
 def parse_document
   @document ||= begin
     # Break the string into tokens
-    GraphQL::Tracing.trace("lex", {query_string: @query_string}) do
+    @tracer.trace("lex", {query_string: @query_string}) do
       @tokens ||= GraphQL.scan(@query_string)
     end
     # From the tokens, build an AST
-    GraphQL::Tracing.trace("parse", {query_string: @query_string}) do
+    @tracer.trace("parse", {query_string: @query_string}) do
       if @tokens.none?
         make_node(:Document, definitions: [], filename: @filename)
       else
@@ -376,8 +377,8 @@ def parse_document
   end
 end
 
-def self.parse(query_string, filename: nil)
-  self.new(query_string, filename: filename).parse_document
+def self.parse(query_string, filename: nil, tracer: GraphQL::Tracing::NullTracer)
+  self.new(query_string, filename: filename, tracer: tracer).parse_document
 end
 
 private

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -15,6 +15,7 @@ require "graphql/query/validation_pipeline"
 module GraphQL
   # A combination of query string and {Schema} instance which can be reduced to a {#result}.
   class Query
+    include Tracing::Traceable
     extend GraphQL::Delegate
 
     class OperationNameMissingError < GraphQL::ExecutionError
@@ -55,6 +56,8 @@ module GraphQL
     # @return [String, nil]
     attr_reader :operation_name
 
+    attr_reader :tracers
+
     # Prepare query `query_string` on `schema`
     # @param schema [GraphQL::Schema]
     # @param query_string [String]
@@ -75,7 +78,8 @@ module GraphQL
       @fragments = nil
       @operations = nil
       @validate = validate
-
+      # TODO: remove support for global tracers
+      @tracers = schema.tracers + GraphQL::Tracing.tracers + (context ? context.fetch(:tracers, []) : [])
       @analysis_errors = []
       if variables.is_a?(String)
         raise ArgumentError, "Query variables should be a Hash, not a String. Try JSON.parse to prepare variables."
@@ -266,7 +270,7 @@ module GraphQL
       parse_error = nil
       @document ||= begin
         if query_string
-          GraphQL.parse(query_string)
+          GraphQL.parse(query_string, tracer: self)
         end
       rescue GraphQL::ParseError => err
         parse_error = err

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -80,6 +80,11 @@ module GraphQL
       @validate = validate
       # TODO: remove support for global tracers
       @tracers = schema.tracers + GraphQL::Tracing.tracers + (context ? context.fetch(:tracers, []) : [])
+      # Support `ctx[:backtrace] = true` for wrapping backtraces
+      if context && context[:backtrace] && !@tracers.include?(GraphQL::Backtrace::Tracer)
+        @tracers << GraphQL::Backtrace::Tracer
+      end
+
       @analysis_errors = []
       if variables.is_a?(String)
         raise ArgumentError, "Query variables should be a Hash, not a String. Try JSON.parse to prepare variables."

--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -161,6 +161,7 @@ module GraphQL
 
       class FieldResolutionContext
         include SharedMethods
+        include Tracing::Traceable
         extend GraphQL::Delegate
 
         attr_reader :irep_node, :field, :parent_type, :query, :schema, :parent, :key, :type
@@ -178,6 +179,7 @@ module GraphQL
           # This is needed constantly, so set it ahead of time:
           @query = context.query
           @schema = context.schema
+          @tracers = @query.tracers
         end
 
         def path

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -70,7 +70,8 @@ module GraphQL
       multiplex_analyzer: ->(schema, analyzer) { schema.multiplex_analyzers << analyzer },
       middleware: ->(schema, middleware) { schema.middleware << middleware },
       lazy_resolve: ->(schema, lazy_class, lazy_value_method) { schema.lazy_methods.set(lazy_class, lazy_value_method) },
-      rescue_from: ->(schema, err_class, &block) { schema.rescue_from(err_class, &block)}
+      rescue_from: ->(schema, err_class, &block) { schema.rescue_from(err_class, &block)},
+      tracer: ->(schema, tracer) { schema.tracers.push(tracer) }
 
     attr_accessor \
       :query, :mutation, :subscription,
@@ -100,6 +101,10 @@ module GraphQL
       GraphQL::Filter.new(except: default_mask)
     end
 
+    # @return [Array<#trace(key, data)>] Tracers applied to every query
+    # @see {Query#tracers} for query-specific tracers
+    attr_reader :tracers
+
     self.default_execution_strategy = GraphQL::Execution::Execute
 
     BUILT_IN_TYPES = Hash[[INT_TYPE, STRING_TYPE, FLOAT_TYPE, BOOLEAN_TYPE, ID_TYPE].map{ |type| [type.name, type] }]
@@ -109,6 +114,7 @@ module GraphQL
     attr_reader :static_validator, :object_from_id_proc, :id_from_object_proc, :resolve_type_proc
 
     def initialize
+      @tracers = []
       @definition_error = nil
       @orphan_types = []
       @directives = DIRECTIVES.reduce({}) { |m, d| m[d.name] = d; m }
@@ -257,7 +263,12 @@ module GraphQL
         kwargs[:query] = query_str
       end
       # Since we're running one query, don't run a multiplex-level complexity analyzer
-      all_results = multiplex([kwargs], max_complexity: nil)
+      multiplex_context = if (ctx = kwargs[:context]) && (tracers = ctx[:tracers])
+        {tracers: tracers}
+      else
+        {}
+      end
+      all_results = multiplex([kwargs], max_complexity: nil, context: multiplex_context)
       all_results[0]
     end
 

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -262,12 +262,16 @@ module GraphQL
       if query_str
         kwargs[:query] = query_str
       end
-      # Since we're running one query, don't run a multiplex-level complexity analyzer
-      multiplex_context = if (ctx = kwargs[:context]) && (tracers = ctx[:tracers])
-        {tracers: tracers}
+      # Some of the query context _should_ be passed to the multiplex, too
+      multiplex_context = if (ctx = kwargs[:context])
+        {
+          backtrace: ctx[:backtrace],
+          tracers: ctx[:tracers],
+        }
       else
         {}
       end
+      # Since we're running one query, don't run a multiplex-level complexity analyzer
       all_results = multiplex([kwargs], max_complexity: nil, context: multiplex_context)
       all_results[0]
     end

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -147,7 +147,7 @@ module GraphQL
       @middleware = other.middleware.dup
       @query_analyzers = other.query_analyzers.dup
       @multiplex_analyzers = other.multiplex_analyzers.dup
-
+      @tracers = other.tracers.dup
       @possible_types = GraphQL::Schema::PossibleTypes.new(self)
 
       @lazy_methods = other.lazy_methods.dup

--- a/lib/graphql/static_validation/validator.rb
+++ b/lib/graphql/static_validation/validator.rb
@@ -22,7 +22,7 @@ module GraphQL
       # @param query [GraphQL::Query]
       # @return [Array<Hash>]
       def validate(query, validate: true)
-        GraphQL::Tracing.trace("validate", { validate: validate, query: query }) do
+        query.trace("validate", { validate: validate, query: query }) do
           context = GraphQL::StaticValidation::ValidationContext.new(query)
           rewrite = GraphQL::InternalRepresentation::Rewrite.new
 

--- a/lib/graphql/tracing.rb
+++ b/lib/graphql/tracing.rb
@@ -15,6 +15,14 @@ module GraphQL
   #     # do stuff ...
   #   end
   #
+  # @example Adding a tracer to a schema
+  #  MySchema = GraphQL::Schema.define do
+  #    tracer MyTracer # <= responds to .trace(key, data, &block)
+  #  end
+  #
+  # @example Adding a tracer to a query
+  #   MySchema.execute(query_str, context: { backtrace: true })
+  #
   # Events:
   #
   # Key | Metadata
@@ -66,6 +74,7 @@ module GraphQL
       # @return [void]
       # @deprecated See {Schema#tracer} or use `context: { tracers: [...] }`
       def install(tracer)
+        warn("GraphQL::Tracing.install is deprecated, add it to the schema with `tracer(my_tracer)` instead.")
         if !tracers.include?(tracer)
           @tracers << tracer
         end
@@ -79,23 +88,6 @@ module GraphQL
       # @deprecated See {Schema#tracer} or use `context: { tracers: [...] }`
       def tracers
         @tracers ||= []
-      end
-
-      private
-
-      # If there's a tracer at `idx`, call it and then increment `idx`.
-      # Otherwise, yield.
-      #
-      # @param idx [Integer] Which tracer to call
-      # @param key [String] The current event name
-      # @param metadata [Object] The current event object
-      # @return Whatever the block returns
-      def call_tracers(idx, key, metadata)
-        if idx == @tracers.length
-          yield
-        else
-          @tracers[idx].trace(key, metadata) { call_tracers(idx + 1, key, metadata) { yield } }
-        end
       end
     end
     # Initialize the array

--- a/spec/graphql/analysis/analyze_query_spec.rb
+++ b/spec/graphql/analysis/analyze_query_spec.rb
@@ -54,7 +54,8 @@ describe GraphQL::Analysis do
 
       it "emits traces" do
         traces = TestTracing.with_trace do
-          Dummy::Schema.execute(document: GraphQL.parse(query_string))
+          ctx = { tracers: [TestTracing] }
+          Dummy::Schema.execute(query_string, context: ctx)
         end
 
         # The query_trace is on the list _first_ because it finished first

--- a/spec/graphql/backtrace_spec.rb
+++ b/spec/graphql/backtrace_spec.rb
@@ -124,8 +124,10 @@ describe GraphQL::Backtrace do
     end
 
     it "annotates errors inside lazy resolution" do
+      # Test context-based flag
+      GraphQL::Backtrace.disable
       err = assert_raises(GraphQL::Backtrace::TracedError) {
-        schema.execute("query StrField { field2 { strField } __typename }")
+        schema.execute("query StrField { field2 { strField } __typename }", context: { backtrace: true })
       }
       assert_instance_of RuntimeError, err.cause
       b = err.cause.backtrace

--- a/spec/graphql/backtrace_spec.rb
+++ b/spec/graphql/backtrace_spec.rb
@@ -158,8 +158,13 @@ describe GraphQL::Backtrace do
     end
 
     it "always stringifies the #inspect response" do
+      # test the schema plugin
+      GraphQL::Backtrace.disable
+      backtrace_schema = schema.redefine {
+        use GraphQL::Backtrace
+      }
       err = assert_raises(GraphQL::Backtrace::TracedError) {
-        schema.execute("query { nilInspect { raiseField(message: \"pop!\") } }")
+        backtrace_schema.execute("query { nilInspect { raiseField(message: \"pop!\") } }")
       }
 
       rendered_table = [

--- a/spec/graphql/execution/execute_spec.rb
+++ b/spec/graphql/execution/execute_spec.rb
@@ -154,7 +154,7 @@ describe GraphQL::Execution::Execute do
           star_wars_query(query_string, {
             "id1" => first_id,
             "id2" => last_id,
-          })
+          }, context: {tracers: [TestTracing]})
         end
 
         exec_traces = traces[5..-1]

--- a/spec/graphql/language/parser_spec.rb
+++ b/spec/graphql/language/parser_spec.rb
@@ -73,9 +73,9 @@ describe GraphQL::Language::Parser do
   end
 
   it "serves traces" do
-    traces = TestTracing.with_trace do
-      GraphQL.parse("{ t: __typename }")
-    end
+    TestTracing.clear
+    GraphQL.parse("{ t: __typename }", tracer: TestTracing)
+    traces = TestTracing.traces
     assert_equal 2, traces.length
     lex_trace, parse_trace = traces
 

--- a/spec/graphql/static_validation/validator_spec.rb
+++ b/spec/graphql/static_validation/validator_spec.rb
@@ -9,6 +9,7 @@ describe GraphQL::StaticValidation::Validator do
 
   describe "tracing" do
     let(:query_string) { "{ t: __typename }"}
+    let(:query) { GraphQL::Query.new(Dummy::Schema, query_string, context: {tracers: [TestTracing]}) }
 
     it "emits a trace" do
       traces = TestTracing.with_trace do

--- a/spec/graphql/tracing/active_support_notifications_tracing_spec.rb
+++ b/spec/graphql/tracing/active_support_notifications_tracing_spec.rb
@@ -2,13 +2,11 @@
 require "spec_helper"
 
 describe GraphQL::Tracing::ActiveSupportNotificationsTracing do
-  before do
-    GraphQL::Tracing.install(GraphQL::Tracing::ActiveSupportNotificationsTracing)
-  end
-
-  after do
-    GraphQL::Tracing.uninstall(GraphQL::Tracing::ActiveSupportNotificationsTracing)
-  end
+  let(:schema) {
+    StarWars::Schema.redefine {
+      tracer GraphQL::Tracing::ActiveSupportNotificationsTracing
+    }
+  }
 
   it "pushes through AS::N" do
     traces = []
@@ -27,7 +25,7 @@ describe GraphQL::Tracing::ActiveSupportNotificationsTracing do
     last_id = StarWars::Base.last.id
 
     ActiveSupport::Notifications.subscribed(callback, /^graphql/) do
-      star_wars_query(query_string, {
+      schema.execute(query_string, variables: {
         "id1" => first_id,
         "id2" => last_id,
       })

--- a/spec/graphql/tracing_spec.rb
+++ b/spec/graphql/tracing_spec.rb
@@ -47,8 +47,6 @@ describe GraphQL::Tracing do
 
       assert_equal ["stuff"], traces.map { |t| t[:key] }
       assert_equal ["STUFF"], OtherRandomTracer::CALLS
-
-      GraphQL::Tracing.uninstall(OtherRandomTracer)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,7 +65,7 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each do |f|
 end
 
 def star_wars_query(string, variables={}, context: {})
-  GraphQL::Query.new(StarWars::Schema, string, variables: variables, context: context).result
+  StarWars::Schema.execute(string, variables: variables, context: context)
 end
 
 def with_bidirectional_pagination
@@ -74,7 +74,7 @@ def with_bidirectional_pagination
   yield
 ensure
   GraphQL::Relay::ConnectionType.bidirectional_pagination = prev_value
-end 
+end
 
 module TestTracing
   class << self
@@ -82,16 +82,14 @@ module TestTracing
       traces.clear
     end
 
-    def traces
-      @traces ||= []
-    end
-
     def with_trace
-      GraphQL::Tracing.install(self)
       clear
       yield
-      GraphQL::Tracing.uninstall(self)
       traces
+    end
+
+    def traces
+      @traces ||= []
     end
 
     def trace(key, data)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -101,7 +101,3 @@ module TestTracing
     end
   end
 end
-
-if rails_should_be_installed?
-  GraphQL::Tracing.uninstall(GraphQL::Tracing::ActiveSupportNotificationsTracing)
-end

--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -284,7 +284,7 @@ module StarWars
       if loaded.empty?
         ids = @context.namespace(:loading)[@model]
         # Example custom tracing
-        GraphQL::Tracing.trace("lazy_loader", { ids: ids, model: @model}) do
+        @context.trace("lazy_loader", { ids: ids, model: @model}) do
           records = @model.where(id: ids)
           records.each do |record|
             loaded[record.id.to_s] = record


### PR DESCRIPTION
A shortcoming of the previous `GraphQL::Tracing` implementation was that adding and removing tracers was not threadsafe. There was no way to add a trace to _one_ query without messing with any other currently-running queries. 

This new approach supports tracers at schema- and query-level, and uses that new support for query-level backtrace annotation via `context {..., backtrace: true}` (or schema-level with `use GraphQL::Backtrace`).

This way, tracers with a perf hit can be applied in cases where they are really necessary _without_ impacting other cases.