### PR TITLE
Adds parsing for https urls passed into the client via commandline

### DIFF
--- a/javascript_client/sync/__tests__/sendPayloadTest.js
+++ b/javascript_client/sync/__tests__/sendPayloadTest.js
@@ -13,6 +13,27 @@ describe("Posting GraphQL to OperationStore Endpoint", () => {
     })
   })
 
+  it("Uses HTTPS when provided", () => {
+    var mock = nock("https://example2.com")
+      .post("/stored_operations/sync")
+      .reply(200, { "ok" : "ok" })
+
+    return sendPayload("payload", { url: "https://example2.com/stored_operations/sync" }).then(function() {
+      expect(mock.isDone()).toEqual(true)
+    })
+  })
+
+  it("Uses auth, port, and query", () => {
+    var mock = nock("https://example2.com:229")
+      .post("/stored_operations/sync?q=1")
+      .basicAuth({ user: "username", pass: "pass" })
+      .reply(200, { "ok" : "ok" })
+
+    return sendPayload("payload", { url: "https://username:pass@example2.com:229/stored_operations/sync?q=1" }).then(function() {
+      expect(mock.isDone()).toEqual(true)
+    })
+  })
+
   it("Returns the response JSON to the promise", () => {
     var mock = nock("http://example.com")
       .post("/stored_operations/sync")

--- a/javascript_client/sync/sendPayload.js
+++ b/javascript_client/sync/sendPayload.js
@@ -25,7 +25,10 @@ function sendPayload(payload, options) {
 
   // Get parts of URL for request options
   var parsedURL = url.parse(syncUrl)
-  var parsedPort = parsedURL.protocol === "https:" ? "443" : "80"
+  var parsedPort = parsedURL.port
+  if (!parsedPort) { // Nothing was passed explicitly, guess from the protocol
+    parsedPort = parsedURL.protocol === "https" ? "443" : "80"
+  }
 
   // Prep options for HTTP request
   var options = {

--- a/javascript_client/sync/sendPayload.js
+++ b/javascript_client/sync/sendPayload.js
@@ -25,10 +25,12 @@ function sendPayload(payload, options) {
 
   // Get parts of URL for request options
   var parsedURL = url.parse(syncUrl)
+  var parsedPort = parsedURL.protocol === "https:" ? "443" : "80"
+
   // Prep options for HTTP request
   var options = {
     hostname: parsedURL.hostname,
-    port: parsedURL.port || "80",
+    port: parsedPort,
     path: parsedURL.path,
     method: 'POST',
     headers: {

--- a/javascript_client/sync/sendPayload.js
+++ b/javascript_client/sync/sendPayload.js
@@ -1,4 +1,5 @@
 var http = require("http")
+var https = require("https")
 var url = require("url")
 var crypto = require('crypto')
 var printResponse = require("./printResponse")
@@ -25,16 +26,14 @@ function sendPayload(payload, options) {
 
   // Get parts of URL for request options
   var parsedURL = url.parse(syncUrl)
-  var parsedPort = parsedURL.port
-  if (!parsedPort) { // Nothing was passed explicitly, guess from the protocol
-    parsedPort = parsedURL.protocol === "https" ? "443" : "80"
-  }
 
   // Prep options for HTTP request
   var options = {
+    protocol: parsedURL.protocol,
     hostname: parsedURL.hostname,
-    port: parsedPort,
+    port: parsedURL.port,
     path: parsedURL.path,
+    auth: parsedURL.auth,
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -51,10 +50,11 @@ function sendPayload(payload, options) {
     options.headers["Authorization"] = "GraphQL::Pro " + clientName + " " + authDigest
   }
 
+  var httpClient = parsedURL.protocol === "https:" ? https : http
   var promise = new Promise(function(resolve, reject) {
     // Make the request,
     // hook up response handler
-    const req = http.request(options, (res) => {
+    const req = httpClient.request(options, (res) => {
       res.setEncoding('utf8');
       var status = res.statusCode
       // 422 gets special treatment because


### PR DESCRIPTION
### The issue

using the client like this:

```
graphql-ruby-client sync --path='app/javascript/packs/myapp/graphql/' --url='https://myapp.mycompany.com/graphql/sync'
```

Was not hitting the `https` endpoints. I needed to specify the port in the url like this `url='https://myapp.mycompany.com:443/graphql/sync'`

### The Solution

Parse the urlString for the protocol and default to `443` for `https`, otherwise use port `80`.