### PR TITLE
Add CHANGELOG entry for v1.6.8 breaking change validating EnumType value names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,10 @@
 
 ## 1.6.8 (8 Sept 2017)
 
+### Breaking changes
+
+- Validate against EnumType value names to match `/^[_a-zA-Z][_a-zA-Z0-9]*$/` #915
+
 ### New features
 
 - Use stdlib `forwardable` when it's not Ruby 2.4.0 #926


### PR DESCRIPTION
Summary
----------
#915 introduced a breaking change to previously expected behavior in values for `EnumType`'s - values started to get validated against `/^[_a-zA-Z][_a-zA-Z0-9]*$/`.

Applications with ruby-graphql prior to 1.6.8 might've had technically correct (not valid under the GraphQL spec) `EnumType` values because the validation was not there. 

Updating >= 1.6.8 will be catch those users by surprise since this change isn't reported in the changelog as a bug fix, but not a breaking change. 

This won't be obvious to users updating to >= 1.6.8 as a bug, since  this is [mentioned pretty obscurely](http://facebook.github.io/graphql/October2016/#sec-Enums) in the the GraphQL spec. It's fine to keep the entry in the bug fix entry, but it'd be helpful to call attention to it as a breaking change as well for end users who are unaware.

Change proposed
------------------
Add an entry to the changelog for 1.6.8 reporting the breaking change with the valid regex pattern.