### PR TITLE
Add introspection attribute to fields

### DIFF
--- a/lib/graphql/field.rb
+++ b/lib/graphql/field.rb
@@ -131,6 +131,7 @@ module GraphQL
       :relay_nodes_field,
       :subscription_scope,
       :trace,
+      :introspection,
       argument: GraphQL::Define::AssignArgument
 
     ensure_defined(
@@ -138,7 +139,8 @@ module GraphQL
       :mutation, :arguments, :complexity, :function,
       :resolve, :resolve=, :lazy_resolve, :lazy_resolve=, :lazy_resolve_proc, :resolve_proc,
       :type, :type=, :name=, :property=, :hash_key=,
-      :relay_node_field, :relay_nodes_field, :edges?, :edge_class, :subscription_scope
+      :relay_node_field, :relay_nodes_field, :edges?, :edge_class, :subscription_scope,
+      :introspection?
     )
 
     # @return [Boolean] True if this is the Relay find-by-id field
@@ -183,6 +185,7 @@ module GraphQL
     attr_accessor :arguments_class
 
     attr_writer :connection
+    attr_writer :introspection
 
     # @return [nil, String] Prefix for subscription names from this field
     attr_accessor :subscription_scope
@@ -217,11 +220,17 @@ module GraphQL
       @connection_max_page_size = nil
       @edge_class = nil
       @trace = nil
+      @introspection = false
     end
 
     def initialize_copy(other)
       super
       @arguments = other.arguments.dup
+    end
+
+    # @return [Boolean] Is this field a predefined introspection field?
+    def introspection?
+      @introspection
     end
 
     # Get a value for this field

--- a/lib/graphql/introspection/arguments_field.rb
+++ b/lib/graphql/introspection/arguments_field.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 GraphQL::Introspection::ArgumentsField = GraphQL::Field.define do
   type !GraphQL::ListType.new(of_type: !GraphQL::Introspection::InputValueType)
+  introspection true
   resolve ->(obj, args, ctx) {
     ctx.warden.arguments(obj)
   }

--- a/lib/graphql/introspection/enum_values_field.rb
+++ b/lib/graphql/introspection/enum_values_field.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 GraphQL::Introspection::EnumValuesField = GraphQL::Field.define do
   type types[!GraphQL::Introspection::EnumValueType]
+  introspection true
   argument :includeDeprecated, types.Boolean, default_value: false
   resolve ->(object, arguments, context) do
     if !object.kind.enum?

--- a/lib/graphql/introspection/fields_field.rb
+++ b/lib/graphql/introspection/fields_field.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 GraphQL::Introspection::FieldsField = GraphQL::Field.define do
   type -> { types[!GraphQL::Introspection::FieldType] }
+  introspection true
   argument :includeDeprecated, GraphQL::BOOLEAN_TYPE, default_value: false
   resolve ->(object, arguments, context) {
     return nil if !object.kind.fields?

--- a/lib/graphql/introspection/input_fields_field.rb
+++ b/lib/graphql/introspection/input_fields_field.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 GraphQL::Introspection::InputFieldsField = GraphQL::Field.define do
   name "inputFields"
+  introspection true
   type types[!GraphQL::Introspection::InputValueType]
   resolve ->(target, a, ctx) {
     if target.kind.input_object?

--- a/lib/graphql/introspection/interfaces_field.rb
+++ b/lib/graphql/introspection/interfaces_field.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 GraphQL::Introspection::InterfacesField = GraphQL::Field.define do
   type -> { types[!GraphQL::Introspection::TypeType] }
+  introspection true
   resolve ->(target, a, ctx) {
     if target.kind == GraphQL::TypeKinds::OBJECT
       ctx.warden.interfaces(target)

--- a/lib/graphql/introspection/of_type_field.rb
+++ b/lib/graphql/introspection/of_type_field.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 GraphQL::Introspection::OfTypeField = GraphQL::Field.define do
   name "ofType"
+  introspection true
   type -> { GraphQL::Introspection::TypeType }
   resolve ->(obj, args, ctx) { obj.kind.wraps? ? obj.of_type : nil }
 end

--- a/lib/graphql/introspection/possible_types_field.rb
+++ b/lib/graphql/introspection/possible_types_field.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 GraphQL::Introspection::PossibleTypesField = GraphQL::Field.define do
   type -> { types[!GraphQL::Introspection::TypeType] }
+  introspection true
   resolve ->(target, args, ctx) {
     if target.kind.resolves?
       ctx.warden.possible_types(target)

--- a/lib/graphql/introspection/schema_field.rb
+++ b/lib/graphql/introspection/schema_field.rb
@@ -4,6 +4,7 @@ module GraphQL
     SchemaField = GraphQL::Field.define do
       name("__schema")
       description("This GraphQL schema")
+      introspection true
       type(!GraphQL::Introspection::SchemaType)
       resolve ->(o, a, ctx) { ctx.query.schema }
     end

--- a/lib/graphql/introspection/type_by_name_field.rb
+++ b/lib/graphql/introspection/type_by_name_field.rb
@@ -5,6 +5,7 @@ module GraphQL
       name("__type")
       description("A type in the GraphQL system")
       type(GraphQL::Introspection::TypeType)
+      introspection true
       argument :name, !types.String
       resolve ->(o, args, ctx) {
         ctx.warden.get_type(args["name"])

--- a/lib/graphql/introspection/typename_field.rb
+++ b/lib/graphql/introspection/typename_field.rb
@@ -5,6 +5,7 @@ module GraphQL
       name "__typename"
       description "The name of this type"
       type -> { !GraphQL::STRING_TYPE }
+      introspection true
       resolve ->(obj, a, ctx) { ctx.irep_node.owner_type }
     end
   end


### PR DESCRIPTION
Types already had the `introspection` attribute, but without it on fields, there was no easy to check if a field is an introspection field or not.

Usually an introspection field returns an introspection type, but this breaks down for `__typename` which always returns a `String`. Instead of treating it differently, this just adds the attribute to all fields.

Now `introspection?` is available. This can be useful for analysis like computing complexity.