### PR TITLE
Update documentation link in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@
 A Ruby implementation of [GraphQL](http://graphql.org/).
 
 - [Website](https://rmosolgo.github.io/graphql-ruby)
-- [API Documentation](http://www.rubydoc.info/github/rmosolgo/graphql-ruby)
+- [API Documentation](http://www.rubydoc.info/gems/graphql)
 - [Newsletter](https://tinyletter.com/graphql-ruby)
 
 ## Installation


### PR DESCRIPTION
This updates the url to the api documentation in the readme to http://www.rubydoc.info/gems/graphql and fixes #1088