### PR TITLE
Increase flexibility when generating functions and loaders through the CLI

### DIFF
--- a/lib/generators/graphql/function_generator.rb
+++ b/lib/generators/graphql/function_generator.rb
@@ -11,7 +11,7 @@ module Graphql
       source_root File.expand_path('../templates', __FILE__)
 
       def create_function_file
-        template "function.erb", "#{options[:directory]}/functions/#{file_name}.rb"
+        template "function.erb", "#{options[:directory]}/functions/#{file_path}.rb"
       end
     end
   end

--- a/lib/generators/graphql/loader_generator.rb
+++ b/lib/generators/graphql/loader_generator.rb
@@ -13,7 +13,7 @@ module Graphql
       source_root File.expand_path('../templates', __FILE__)
 
       def create_loader_file
-        template "loader.erb", "#{options[:directory]}/loaders/#{file_name}.rb"
+        template "loader.erb", "#{options[:directory]}/loaders/#{file_path}.rb"
       end
     end
   end

--- a/lib/generators/graphql/templates/function.erb
+++ b/lib/generators/graphql/templates/function.erb
@@ -1,7 +1,7 @@
-class Functions::<%= name %> < GraphQL::Function
+class Functions::<%= class_name %> < GraphQL::Function
   # Define `initialize` to store field-level options, eg
   #
-  #     field :myField, function: Functions::<%= name %>.new(type: MyType)
+  #     field :myField, function: Functions::<%= class_name %>.new(type: MyType)
   #
   # attr_reader :type
   # def initialize(type:)

--- a/lib/generators/graphql/templates/loader.erb
+++ b/lib/generators/graphql/templates/loader.erb
@@ -1,7 +1,7 @@
-class Loaders::<%= name %> < GraphQL::Batch::Loader
+class Loaders::<%= class_name %> < GraphQL::Batch::Loader
   # Define `initialize` to store grouping arguments, eg
   #
-  #     Loaders::<%= name %>.for(group).load(value)
+  #     Loaders::<%= class_name %>.for(group).load(value)
   #
   # def initialize()
   # end

--- a/spec/generators/graphql/function_generator_spec.rb
+++ b/spec/generators/graphql/function_generator_spec.rb
@@ -30,4 +30,30 @@ RUBY
 
     assert_file "app/graphql/functions/find_record.rb", expected_content
   end
+
+  test "it generates a namespaced function by name" do
+    run_generator(["finders::find_record"])
+
+    expected_content = <<-RUBY
+class Functions::Finders::FindRecord < GraphQL::Function
+  # Define `initialize` to store field-level options, eg
+  #
+  #     field :myField, function: Functions::Finders::FindRecord.new(type: MyType)
+  #
+  # attr_reader :type
+  # def initialize(type:)
+  #   @type = type
+  # end
+
+  # add arguments by type:
+  # argument :id, !types.ID
+
+  # Resolve function:
+  def call(obj, args, ctx)
+  end
+end
+RUBY
+
+    assert_file "app/graphql/functions/finders/find_record.rb", expected_content
+  end
 end

--- a/spec/generators/graphql/loader_generator_spec.rb
+++ b/spec/generators/graphql/loader_generator_spec.rb
@@ -28,4 +28,28 @@ RUBY
 
     assert_file "app/graphql/loaders/record_loader.rb", expected_content
   end
+
+  test "it generates a namespaced loader by name" do
+    run_generator(["active_record::record_loader"])
+
+    expected_content = <<-RUBY
+class Loaders::ActiveRecord::RecordLoader < GraphQL::Batch::Loader
+  # Define `initialize` to store grouping arguments, eg
+  #
+  #     Loaders::ActiveRecord::RecordLoader.for(group).load(value)
+  #
+  # def initialize()
+  # end
+
+  # `keys` contains each key from `.load(key)`.
+  # Find the corresponding values, then
+  # call `fulfill(key, value)` or `fulfill(key, nil)`
+  # for each key.
+  def perform(keys)
+  end
+end
+RUBY
+
+    assert_file "app/graphql/loaders/active_record/record_loader.rb", expected_content
+  end
 end


### PR DESCRIPTION
### Overview

This enforces camel-casing of class names when generating functions and loaders. It also allows them to be namespaced if one wants to structure them that way.

### Examples

Running `rails g graphql:function find_records` generates the following in `app/graphql/functions/find_records.rb`:
```
class Functions::FindRecords < GraphQL::Function
  ...
end
```

Running `rails g graphql:function finders::find_records` generates the following in `app/graphql/functions/finders/find_records.rb`:
```
class Functions::Finders::FindRecords < GraphQL::Function
  ...
end
```