### PR TITLE
Fix useless block parameter

### DIFF
--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -254,7 +254,7 @@ module Dummy
 
     def call(obj, args, ctx)
       id_string = args["id"].to_s # Cheese has Int type, Milk has ID type :(
-      _id, item = @data.find { |id, item| id.to_s == id_string }
+      _id, item = @data.find { |id, _item| id.to_s == id_string }
       item
     end
   end


### PR DESCRIPTION
Add underscore to `item` of block parameter.
