### PR TITLE
Remove confusing Notify statement.

### DIFF
--- a/guides/queries/error_handling.md
+++ b/guides/queries/error_handling.md
@@ -120,10 +120,10 @@ class RescueFrom
     nil
   rescue ActiveRecord::RecordInvalid => err
     # return a GraphQL error with validation details
-    GraphQL::ExecutionError.new("Validation failed: " + e.record.errors.full_messages.join("\n"))
+    messages = e.record.errors.full_messages.join("\n")
+    GraphQL::ExecutionError.new("Validation failed: #{messages}")
   rescue StandardError => err
     # handle all other errors
-    Notify.about(err)
     GraphQL::ExecutionError.new("Unexpected error: #{err.message}")
   end
 end


### PR DESCRIPTION
Just like https://github.com/exAspArk/graphql-errors/pull/3. The `Notify` statement is confusing because it doesn't work in a default Rails setup, I copy-pasted it a few times by mistake.

Also is there anything in http://code.dblock.org/2017/10/30/generating-and-handling-errors-in-graphql-in-ruby.html that you would find valuable in this doc?