### PR TITLE
Fix typo in GraphQL::InternalRepresentation::Node#typed_children

### DIFF
--- a/lib/graphql/internal_representation/node.rb
+++ b/lib/graphql/internal_representation/node.rb
@@ -16,7 +16,7 @@ module GraphQL
       # This value is derived from {#scoped_children} after the rewrite is finished.
       # @return [Hash<GraphQL::ObjectType, Hash<String => Node>>]
       def typed_children
-        @typed_childen ||= begin
+        @typed_children ||= begin
           new_tc = Hash.new(&DEFAULT_TYPED_CHILDREN)
           if @scoped_children.any?
             all_object_types = Set.new


### PR DESCRIPTION
Fixes typo of instance variable name. It's only used for caching the result of `typed_children`, and the typo isn't referenced anywhere else, so no difference in behaviour.