### PR TITLE
Fixes ArgumentError by adding the missing comma

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -16,7 +16,7 @@ module GraphQL
       def initialize(name, return_type_expr = nil, desc = nil, null: nil, field: nil, function: nil, deprecation_reason: nil, method: nil, connection: nil, max_page_size: nil, resolve: nil, &args_block)
         if !(field || function)
           if return_type_expr.nil?
-            raise ArgumentError "missing possitional argument `type`"
+            raise ArgumentError, "missing possitional argument `type`"
           end
           if null.nil?
             raise ArgumentError, "missing keyword argument null:"

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -16,7 +16,7 @@ module GraphQL
       def initialize(name, return_type_expr = nil, desc = nil, null: nil, field: nil, function: nil, deprecation_reason: nil, method: nil, connection: nil, max_page_size: nil, resolve: nil, &args_block)
         if !(field || function)
           if return_type_expr.nil?
-            raise ArgumentError, "missing possitional argument `type`"
+            raise ArgumentError, "missing positional argument `type`"
           end
           if null.nil?
             raise ArgumentError, "missing keyword argument null:"


### PR DESCRIPTION
While trying to upgrade graphql-ruby-demo to 1.8-dev I got this error:
```
NoMethodError: undefined method `ArgumentError' for #<GraphQL::Schema::Field:0x007f82dcbae170>
```

This PR fixes the error so it becomes the actual error:
```
ArgumentError: missing positional argument `type`
```
much better.
