### PR TITLE
test(ActionCableSubscriptions) test partial unsubscribe

### DIFF
--- a/spec/dummy/app/views/pages/show.html
+++ b/spec/dummy/app/views/pages/show.html
@@ -1,6 +1,6 @@
 <h1>ActionCable Test Page</h1>
-<button onClick="sub1.trigger()" id="trigger-1">Trigger 1</button>
-<button onClick="sub2.trigger()" id="trigger-2">Trigger 2</button>
+<button onClick="sub1.trigger()">Trigger 1</button>
+<button onClick="sub2.trigger()">Trigger 2</button>
 <p>ActionCable updates:</p>
 <ul id="updates-1">
 </ul>
@@ -8,6 +8,8 @@
 <ul id="updates-2">
 </ul>
 
+<button onClick="sub1.unsubscribe()">Unsubscribe 1</button>
+<button onClick="sub2.unsubscribe()">Unsubscribe 2</button>
 <script>
 var sub1 = App.subscribe("updates-1")
 var sub2 = App.subscribe("updates-2")

--- a/spec/dummy/test/system/action_cable_subscription_test.rb
+++ b/spec/dummy/test/system/action_cable_subscription_test.rb
@@ -25,6 +25,17 @@ class ActionCableSubscriptionsTest < ApplicationSystemTestCase
     click_on("Trigger 2")
     assert_selector "#updates-2-1", text: "1"
     assert_selector "#updates-2-2", text: "2"
+    refute_selector "#updates-2-3"
+    refute_selector "#updates-1-4"
+
+    # Now unsubscribe one, it should not receive updates but the other should
+    click_on("Unsubscribe 1")
+    click_on("Trigger 1")
+    # This should not have changed
+    refute_selector "#updates-1-4"
+
+    click_on("Trigger 2")
+    assert_selector "#updates-2-3", text: "3"
     refute_selector "#updates-1-4"
   end
 end


### PR DESCRIPTION
I'm still getting the hang of how to do subscriptions over ActionCable. 

This adds a new step to the test case: after making two subscriptions and triggering them separately, also unsubscribe one of them. Make sure the unsubscribed channel doesn't get more updates, but the still-subscribed one does. 