### PR TITLE
[1.8] Handle underscored argument names

### DIFF
--- a/guides/schema/class_based_api.md
+++ b/guides/schema/class_based_api.md
@@ -131,6 +131,8 @@ Classes extending {{ "GraphQL::Schema::Object" | api_doc }} describe [Object typ
 
 Object fields can be created with the `field(...)` class method, which accepts the similar arguments as the previous `field(...)` method.
 
+Field and argument names should be underscored as a convention. They will be converted to camelCase in the underlying GraphQL type and be camelCase in the schema itself.
+
 ```ruby
 # first, somewhere, a base class:
 class Types::BaseObject < GraphQL::Schema::Object
@@ -139,6 +141,7 @@ end
 # then...
 class Types::TodoList < BaseObject
   field :name, String, "The unique name of this list", null: false
+  field :is_completed, String, "Completed status depending on all tasks being done.", null: false
   # Related Object:
   field :owner, Types::User, "The creator of this list", null: false
   # List field:
@@ -189,7 +192,7 @@ If you define a type with a class, you can use existing GraphQL-Ruby resolve fun
 # Using a Proc literal or #call-able
 field :something, ... resolve: ->(obj, args, ctx) { ... }
 # Using a predefined field
-field :doSomething, field: Mutations::DoSomething.field
+field :do_something, field: Mutations::DoSomething.field
 # Using a GraphQL::Function
 field :something, function: Functions::Something.new
 ```
@@ -201,8 +204,8 @@ When using these resolution implementations, they will be called with the same `
 If you implement a field by defining a method, you should expect some automatic transformations:
 
 - GraphQL arguments will be converted to Ruby keyword arguments.
-- If the field name is `camelCased`, the method name should be `underscore_cased`.
-- If any argument names are `camelCased`, they will be passed to the method as `underscore_cased` Ruby keyword args.
+- method names should be `underscore_cased`.
+- argument names will be passed to the method as `underscore_cased` Ruby keyword args.
 
 Inside the method, you can access some instance variables:
 
@@ -339,7 +342,7 @@ Then extend it for your input objects:
 class PostInputType < BaseInputObject
   argument :title, String, required: true
   argument :body, String, required: true
-  argument :isDraft, Boolean, required: false, default_value: false
+  argument :is_draft, Boolean, required: false, default_value: false
 end
 ```
 
@@ -356,7 +359,7 @@ For fields on class-based objects, inputs are provided as Ruby keyword arguments
 ```ruby
 class MutationType < BaseObject
   field :createPost, PostType, null: false do
-    argument :postInput, PostInputType, required: true
+    argument :post_input, PostInputType, required: true
   end
 
   def create_post(post_input:)

--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -18,7 +18,7 @@ module GraphQL
 
       def to_graphql
         argument = GraphQL::Argument.new
-        argument.name = @name
+        argument.name = Member::BuildType.camelize(@name)
         argument.type = -> {
           Member::BuildType.parse_type(@type_expr, null: @null)
         }

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -48,7 +48,7 @@ module GraphQL
           GraphQL::Field.new
         end
 
-        field_defn.name = camelize(name)
+        field_defn.name = Member::BuildType.camelize(name)
 
         if @return_type_expr
           return_type_name = Member::BuildType.to_type_name(@return_type_expr)
@@ -98,14 +98,6 @@ module GraphQL
       end
 
       private
-
-      def camelize(string)
-        return string unless string.include?('_')
-
-        string.split('_').map(&:capitalize).join.tap do |camelized|
-          camelized[0] = camelized[0].downcase
-        end
-      end
 
       class << self
         def argument_class(new_arg_class = nil)

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -20,7 +20,7 @@ module GraphQL
         def argument(*args)
           argument = GraphQL::Schema::Argument.new(*args)
           own_arguments << argument
-          arg_name = argument.name
+          arg_name = argument.graphql_definition.name
           # Add a method access
           define_method(Member::BuildType.underscore(arg_name)) do
             @arguments.public_send(arg_name)
@@ -47,7 +47,7 @@ module GraphQL
           type_defn.name = graphql_name
           type_defn.description = description
           arguments.each do |arg|
-            type_defn.arguments[arg.name] = arg.graphql_definition
+            type_defn.arguments[arg.graphql_definition.name] = arg.graphql_definition
           end
           # Make a reference to a classic-style Arguments class
           self.arguments_class = GraphQL::Query::Arguments.construct_arguments_class(type_defn)

--- a/lib/graphql/schema/member/build_type.rb
+++ b/lib/graphql/schema/member/build_type.rb
@@ -94,6 +94,14 @@ module GraphQL
           end
         end
 
+        def camelize(string)
+          return string unless string.include?('_')
+
+          string.split('_').map(&:capitalize).join.tap do |camelized|
+            camelized[0] = camelized[0].downcase
+          end
+        end
+
         def underscore(string)
           string
             .gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2') # URLDecoder -> URL_Decoder

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -207,9 +207,9 @@ module Jazz
   end
 
   class InspectableInput < GraphQL::Schema::InputObject
-    argument :stringValue, String, required: true
-    argument :nestedInput, InspectableInput, required: false
-    argument :legacyInput, LegacyInputType, required: false
+    argument :string_value, String, required: true
+    argument :nested_input, InspectableInput, required: false
+    argument :legacy_input, LegacyInputType, required: false
     def helper_method
       [
         # Context is available in the InputObject


### PR DESCRIPTION
This is a follow-up to https://github.com/rmosolgo/graphql-ruby/pull/1126.

Completely forgot about arguments 😰 . The actual implementation of this was a little more involved than fields. I think it's correct?

Also updated the new guide to use this convention.