### PR TITLE
Remove support for Ruby 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - gem install bundler
 
 rvm:
-- 2.1.10 # Lowest version officially supported by the gem is 2.1
+- 2.2.8 # Lowest version officially supported by the gem is 2.2
 - 2.4.2
 - jruby-9.1.9.0
 
@@ -66,11 +66,7 @@ matrix:
     gemfile: gemfiles/rails_4.1.gemfile
   - rvm: 2.4.2
     gemfile: gemfiles/rails_4.2.gemfile
-  - rvm: 2.1.10
-    gemfile: gemfiles/rails_5.0.gemfile # Rails 5 requires Ruby 2.2.2+
   - rvm: jruby-9.1.9.0
     gemfile: gemfiles/rails_5.0.gemfile # Rails 5 is not supported atm
-  - rvm: 2.1.10
-    gemfile: gemfiles/rails_5.1.gemfile # Rails 5 requires Ruby 2.2.2+
   - rvm: jruby-9.1.9.0
     gemfile: gemfiles/rails_5.1.gemfile # Rails 5 is not supported atm

--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.authors     = ["Robert Mosolgo"]
   s.email       = ["rdmosolgo@gmail.com"]
   s.license     = "MIT"
-  s.required_ruby_version = ">= 2.1.0" # bc optional keyword args
+  s.required_ruby_version = ">= 2.2.0" # bc `.to_sym` used on user input
 
   s.files = Dir["{lib}/**/*", "MIT-LICENSE", "readme.md", ".yardopts"]
   s.test_files = Dir["spec/**/*"]


### PR DESCRIPTION
My interest here is in [Symbol GC](https://bugs.ruby-lang.org/issues/9634), which means we can use `.to_sym` without worrying about a DOS vulnerability. This will simplify code in Argument and Variable hashes, which can use symbols under the hood, which people prefer for access anyways. 

Oh, and I should add, support for Ruby 2.1 [ended in April 2017](https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/).