### PR TITLE
Add ArgumentValue#default_used? and Arguments#default_used?

### DIFF
--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -84,6 +84,7 @@ module GraphQL
 
     def coerce_non_null_input(value, ctx)
       input_values = {}
+      defaults_used = Hash.new(false)
 
       arguments.each do |input_key, input_field_defn|
         field_value = value[input_key]
@@ -93,10 +94,11 @@ module GraphQL
           input_values[input_key] = input_field_defn.prepare(coerced_value, ctx)
         elsif input_field_defn.default_value?
           input_values[input_key] = input_field_defn.default_value
+          defaults_used[input_key] = true
         end
       end
 
-      arguments_class.new(input_values)
+      arguments_class.new(input_values, defaults_used)
     end
 
     # @api private

--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -84,7 +84,7 @@ module GraphQL
 
     def coerce_non_null_input(value, ctx)
       input_values = {}
-      defaults_used = Hash.new(false)
+      defaults_used = Set.new
 
       arguments.each do |input_key, input_field_defn|
         field_value = value[input_key]
@@ -94,7 +94,7 @@ module GraphQL
           input_values[input_key] = input_field_defn.prepare(coerced_value, ctx)
         elsif input_field_defn.default_value?
           input_values[input_key] = input_field_defn.default_value
-          defaults_used[input_key] = true
+          defaults_used << input_key
         end
       end
 

--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -41,7 +41,7 @@ module GraphQL
           arg_name = inner_key.to_s
 
           arg_defn = argument_definitions[arg_name]
-          arg_default_used = defaults_used[arg_name]
+          arg_default_used = defaults_used.include?(arg_name)
 
           arg_value = wrap_value(inner_value, arg_defn.type)
           string_key = arg_defn.expose_as
@@ -133,7 +133,7 @@ module GraphQL
             wrap_value(value, arg_defn_type.of_type)
           when GraphQL::InputObjectType
             if value.is_a?(Hash)
-              arg_defn_type.arguments_class.new(value, Hash.new(false))
+              arg_defn_type.arguments_class.new(value, Set.new)
             else
               value
             end

--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -12,8 +12,8 @@ module GraphQL
         argument_owner.arguments_class = Class.new(self) do
           self.argument_definitions = argument_definitions
 
-          def initialize(values)
-            super(values, argument_definitions: self.class.argument_definitions)
+          def initialize(values, defaults_used)
+            super(values, argument_definitions: self.class.argument_definitions, defaults_used: defaults_used)
           end
 
           argument_definitions.each do |_arg_name, arg_definition|
@@ -36,13 +36,16 @@ module GraphQL
         end
       end
 
-      def initialize(values, argument_definitions:)
+      def initialize(values, argument_definitions:, defaults_used:)
         @argument_values = values.inject({}) do |memo, (inner_key, inner_value)|
-          arg_defn = argument_definitions[inner_key.to_s]
+          arg_name = inner_key.to_s
+
+          arg_defn = argument_definitions[arg_name]
+          arg_default_used = defaults_used[arg_name]
 
           arg_value = wrap_value(inner_value, arg_defn.type)
           string_key = arg_defn.expose_as
-          memo[string_key] = ArgumentValue.new(string_key, arg_value, arg_defn)
+          memo[string_key] = ArgumentValue.new(string_key, arg_value, arg_defn, arg_default_used)
           memo
         end
       end
@@ -59,6 +62,13 @@ module GraphQL
       def key?(key)
         key_s = key.is_a?(String) ? key : key.to_s
         @argument_values.key?(key_s)
+      end
+
+      # @param key [String, Symbol] name of value to access
+      # @return [Boolean] true if the argument default was passed as the argument value to the resolver
+      def default_used?(key)
+        key_s = key.is_a?(String) ? key : key.to_s
+        @argument_values.fetch(key_s, NULL_ARGUMENT_VALUE).default_used?
       end
 
       # Get the hash of all values, with stringified keys
@@ -85,7 +95,7 @@ module GraphQL
         end
       end
 
-      NO_ARGS = self.new({}, argument_definitions: [])
+      NO_ARGS = self.new({}, argument_definitions: [], defaults_used: {})
 
       class << self
         attr_accessor :argument_definitions
@@ -95,14 +105,22 @@ module GraphQL
 
       class ArgumentValue
         attr_reader :key, :value, :definition
-        def initialize(key, value, definition)
+        attr_writer :default_used
+
+        def initialize(key, value, definition, default_used)
           @key = key
           @value = value
           @definition = definition
+          @default_used = default_used
+        end
+
+        # @return [Boolean] true if the argument default was passed as the argument value to the resolver
+        def default_used?
+          @default_used
         end
       end
 
-      NULL_ARGUMENT_VALUE = ArgumentValue.new(nil, nil, nil)
+      NULL_ARGUMENT_VALUE = ArgumentValue.new(nil, nil, nil, nil)
 
       def wrap_value(value, arg_defn_type)
         if value.nil?
@@ -115,7 +133,7 @@ module GraphQL
             wrap_value(value, arg_defn_type.of_type)
           when GraphQL::InputObjectType
             if value.is_a?(Hash)
-              arg_defn_type.arguments_class.new(value)
+              arg_defn_type.arguments_class.new(value, Hash.new(false))
             else
               value
             end

--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -95,7 +95,7 @@ module GraphQL
         end
       end
 
-      NO_ARGS = self.new({}, argument_definitions: [], defaults_used: {})
+      NO_ARGS = self.new({}, argument_definitions: [], defaults_used: Set.new)
 
       class << self
         attr_accessor :argument_definitions

--- a/lib/graphql/query/literal_input.rb
+++ b/lib/graphql/query/literal_input.rb
@@ -49,6 +49,8 @@ module GraphQL
       def self.from_arguments(ast_arguments, argument_owner, variables)
         context = variables ? variables.context : nil
         values_hash = {}
+        defaults_used = Hash.new(false)
+
         indexed_arguments = case ast_arguments
         when Hash
           ast_arguments
@@ -93,6 +95,7 @@ module GraphQL
           # then add the default value.
           if arg_defn.default_value? && !values_hash.key?(arg_name)
             value = arg_defn.default_value
+            defaults_used[arg_name] = true
             # `context` isn't present when pre-calculating defaults
             if context
               value = arg_defn.prepare(value, context)
@@ -105,7 +108,7 @@ module GraphQL
           end
         end
 
-        argument_owner.arguments_class.new(values_hash)
+        argument_owner.arguments_class.new(values_hash, defaults_used)
       end
     end
   end

--- a/lib/graphql/query/literal_input.rb
+++ b/lib/graphql/query/literal_input.rb
@@ -49,7 +49,7 @@ module GraphQL
       def self.from_arguments(ast_arguments, argument_owner, variables)
         context = variables ? variables.context : nil
         values_hash = {}
-        defaults_used = Hash.new(false)
+        defaults_used = Set.new
 
         indexed_arguments = case ast_arguments
         when Hash
@@ -95,7 +95,7 @@ module GraphQL
           # then add the default value.
           if arg_defn.default_value? && !values_hash.key?(arg_name)
             value = arg_defn.default_value
-            defaults_used[arg_name] = true
+            defaults_used << arg_name
             # `context` isn't present when pre-calculating defaults
             if context
               value = arg_defn.prepare(value, context)

--- a/spec/graphql/query/arguments_spec.rb
+++ b/spec/graphql/query/arguments_spec.rb
@@ -26,11 +26,11 @@ describe GraphQL::Query::Arguments do
             e: 4,
           },
           argument_definitions: test_input_1.arguments,
-          defaults_used: {}
+          defaults_used: Set.new
         ),
       },
       argument_definitions: test_input_2.arguments,
-      defaults_used: {}
+      defaults_used: Set.new
     )
   }
 
@@ -84,7 +84,7 @@ describe GraphQL::Query::Arguments do
     new_arguments = GraphQL::Query::Arguments.new(
       transformed_args,
       argument_definitions: types,
-      defaults_used: {}
+      defaults_used: Set.new
     )
     expected_hash = {
       "A" => 1,
@@ -109,7 +109,7 @@ describe GraphQL::Query::Arguments do
       args = GraphQL::Query::Arguments.new(
         {a: 1, b: {a: 2}, c: {a: 3}},
         argument_definitions: input_type.arguments,
-        defaults_used: {}
+        defaults_used: Set.new
       )
       assert_kind_of GraphQL::Query::Arguments, args["b"]
       assert_instance_of Hash, args["c"]

--- a/spec/graphql/query/arguments_spec.rb
+++ b/spec/graphql/query/arguments_spec.rb
@@ -328,7 +328,7 @@ describe GraphQL::Query::Arguments do
       assert_equal nil, input_object.arguments_class
 
       GraphQL::Query::Arguments.construct_arguments_class(input_object)
-      args = input_object.arguments_class.new({foo: 3, bar: -90}, {})
+      args = input_object.arguments_class.new({foo: 3, bar: -90}, Set.new)
 
       assert_equal 3, args.foo
       assert_equal -90, args.bar

--- a/spec/graphql/query/arguments_spec.rb
+++ b/spec/graphql/query/arguments_spec.rb
@@ -16,14 +16,22 @@ describe GraphQL::Query::Arguments do
       argument :c, !test_input_1, as: :inputObject
     end
 
-    GraphQL::Query::Arguments.new({
-      a: 1,
-      b: 2,
-      c: GraphQL::Query::Arguments.new({
-        d: 3,
-        e: 4,
-      }, argument_definitions: test_input_1.arguments),
-    }, argument_definitions: test_input_2.arguments)
+    GraphQL::Query::Arguments.new(
+      {
+        a: 1,
+        b: 2,
+        c: GraphQL::Query::Arguments.new(
+          {
+            d: 3,
+            e: 4,
+          },
+          argument_definitions: test_input_1.arguments,
+          defaults_used: {}
+        ),
+      },
+      argument_definitions: test_input_2.arguments,
+      defaults_used: {}
+    )
   }
 
   it "returns keys as strings, with aliases" do
@@ -73,7 +81,11 @@ describe GraphQL::Query::Arguments do
       )
     end
 
-    new_arguments = GraphQL::Query::Arguments.new(transformed_args, argument_definitions: types)
+    new_arguments = GraphQL::Query::Arguments.new(
+      transformed_args,
+      argument_definitions: types,
+      defaults_used: {}
+    )
     expected_hash = {
       "A" => 1,
       "B" => 2,
@@ -96,7 +108,8 @@ describe GraphQL::Query::Arguments do
     it "wraps input objects, but not other hashes" do
       args = GraphQL::Query::Arguments.new(
         {a: 1, b: {a: 2}, c: {a: 3}},
-        argument_definitions: input_type.arguments
+        argument_definitions: input_type.arguments,
+        defaults_used: {}
       )
       assert_kind_of GraphQL::Query::Arguments, args["b"]
       assert_instance_of Hash, args["c"]
@@ -196,6 +209,15 @@ describe GraphQL::Query::Arguments do
       assert_equal true, last_args.key?(:b)
       assert_equal false, last_args.key?(:c)
       assert_equal({"a" => 1, "b" => 2}, last_args.to_h)
+    end
+
+    it "indicates when default argument values were applied" do
+      schema.execute("{ argTest(a: 1) }")
+
+      last_args = arg_values.last
+
+      assert_equal false, last_args.default_used?('a')
+      assert_equal true, last_args.default_used?('b')
     end
 
     it "works from variables" do
@@ -306,7 +328,7 @@ describe GraphQL::Query::Arguments do
       assert_equal nil, input_object.arguments_class
 
       GraphQL::Query::Arguments.construct_arguments_class(input_object)
-      args = input_object.arguments_class.new({foo: 3, bar: -90})
+      args = input_object.arguments_class.new({foo: 3, bar: -90}, {})
 
       assert_equal 3, args.foo
       assert_equal -90, args.bar


### PR DESCRIPTION
As discussed the other day in the GraphQL #ruby Slack channel, I've been looking for a way, via instrumentation http://graphql-ruby.org/queries/instrumentation.html in an `after_query` method, to determine whether an `GraphQL::Argument` defined on a `GraphQL::InputObjectType` _that has a default_ actually used the default during resolution.

Argument values can be of type `GraphQL::Language::Nodes::VariableIdentifier` when the input object value is defined in a variable, or of the type `GraphQL::Language::Nodes::InputObject` when its defined inline. I could traverse through either to determine if a given argument fell back to its default that way.

But it seems like instrumentation code that seeks to know if argument defaults were used would be greatly simplified if we simply added this detail to ArgumentValue.

@rmosolgo I took your suggestion:

> makes sense to me, maybe `arguments_class.new(...)` could take a new parameter of names where the default was applied?

... and came up with a working solution, but would like some input on my approach and naming of things.

## tldr
With this change, arguments specified either inline or in variables that end up falling back to their definition's default are marked as such through the new methods `GraphQL::Query::ArgumentValue#default_used?` and `GraphQL::Query::Arguments#default_used?(key)`.

Also note that the `assert_nil` warning surfaced when running ArgumentsSpec is fixed in https://github.com/rmosolgo/graphql-ruby/pull/1140

Closed https://github.com/rmosolgo/graphql-ruby/pull/1141 in favour of this PR

cc: @eapache @swalkinshaw 