### PR TITLE
Only raise TracedError when context exists

### DIFF
--- a/lib/graphql/backtrace/tracer.rb
+++ b/lib/graphql/backtrace/tracer.rb
@@ -31,7 +31,13 @@ module GraphQL
             rescue StandardError => err
               # This is an unhandled error from execution,
               # Re-raise it with a GraphQL trace.
-              raise TracedError.new(err, execution_context.last)
+              potential_context = execution_context.last
+
+              if potential_context.is_a?(GraphQL::Query::Context) || potential_context.is_a?(GraphQL::Query::Context::FieldResolutionContext)
+                raise TracedError.new(err, potential_context)
+              else
+                raise
+              end
             ensure
               execution_context.clear
             end

--- a/spec/graphql/backtrace_spec.rb
+++ b/spec/graphql/backtrace_spec.rb
@@ -21,6 +21,15 @@ describe GraphQL::Backtrace do
     def inspect; nil; end
   end
 
+  class ErrorInstrumentation
+    def self.before_query(_query)
+    end
+
+    def self.after_query(query)
+      raise "Instrumentation Boom"
+    end
+  end
+
   let(:resolvers) {
     {
       "Query" => {
@@ -113,7 +122,7 @@ describe GraphQL::Backtrace do
       assert_includes err.message, rendered_table
       # The message includes the original error message
       assert_includes err.message, "This is broken: Boom"
-      assert_includes err.message, "spec/graphql/backtrace_spec.rb:33", "It includes the original backtrace"
+      assert_includes err.message, "spec/graphql/backtrace_spec.rb:42", "It includes the original backtrace"
       assert_includes err.message, "more lines"
     end
 
@@ -164,6 +173,17 @@ describe GraphQL::Backtrace do
       ].join("\n")
 
       assert_includes(err.message, rendered_table)
+    end
+
+
+    it "raises original exception instead of a TracedError when error does not occur during resolving" do
+      instrumentation_schema = schema.redefine do
+        instrument(:query, ErrorInstrumentation)
+      end
+
+      assert_raises(RuntimeError) {
+        instrumentation_schema.execute(GraphQL::Introspection::INTROSPECTION_QUERY, context: { backtrace: true })
+      }
     end
   end
 


### PR DESCRIPTION
`execution_context.last` is not guaranteed to be a context object.

This can occur when an exception is raised outside of field resolution.
There's not much use in a `TracedError` in this situation, instead of
trying to normalize and find the context, let's just re-raise the
original exception.

See https://github.com/rmosolgo/graphql-ruby/pull/1071 for more background.

cc @eapache 