### PR TITLE
Improve generated controller code

### DIFF
--- a/lib/generators/graphql/templates/graphql_controller.erb
+++ b/lib/generators/graphql/templates/graphql_controller.erb
@@ -1,33 +1,37 @@
 class GraphqlController < ApplicationController
   def execute
-    variables = ensure_hash(params[:variables])
-    query = params[:query]
-    operation_name = params[:operationName]
-    context = {
-      # Query context goes here, for example:
-      # current_user: current_user,
-    }
-    result = <%= schema_name %>.execute(query, variables: variables, context: context, operation_name: operation_name)
+    result = <%= schema_name %>.execute(
+      query,
+      variables: variables,
+      context: context,
+      operation_name: operation_name,
+    )
+
     render json: result
   end
 
   private
 
-  # Handle form data, JSON body, or a blank value
-  def ensure_hash(ambiguous_param)
-    case ambiguous_param
+  def query
+    params[:query]
+  end
+
+  def variables
+    vars = params.fetch(:variables, {})
+
+    case vars
     when String
-      if ambiguous_param.present?
-        ensure_hash(JSON.parse(ambiguous_param))
-      else
-        {}
-      end
-    when Hash, ActionController::Parameters
-      ambiguous_param
-    when nil
-      {}
+      JSON.parse(vars)
     else
-      raise ArgumentError, "Unexpected parameter: #{ambiguous_param}"
+      vars
     end
+  end
+
+  def context
+    {}
+  end
+
+  def operation_name
+    params[:operationName]
   end
 end

--- a/spec/generators/graphql/install_generator_spec.rb
+++ b/spec/generators/graphql/install_generator_spec.rb
@@ -126,35 +126,39 @@ RUBY
   EXPECTED_GRAPHQLS_CONTROLLER = <<-RUBY
 class GraphqlController < ApplicationController
   def execute
-    variables = ensure_hash(params[:variables])
-    query = params[:query]
-    operation_name = params[:operationName]
-    context = {
-      # Query context goes here, for example:
-      # current_user: current_user,
-    }
-    result = DummySchema.execute(query, variables: variables, context: context, operation_name: operation_name)
+    result = DummySchema.execute(
+      query,
+      variables: variables,
+      context: context,
+      operation_name: operation_name,
+    )
+
     render json: result
   end
 
   private
 
-  # Handle form data, JSON body, or a blank value
-  def ensure_hash(ambiguous_param)
-    case ambiguous_param
+  def query
+    params[:query]
+  end
+
+  def variables
+    vars = params.fetch(:variables, {})
+
+    case vars
     when String
-      if ambiguous_param.present?
-        ensure_hash(JSON.parse(ambiguous_param))
-      else
-        {}
-      end
-    when Hash, ActionController::Parameters
-      ambiguous_param
-    when nil
-      {}
+      JSON.parse(vars)
     else
-      raise ArgumentError, "Unexpected parameter: \#{ambiguous_param}"
+      vars
     end
+  end
+
+  def context
+    {}
+  end
+
+  def operation_name
+    params[:operationName]
   end
 end
 RUBY


### PR DESCRIPTION
* `ensure_hash` was used once to parse the variables for a query. This
  logic was moved into a `variables` method and simplified some through
  the use of `fetch` to default `nil` variables to a hash and by
  eliminating the explicit `raise` case from the switch statement. In
  normal operation, that case should never be hit.
* For the sake of balance, the other parts of the query were also pulled
  into their own private methods. This is particularly useful for
  `context` which is the most likely to change.
* The resulting `execute` action is reformatted to obey common long-line
  linters.