### PR TITLE
Adding `all_arguments` and `get_argument` to InputObjectType

### DIFF
--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -80,6 +80,18 @@ module GraphQL
       result
     end
 
+    # @return [GraphQL::Argument] The argument definition for `argument_name`
+    def get_argument(argument_name)
+      arguments[argument_name.to_s]
+    end
+    alias :get_input_field :get_argument
+
+    # @return [Array<GraphQL::Argument>] All arguments
+    def all_arguments
+      self.arguments.values
+    end
+    alias :all_input_fields :all_arguments
+
     private
 
     def coerce_non_null_input(value, ctx)

--- a/spec/graphql/input_object_type_spec.rb
+++ b/spec/graphql/input_object_type_spec.rb
@@ -329,6 +329,35 @@ describe GraphQL::InputObjectType do
     end
   end
 
+  describe "#get_argument" do
+    it "exposes argument" do
+      argument = input_object.get_argument("source")
+      assert_equal(GraphQL::TypeKinds::NON_NULL, argument.type.kind)
+      assert_equal(GraphQL::TypeKinds::ENUM, argument.type.of_type.kind)
+    end
+
+    it "alias get_input_field" do
+      assert_equal(input_object.method(:get_argument), input_object.method(:get_input_field))
+    end
+  end
+
+  describe "#all_arguments" do
+    it "exposes all arguments" do
+      input = GraphQL::InputObjectType.define do
+        name 'TwoArgsInputType'
+        description 'An input object type having two arguments.'
+
+        argument :field, types.String
+        argument :name, types.String
+      end
+      assert_equal([input.arguments['field'], input.arguments['name']], input.all_arguments.sort_by(&:name))
+    end
+
+    it "alias all_input_types" do
+      assert_equal(input_object.method(:all_arguments), input_object.method(:all_input_fields))
+    end
+  end
+
   describe "#dup" do
     it "shallow-copies internal state" do
       input_object_2 = input_object.dup


### PR DESCRIPTION
Adds `get_argument(arg_name)` and `all_arguments` to `InputObjectType`, very similar to `get_field` and `all_fields` of `ObjectType`:

```ruby
input_type = GraphQL::InputObjectType.define do
  name "Hello"
  argument :word, types.String
end

input_type.all_arguments
# => [#<GraphQL::Argument @name="word" ...>] 

input_type.get_argument('world') # works with symbol too 
# => #<GraphQL::Argument @name="word" ...>

# alias *_input_field instead of *_argument
input_type.method(:get_argument) == input_type.method(:get_input_field)
# => true

input_type.method(:all_arguments) == input_type.method(:all_input_fields)
# => true
```