### PR TITLE
[1.8] Handle underscored field names

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -47,7 +47,8 @@ module GraphQL
         else
           GraphQL::Field.new
         end
-        field_defn.name = @name
+
+        field_defn.name = camelize(name)
 
         if @return_type_expr
           return_type_name = Member::BuildType.to_type_name(@return_type_expr)
@@ -94,6 +95,16 @@ module GraphQL
         end
 
         field_defn
+      end
+
+      private
+
+      def camelize(string)
+        return string unless string.include?('_')
+
+        string.split('_').map(&:capitalize).join.tap do |camelized|
+          camelized[0] = camelized[0].downcase
+        end
       end
 
       class << self

--- a/spec/graphql/schema/field_spec.rb
+++ b/spec/graphql/schema/field_spec.rb
@@ -4,11 +4,15 @@ require "spec_helper"
 describe GraphQL::Schema::Field do
   describe "graphql definition" do
     let(:object_class) { Jazz::Query }
-    let(:field) { object_class.fields.find { |f| f.name == "find" } }
+    let(:field) { object_class.fields.find { |f| f.name == "inspect_input" } }
 
     it "uses the argument class" do
       arg_defn = field.graphql_definition.arguments.values.first
       assert_equal :ok, arg_defn.metadata[:custom]
+    end
+
+    it "camelizes the field name" do
+      assert_equal 'inspectInput', field.graphql_definition.name
     end
   end
 end

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -110,7 +110,7 @@ module Jazz
   class GloballyIdentifiableType < BaseInterface
     description "A fetchable object in the system"
     field :id, ID, "A unique identifier for this object", null: false
-    field :upcasedId, ID, null: false, upcase: true, method: :id
+    field :upcased_id, ID, null: false, upcase: true, method: :id
 
     module Implementation
       def id
@@ -137,7 +137,7 @@ module Jazz
   # test field inheritance
   class ObjectWithUpcasedName < BaseObject
     # Test extra arguments:
-    field :upcaseName, String, null: false, upcase: true
+    field :upcase_name, String, null: false, upcase: true
 
     def upcase_name
       @object.name # upcase is applied by the superclass
@@ -198,7 +198,7 @@ module Jazz
     implements NamedEntity
     description "Someone who plays an instrument"
     field :instrument, InstrumentType, null: false
-    field :favoriteKey, Key, null: true
+    field :favorite_key, Key, null: true
   end
 
   LegacyInputType = GraphQL::InputObjectType.define do
@@ -226,8 +226,8 @@ module Jazz
 
   class InspectableKey < BaseObject
     field :root, String, null: false
-    field :isSharp, Boolean, null: false, method: :sharp
-    field :isFlat, Boolean, null: false, method: :flat
+    field :is_sharp, Boolean, null: false, method: :sharp
+    field :is_flat, Boolean, null: false, method: :flat
   end
 
   class PerformingAct < GraphQL::Schema::Union
@@ -246,20 +246,20 @@ module Jazz
   class Query < BaseObject
     field :ensembles, [Ensemble], null: false
     field :find, GloballyIdentifiableType, null: true do
-      argument :id, ID, required: true, custom: :ok
+      argument :id, ID, required: true
     end
     field :instruments, [InstrumentType], null: false do
       argument :family, Family, required: false
     end
-    field :inspectInput, [String], null: false do
-      argument :input, InspectableInput, required: true
+    field :inspect_input, [String], null: false do
+      argument :input, InspectableInput, required: true, custom: :ok
     end
-    field :inspectKey, InspectableKey, null: false do
+    field :inspect_key, InspectableKey, null: false do
       argument :key, Key, required: true
     end
     field :nowPlaying, PerformingAct, null: false, resolve: ->(o, a, c) { Models.data["Ensemble"].first }
     # For asserting that the object is initialized once:
-    field :objectId, Integer, null: false
+    field :object_id, Integer, null: false
 
     def ensembles
       Models.data["Ensemble"]
@@ -304,7 +304,7 @@ module Jazz
   end
 
   class Mutation < BaseObject
-    field :addEnsemble, Ensemble, null: false do
+    field :add_ensemble, Ensemble, null: false do
       argument :input, EnsembleInput, required: true
     end
 


### PR DESCRIPTION
Closes #1124

Here's a quick attempt at supporting underscored field names.

I think this is the easiest place to handle it? The only question is how opinionated the gem should be on this. This means that only camelCased field names will end up in the schema.

We could allow this to be configuration in the same way as `field_class`.