### PR TITLE
Fix default value input object b from def

### DIFF
--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -191,6 +191,8 @@ module GraphQL
             default_value.name
           when GraphQL::Language::Nodes::NullValue
             nil
+          when GraphQL::Language::Nodes::InputObject
+            default_value.to_h
           else
             default_value
           end

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -30,6 +30,20 @@ type HelloScalars {
       build_schema_and_compare_output(schema.chop)
     end
 
+    it 'can build a schema with default input object values' do
+      schema = <<-SCHEMA
+input InputObject {
+  a: Int
+}
+
+type Query {
+  a(input: InputObject = {a: 1}): String
+}
+      SCHEMA
+
+      build_schema_and_compare_output(schema.chop)
+    end
+
     it 'can build a schema with directives' do
       schema = <<-SCHEMA
 schema {


### PR DESCRIPTION
`build_from_definition` would 💥 when passed a schema with input object default values. See test for example :)