### PR TITLE
Adding some helpers for querying graphql types

### DIFF
--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -206,6 +206,16 @@ module GraphQL
       printer.print_type(self)
     end
 
+    # Returns true if this is a non-nullable type. A nullable list of non-nullables is considered nullable.
+    def non_null?
+      false
+    end
+
+    # Returns true if this is a list type. A non-nullable list is considered a list.
+    def list?
+      false
+    end
+
     private
 
     def warn_deprecated_coerce(alt_method_name)

--- a/lib/graphql/list_type.rb
+++ b/lib/graphql/list_type.rb
@@ -49,6 +49,10 @@ module GraphQL
       ensure_array(value).map { |item| item.nil? ? nil : of_type.coerce_result(item, ctx) }
     end
 
+    def list?
+      true
+    end
+
     private
 
     def coerce_non_null_input(value, ctx)

--- a/lib/graphql/non_null_type.rb
+++ b/lib/graphql/non_null_type.rb
@@ -62,7 +62,7 @@ module GraphQL
       end
     end
 
-    def_delegators :@of_type, :coerce_input, :coerce_result
+    def_delegators :@of_type, :coerce_input, :coerce_result, :list?
 
     def kind
       GraphQL::TypeKinds::NON_NULL
@@ -72,5 +72,9 @@ module GraphQL
       "#{of_type.to_s}!"
     end
     alias_method :inspect, :to_s
+
+    def non_null?
+      true
+    end
   end
 end

--- a/spec/graphql/base_type_spec.rb
+++ b/spec/graphql/base_type_spec.rb
@@ -82,4 +82,46 @@ TYPE
       assert_equal expected.chomp, post_type.to_definition(schema)
     end
   end
+
+  describe 'non_null?' do
+    let(:type) do
+      GraphQL::EnumType.define do
+        name "Hello"
+        value 'WORLD'
+      end
+    end
+
+    it "returns false for nullable types" do
+      assert_equal(type.non_null?, false)
+    end
+
+    it "returns true for non-nulls" do
+      assert_equal(type.to_non_null_type.non_null?, true)
+    end
+
+    it "returns false for a nullable list of non-nulls" do
+      assert_equal(type.to_non_null_type.to_list_type.non_null?, false)
+    end
+  end
+
+  describe 'list?' do
+    let(:type) do
+      GraphQL::EnumType.define do
+        name "Hello"
+        value 'WORLD'
+      end
+    end
+
+    it "returns false for non-list types" do
+      assert_equal(type.list?, false)
+    end
+
+    it "returns true for lists" do
+      assert_equal(type.to_list_type.list?, true)
+    end
+
+    it "returns true for a non-nullable list" do
+      assert_equal(type.to_list_type.to_non_null_type.list?, true)
+    end
+  end
 end


### PR DESCRIPTION
Adds a couple helpers:
```ruby
type = GraphQL::EnumType.define do
  name "Hello"
  value 'WORLD'
end

type.non_null?
# => false

type.to_non_null_type.non_null?
# => true

type.to_non_null_type.to_list_type.non_null?
# => false

type.list?
# => false

type.to_list_type.list?
# => true

type.to_list_type.to_non_null_type.list?
# => true
```