### PR TITLE
Add message about gem order in tracing guide

### DIFF
--- a/guides/queries/tracing.md
+++ b/guides/queries/tracing.md
@@ -66,6 +66,16 @@ Leaf fields are _not_ monitored (to avoid high cardinality in the metrics servic
 
 Implementations are based on {{ "Tracing::PlatformTracing" | api_doc }}.
 
+You may need to define the monitoring gem **before** the `graphql` gem in your Gemfile for this to work.
+ 
+For example:
+ 
+```ruby
+# Gemfile
+gem 'scout_apm'
+gem 'graphql'
+```
+
 ## Appsignal
 
 To add [AppSignal](https://appsignal.com/) instrumentation:


### PR DESCRIPTION
I was receiving an error when trying to implement the built-in tracing feature for Scout. It turns out that this is due to this piece of code where the library gets included if it has been defined:

https://github.com/rmosolgo/graphql-ruby/blob/d7bb70dd18d17cf9eae119a0ba88340b85ff9044/lib/graphql/tracing/scout_tracing.rb#L6-L8

If your Gemfile is ordered such that `gem graphql` comes before `gem scout_apm`, the `include` never gets run because `ScoutApm` is not defined yet, causing the code to blow up when it can't find the `instrument` message. If you order your Gemfile such that `scout_apm` comes first, it works fine.

This change adds a quick note in the docs to warn developers that they might need to make sure that they are defining their monitoring gem before the `graphql` gem.