### PR TITLE
Split up the instrumentation of fields for tracing

### DIFF
--- a/lib/graphql/tracing/platform_tracing.rb
+++ b/lib/graphql/tracing/platform_tracing.rb
@@ -41,12 +41,20 @@ module GraphQL
         return_type = field.type.unwrap
         case return_type
         when GraphQL::ScalarType, GraphQL::EnumType
-          field
+          instrument_scalar_field(type, field)
         else
-          new_f = field.redefine
-          new_f.metadata[:platform_key] = platform_field_key(type, field)
-          new_f
+          instrument_nonscalar_field(type, field)
         end
+      end
+
+      def instrument_scalar_field(type, field)
+        field
+      end
+
+      def instrument_nonscalar_field(type, field)
+        new_f = field.redefine
+        new_f.metadata[:platform_key] = platform_field_key(type, field)
+        new_f
       end
 
       def self.use(schema_defn)


### PR DESCRIPTION
As mentioned in a comment in https://github.com/rmosolgo/graphql-ruby/pull/1060, this code should make it easier to do tracing for a field should you be so inclined. 

I'm unsure how this should work exactly, considering that depending on your schema and the queries you execute, this could result in a lot of additional keys being used on the service. That, in turn, may result in a much higher bill.

At least (selfishly :see_no_evil:) this allows us to play around with it internally and see if it's worth the cost.
Curious to know what others think!