### PR TITLE
Fix Sync client compatibility with Apollo's createBatchingNetworkInterface

### DIFF
--- a/javascript_client/sync/generateClient.js
+++ b/javascript_client/sync/generateClient.js
@@ -68,6 +68,18 @@ var OperationStoreClient = {
    * Replace the query with an operationId
   */
   apolloMiddleware: {
+    applyBatchMiddleware: function(options, next) {
+      options.requests = options.requests.map(function(req) {
+        // Fetch the persisted alias for this operation
+        req.operationId = OperationStoreClient.getOperationId(req.operationName)
+        // Remove the now-unused query string
+        delete req.query
+        return req
+      })
+      // Continue the request
+      next()
+    },
+
     applyMiddleware: function(options, next) {
       var req = options.request
       // Fetch the persisted alias for this operation


### PR DESCRIPTION
This is required to use Apollo's `createBatchingNetworkInterface` API. Fortunately, the rest of the Sync client works just fine after this change (that's a different story with Apollo Client 2.0, but one step at a time!).