### PR TITLE
Don't propogate nil to sibling query selections

### DIFF
--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -219,9 +219,6 @@ module GraphQL
           when GraphQL::Execution::Execute::PROPAGATE_NULL, nil
             @invalid_null = true
             @value = nil
-            if @type.kind.non_null?
-              @parent.received_null_child
-            end
           when GraphQL::Execution::Execute::SKIP
             @parent.skipped = true
             @parent.delete(self)


### PR DESCRIPTION
The problem we ran into is that we want to provide as much data as possible, even when there are errors. For example, given this query:

```
query {
  resourceA {
    id
  }
  resourceB {
    id
  }
}
```

and provided that the response indicates that both fields are not nullable, then graphql-ruby will currently seemingly give up on resolving `resourceB` when resolving `resourceA` is somehow nil.

What seems to be going is that whenever a node being resolved results in a `nil` being put in a non-nullable field (-> no valid result possible), it marks the parent as having `received_null_child`. When continuing resolving the siblings, specifically in `continue_resolve_field`, this causes the following early-exit:

```lang=ruby
          if field_ctx.parent.invalid_null?
            return nil
          end
```

So, reusing the example, graphql-ruby evaluate `resourceA`, this results in a nil, and the parent (`query`) is marked with `received_null_child`. Next, when evaluating `resourceB`, graphql-ruby checks that the parent (again, `query`) has received `invalid_null?`. This evaluates to `true`, and causes `resourceB` to be `nil` as well.

We "solved" this problem by making all top-level types nullable. However, we still thought this behavior was a bit puzzling, so wanted to bring it up here to see if it's helpful to make a change here!

cc @mvgijssel 