### PR TITLE
Make dummy app work

### DIFF
--- a/spec/dummy/Gemfile
+++ b/spec/dummy/Gemfile
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
+source 'https://rubygems.org'
+
 gem 'rails'
 gem 'puma'
 gem 'capybara'
 gem 'selenium-webdriver'
-gem 'graphql', path: File.expand_path("../../", __dir__)
+gem 'graphql', path: File.expand_path('../../', __dir__)
 
 group :development do
-  gem "listen"
+  gem 'listen'
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -10,7 +10,6 @@ require "action_view/railtie"
 require "action_cable/engine"
 require "sprockets/railtie"
 require "rails/test_unit/railtie"
-require "puma"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
I wanted to try out the Dummy app inside the `spec` folder, but I wasn't able to run `bundle exec rails server` due to the missing gems, and because Puma was required when it shouldn't. 