### PR TITLE
[1.8] Support custom context classes

### DIFF
--- a/guides/schema/class_based_api.md
+++ b/guides/schema/class_based_api.md
@@ -103,7 +103,7 @@ Here is a working plan for rolling out this feature:
   - ☑ Build a schema definition API based on classes instead of singletons
   - ☑ Migrate a few components of GitHub's GraphQL schema to this new API
   - ☐ Build advanced class-based features:
-    - ☐ Custom `Context` classes
+    - ☑ Custom `Context` classes
     - ☐ Custom introspection types
     - ☐ Custom directives
     - ☐ Custom `Schema#execute` method
@@ -529,6 +529,27 @@ Scalars are never initialized; only their `.coerce_*` methods are called at runt
 ## Customizing definitions
 
 The new API provides alternatives to `accepts_definitions`.
+
+### Customizing `@context`
+
+The `@context` object passed through each query may be customized by creating a subclass of {{ "GraphQL::Query::Context" | api_doc }} and passing it to `context_class` in your schema class:
+
+```ruby
+class MyContext < GraphQL::Query::Context
+  # short-hand access to a value:
+  def current_user
+    self[:current_user]
+  end
+end
+
+# then:
+class MySchema < GraphQL::Schema
+  # ...
+  context_class MyContext
+end
+```
+
+Then, during queries, `@context` will be an instance of `MyContext`.
 
 ### Customizing type definitions
 

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -79,7 +79,7 @@ module GraphQL
     def initialize(schema, query_string = nil, query: nil, document: nil, context: nil, variables: {}, validate: true, subscription_topic: nil, operation_name: nil, root_value: nil, max_depth: nil, max_complexity: nil, except: nil, only: nil)
       @schema = schema
       @filter = schema.default_filter.merge(except: except, only: only)
-      @context = Context.new(query: self, object: root_value, values: context)
+      @context = schema.context_class.new(query: self, object: root_value, values: context)
       @subscription_topic = subscription_topic
       @root_value = root_value
       @fragments = nil

--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -268,3 +268,6 @@ module GraphQL
     end
   end
 end
+
+
+GraphQL::Schema::Context = GraphQL::Query::Context

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -104,6 +104,10 @@ module GraphQL
     # @see {Query.new} for query-specific filters with `except:`
     attr_accessor :default_mask
 
+    # @see {GraphQL::Query::Context} The parent class of these classes
+    # @return [Class] Instantiated for each query
+    attr_accessor :context_class
+
     class << self
       attr_accessor :default_execution_strategy
     end
@@ -148,6 +152,7 @@ module GraphQL
       @subscription_execution_strategy = self.class.default_execution_strategy
       @default_mask = GraphQL::Schema::NullMask
       @rebuilding_artifacts = false
+      @context_class = GraphQL::Query::Context
     end
 
     def initialize_copy(other)
@@ -635,6 +640,7 @@ module GraphQL
         schema_defn.resolve_type = method(:resolve_type)
         schema_defn.object_from_id = method(:object_from_id)
         schema_defn.id_from_object = method(:id_from_object)
+        schema_defn.context_class = context_class
         instrumenters.each do |step, insts|
           insts.each do |inst|
             schema_defn.instrumenters[step] << inst
@@ -715,6 +721,14 @@ module GraphQL
           superclass.default_execution_strategy
         else
           @default_execution_strategy
+        end
+      end
+
+      def context_class(new_context_class = nil)
+        if new_context_class
+          @context_class = new_context_class
+        else
+          @context_class || GraphQL::Query::Context
         end
       end
 

--- a/lib/graphql/schema/member/instrumentation.rb
+++ b/lib/graphql/schema/member/instrumentation.rb
@@ -100,7 +100,9 @@ module GraphQL
               end
 
               if concrete_type && (object_class = concrete_type.metadata[:object_class])
-                object_class.new(obj, ctx)
+                # use the query-level context here, since it won't be field-specific anyways
+                query_ctx = ctx.query.context
+                object_class.new(obj, query_ctx)
               else
                 obj
               end

--- a/spec/graphql/query/context_spec.rb
+++ b/spec/graphql/query/context_spec.rb
@@ -243,4 +243,13 @@ TABLE
       assert_equal [expected_err], result["errors"]
     end
   end
+
+  describe "custom context class" do
+    it "can be specified" do
+      query_str = "{ inspectContext }"
+      res = Jazz::Schema.execute(query_str, context: { magic_key: :ignored, normal_key: "normal_value" })
+      expected_values = ["custom_method", "magic_value", "normal_value"]
+      assert_equal expected_values, res["data"]["inspectContext"]
+    end
+  end
 end

--- a/spec/graphql/query/context_spec.rb
+++ b/spec/graphql/query/context_spec.rb
@@ -246,10 +246,18 @@ TABLE
 
   describe "custom context class" do
     it "can be specified" do
-      query_str = "{ inspectContext }"
+      query_str = '{
+        inspectContext
+        find(id: "Musician/Herbie Hancock") {
+          ... on Musician {
+            inspectContext
+          }
+        }
+      }'
       res = Jazz::Schema.execute(query_str, context: { magic_key: :ignored, normal_key: "normal_value" })
       expected_values = ["custom_method", "magic_value", "normal_value"]
       assert_equal expected_values, res["data"]["inspectContext"]
+      assert_equal expected_values, res["data"]["find"]["inspectContext"]
     end
   end
 end

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -199,6 +199,15 @@ module Jazz
     description "Someone who plays an instrument"
     field :instrument, InstrumentType, null: false
     field :favorite_key, Key, null: true
+    field :inspect_context, [String], null: false
+
+    def inspect_context
+      [
+        @context.custom_method,
+        @context[:magic_key],
+        @context[:normal_key]
+      ]
+    end
   end
 
   LegacyInputType = GraphQL::InputObjectType.define do

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -260,6 +260,7 @@ module Jazz
     field :nowPlaying, PerformingAct, null: false, resolve: ->(o, a, c) { Models.data["Ensemble"].first }
     # For asserting that the object is initialized once:
     field :object_id, Integer, null: false
+    field :inspect_context, [String], null: false
 
     def ensembles
       Models.data["Ensemble"]
@@ -297,6 +298,14 @@ module Jazz
     def inspect_key(key:)
       key
     end
+
+    def inspect_context
+      [
+        @context.custom_method,
+        @context[:magic_key],
+        @context[:normal_key]
+      ]
+    end
   end
 
   class EnsembleInput < GraphQL::Schema::InputObject
@@ -321,10 +330,25 @@ module Jazz
     end
   end
 
+  class CustomContext < GraphQL::Query::Context
+    def [](key)
+      if key == :magic_key
+        "magic_value"
+      else
+        super
+      end
+    end
+
+    def custom_method
+      "custom_method"
+    end
+  end
+
   # New-style Schema definition
   class Schema < GraphQL::Schema
     query(Query)
     mutation(Mutation)
+    context_class CustomContext
     use MetadataPlugin, value: "xyz"
     def self.resolve_type(type, obj, ctx)
       class_name = obj.class.name.split("::").last


### PR DESCRIPTION
Custom context classes will allow you to put a bit of logic or caching in `@context`

This also points out a change in 1.8: 

Previously, `context` was field-specific, holding references to things like `ast_node`, `irep_node`, `parent`, `object`, `value`. But now, individual fields don't get called with their own contexts. Instead, the context is provided at object-level, then shared between fields on that object. 

So, we will need (?) some API for getting that info to fields who are using it. 