### PR TITLE
Fix Warning: shadowing outer local variable

### DIFF
--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -76,7 +76,7 @@ module Dummy
         if sources.include?("YAK")
           raise NoSuchDairyError.new("No cheeses are made from Yak milk!")
         else
-          CHEESES.values.find { |c| sources.include?(c.source) }
+          CHEESES.values.find { |cheese| sources.include?(cheese.source) }
         end
       }
     end


### PR DESCRIPTION
I found same name variables are used at local variable and block params, so I fixed.