### PR TITLE
Allow generator directory to be configured

### DIFF
--- a/lib/generators/graphql/core.rb
+++ b/lib/generators/graphql/core.rb
@@ -4,6 +4,16 @@ require 'rails/generators/base'
 module Graphql
   module Generators
     module Core
+      def self.included(base)
+        base.send(
+          :class_option,
+          :directory,
+          type: :string,
+          default: "app/graphql",
+          desc: "Directory where generated files should be saved"
+        )
+      end
+
       def insert_root_type(type, name)
         log :add_root_type, type
         sentinel = /GraphQL\:\:Schema\.define do\s*\n/m
@@ -14,13 +24,13 @@ module Graphql
       end
 
       def create_mutation_root_type
-        create_dir("app/graphql/mutations")
-        template("mutation_type.erb", "app/graphql/types/mutation_type.rb", { skip: true })
+        create_dir("#{options[:directory]}/mutations")
+        template("mutation_type.erb", "#{options[:directory]}/types/mutation_type.rb", { skip: true })
         insert_root_type('mutation', 'MutationType')
       end
 
       def schema_file_path
-        "app/graphql/#{schema_name.underscore}.rb"
+        "#{options[:directory]}/#{schema_name.underscore}.rb"
       end
 
       def create_dir(dir)

--- a/lib/generators/graphql/enum_generator.rb
+++ b/lib/generators/graphql/enum_generator.rb
@@ -20,7 +20,7 @@ module Graphql
         desc: "Values for this enum (if present, ruby_value will be inserted verbatim)"
 
       def create_type_file
-        template "enum.erb", "app/graphql/types/#{type_file_name}.rb"
+        template "enum.erb", "#{options[:directory]}/types/#{type_file_name}.rb"
       end
 
       private

--- a/lib/generators/graphql/function_generator.rb
+++ b/lib/generators/graphql/function_generator.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 require "rails/generators/named_base"
+require_relative "core"
 
 module Graphql
   module Generators
     class FunctionGenerator < Rails::Generators::NamedBase
+      include Core
+
       desc "Create a GraphQL::Function by name"
       source_root File.expand_path('../templates', __FILE__)
 
       def create_function_file
-        template "function.erb", "app/graphql/functions/#{file_name}.rb"
+        template "function.erb", "#{options[:directory]}/functions/#{file_name}.rb"
       end
     end
   end

--- a/lib/generators/graphql/install_generator.rb
+++ b/lib/generators/graphql/install_generator.rb
@@ -89,11 +89,11 @@ if Rails.env.development?
 RUBY
 
       def create_folder_structure
-        create_dir("app/graphql/types")
+        create_dir("#{options[:directory]}/types")
         template("schema.erb", schema_file_path)
 
         # Note: Yuo can't have a schema without the query type, otherwise introspection breaks
-        template("query_type.erb", "app/graphql/types/query_type.rb")
+        template("query_type.erb", "#{options[:directory]}/types/query_type.rb")
         insert_root_type('query', 'QueryType')
 
         create_mutation_root_type unless options.skip_mutation_root_type?
@@ -103,7 +103,7 @@ RUBY
 
         if options[:batch]
           gem("graphql-batch")
-          create_dir("app/graphql/loaders")
+          create_dir("#{options[:directory]}/loaders")
         end
 
         if options.api?

--- a/lib/generators/graphql/interface_generator.rb
+++ b/lib/generators/graphql/interface_generator.rb
@@ -20,7 +20,7 @@ module Graphql
         desc: "Fields for this interface (type may be expressed as Ruby or GraphQL)"
 
       def create_type_file
-        template "interface.erb", "app/graphql/types/#{type_file_name}.rb"
+        template "interface.erb", "#{options[:directory]}/types/#{type_file_name}.rb"
       end
     end
   end

--- a/lib/generators/graphql/loader_generator.rb
+++ b/lib/generators/graphql/loader_generator.rb
@@ -1,16 +1,19 @@
 # frozen_string_literal: true
 require "rails/generators/named_base"
+require_relative "core"
 
 module Graphql
   module Generators
     # @example Generate a `GraphQL::Batch` loader by name.
     #     rails g graphql:loader RecordLoader
     class LoaderGenerator < Rails::Generators::NamedBase
+      include Core
+
       desc "Create a GraphQL::Batch::Loader by name"
       source_root File.expand_path('../templates', __FILE__)
 
       def create_loader_file
-        template "loader.erb", "app/graphql/loaders/#{file_name}.rb"
+        template "loader.erb", "#{options[:directory]}/loaders/#{file_name}.rb"
       end
     end
   end

--- a/lib/generators/graphql/mutation_generator.rb
+++ b/lib/generators/graphql/mutation_generator.rb
@@ -28,12 +28,12 @@ module Graphql
 
       def create_mutation_file
         create_mutation_root_type
-        template "mutation.erb", "app/graphql/mutations/#{file_name}.rb"
+        template "mutation.erb", "#{options[:directory]}/mutations/#{file_name}.rb"
 
         sentinel = /name "Mutation"\s*\n/m
         in_root do
-          gsub_file "app/graphql/types/mutation_type.rb", /  \# TODO\: Add Mutations as fields\s*\n/m, ""
-          inject_into_file "app/graphql/types/mutation_type.rb", "  field :#{field_name}, Mutations::#{mutation_name}.field\n", after: sentinel, verbose: false, force: false
+          gsub_file "#{options[:directory]}/types/mutation_type.rb", /  \# TODO\: Add Mutations as fields\s*\n/m, ""
+          inject_into_file "#{options[:directory]}/types/mutation_type.rb", "  field :#{field_name}, Mutations::#{mutation_name}.field\n", after: sentinel, verbose: false, force: false
         end
       end
 

--- a/lib/generators/graphql/object_generator.rb
+++ b/lib/generators/graphql/object_generator.rb
@@ -27,7 +27,7 @@ module Graphql
         desc: "Include the Relay Node interface"
 
       def create_type_file
-        template "object.erb", "app/graphql/types/#{type_file_name}.rb"
+        template "object.erb", "#{options[:directory]}/types/#{type_file_name}.rb"
       end
     end
   end

--- a/lib/generators/graphql/type_generator.rb
+++ b/lib/generators/graphql/type_generator.rb
@@ -3,10 +3,13 @@ require 'rails/generators/base'
 require 'graphql'
 require 'active_support'
 require 'active_support/core_ext/string/inflections'
+require_relative 'core'
 
 module Graphql
   module Generators
     class TypeGeneratorBase < Rails::Generators::Base
+      include Core
+
       argument :type_name,
         type: :string,
         required: true,

--- a/lib/generators/graphql/union_generator.rb
+++ b/lib/generators/graphql/union_generator.rb
@@ -20,7 +20,7 @@ module Graphql
         desc: "Possible types for this union (expressed as Ruby or GraphQL)"
 
       def create_type_file
-        template "union.erb", "app/graphql/types/#{type_file_name}.rb"
+        template "union.erb", "#{options[:directory]}/types/#{type_file_name}.rb"
       end
 
       private

--- a/spec/generators/graphql/install_generator_spec.rb
+++ b/spec/generators/graphql/install_generator_spec.rb
@@ -64,6 +64,13 @@ RUBY
     assert_file "app/controllers/graphql_controller.rb", EXPECTED_GRAPHQLS_CONTROLLER
   end
 
+  test "it allows for a user-specified install directory" do
+    run_generator(["--directory", "app/mydirectory"])
+
+    assert_file "app/mydirectory/types/.keep"
+    assert_file "app/mydirectory/mutations/.keep"
+  end
+
   test "it generates graphql-batch and relay boilerplate" do
     run_generator(["--batch", "--relay"])
     assert_file "app/graphql/loaders/.keep"

--- a/spec/generators/graphql/mutation_generator_spec.rb
+++ b/spec/generators/graphql/mutation_generator_spec.rb
@@ -7,7 +7,7 @@ class GraphQLGeneratorsMutationGeneratorTest < BaseGeneratorTest
 
   destination File.expand_path("../../../tmp/dummy", File.dirname(__FILE__))
 
-  setup do
+  def setup(directory = "app/graphql")
     prepare_destination
     FileUtils.cd(File.expand_path("../../../tmp", File.dirname(__FILE__))) do
       `rm -rf dummy`
@@ -15,11 +15,12 @@ class GraphQLGeneratorsMutationGeneratorTest < BaseGeneratorTest
     end
 
     FileUtils.cd(destination_root) do
-      `rails g graphql:install`
+      `rails g graphql:install --directory #{directory}`
     end
   end
 
   test "it generates an empty resolver by name" do
+    setup
     run_generator(["UpdateName"])
 
     expected_content = <<-RUBY
@@ -38,5 +39,27 @@ end
 RUBY
 
     assert_file "app/graphql/mutations/update_name.rb", expected_content
+  end
+
+  test "it allows for user-specified directory" do
+    setup "app/mydirectory"
+    run_generator(["UpdateName", "--directory", "app/mydirectory"])
+
+    expected_content = <<-RUBY
+Mutations::UpdateName = GraphQL::Relay::Mutation.define do
+  name "UpdateName"
+  # TODO: define return fields
+  # return_field :post, Types::PostType
+
+  # TODO: define arguments
+  # input_field :name, !types.String
+
+  resolve ->(obj, args, ctx) {
+    # TODO: define resolve function
+  }
+end
+RUBY
+
+    assert_file "app/mydirectory/mutations/update_name.rb", expected_content
   end
 end

--- a/spec/generators/graphql/union_generator_spec.rb
+++ b/spec/generators/graphql/union_generator_spec.rb
@@ -47,4 +47,18 @@ RUBY
       assert_file "app/graphql/types/winged_creature_type.rb", expected_content
     end
   end
+
+  test "it accepts a user-specified directory" do
+    command = ["WingedCreature", "--directory", "app/mydirectory"]
+
+    expected_content = <<-RUBY
+Types::WingedCreatureType = GraphQL::UnionType.define do
+  name "WingedCreature"
+end
+RUBY
+
+    prepare_destination
+    run_generator(command)
+    assert_file "app/mydirectory/types/winged_creature_type.rb", expected_content
+  end
 end


### PR DESCRIPTION
This PR allows users to specify where to install generated files in Rails. At AdHawk, we setup graphql before generators were around, so it is in `app/graph`. Instead of moving all the files in git, we would like to be able to configure this option. This PR makes that happen 😄 