### PR TITLE
Explore RDL 

### DIFF
--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest-reporters", "~>1.0"
   s.add_development_dependency "racc", "~> 1.4"
   s.add_development_dependency "rake", "~> 11"
+  s.add_development_dependency "rdl"
   s.add_development_dependency "rubocop", "~> 0.45"
   # following are required for relay helpers
   s.add_development_dependency "appraisal"

--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -5,6 +5,13 @@ require "set"
 require "singleton"
 
 module GraphQL
+  if ENV["SKIP_RDL"]
+    def self.type(*); end
+  else
+    require "rdl"
+    extend RDL::Annotate
+  end
+
   if RUBY_VERSION == "2.4.0"
     # Ruby stdlib was pretty busted until this fix:
     # https://bugs.ruby-lang.org/issues/13111
@@ -35,6 +42,7 @@ module GraphQL
   # Turn a query string or schema definition into an AST
   # @param graphql_string [String] a GraphQL query string or schema definition
   # @return [GraphQL::Language::Nodes::Document]
+  type("(String, tracer: ?[trace: (String, Hash) -> %any]) -> GraphQL::Language::Nodes::Document")
   def self.parse(graphql_string, tracer: GraphQL::Tracing::NullTracer)
     parse_with_racc(graphql_string, tracer: tracer)
   end
@@ -42,6 +50,7 @@ module GraphQL
   # Read the contents of `filename` and parse them as GraphQL
   # @param filename [String] Path to a `.graphql` file containing IDL or query
   # @return [GraphQL::Language::Nodes::Document]
+  type("(String) -> GraphQL::Language::Nodes::Document")
   def self.parse_file(filename)
     content = File.read(filename)
     parse_with_racc(content, filename: filename)

--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -4,6 +4,7 @@ module GraphQL
     # A valid execution strategy
     # @api private
     class Execute
+      extend RDL::Annotate
 
       # @api private
       class Skip; end
@@ -18,6 +19,7 @@ module GraphQL
       # @api private
       PROPAGATE_NULL = PropagateNull.new
 
+      type("(GraphQL::Language::Nodes::OperationDefinition, GraphQL::ObjectType, GraphQL::Query) -> Hash<String, %any>")
       def execute(ast_operation, root_type, query)
         result = resolve_root_selection(query)
         lazy_resolve_root_selection(result, {query: query})
@@ -26,8 +28,10 @@ module GraphQL
 
       # @api private
       module ExecutionFunctions
+        extend RDL::Annotate
         module_function
 
+        type("(GraphQL::Query) -> Hash<String, %any>")
         def resolve_root_selection(query)
           query.trace("execute_query", query: query) do
             operation = query.selected_operation
@@ -53,6 +57,7 @@ module GraphQL
           end
         end
 
+        type("(%any, GraphQL::ObjectType, GraphQL::Query::Context or GraphQL::Query::Context::FieldResolutionContext, mutation: %bool) -> %any")
         def resolve_selection(object, current_type, current_ctx, mutation: false )
           # Assign this _before_ resolving the children
           # so that when a child propagates null, the selection result is
@@ -97,6 +102,7 @@ module GraphQL
           current_ctx.value
         end
 
+        type("(%any, GraphQL::Query::Context::FieldResolutionContext) -> %any")
         def resolve_field(object, field_ctx)
           query = field_ctx.query
           irep_node = field_ctx.irep_node
@@ -131,6 +137,7 @@ module GraphQL
           end
         end
 
+        type("(%any, GraphQL::Query::Context::FieldResolutionContext) -> %any")
         def continue_resolve_field(raw_value, field_ctx)
           if field_ctx.parent.invalid_null?
             return nil
@@ -160,6 +167,7 @@ module GraphQL
           )
         end
 
+        type("(%any, GraphQL::BaseType, GraphQL::Query::Context::FieldResolutionContext) -> %any")
         def resolve_value(value, field_type, field_ctx)
           field_defn = field_ctx.field
 

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -192,6 +192,10 @@ module GraphQL
       end
     end
 
+    def inspect
+      "#<GraphQL::Query #{selected_operation_name}(#{variables.to_h})...>"
+    end
+
     # Node-level cache for calculating arguments. Used during execution and query analysis.
     # @api private
     # @return [GraphQL::Query::Arguments] Arguments for this node, merging default values, literal values and query variables

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -17,6 +17,7 @@ module GraphQL
   class Query
     include Tracing::Traceable
     extend GraphQL::Delegate
+    extend RDL::Annotate
 
     class OperationNameMissingError < GraphQL::ExecutionError
       def initialize(name)
@@ -69,6 +70,22 @@ module GraphQL
     # @param max_complexity [Numeric] the maximum field complexity for this query (falls back to schema-level value)
     # @param except [<#call(schema_member, context)>] If provided, objects will be hidden from the schema when `.call(schema_member, context)` returns truthy
     # @param only [<#call(schema_member, context)>] If provided, objects will be hidden from the schema when `.call(schema_member, context)` returns false
+    type "(
+      GraphQL::Schema,
+      ?String,
+      query: ?String,
+      document: ?GraphQL::Language::Nodes::Document,
+      context: ?Hash,
+      variables: ?(Hash<String, %any> or String or ActionController::Parameters),
+      validate: ?%bool,
+      operation_name: ?String,
+      subscription_topic: ?String,
+      root_value: ?%any,
+      only: ?%any,
+      except: ?%any,
+      max_complexity: ?Integer,
+      max_depth: ?Integer
+    ) -> %any"
     def initialize(schema, query_string = nil, query: nil, document: nil, context: nil, variables: {}, validate: true, subscription_topic: nil, operation_name: nil, root_value: nil, max_depth: nil, max_complexity: nil, except: nil, only: nil)
       @schema = schema
       @filter = schema.default_filter.merge(except: except, only: only)

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -465,6 +465,10 @@ module GraphQL
       @type_error_proc = new_proc
     end
 
+    def inspect
+      "#<GraphQL::Schema ...>"
+    end
+
     # A function to call when {#execute} receives an invalid query string
     #
     # @see {DefaultParseError} is the default behavior.

--- a/spec/graphql/language/parser_spec.rb
+++ b/spec/graphql/language/parser_spec.rb
@@ -72,9 +72,17 @@ describe GraphQL::Language::Parser do
     end
   end
 
+  # This is a workaround for RDL, see:
+  # https://github.com/plum-umd/rdl/issues/60
+  class TestTracingDelegate
+    def trace(*args, &block)
+      TestTracing.trace(*args, &block)
+    end
+  end
+
   it "serves traces" do
     TestTracing.clear
-    GraphQL.parse("{ t: __typename }", tracer: TestTracing)
+    GraphQL.parse("{ t: __typename }", tracer: TestTracingDelegate.new)
     traces = TestTracing.traces
     assert_equal 2, traces.length
     lex_trace, parse_trace = traces


### PR DESCRIPTION
I'm a lover of type systems, so I thought I would try [RDL](). 

This is just an experiment and could never be merged UNTIL: 

- [ ] The perf hit for development is not bad (currently a 300% slowdown) 
- [ ] We can be sure that gem users won't be affected 
- [ ] It's worth the value 

Personally, I'm not interested in annotating types _twice_, once for YARD and again for RDL. But I think it might be possible to _generate_ types for RDL from YARD. But the first step is to try RDL.


