### PR TITLE
allow description to be defined within field block

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -124,6 +124,14 @@ module GraphQL
           arg = @argument_class.new(*args)
           @field.arguments[arg.name] = arg.graphql_definition
         end
+
+        def description(text)
+          if @field.description
+            fail "You're overriding the description of #{@field.name} in the provided block!"
+          else
+            @field.description = text
+          end
+        end
       end
     end
   end

--- a/spec/graphql/schema/field_spec.rb
+++ b/spec/graphql/schema/field_spec.rb
@@ -14,5 +14,17 @@ describe GraphQL::Schema::Field do
     it "camelizes the field name" do
       assert_equal 'inspectInput', field.graphql_definition.name
     end
+
+    describe "description in block" do
+      it "will raise if description is defined both in the argument and in the block" do
+        assert_raises RuntimeError do
+          class DescriptionInBlock < Jazz::BaseObject
+            field :should_raise, Jazz::Key, "this should not raise" do
+              description "This should raise"
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/graphql/schema/field_spec.rb
+++ b/spec/graphql/schema/field_spec.rb
@@ -17,12 +17,14 @@ describe GraphQL::Schema::Field do
 
     describe "description in block" do
       it "will raise if description is defined both in the argument and in the block" do
-        assert_raises RuntimeError do
-          class DescriptionInBlock < Jazz::BaseObject
-            field :should_raise, Jazz::Key, "this should not raise" do
+        assert_raises RuntimeError, "You're overriding the description of shouldRaise in the provided block!" do
+          Class.new(Jazz::BaseObject) do
+            graphql_name "JustAName"
+
+            field :should_raise, Jazz::Key, "this should not raise", null: true do
               description "This should raise"
             end
-          end
+          end.to_graphql
         end
       end
     end

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -59,9 +59,9 @@ module Jazz
   # A custom field class that supports the `upcase:` option
   class BaseField < GraphQL::Schema::Field
     argument_class BaseArgument
-    def initialize(*args, options, &block)
+    def initialize(*args, **options, &block)
       @upcase = options.delete(:upcase)
-      super(*args, options, &block)
+      super(*args, **options, &block)
     end
 
     def to_graphql

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -197,7 +197,9 @@ module Jazz
     implements GloballyIdentifiableType
     implements NamedEntity
     description "Someone who plays an instrument"
-    field :instrument, InstrumentType, null: false
+    field :instrument, InstrumentType, null: false do
+      description "An object played in order to produce music"
+    end
     field :favorite_key, Key, null: true
   end
 


### PR DESCRIPTION
It seems there are no objects to https://github.com/rmosolgo/graphql-ruby/issues/1158, so let's implement it!