### PR TITLE
fix: rails destroy graphql:mutation

### DIFF
--- a/lib/generators/graphql/mutation_generator.rb
+++ b/lib/generators/graphql/mutation_generator.rb
@@ -27,7 +27,12 @@ module Graphql
       attr_reader :file_name, :mutation_name, :field_name
 
       def create_mutation_file
-        create_mutation_root_type unless @behavior == :revoke
+        unless @behavior == :revoke
+          create_mutation_root_type
+        else
+          log :gsub, "#{options[:directory]}/types/mutation_type.rb"
+        end
+        
         template "mutation.erb", "#{options[:directory]}/mutations/#{file_name}.rb"
 
         sentinel = /name "Mutation"\s*\n/m

--- a/lib/generators/graphql/mutation_generator.rb
+++ b/lib/generators/graphql/mutation_generator.rb
@@ -27,7 +27,7 @@ module Graphql
       attr_reader :file_name, :mutation_name, :field_name
 
       def create_mutation_file
-        create_mutation_root_type
+        create_mutation_root_type unless @behavior == :revoke
         template "mutation.erb", "#{options[:directory]}/mutations/#{file_name}.rb"
 
         sentinel = /name "Mutation"\s*\n/m


### PR DESCRIPTION
This patch fixes issue #1099 
Now, if you run `rails g graphql:mutation TestMutation` you'll see

```
       create  app/graphql/mutations
       create  app/graphql/mutations/.keep
       create  app/graphql/types/mutation_type.rb
add_root_type  mutation
       create  app/graphql/mutations/test_mutation.rb
         gsub  app/graphql/types/mutation_type.rb
```
And if you then run `rails d graphql:mutation TestMutation` you'll see

```
        gsub  app/graphql/types/mutation_type.rb
      remove  app/graphql/mutations/test_mutation.rb
```
`app/graphql/types/mutation_type.rb` will also be updated to remove the appropriate line of code (rather than removing the file entirely).

Some comments / tips for people trying to create rails generators in the future (because generators aren't well documented)

1. When a generator is run with `destroy`, rails automatically runs the `generate` version of the generator, sees what files would be created, and instead removes those files. Oftentimes, this results in the correct destroy functionality and so devs get `rails destroy` for free. This strategy for building `rails destroy` isn't well documented however, so figuring this out the first time can be rather confusing (at least it was for me).
2. In the cases where the default `rails destroy` behavior isn't working, in order to get it working you need to update the `rails generate` code to behave differently if the code is being run with `@behavior == :revoke`. `@behavior` is an instance variable that `rails` automatically sets for you. This also wasn't very intuitive for me, because I wouldn't naturally guess that fixing `rails destroy` involved patching `rails generate` (I would have expected it to involve creating a separate `destroy` method). 
3. Most of the generator functionality is provided by the `thor` gem, which rails' generator code relies heavily upon. Thor methods are automatically added with `require 'rails/generators/named_base'` and provide a lot of functionality out of the box. In this case [`inject_into_file` is a Thor action](http://www.rubydoc.info/github/wycats/thor/Thor%2FActions:insert_into_file) and it automatically finds and removes the appropriate code when run with `@behavior == :revoke`