### PR TITLE
Add ArgumentValue#default_used? and GraphQL::Query::Arguments#default_used?(key)

### DIFF
--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -84,6 +84,7 @@ module GraphQL
 
     def coerce_non_null_input(value, ctx)
       input_values = {}
+      arg_default_used = {}
 
       arguments.each do |input_key, input_field_defn|
         field_value = value[input_key]
@@ -93,10 +94,11 @@ module GraphQL
           input_values[input_key] = input_field_defn.prepare(coerced_value, ctx)
         elsif input_field_defn.default_value?
           input_values[input_key] = input_field_defn.default_value
+          arg_default_used[input_key] = true
         end
       end
 
-      arguments_class.new(input_values)
+      arguments_class.new(input_values, arg_default_used)
     end
 
     # @api private

--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -72,7 +72,7 @@ module GraphQL
       end
 
       # @param key [String, Symbol] name of value to access
-      # @return [Boolean] true if the argument was present in this field
+      # @return [Boolean] true if the argument default was passed as the argument value to the resolver
       def default_used?(key)
         key_s = key.is_a?(String) ? key : key.to_s
         @argument_values.fetch(key_s, NULL_ARGUMENT_VALUE).default_used?
@@ -121,6 +121,7 @@ module GraphQL
           @default_used = false
         end
 
+        # @return [Boolean] true if the argument default was passed as the argument value to the resolver
         def default_used?
           @default_used
         end

--- a/lib/graphql/query/literal_input.rb
+++ b/lib/graphql/query/literal_input.rb
@@ -49,6 +49,8 @@ module GraphQL
       def self.from_arguments(ast_arguments, argument_owner, variables)
         context = variables ? variables.context : nil
         values_hash = {}
+        values_used_default = Hash.new(false)
+
         indexed_arguments = case ast_arguments
         when Hash
           ast_arguments
@@ -93,6 +95,7 @@ module GraphQL
           # then add the default value.
           if arg_defn.default_value? && !values_hash.key?(arg_name)
             value = arg_defn.default_value
+            values_used_default[arg_name] = true
             # `context` isn't present when pre-calculating defaults
             if context
               value = arg_defn.prepare(value, context)
@@ -105,7 +108,7 @@ module GraphQL
           end
         end
 
-        argument_owner.arguments_class.new(values_hash)
+        argument_owner.arguments_class.new(values_hash, values_used_default)
       end
     end
   end

--- a/spec/graphql/query/arguments_spec.rb
+++ b/spec/graphql/query/arguments_spec.rb
@@ -203,8 +203,8 @@ describe GraphQL::Query::Arguments do
 
       last_args = arg_values.last
 
-      assert_equal false, arg_values.last.default_used?('a')
-      assert_equal true, arg_values.last.default_used?('b')
+      assert_equal false, last_args.default_used?('a')
+      assert_equal true, last_args.default_used?('b')
     end
 
     it "works from variables" do

--- a/spec/graphql/query/arguments_spec.rb
+++ b/spec/graphql/query/arguments_spec.rb
@@ -198,6 +198,15 @@ describe GraphQL::Query::Arguments do
       assert_equal({"a" => 1, "b" => 2}, last_args.to_h)
     end
 
+    it "indicates when default argument values were applied" do
+      schema.execute("{ argTest(a: 1) }")
+
+      last_args = arg_values.last
+
+      assert_equal false, arg_values.last.default_used?('a')
+      assert_equal true, arg_values.last.default_used?('b')
+    end
+
     it "works from variables" do
       variables = { "arg" => { "a" => 1, "d" => nil } }
       schema.execute("query ArgTest($arg: TestInput){ argTest(d: $arg) }", variables: variables)


### PR DESCRIPTION
As discussed yesterday in the GraphQL #ruby Slack channel.

I've been looking for a way, via instrumentation http://graphql-ruby.org/queries/instrumentation.html in an `after_query` method, to determine whether an `GraphQL::Argument` defined on a `GraphQL::InputObjectType` _that has a default_ actually used the default during resolution.

Argument values can be of type `GraphQL::Language::Nodes::VariableIdentifier` when the input object value is defined in a variable, or of the type `GraphQL::Language::Nodes::InputObject` when its defined inline. I could traverse through either to determine if a given argument fell back to its default that way.

But it seems like instrumentation code that seeks to know if argument defaults were used would be greatly simplified if we simply added this detail to ArgumentValue.

@rmosolgo I took your suggestion:

> makes sense to me, maybe `arguments_class.new(...)` could take a new parameter of names where the default was applied?

... and came up with a working solution, but would like some input on my approach and naming of things.

## tldr
With this change, arguments specified either inline or in variables that end up falling back to their definition's default are marked as such through the new methods `GraphQL::Query::ArgumentValue#default_used?` and `GraphQL::Query::Arguments#default_used?(key)`.

Also note that the assert_nil warning surfaced when running ArgumentsSpec is fixed in https://github.com/rmosolgo/graphql-ruby/pull/1140

cc: @eapache @swalkinshaw 