### PR TITLE
Add usage example for `hash_key` option for `field` definition

### DIFF
--- a/guides/fields/introduction.md
+++ b/guides/fields/introduction.md
@@ -17,7 +17,14 @@ PostType = GraphQL::ObjectType.define do
 end
 ```
 
-By default, fields are resolved by sending the name to the underlying object (eg `post.title` in the example above).
+By default, fields are resolved by sending the name to the underlying object (eg `post.title` in the example above). 
+
+You can use the `hash_key` option instead to force a hash lookup instead of the default behaviour:
+
+```ruby
+field :title, types.String, hash_key: :title
+# resolved with `post[:title]` instead of `post.title`
+```
 
 You can define a different resolution by providing a `resolve` function:
 


### PR DESCRIPTION
No hint or doc on this magical option which can be used instead of rewriting `resolve` with a lambda or resolver class