### PR TITLE
Load and dump symbols with Subscriptions::Serialize

### DIFF
--- a/spec/graphql/subscriptions/serialize_spec.rb
+++ b/spec/graphql/subscriptions/serialize_spec.rb
@@ -24,13 +24,21 @@ if defined?(GlobalID)
 end
 
 describe GraphQL::Subscriptions::Serialize do
+  def serialize_dump(v)
+    GraphQL::Subscriptions::Serialize.dump(v)
+  end
+
+  def serialize_load(v)
+    GraphQL::Subscriptions::Serialize.load(v)
+  end
+
   if defined?(GlobalID)
     it "should serialize GlobalID::Identification in Array/Hash" do
       user_a = GlobalIDUser.new("a")
       user_b = GlobalIDUser.new("b")
 
-      str_a = GraphQL::Subscriptions::Serialize.dump(["first", 2, user_a])
-      str_b = GraphQL::Subscriptions::Serialize.dump({first: 'first', second: 2, user: user_b})
+      str_a = serialize_dump(["first", 2, user_a])
+      str_b = serialize_dump({"first" => 'first', "second" => 2, "user" => user_b})
 
       assert_equal str_a, '["first",2,{"__gid__":"Z2lkOi8vZ3JhcGhxbC1ydWJ5LXRlc3QvR2xvYmFsSURVc2VyL2E"}]'
       assert_equal str_b, '{"first":"first","second":2,"user":{"__gid__":"Z2lkOi8vZ3JhcGhxbC1ydWJ5LXRlc3QvR2xvYmFsSURVc2VyL2I"}}'
@@ -43,11 +51,21 @@ describe GraphQL::Subscriptions::Serialize do
       str_a = '["first",2,{"__gid__":"Z2lkOi8vZ3JhcGhxbC1ydWJ5LXRlc3QvR2xvYmFsSURVc2VyL2E"}]'
       str_b = '{"first":"first","second":2,"user":{"__gid__":"Z2lkOi8vZ3JhcGhxbC1ydWJ5LXRlc3QvR2xvYmFsSURVc2VyL2I"}}'
 
-      parsed_obj_a = GraphQL::Subscriptions::Serialize.load(str_a)
-      parsed_obj_b = GraphQL::Subscriptions::Serialize.load(str_b)
+      parsed_obj_a = serialize_load(str_a)
+      parsed_obj_b = serialize_load(str_b)
 
       assert_equal parsed_obj_a, ["first", 2, user_a]
       assert_equal parsed_obj_b, {'first' => 'first', 'second' => 2, 'user' => user_b}
     end
+  end
+
+  it "can deserialize symbols" do
+    value = { a: :a, "b" => 2 }
+
+    dumped = serialize_dump(value)
+    expected_dumped = '{"a":{"__sym__":"a"},"b":2,"__sym_keys__":["a"]}'
+    assert_equal expected_dumped, dumped
+    loaded = serialize_load(dumped)
+    assert_equal value, loaded
   end
 end


### PR DESCRIPTION
Currently, this serialization module will _not_ properly reload symbols. For example: 

```ruby
[:a, {b: :c}]
# dump + load, becomes: 
["a", {"b" => "c"}]
```

However, that can be a nasty surprise if you're expecting `:current_user` in your context, not `"current_user"`. 

So, this adds support for: 

- Symbol values (bare, arrays, hashes)
- Symbol hash keys 

This approach is inspired by ActiveJob: https://github.com/rails/rails/blob/4528dd6327f35d3139a48cbac9c9192f2253cbad/activejob/lib/active_job/arguments.rb#L55-L75

It's not _exactly_ backwards compatible, since code that _expected_ this behavior won't work anymore. 

cc @cpunion , will this work for you?