### PR TITLE
Include necessary Scout module from initialize on ScoutTracing

### DIFF
--- a/lib/graphql/tracing/scout_tracing.rb
+++ b/lib/graphql/tracing/scout_tracing.rb
@@ -3,9 +3,6 @@
 module GraphQL
   module Tracing
     class ScoutTracing < PlatformTracing
-      if defined?(ScoutApm)
-        include ScoutApm::Tracer
-      end
       INSTRUMENT_OPTS = { scope: true }
 
       self.platform_keys = {
@@ -18,6 +15,11 @@ module GraphQL
         "execute_query" => "execute.graphql",
         "execute_query_lazy" => "execute.graphql",
       }
+
+      def initialize
+        self.class.include ScoutApm::Tracer
+        super
+      end
 
       def platform_trace(platform_key, key, data)
         self.class.instrument("GraphQL", platform_key, INSTRUMENT_OPTS) do

--- a/spec/graphql/tracing/scout_tracing_spec.rb
+++ b/spec/graphql/tracing/scout_tracing_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe GraphQL::Tracing::ScoutTracing do
+  class ScoutApm
+    module Tracer
+    end
+  end
+
+  describe "Initializing" do
+    it "should include the module only after initilization" do
+      refute GraphQL::Tracing::ScoutTracing.included_modules.include?(ScoutApm::Tracer)
+      assert GraphQL::Tracing::ScoutTracing.new.class.included_modules.include?(ScoutApm::Tracer)
+    end
+  end
+end


### PR DESCRIPTION
### Issue

When attempting to use the built-in tracing feature and plugging in Scout, the order that you specify your dependencies in your Gemfile can cause your code to blow up. For example, if your Gemfile specifies:

```
gem 'scout_apm'
gem 'graphql'
```

Then the code works fine. If, however, it specifies `gem 'graphql'` _first_, it will blow up because `ScoutApm` is not defined when `ScoutTracing` attempts to include the module.

### Solution

Per [this conversation](https://github.com/rmosolgo/graphql-ruby/pull/1062) with @rmosolgo, I have removed the offending lines and am now performing the include on initialize.