### PR TITLE
Serialize Subscription Scopes

### DIFF
--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "benchmark-ips"
   s.add_development_dependency "codeclimate-test-reporter", "~>0.4"
   s.add_development_dependency "concurrent-ruby", "~>1.0"
-  s.add_development_dependency "globalid", "~> 0.4"
   s.add_development_dependency "guard", "~> 2.12"
   s.add_development_dependency "guard-bundler", "~> 2.1"
   s.add_development_dependency "guard-minitest", "~> 2.4"

--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "benchmark-ips"
   s.add_development_dependency "codeclimate-test-reporter", "~>0.4"
   s.add_development_dependency "concurrent-ruby", "~>1.0"
+  s.add_development_dependency "globalid", "~> 0.4"
   s.add_development_dependency "guard", "~> 2.12"
   s.add_development_dependency "guard-bundler", "~> 2.1"
   s.add_development_dependency "guard-minitest", "~> 2.4"

--- a/lib/graphql/subscriptions/event.rb
+++ b/lib/graphql/subscriptions/event.rb
@@ -46,7 +46,21 @@ module GraphQL
         end
 
         sorted_h = normalized_args.to_h.sort.to_h
-        JSON.dump([scope, name, sorted_h])
+        JSON.dump([serialize_scope(scope), name, sorted_h])
+      end
+
+      # @return [String] an identifier for the subscription scope.
+      def self.serialize_scope(scope)
+        case
+        when scope.is_a?(Array)
+          scope.map { |s| serialize_scope(s) }.join(':')
+        when scope.respond_to?(:to_gid_param)
+          scope.to_gid_param
+        when scope.respond_to?(:to_param)
+          scope.to_param
+        else
+          scope.to_s
+        end
       end
     end
   end

--- a/spec/graphql/subscriptions_spec.rb
+++ b/spec/graphql/subscriptions_spec.rb
@@ -133,25 +133,27 @@ class InMemoryBackend
   Schema.get_field("Subscription", "myEvent").subscription_scope = :me
 end
 
-GlobalID.app = "graphql-ruby-test"
+if rails_should_be_installed? && defined?(GlobalID)
+  GlobalID.app = "graphql-ruby-test"
 
-class GlobalIDUser
-  include GlobalID::Identification
+  class GlobalIDUser
+    include GlobalID::Identification
 
-  attr_reader :id
+    attr_reader :id
 
-  def initialize(id)
-    @id = id
-  end
-end
-
-class ToParamUser
-  def initialize(id)
-    @id = id
+    def initialize(id)
+      @id = id
+    end
   end
 
-  def to_param
-    @id
+  class ToParamUser
+    def initialize(id)
+      @id = id
+    end
+
+    def to_param
+      @id
+    end
   end
 end
 
@@ -305,33 +307,35 @@ describe GraphQL::Subscriptions do
       assert_equal [3], deliveries["3"].map { |d| d["data"]["myEvent"]["int"] }
     end
 
-    it "allows complex object subscription scopes" do
-      query_str = <<-GRAPHQL
-        subscription($type: PayloadType) {
-          myEvent(type: $type) { int }
-        }
-      GRAPHQL
+    if rails_should_be_installed? && defined?(GlobalID)
+      it "allows complex object subscription scopes" do
+        query_str = <<-GRAPHQL
+          subscription($type: PayloadType) {
+            myEvent(type: $type) { int }
+          }
+        GRAPHQL
 
-      # Global ID Backed User
-      schema.execute(query_str, context: { socket: "1", me: GlobalIDUser.new(1) }, variables: { "type" => "ONE" }, root_value: root_object)
-      schema.execute(query_str, context: { socket: "2", me: GlobalIDUser.new(1) }, variables: { "type" => "TWO" }, root_value: root_object)
-      # ToParam Backed User
-      schema.execute(query_str, context: { socket: "3", me: ToParamUser.new(2) }, variables: { "type" => "ONE" }, root_value: root_object)
-      # Array of Objects
-      schema.execute(query_str, context: { socket: "4", me: [GlobalIDUser.new(4), ToParamUser.new(5)] }, variables: { "type" => "ONE" }, root_value: root_object)
-      
-      schema.subscriptions.trigger("myEvent", { "type" => "ONE" }, OpenStruct.new(str: "", int: 1), scope: GlobalIDUser.new(1))
-      schema.subscriptions.trigger("myEvent", { "type" => "TWO" }, OpenStruct.new(str: "", int: 2), scope: GlobalIDUser.new(1))
-      schema.subscriptions.trigger("myEvent", { "type" => "ONE" }, OpenStruct.new(str: "", int: 3), scope: ToParamUser.new(2))
-      schema.subscriptions.trigger("myEvent", { "type" => "ONE" }, OpenStruct.new(str: "", int: 4), scope: [GlobalIDUser.new(4), ToParamUser.new(5)])
+        # Global ID Backed User
+        schema.execute(query_str, context: { socket: "1", me: GlobalIDUser.new(1) }, variables: { "type" => "ONE" }, root_value: root_object)
+        schema.execute(query_str, context: { socket: "2", me: GlobalIDUser.new(1) }, variables: { "type" => "TWO" }, root_value: root_object)
+        # ToParam Backed User
+        schema.execute(query_str, context: { socket: "3", me: ToParamUser.new(2) }, variables: { "type" => "ONE" }, root_value: root_object)
+        # Array of Objects
+        schema.execute(query_str, context: { socket: "4", me: [GlobalIDUser.new(4), ToParamUser.new(5)] }, variables: { "type" => "ONE" }, root_value: root_object)
+        
+        schema.subscriptions.trigger("myEvent", { "type" => "ONE" }, OpenStruct.new(str: "", int: 1), scope: GlobalIDUser.new(1))
+        schema.subscriptions.trigger("myEvent", { "type" => "TWO" }, OpenStruct.new(str: "", int: 2), scope: GlobalIDUser.new(1))
+        schema.subscriptions.trigger("myEvent", { "type" => "ONE" }, OpenStruct.new(str: "", int: 3), scope: ToParamUser.new(2))
+        schema.subscriptions.trigger("myEvent", { "type" => "ONE" }, OpenStruct.new(str: "", int: 4), scope: [GlobalIDUser.new(4), ToParamUser.new(5)])
 
-      # Delivered to GlobalIDUser
-      assert_equal [1], deliveries["1"].map { |d| d["data"]["myEvent"]["int"] }
-      assert_equal [2], deliveries["2"].map { |d| d["data"]["myEvent"]["int"] }
-      # Delivered to ToParamUser
-      assert_equal [3], deliveries["3"].map { |d| d["data"]["myEvent"]["int"] }
-      # Delivered to Array of GlobalIDUser and ToParamUser
-      assert_equal [4], deliveries["4"].map { |d| d["data"]["myEvent"]["int"] }
+        # Delivered to GlobalIDUser
+        assert_equal [1], deliveries["1"].map { |d| d["data"]["myEvent"]["int"] }
+        assert_equal [2], deliveries["2"].map { |d| d["data"]["myEvent"]["int"] }
+        # Delivered to ToParamUser
+        assert_equal [3], deliveries["3"].map { |d| d["data"]["myEvent"]["int"] }
+        # Delivered to Array of GlobalIDUser and ToParamUser
+        assert_equal [4], deliveries["4"].map { |d| d["data"]["myEvent"]["int"] }
+      end
     end
 
     describe "errors" do

--- a/spec/graphql/subscriptions_spec.rb
+++ b/spec/graphql/subscriptions_spec.rb
@@ -133,6 +133,28 @@ class InMemoryBackend
   Schema.get_field("Subscription", "myEvent").subscription_scope = :me
 end
 
+GlobalID.app = "graphql-ruby-test"
+
+class GlobalIDUser
+  include GlobalID::Identification
+
+  attr_reader :id
+
+  def initialize(id)
+    @id = id
+  end
+end
+
+class ToParamUser
+  def initialize(id)
+    @id = id
+  end
+
+  def to_param
+    @id
+  end
+end
+
 describe GraphQL::Subscriptions do
   before do
     schema.subscriptions.reset
@@ -281,6 +303,35 @@ describe GraphQL::Subscriptions do
       assert_equal [2], deliveries["2"].map { |d| d["data"]["myEvent"]["int"] }
       # Delivered to user 2
       assert_equal [3], deliveries["3"].map { |d| d["data"]["myEvent"]["int"] }
+    end
+
+    it "allows complex object subscription scopes" do
+      query_str = <<-GRAPHQL
+        subscription($type: PayloadType) {
+          myEvent(type: $type) { int }
+        }
+      GRAPHQL
+
+      # Global ID Backed User
+      schema.execute(query_str, context: { socket: "1", me: GlobalIDUser.new(1) }, variables: { "type" => "ONE" }, root_value: root_object)
+      schema.execute(query_str, context: { socket: "2", me: GlobalIDUser.new(1) }, variables: { "type" => "TWO" }, root_value: root_object)
+      # ToParam Backed User
+      schema.execute(query_str, context: { socket: "3", me: ToParamUser.new(2) }, variables: { "type" => "ONE" }, root_value: root_object)
+      # Array of Objects
+      schema.execute(query_str, context: { socket: "4", me: [GlobalIDUser.new(4), ToParamUser.new(5)] }, variables: { "type" => "ONE" }, root_value: root_object)
+      
+      schema.subscriptions.trigger("myEvent", { "type" => "ONE" }, OpenStruct.new(str: "", int: 1), scope: GlobalIDUser.new(1))
+      schema.subscriptions.trigger("myEvent", { "type" => "TWO" }, OpenStruct.new(str: "", int: 2), scope: GlobalIDUser.new(1))
+      schema.subscriptions.trigger("myEvent", { "type" => "ONE" }, OpenStruct.new(str: "", int: 3), scope: ToParamUser.new(2))
+      schema.subscriptions.trigger("myEvent", { "type" => "ONE" }, OpenStruct.new(str: "", int: 4), scope: [GlobalIDUser.new(4), ToParamUser.new(5)])
+
+      # Delivered to GlobalIDUser
+      assert_equal [1], deliveries["1"].map { |d| d["data"]["myEvent"]["int"] }
+      assert_equal [2], deliveries["2"].map { |d| d["data"]["myEvent"]["int"] }
+      # Delivered to ToParamUser
+      assert_equal [3], deliveries["3"].map { |d| d["data"]["myEvent"]["int"] }
+      # Delivered to Array of GlobalIDUser and ToParamUser
+      assert_equal [4], deliveries["4"].map { |d| d["data"]["myEvent"]["int"] }
     end
 
     describe "errors" do


### PR DESCRIPTION
Adds support for serializing the `subscription_scope` used for GraphQL subscriptions. The new `serialize_scope` method is based on [`broadcasting_for`](https://github.com/rails/rails/blob/012196bbc78cf1c9243d0c2ceaa1e509a9a34a11/actioncable/lib/action_cable/channel/broadcasting.rb#L18-L27) used by ActionCable for a similar purpose.

This solves a bug when using an ActiveRecord model object to scope the subscription. `GraphQL::Subscriptions::Event.serialize` calls `JSON.dump([scope, name, sorted_h])` which appears to call `to_s` on each of the array elements. In the case of `scope`, it returns a string like `"#<User:0x00000005e01c80>"` containing the `object_id` and breaking scoped subscriptions.

Example:
```ruby
Schema = GraphQL::Schema.define do
  subscription(SubscriptionType)
end

SubscriptionType = GraphQL::ObjectType.define do
  field :activityFeed, ActivityType do
    subscription_scope :current_user
  end
end

context = {
  current_user: User.find(1)
}

Schema.execute(query: 'subscription { activityFeed() { id } }', context: context)
```