### PR TITLE
Rename Backtrace::InspectResult.inspect to .inspect_result

### DIFF
--- a/lib/graphql/backtrace/inspect_result.rb
+++ b/lib/graphql/backtrace/inspect_result.rb
@@ -5,7 +5,7 @@ module GraphQL
     module InspectResult
       module_function
 
-      def inspect(obj)
+      def inspect_result(obj)
         case obj
         when Hash
           "{" +

--- a/lib/graphql/backtrace/table.rb
+++ b/lib/graphql/backtrace/table.rb
@@ -89,7 +89,7 @@ module GraphQL
             "#{field_name}#{field_alias ? " as #{field_alias}" : ""}",
             "#{ctx.object.inspect}",
             ctx.irep_node.arguments.to_h.inspect,
-            Backtrace::InspectResult.inspect(top && @override_value ? @override_value : ctx.value),
+            Backtrace::InspectResult.inspect_result(top && @override_value ? @override_value : ctx.value),
           ]
 
           build_rows(ctx.parent, rows: rows)
@@ -109,7 +109,7 @@ module GraphQL
             "#{op_type}#{op_name ? " #{op_name}" : ""}",
             "#{query.root_value.inspect}",
             query.variables.to_h.inspect,
-            Backtrace::InspectResult.inspect(query.context.value),
+            Backtrace::InspectResult.inspect_result(query.context.value),
           ]
         else
           raise "Unexpected get_rows subject #{context_entry.inspect}"


### PR DESCRIPTION
### Summary

While running the Shopify codebase through [Mirrors](https://github.com/Shopify/mirrors), I hit a snag that caused it to blow up when trying to `inspect` the `GraphQL::Backtrace::InspectResult` module. This is because that module's `inspect` definition has an arity of 1, where the assumed arity of inspect is always 0.

This PR renames `Backtrace::InspectResult.inspect` to `Backtrace::InspectResult.inspect_result`, so that the default definition of `inspect` still exists on the object.

### Details

The [current implementation](https://github.com/rmosolgo/graphql-ruby/blob/b9433c3f5ce1554a2b37329d3eca467c02f066ba/lib/graphql/backtrace/inspect_result.rb#L8) of `Backtrace::InspectResult.inspect` (introduced in https://github.com/rmosolgo/graphql-ruby/pull/946) accepts an object to interpret and stringify, but calling `inspect` should return a human-readable string of the invoked object, not its arguments.

Ruby encourages the overriding of this method, but `Backtrace::InspectResult.inspect` was never intended to replace the default definition of `inspect` since it provides new functionality with a different arity.

@rmosolgo @eapache for review/comments 🙏 