### PR TITLE
remove redundant 'if after'

### DIFF
--- a/lib/graphql/relay/relation_connection.rb
+++ b/lib/graphql/relay/relation_connection.rb
@@ -131,7 +131,7 @@ module GraphQL
 
         if after
           offset = (relation_offset(@sliced_nodes) || 0) + offset_from_cursor(after)
-          @sliced_nodes = @sliced_nodes.offset(offset) if after
+          @sliced_nodes = @sliced_nodes.offset(offset)
         end
 
         if before && after


### PR DESCRIPTION
This is already inside an `if after` block so this condition is redundant and always evaluates to true.

Unless there's some side effect I'm missing 😃