### PR TITLE
[Class based API] Check for nil before checking depth

### DIFF
--- a/lib/graphql/schema/member/instrumentation.rb
+++ b/lib/graphql/schema/member/instrumentation.rb
@@ -85,10 +85,10 @@ module GraphQL
           private
 
           def proxy_to_depth(obj, depth, type, ctx)
-            if depth > 0
-              obj.map { |inner_obj| proxy_to_depth(inner_obj, depth - 1, type, ctx) }
-            elsif obj.nil?
+            if obj.nil?
               obj
+            elsif depth > 0
+              obj.map { |inner_obj| proxy_to_depth(inner_obj, depth - 1, type, ctx) }
             else
               concrete_type = case type
               when GraphQL::UnionType, GraphQL::InterfaceType


### PR DESCRIPTION
Fixes ``undefined method `map' for nil:NilClass`` for nullable lists of an Interface when resolving to `nil`

I'm not sure what the best location for a test for this is, since there is no `spec/graphql/schema/members/instrumentation_spec.rb` and the bug affects `Union`s and `Interface`s, but also `List`s.

Anyway, for now here's how to reproduce the bug:

```ruby
require 'graphql'

class Foo < GraphQL::Schema::Interface
  field :name, String, null: false

  def name
    "something"
  end
end

class Bar < GraphQL::Schema::Object
  implements Foo
end

class Query < GraphQL::Schema::Object
  field :foos, [Foo], null: true

  def foos
    nil
  end
end

class Schema < GraphQL::Schema
  query Query
  orphan_types [Bar]
end

Schema.execute("query { foos { name } }")
```