### PR TITLE
Add convenience method "name" to point out that graphql_name exists

### DIFF
--- a/lib/graphql/schema/member.rb
+++ b/lib/graphql/schema/member.rb
@@ -64,7 +64,7 @@ module GraphQL
 
         # Just a convenience method to point out that people should use graphql_name instead
         def name(new_name = nil)
-          return method(:name).super_method.call if new_name.nil?
+          return super() if new_name.nil?
 
           fail(
             "The new name override method is `graphql_name`, not `name`. Usage: "\

--- a/lib/graphql/schema/member.rb
+++ b/lib/graphql/schema/member.rb
@@ -64,10 +64,11 @@ module GraphQL
 
         # Just a convenience method to point out that people should use graphql_name instead
         def name(new_name = nil)
-          new_name ||= "Your name here"
+          return method(:name).super_method.call if new_name.nil?
+
           fail(
             "The new name override method is `graphql_name`, not `name`. Usage: "\
-            "graphql_name '#{new_name}"
+            "graphql_name \"#{new_name}\""
           )
         end
 

--- a/lib/graphql/schema/member.rb
+++ b/lib/graphql/schema/member.rb
@@ -62,6 +62,14 @@ module GraphQL
           end
         end
 
+        # Just a convenience method to point out that people should use graphql_name instead
+        def name(new_name = nil)
+          fail(
+            "The new name override method is `graphql_name`, not `name`. Usage: "\
+            "graphql_name #{new_name || \"Your name here\"}"
+          )
+        end
+
         # Call this method to provide a new description; OR
         # call it without an argument to get the description
         # @param new_description [String]

--- a/lib/graphql/schema/member.rb
+++ b/lib/graphql/schema/member.rb
@@ -64,9 +64,10 @@ module GraphQL
 
         # Just a convenience method to point out that people should use graphql_name instead
         def name(new_name = nil)
+          new_name ||= "Your name here"
           fail(
             "The new name override method is `graphql_name`, not `name`. Usage: "\
-            "graphql_name #{new_name || \"Your name here\"}"
+            "graphql_name '#{new_name}"
           )
         end
 

--- a/spec/graphql/base_type_spec.rb
+++ b/spec/graphql/base_type_spec.rb
@@ -31,12 +31,12 @@ describe GraphQL::BaseType do
   describe "name" do
     it "fails with a helpful message" do
       error = assert_raises RuntimeError do
-        GraphQL::ObjectType.define do
-          name "kerkshine"
+        class BaseType < GraphQL::Schema::Object
+          name "KerkShine"
         end
       end
 
-      assert_equal error.message, "The new name override method is `graphql_name`, not `name`. Usage: graphql_name 'kerkshine'"
+      assert_equal error.message, "The new name override method is `graphql_name`, not `name`. Usage: graphql_name \"KerkShine\""
     end
   end
 

--- a/spec/graphql/base_type_spec.rb
+++ b/spec/graphql/base_type_spec.rb
@@ -28,6 +28,18 @@ describe GraphQL::BaseType do
     assert_equal ["Cheese"], Dummy::CheeseType.metadata[:class_names]
   end
 
+  describe "name" do
+    it "fails with a helpful message" do
+      error = assert_raises RuntimeError do
+        GraphQL::ObjectType.define do
+          name "kerkshine"
+        end
+      end
+
+      assert_equal error.message, "The new name override method is `graphql_name`, not `name`. Usage: graphql_name 'kerkshine'"
+    end
+  end
+
   describe "forwards-compat with new api" do
     let(:type_defn) { Dummy::CheeseType }
     it "responds to new methods" do


### PR DESCRIPTION
Fixes https://github.com/rmosolgo/graphql-ruby/issues/1097