### PR TITLE
Replace instances of 'assert_equal nil, x' with 'assert_nil x'

### DIFF
--- a/spec/graphql/analysis/max_query_complexity_spec.rb
+++ b/spec/graphql/analysis/max_query_complexity_spec.rb
@@ -37,7 +37,7 @@ describe GraphQL::Analysis::MaxQueryComplexity do
       Dummy::Schema.max_complexity = nil
     end
     it "doesn't error" do
-      assert_equal nil, result["errors"]
+      assert_nil result["errors"]
     end
   end
 
@@ -46,7 +46,7 @@ describe GraphQL::Analysis::MaxQueryComplexity do
       Dummy::Schema.max_complexity = 99
     end
     it "doesn't error" do
-      assert_equal nil, result["errors"]
+      assert_nil result["errors"]
     end
   end
 
@@ -68,7 +68,7 @@ describe GraphQL::Analysis::MaxQueryComplexity do
     let(:result) { Dummy::Schema.execute(query_string, max_complexity: 10) }
 
     it "doesn't error" do
-      assert_equal nil, result["errors"]
+      assert_nil result["errors"]
     end
   end
 

--- a/spec/graphql/analysis/max_query_depth_spec.rb
+++ b/spec/graphql/analysis/max_query_depth_spec.rb
@@ -39,7 +39,7 @@ describe GraphQL::Analysis::MaxQueryDepth do
     let(:result) { Dummy::Schema.execute(query_string, max_depth: 100) }
 
     it "obeys that max_depth" do
-      assert_equal nil, result["errors"]
+      assert_nil result["errors"]
     end
   end
 
@@ -49,7 +49,7 @@ describe GraphQL::Analysis::MaxQueryDepth do
     end
 
     it "doesn't add an error" do
-      assert_equal nil, result["errors"]
+      assert_nil result["errors"]
     end
   end
 
@@ -59,7 +59,7 @@ describe GraphQL::Analysis::MaxQueryDepth do
     end
 
     it "doesn't add an error message" do
-      assert_equal nil, result["errors"]
+      assert_nil result["errors"]
     end
   end
 

--- a/spec/graphql/boolean_type_spec.rb
+++ b/spec/graphql/boolean_type_spec.rb
@@ -13,9 +13,9 @@ describe GraphQL::BOOLEAN_TYPE do
     end
 
     it "rejects other types" do
-      assert_equal nil, coerce_input("true")
-      assert_equal nil, coerce_input(5.5)
-      assert_equal nil, coerce_input(nil)
+      assert_nil coerce_input("true")
+      assert_nil coerce_input(5.5)
+      assert_nil coerce_input(nil)
     end
   end
 end

--- a/spec/graphql/execution/execute_spec.rb
+++ b/spec/graphql/execution/execute_spec.rb
@@ -120,7 +120,7 @@ describe GraphQL::Execution::Execute do
       }
       GRAPHQL
 
-      assert_equal nil, res["data"]
+      assert_nil res["data"]
       assert_equal "👻", res["errors"].first["message"]
     end
 

--- a/spec/graphql/float_type_spec.rb
+++ b/spec/graphql/float_type_spec.rb
@@ -9,8 +9,8 @@ describe GraphQL::FLOAT_TYPE do
     end
 
     it "rejects other types" do
-      assert_equal nil, GraphQL::FLOAT_TYPE.coerce_isolated_input("55")
-      assert_equal nil, GraphQL::FLOAT_TYPE.coerce_isolated_input(true)
+      assert_nil GraphQL::FLOAT_TYPE.coerce_isolated_input("55")
+      assert_nil GraphQL::FLOAT_TYPE.coerce_isolated_input(true)
     end
   end
 end

--- a/spec/graphql/id_type_spec.rb
+++ b/spec/graphql/id_type_spec.rb
@@ -26,7 +26,7 @@ describe GraphQL::ID_TYPE do
     let(:query_string) { %|query getMilk { cow: milk(id: 1.0) { id } }| }
 
     it "doesn't allow other types" do
-      assert_equal nil, result["data"]
+      assert_nil result["data"]
       assert_equal 1, result["errors"].length
     end
   end

--- a/spec/graphql/input_object_type_spec.rb
+++ b/spec/graphql/input_object_type_spec.rb
@@ -251,7 +251,7 @@ describe GraphQL::InputObjectType do
       assert_equal 'Test', result['a']
 
       assert result.key?('b')
-      assert_equal nil, result['b']
+      assert_nil result['b']
 
       assert_equal "Test", result['c']
     end
@@ -264,7 +264,7 @@ describe GraphQL::InputObjectType do
       assert_equal 1, result['b']
 
       assert result.key?('c')
-      assert_equal nil, result['c']
+      assert_nil result['c']
     end
 
     it "omitted arguments are not returned" do

--- a/spec/graphql/int_type_spec.rb
+++ b/spec/graphql/int_type_spec.rb
@@ -9,8 +9,8 @@ describe GraphQL::INT_TYPE do
     end
 
     it "rejects other types" do
-      assert_equal nil, GraphQL::INT_TYPE.coerce_isolated_input("55")
-      assert_equal nil, GraphQL::INT_TYPE.coerce_isolated_input(true)
+      assert_nil GraphQL::INT_TYPE.coerce_isolated_input("55")
+      assert_nil GraphQL::INT_TYPE.coerce_isolated_input(true)
     end
   end
 end

--- a/spec/graphql/internal_representation/rewrite_spec.rb
+++ b/spec/graphql/internal_representation/rewrite_spec.rb
@@ -110,7 +110,7 @@ describe GraphQL::InternalRepresentation::Rewrite do
 
     it "groups selections by object types which they apply to" do
       doc = rewrite_result.operation_definitions["getPlant"]
-      assert_equal nil, doc.definition
+      assert_nil doc.definition
 
       plant_scoped_selection = doc.scoped_children[schema.types["Query"]]["plant"]
       assert_equal ["Fruit", "Nut", "Plant"], plant_scoped_selection.scoped_children.keys.map(&:name).sort
@@ -132,7 +132,7 @@ describe GraphQL::InternalRepresentation::Rewrite do
 
     it "tracks parent nodes" do
       doc = rewrite_result.operation_definitions["getPlant"]
-      assert_equal nil, doc.parent
+      assert_nil doc.parent
 
       plant_selection = doc.typed_children[schema.types["Query"]]["plant"]
       assert_equal doc, plant_selection.parent

--- a/spec/graphql/language/lexer_spec.rb
+++ b/spec/graphql/language/lexer_spec.rb
@@ -40,7 +40,7 @@ describe GraphQL::Language::Lexer do
 
     it "clears the previous_token between runs" do
       tok_2 = subject.tokenize(query_string)
-      assert_equal nil, tok_2[0].prev_token
+      assert_nil tok_2[0].prev_token
     end
   end
 end

--- a/spec/graphql/language/parser_spec.rb
+++ b/spec/graphql/language/parser_spec.rb
@@ -16,7 +16,7 @@ describe GraphQL::Language::Parser do
 
     it "creates an anonymous fragment definition" do
       assert fragment.is_a?(GraphQL::Language::Nodes::FragmentDefinition)
-      assert_equal nil, fragment.name
+      assert_nil fragment.name
       assert_equal 1, fragment.selections.length
       assert_equal "NestedType", fragment.type.name
       assert_equal 1, fragment.directives.length

--- a/spec/graphql/query/arguments_spec.rb
+++ b/spec/graphql/query/arguments_spec.rb
@@ -115,8 +115,8 @@ describe GraphQL::Query::Arguments do
     end
 
     it "returns nil for missing keys" do
-      assert_equal nil, arguments["z"]
-      assert_equal nil, arguments[7]
+      assert_nil arguments["z"]
+      assert_nil arguments[7]
     end
   end
 
@@ -303,7 +303,7 @@ describe GraphQL::Query::Arguments do
     end
 
     it "generates argument classes that responds to keys as functions" do
-      assert_equal nil, input_object.arguments_class
+      assert_nil input_object.arguments_class
 
       GraphQL::Query::Arguments.construct_arguments_class(input_object)
       args = input_object.arguments_class.new({foo: 3, bar: -90})

--- a/spec/graphql/query/variables_spec.rb
+++ b/spec/graphql/query/variables_spec.rb
@@ -111,7 +111,7 @@ describe GraphQL::Query::Variables do
         let(:provided_variables) { { "ids" => [nil] } }
         it "returns an error" do
           assert_equal 1, result["errors"].length
-          assert_equal nil, result["data"]
+          assert_nil result["data"]
         end
       end
     end

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -111,7 +111,7 @@ describe GraphQL::Query do
       }
 
       it "returns nil" do
-        assert_equal nil, query.operation_name
+        assert_nil query.operation_name
       end
     end
 
@@ -148,7 +148,7 @@ describe GraphQL::Query do
         }
 
         it "returns the inferred operation name" do
-          assert_equal nil, query.selected_operation_name
+          assert_nil query.selected_operation_name
         end
       end
     end
@@ -532,7 +532,7 @@ describe GraphQL::Query do
 
       it "overrides the schema's max_depth" do
         assert result["data"].key?("cheese")
-        assert_equal nil, result["errors"]
+        assert_nil result["errors"]
       end
     end
   end
@@ -699,7 +699,7 @@ describe GraphQL::Query do
 
     it "returns nil when there is no selected operation" do
       query = GraphQL::Query.new(schema, '# Only a comment')
-      assert_equal nil, query.irep_selection
+      assert_nil query.irep_selection
     end
   end
 

--- a/spec/graphql/relay/base_connection_spec.rb
+++ b/spec/graphql/relay/base_connection_spec.rb
@@ -38,7 +38,7 @@ describe GraphQL::Relay::BaseConnection do
         first: nil,
       }
       conn = GraphQL::Relay::BaseConnection.new([], args, context: context)
-      assert_equal nil, conn.first
+      assert_nil conn.first
     end
   end
 

--- a/spec/graphql/relay/connection_resolve_spec.rb
+++ b/spec/graphql/relay/connection_resolve_spec.rb
@@ -57,7 +57,7 @@ describe GraphQL::Relay::ConnectionResolve do
     it "becomes null" do
       result = star_wars_query(query_string, { "name" => "null" })
       conn = result["data"]["rebels"]["ships"]
-      assert_equal nil, conn
+      assert_nil conn
     end
   end
 end

--- a/spec/graphql/relay/connection_type_spec.rb
+++ b/spec/graphql/relay/connection_type_spec.rb
@@ -73,7 +73,7 @@ describe GraphQL::Relay::ConnectionType do
 
       it "nullifies the parent and adds an error" do
         result = star_wars_query(query_string)
-        assert_equal nil, result["data"]["basesWithNullName"]["edges"][0]["node"]
+        assert_nil result["data"]["basesWithNullName"]["edges"][0]["node"]
         assert_equal "Boom!", result["errors"][0]["message"]
       end
     end

--- a/spec/graphql/relay/mutation_spec.rb
+++ b/spec/graphql/relay/mutation_spec.rb
@@ -193,17 +193,17 @@ describe GraphQL::Relay::Mutation do
     end
 
     it "doesn't get a mutation in the metadata" do
-      assert_equal nil, custom_return_type.mutation
+      assert_nil custom_return_type.mutation
     end
 
     it "supports input fields with nil default value" do
       assert input.arguments['nullDefault'].default_value?
-      assert_equal nil, input.arguments['nullDefault'].default_value
+      assert_nil input.arguments['nullDefault'].default_value
     end
 
     it "supports input fields with no default value" do
       assert !input.arguments['noDefault'].default_value?
-      assert_equal nil, input.arguments['noDefault'].default_value
+      assert_nil input.arguments['noDefault'].default_value
     end
 
     it "supports input fields with non-nil default value" do

--- a/spec/graphql/schema/validation_spec.rb
+++ b/spec/graphql/schema/validation_spec.rb
@@ -333,7 +333,7 @@ describe GraphQL::Schema::Validation do
     end
 
     it "allows null default value for nullable argument" do
-      assert_equal nil, GraphQL::Schema::Validation.validate(null_default_value)
+      assert_nil GraphQL::Schema::Validation.validate(null_default_value)
     end
   end
 

--- a/spec/graphql/schema/warden_spec.rb
+++ b/spec/graphql/schema/warden_spec.rb
@@ -242,8 +242,8 @@ describe GraphQL::Schema::Warden do
       GRAPHQL
       res = MaskHelpers.query_with_mask(query_string, mask)
       assert_equal "Query", res["data"]["__schema"]["queryType"]["name"]
-      assert_equal nil, res["data"]["__schema"]["mutationType"]
-      assert_equal nil, res["data"]["__schema"]["subscriptionType"]
+      assert_nil res["data"]["__schema"]["mutationType"]
+      assert_nil res["data"]["__schema"]["subscriptionType"]
       type_names = res["data"]["__schema"]["types"].map { |t| t["name"] }
       refute type_names.include?("Mutation")
       refute type_names.include?("Subscription")
@@ -344,7 +344,7 @@ describe GraphQL::Schema::Warden do
       res = MaskHelpers.run_query(query_string, only: whitelist)
 
       # It's not visible by name
-      assert_equal nil, res["data"]["Phoneme"]
+      assert_nil res["data"]["Phoneme"]
 
       # It's not visible in `__schema`
       all_type_names = type_names(res)
@@ -423,7 +423,7 @@ describe GraphQL::Schema::Warden do
 
         res = MaskHelpers.query_with_mask(query_string, mask)
         type = res["data"]["__type"]
-        assert_equal nil, type
+        assert_nil type
       end
     end
   end
@@ -543,7 +543,7 @@ describe GraphQL::Schema::Warden do
 
       res = MaskHelpers.query_with_mask(query_string, mask)
 
-      assert_equal nil, res["data"]["WithinInput"], "The type isn't accessible by name"
+      assert_nil res["data"]["WithinInput"], "The type isn't accessible by name"
 
       languages_arg_names = res["data"]["Query"]["fields"].find { |f| f["name"] == "languages" }["args"].map { |a| a["name"] }
       refute_includes languages_arg_names, "within", "Arguments that point to it are gone"
@@ -666,7 +666,7 @@ describe GraphQL::Schema::Warden do
     it "is additive with query filters" do
       query_except = ->(member, ctx) { member.metadata[:hidden_input_object_type] }
       res = schema.execute(query_str, except: query_except)
-      assert_equal nil, res["data"]["input"]
+      assert_nil res["data"]["input"]
       enum_values = res["data"]["enum"]["enumValues"].map { |v| v["name"] }
       refute_includes enum_values, "TRILL"
     end
@@ -695,13 +695,13 @@ describe GraphQL::Schema::Warden do
           only: [visible_enum_value, visible_abstract_type],
           except: [hidden_input_object, hidden_type],
         )
-        assert_equal nil, res["data"]["input"]
+        assert_nil res["data"]["input"]
         enum_values = res["data"]["enum"]["enumValues"].map { |v| v["name"] }
         assert_equal 5, enum_values.length
         refute_includes enum_values, "TRILL"
         # These are also filtered out:
         assert_equal 0, res["data"]["abstractType"]["interfaces"].length
-        assert_equal nil, res["data"]["type"]
+        assert_nil res["data"]["type"]
       end
     end
 
@@ -712,7 +712,7 @@ describe GraphQL::Schema::Warden do
           except: hidden_input_object,
         }
         res = MaskHelpers.run_query(query_str, context: { filters: filters })
-        assert_equal nil, res["data"]["input"]
+        assert_nil res["data"]["input"]
         enum_values = res["data"]["enum"]["enumValues"].map { |v| v["name"] }
         assert_equal 5, enum_values.length
         refute_includes enum_values, "TRILL"
@@ -727,13 +727,13 @@ describe GraphQL::Schema::Warden do
           except: [hidden_input_object, hidden_type],
         }
         res = MaskHelpers.run_query(query_str, context: { filters: filters })
-        assert_equal nil, res["data"]["input"]
+        assert_nil res["data"]["input"]
         enum_values = res["data"]["enum"]["enumValues"].map { |v| v["name"] }
         assert_equal 5, enum_values.length
         refute_includes enum_values, "TRILL"
         # These are also filtered out:
         assert_equal 0, res["data"]["abstractType"]["interfaces"].length
-        assert_equal nil, res["data"]["type"]
+        assert_nil res["data"]["type"]
       end
     end
   end

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -372,7 +372,7 @@ type Query {
       assert_equal true, schema.lazy?(LazyObj.new)
       assert_equal :dup, schema.lazy_method_name(LazyObjChild.new)
       assert_equal true, schema.lazy?(LazyObjChild.new)
-      assert_equal nil, schema.lazy_method_name({})
+      assert_nil schema.lazy_method_name({})
       assert_equal false, schema.lazy?({})
     end
   end

--- a/spec/graphql/string_type_spec.rb
+++ b/spec/graphql/string_type_spec.rb
@@ -72,9 +72,9 @@ describe GraphQL::STRING_TYPE do
     end
 
     it "doesn't accept other types" do
-      assert_equal nil, string_type.coerce_isolated_input(100)
-      assert_equal nil, string_type.coerce_isolated_input(true)
-      assert_equal nil, string_type.coerce_isolated_input(0.999)
+      assert_nil string_type.coerce_isolated_input(100)
+      assert_nil string_type.coerce_isolated_input(true)
+      assert_nil string_type.coerce_isolated_input(0.999)
     end
   end
 end

--- a/spec/graphql/subscriptions_spec.rb
+++ b/spec/graphql/subscriptions_spec.rb
@@ -242,7 +242,7 @@ describe GraphQL::Subscriptions do
       schema.execute(query_str, context: { socket: "1" }, variables: { "id" => "8" }, root_value: root_object)
       schema.subscriptions.trigger("payload", { "id" => "8"}, OpenStruct.new(str: nil, int: nil))
       delivery = deliveries["1"].first
-      assert_equal nil, delivery.fetch("data")
+      assert_nil delivery.fetch("data")
       assert_equal 1, delivery["errors"].length
     end
 


### PR DESCRIPTION
Resolves warnings when running tests of the form `Use assert_nil if expecting nil from <file name, context>. This will fail in MT6.`

@rmosolgo 