### PR TITLE
Add options parameter to GraphQL::ExecutionError

### DIFF
--- a/lib/graphql/execution_error.rb
+++ b/lib/graphql/execution_error.rb
@@ -11,8 +11,12 @@ module GraphQL
     # response which corresponds to this error.
     attr_accessor :path
 
-    def initialize(message, ast_node: nil)
+    # @return [Hash] Optional data for error objects
+    attr_accessor :options
+
+    def initialize(message, ast_node: nil, options: nil)
       @ast_node = ast_node
+      @options = options
       super(message)
     end
 
@@ -31,6 +35,9 @@ module GraphQL
       end
       if path
         hash["path"] = path
+      end
+      if options
+        hash.merge!(options)
       end
       hash
     end

--- a/spec/graphql/execution_error_spec.rb
+++ b/spec/graphql/execution_error_spec.rb
@@ -252,4 +252,23 @@ describe GraphQL::ExecutionError do
       assert_equal(expected_result, result)
     end
   end
+
+  describe "options in ExecutionError" do
+    let(:query_string) {%|
+    {
+      executionErrorWithOptions
+    }
+    |}
+    it "the error is inserted into the errors key and the rest of the query is fulfilled" do
+      expected_result = {
+        "data"=>{"executionErrorWithOptions"=>nil},
+        "errors"=>
+            [{"message"=>"Permission Denied!",
+              "locations"=>[{"line"=>3, "column"=>7}],
+              "path"=>["executionErrorWithOptions"],
+              "code"=>"permission_denied"}]
+      }
+      assert_equal(expected_result, result)
+    end
+  end
 end

--- a/spec/graphql/introspection/schema_type_spec.rb
+++ b/spec/graphql/introspection/schema_type_spec.rb
@@ -30,6 +30,7 @@ describe GraphQL::Introspection::SchemaType do
             {"name"=>"deepNonNull"},
             {"name"=>"error"},
             {"name"=>"executionError"},
+            {"name"=>"executionErrorWithOptions"},
             {"name"=>"favoriteEdible"},
             {"name"=>"fromSource"},
             {"name"=>"maybeNull"},

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -360,6 +360,13 @@ module Dummy
       }
     end
 
+    field :executionErrorWithOptions do
+      type GraphQL::INT_TYPE
+      resolve ->(t, a, c) {
+        GraphQL::ExecutionError.new("Permission Denied!", options: { "code" => "permission_denied" })
+      }
+    end
+
     # To test possibly-null fields
     field :maybeNull, MaybeNullType do
       resolve ->(t, a, c) { OpenStruct.new(cheese: nil) }


### PR DESCRIPTION
There are cases where I'd like to add an arbitrary data structure to error objects, like `{ "code": "payment_required" }`.

What do you think of it?