### PR TITLE
Fix call to to_query_string in Language::Generation

### DIFF
--- a/lib/graphql/language/generation.rb
+++ b/lib/graphql/language/generation.rb
@@ -149,7 +149,7 @@ module GraphQL
           out << "(#{node.arguments.map { |a| generate(a) }.join(", ")})" if node.arguments.any?
           out << " on #{node.locations.join(' | ')}"
         when Nodes::AbstractNode
-          node.to_query_string(indent: indent)
+          generate(node, indent: indent)
         when FalseClass, Float, Integer, NilClass, String, TrueClass
           GraphQL::Language.serialize(node)
         when Array


### PR DESCRIPTION
Looks like this one slipped through when refactored.

`to_query_string` does not take `indent` as an argument. Instead, call generate on an abstract node.

On another note, when would we get an abstract node here?