### PR TITLE
Failing test: Query without selections raise validation error

### DIFF
--- a/spec/graphql/static_validation/validator_spec.rb
+++ b/spec/graphql/static_validation/validator_spec.rb
@@ -137,5 +137,14 @@ describe GraphQL::StaticValidation::Validator do
         assert_equal(1, errors.length)
       end
     end
+
+    describe "queries with no selections" do
+      let(:query_string) {%|
+        # Welcome to GraphiQL!
+      |}
+      it "marks an error" do
+        assert_equal(1, errors.length)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds a failing test to demonstrate that, at present, a GraphQL Ruby app will fail to report any errors if the query document contains only comments or no contents at all.

Expected: The result should populate `errors` to indicate to the client that the request was invalid
Actual: The result contains only `{}`

@rmosolgo 