### PR TITLE
Fix upgrader for some cases

### DIFF
--- a/lib/graphql/railtie.rb
+++ b/lib/graphql/railtie.rb
@@ -32,6 +32,22 @@ module GraphQL
                    'For example: `bin/rake graphql:upgrade:create_base_objects[app/graphql]`'
             end
 
+            destination_file = File.join(base_dir, "types", "base_scalar.rb")
+            unless File.exists?(destination_file)
+              FileUtils.mkdir_p(File.dirname(destination_file))
+              File.open(destination_file, 'w') do |f|
+                f.write "class Types::BaseScalar < GraphQL::Schema::Scalar; end"
+              end
+            end
+
+            destination_file = File.join(base_dir, "types", "base_input_object.rb")
+            unless File.exists?(destination_file)
+              FileUtils.mkdir_p(File.dirname(destination_file))
+              File.open(destination_file, 'w') do |f|
+                f.write "class Types::BaseInputObject < GraphQL::Schema::InputObject; end"
+              end
+            end
+
             destination_file = File.join(base_dir, "types", "base_enum.rb")
             unless File.exists?(destination_file)
               FileUtils.mkdir_p(File.dirname(destination_file))

--- a/lib/graphql/upgrader/member.rb
+++ b/lib/graphql/upgrader/member.rb
@@ -101,12 +101,12 @@ module GraphQL
 
       def transform_to_class(transformable)
         transformable.sub(
-          /([a-zA-Z_0-9:]*) = GraphQL::(Object|Interface|Enum|Union)Type\.define do/, 'class \1 < Base\2'
+          /([a-zA-Z_0-9:]*) = GraphQL::(Object|Interface|Enum|Union)Type\.define do/, 'class \1 < Types::Base\2'
         )
       end
 
       def transform_or_remove_name(transformable)
-        if (matches = transformable.match(/class (?<type_name>[a-zA-Z_0-9]*) < Base(Object|Interface|Enum|Union)/))
+        if (matches = transformable.match(/class (?<type_name>[a-zA-Z_0-9:]*) < Types::Base(Object|Interface|Enum|Union)/))
           type_name = matches[:type_name]
           type_name_without_the_type_part = type_name.gsub(/Type$/, '')
 

--- a/lib/graphql/upgrader/member.rb
+++ b/lib/graphql/upgrader/member.rb
@@ -69,9 +69,7 @@ module GraphQL
 
       def upgradeable?
         return false if member.include? '< GraphQL::Schema::'
-        return false if member.include? '< BaseObject'
-        return false if member.include? '< BaseInterface'
-        return false if member.include? '< BaseEnum'
+        return false if member =~ /< Types::Base#{GRAPHQL_TYPES}/
 
         true
       end
@@ -101,12 +99,12 @@ module GraphQL
 
       def transform_to_class(transformable)
         transformable.sub(
-          /([a-zA-Z_0-9:]*) = GraphQL::(Object|Interface|Enum|Union)Type\.define do/, 'class \1 < Types::Base\2'
+          /([a-zA-Z_0-9:]*) = GraphQL::#{GRAPHQL_TYPES}Type\.define do/, 'class \1 < Types::Base\2'
         )
       end
 
       def transform_or_remove_name(transformable)
-        if (matches = transformable.match(/class (?<type_name>[a-zA-Z_0-9:]*) < Types::Base(Object|Interface|Enum|Union)/))
+        if (matches = transformable.match(/class (?<type_name>[a-zA-Z_0-9:]*) < Types::Base#{GRAPHQL_TYPES}/))
           type_name = matches[:type_name]
           type_name_without_the_type_part = type_name.split('::').last.gsub(/Type$/, '')
 
@@ -128,6 +126,9 @@ module GraphQL
       end
 
       attr_reader :member
+
+      private
+        GRAPHQL_TYPES = '(Object|InputObject|Interface|Enum|Scalar|Union)'
     end
   end
 end

--- a/lib/graphql/upgrader/member.rb
+++ b/lib/graphql/upgrader/member.rb
@@ -108,7 +108,7 @@ module GraphQL
       def transform_or_remove_name(transformable)
         if (matches = transformable.match(/class (?<type_name>[a-zA-Z_0-9:]*) < Types::Base(Object|Interface|Enum|Union)/))
           type_name = matches[:type_name]
-          type_name_without_the_type_part = type_name.gsub(/Type$/, '')
+          type_name_without_the_type_part = type_name.split('::').last.gsub(/Type$/, '')
 
           if matches = transformable.match(/name ('|")(?<type_name>.*)('|")/)
             name = matches[:type_name]

--- a/lib/graphql/upgrader/member.rb
+++ b/lib/graphql/upgrader/member.rb
@@ -33,7 +33,7 @@ module GraphQL
             remainder.gsub! /^,/, ''
             remainder.chomp!
 
-            may_return_null = !(return_type.gsub! '!', '')
+            has_bang = !(return_type.gsub! '!', '')
             return_type.gsub! 'types.', ''
             return_type.gsub! 'types[', '['
 
@@ -48,13 +48,13 @@ module GraphQL
               end
 
               if is_argument
-                if may_return_null
+                if has_bang
                   f += ', required: false'
                 else
                   f += ', required: true'
                 end
               else
-                if may_return_null
+                if has_bang
                   f += ', null: true'
                 else
                   f += ', null: false'

--- a/lib/graphql/upgrader/member.rb
+++ b/lib/graphql/upgrader/member.rb
@@ -14,6 +14,7 @@ module GraphQL
         transformable = simplify_field_definition_for_easier_processing transformable
         transformable = move_the_type_from_the_block_to_the_field transformable
         transformable = rename_property_to_method transformable
+        transformable = transform_interfaces_to_implements transformable
 
         transformable.scan(/(?:input_field|field|connection|argument) .*$/).each do |field|
           field_regex =
@@ -132,6 +133,19 @@ module GraphQL
 
       def rename_property_to_method(transformable)
         transformable.gsub /property:/, 'method:'
+      end
+
+      def transform_interfaces_to_implements(transformable)
+        transformable.gsub(
+          /(?<indent>\s*)(?:interfaces) \[(?<interfaces>(?:[a-zA-Z_0-9:]+)(?:,\s*[a-zA-Z_0-9:]+)*)\]/
+        ) do
+          indent = $~[:indent]
+          interfaces = $~[:interfaces].split(',').map(&:strip)
+
+          interfaces.map do |interface|
+            "#{indent}implements #{interface}"
+          end.join
+        end
       end
 
       attr_reader :member

--- a/spec/graphql/upgrader/member_spec.rb
+++ b/spec/graphql/upgrader/member_spec.rb
@@ -77,12 +77,12 @@ describe GraphQL::Upgrader::Member do
       assert_equal new, upgrade(old)
 
       old = %{
-        UserInterface = GraphQL::InterfaceType.define do
+        UserEnum = GraphQL::EnumType.define do
           name "User"
         end
       }
       new = %{
-        class UserInterface < Types::BaseInterface
+        class UserEnum < Types::BaseEnum
           graphql_name "User"
         end
       }
@@ -115,12 +115,12 @@ describe GraphQL::Upgrader::Member do
       assert_equal new, upgrade(old)
 
       old = %{
-        Types::UserInterface = GraphQL::InterfaceType.define do
+        Types::UserEnum = GraphQL::EnumType.define do
           name "User"
         end
       }
       new = %{
-        class Types::UserInterface < Types::BaseInterface
+        class Types::UserEnum < Types::BaseEnum
           graphql_name "User"
         end
       }

--- a/spec/graphql/upgrader/member_spec.rb
+++ b/spec/graphql/upgrader/member_spec.rb
@@ -11,7 +11,7 @@ describe GraphQL::Upgrader::Member do
   describe 'field arguments' do
     it 'upgrades' do
       old = %{argument :status, !TodoStatus, "Restrict items to this status"}
-      new = %{argument :status, TodoStatus, "Restrict items to this status", null: false}
+      new = %{argument :status, TodoStatus, "Restrict items to this status", required: true}
 
       assert_equal new, upgrade(old)
     end
@@ -267,6 +267,14 @@ describe GraphQL::Upgrader::Member do
           method: :example_connections
       }
 
+      assert_equal new, upgrade(old)
+    end
+  end
+
+  describe 'input_field' do
+    it 'upgrades to argument' do
+      old = %{input_field :id, !types.ID}
+      new = %{argument :id, ID, required: true}
       assert_equal new, upgrade(old)
     end
   end

--- a/spec/graphql/upgrader/member_spec.rb
+++ b/spec/graphql/upgrader/member_spec.rb
@@ -32,7 +32,7 @@ describe GraphQL::Upgrader::Member do
         end
       }
       new = %{
-        class UserType < BaseObject
+        class UserType < Types::BaseObject
         end
       }
       assert_equal upgrade(old), new
@@ -45,7 +45,7 @@ describe GraphQL::Upgrader::Member do
         end
       }
       new = %{
-        class TeamType < BaseObject
+        class TeamType < Types::BaseObject
           graphql_name "User"
         end
       }
@@ -57,7 +57,7 @@ describe GraphQL::Upgrader::Member do
         end
       }
       new = %{
-        class UserInterface < BaseInterface
+        class UserInterface < Types::BaseInterface
           graphql_name "User"
         end
       }
@@ -69,7 +69,7 @@ describe GraphQL::Upgrader::Member do
         end
       }
       new = %{
-        class UserInterface < BaseInterface
+        class UserInterface < Types::BaseInterface
           graphql_name "User"
         end
       }
@@ -80,25 +80,25 @@ describe GraphQL::Upgrader::Member do
   describe 'definition' do
     it 'upgrades the .define into class based definition' do
       old = %{UserType = GraphQL::ObjectType.define do}
-      new = %{class UserType < BaseObject}
+      new = %{class UserType < Types::BaseObject}
       assert_equal upgrade(old), new
 
       old = %{UserInterface = GraphQL::InterfaceType.define do}
-      new = %{class UserInterface < BaseInterface}
+      new = %{class UserInterface < Types::BaseInterface}
       assert_equal upgrade(old), new
 
       old = %{UserUnion = GraphQL::UnionType.define do}
-      new = %{class UserUnion < BaseUnion}
+      new = %{class UserUnion < Types::BaseUnion}
       assert_equal upgrade(old), new
 
       old = %{UserEnum = GraphQL::EnumType.define do}
-      new = %{class UserEnum < BaseEnum}
+      new = %{class UserEnum < Types::BaseEnum}
       assert_equal upgrade(old), new
     end
 
     it 'upgrades including the module' do
       old = %{Module::UserType = GraphQL::ObjectType.define do}
-      new = %{class Module::UserType < BaseObject}
+      new = %{class Module::UserType < Types::BaseObject}
       assert_equal upgrade(old), new
     end
   end

--- a/spec/graphql/upgrader/member_spec.rb
+++ b/spec/graphql/upgrader/member_spec.rb
@@ -88,44 +88,6 @@ describe GraphQL::Upgrader::Member do
       }
       assert_equal new, upgrade(old)
     end
-
-    it 'upgrades the name into graphql_name if it can\'t be inferred from the class and under a module' do
-      old = %{
-        Types::TeamType = GraphQL::ObjectType.define do
-          name "User"
-        end
-      }
-      new = %{
-        class Types::TeamType < Types::BaseObject
-          graphql_name "User"
-        end
-      }
-      assert_equal new, upgrade(old)
-
-      old = %{
-        Types::UserInterface = GraphQL::InterfaceType.define do
-          name "User"
-        end
-      }
-      new = %{
-        class Types::UserInterface < Types::BaseInterface
-          graphql_name "User"
-        end
-      }
-      assert_equal new, upgrade(old)
-
-      old = %{
-        Types::UserEnum = GraphQL::EnumType.define do
-          name "User"
-        end
-      }
-      new = %{
-        class Types::UserEnum < Types::BaseEnum
-          graphql_name "User"
-        end
-      }
-      assert_equal new, upgrade(old)
-    end
   end
 
   describe 'definition' do

--- a/spec/graphql/upgrader/member_spec.rb
+++ b/spec/graphql/upgrader/member_spec.rb
@@ -38,6 +38,19 @@ describe GraphQL::Upgrader::Member do
       assert_equal new, upgrade(old)
     end
 
+    it 'removes the name field if it can be inferred from the class and under a module' do
+      old = %{
+        Types::UserType = GraphQL::ObjectType.define do
+          name "User"
+        end
+      }
+      new = %{
+        class Types::UserType < Types::BaseObject
+        end
+      }
+      assert_equal new, upgrade(old)
+    end
+
     it 'upgrades the name into graphql_name if it can\'t be inferred from the class' do
       old = %{
         TeamType = GraphQL::ObjectType.define do
@@ -70,6 +83,44 @@ describe GraphQL::Upgrader::Member do
       }
       new = %{
         class UserInterface < Types::BaseInterface
+          graphql_name "User"
+        end
+      }
+      assert_equal new, upgrade(old)
+    end
+
+    it 'upgrades the name into graphql_name if it can\'t be inferred from the class and under a module' do
+      old = %{
+        Types::TeamType = GraphQL::ObjectType.define do
+          name "User"
+        end
+      }
+      new = %{
+        class Types::TeamType < Types::BaseObject
+          graphql_name "User"
+        end
+      }
+      assert_equal new, upgrade(old)
+
+      old = %{
+        Types::UserInterface = GraphQL::InterfaceType.define do
+          name "User"
+        end
+      }
+      new = %{
+        class Types::UserInterface < Types::BaseInterface
+          graphql_name "User"
+        end
+      }
+      assert_equal new, upgrade(old)
+
+      old = %{
+        Types::UserInterface = GraphQL::InterfaceType.define do
+          name "User"
+        end
+      }
+      new = %{
+        class Types::UserInterface < Types::BaseInterface
           graphql_name "User"
         end
       }

--- a/spec/graphql/upgrader/member_spec.rb
+++ b/spec/graphql/upgrader/member_spec.rb
@@ -13,7 +13,7 @@ describe GraphQL::Upgrader::Member do
       old = %{argument :status, !TodoStatus, "Restrict items to this status"}
       new = %{argument :status, TodoStatus, "Restrict items to this status", null: false}
 
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
     end
   end
 
@@ -21,7 +21,7 @@ describe GraphQL::Upgrader::Member do
     old = %{field :name, String, property: :name}
     new = %{field :name, String, method: :name, null: true}
 
-    assert_equal upgrade(old), new
+    assert_equal new, upgrade(old)
   end
 
   describe 'name' do
@@ -35,7 +35,7 @@ describe GraphQL::Upgrader::Member do
         class UserType < Types::BaseObject
         end
       }
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
     end
 
     it 'upgrades the name into graphql_name if it can\'t be inferred from the class' do
@@ -49,7 +49,7 @@ describe GraphQL::Upgrader::Member do
           graphql_name "User"
         end
       }
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
 
       old = %{
         UserInterface = GraphQL::InterfaceType.define do
@@ -61,7 +61,7 @@ describe GraphQL::Upgrader::Member do
           graphql_name "User"
         end
       }
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
 
       old = %{
         UserInterface = GraphQL::InterfaceType.define do
@@ -73,7 +73,7 @@ describe GraphQL::Upgrader::Member do
           graphql_name "User"
         end
       }
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
     end
   end
 
@@ -81,25 +81,25 @@ describe GraphQL::Upgrader::Member do
     it 'upgrades the .define into class based definition' do
       old = %{UserType = GraphQL::ObjectType.define do}
       new = %{class UserType < Types::BaseObject}
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
 
       old = %{UserInterface = GraphQL::InterfaceType.define do}
       new = %{class UserInterface < Types::BaseInterface}
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
 
       old = %{UserUnion = GraphQL::UnionType.define do}
       new = %{class UserUnion < Types::BaseUnion}
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
 
       old = %{UserEnum = GraphQL::EnumType.define do}
       new = %{class UserEnum < Types::BaseEnum}
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
     end
 
     it 'upgrades including the module' do
       old = %{Module::UserType = GraphQL::ObjectType.define do}
       new = %{class Module::UserType < Types::BaseObject}
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
     end
   end
 
@@ -107,31 +107,31 @@ describe GraphQL::Upgrader::Member do
     it 'upgrades to the new definition' do
       old = %{field :name, !types.String}
       new = %{field :name, String, null: false}
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
 
       old = %{field :name, !types.String, "description", method: :name}
       new = %{field :name, String, "description", method: :name, null: false}
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
 
       old = %{field :name, -> { !types.String }}
       new = %{field :name, -> { String }, null: false}
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
 
       old = %{connection :name, Name.connection_type, "names"}
       new = %{field :name, Name.connection_type, "names", null: true, connection: true}
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
 
       old = %{connection :name, !Name.connection_type, "names"}
       new = %{field :name, Name.connection_type, "names", null: false, connection: true}
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
 
       old = %{field :names, types[types.String]}
       new = %{field :names, [String], null: true}
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
 
       old = %{field :names, !types[types.String]}
       new = %{field :names, [String], null: false}
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
 
       old = %{
         field :name, types.String do
@@ -141,7 +141,7 @@ describe GraphQL::Upgrader::Member do
         field :name, String, null: true do
         end
       }
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
 
       old = %{
         field :name, !types.String do
@@ -151,7 +151,7 @@ describe GraphQL::Upgrader::Member do
         field :name, String, null: false do
         end
       }
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
 
       old = %{
         field :name, -> { !types.String } do
@@ -161,7 +161,7 @@ describe GraphQL::Upgrader::Member do
         field :name, -> { String }, null: false do
         end
       }
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
 
       old = %{
         field :name do
@@ -172,7 +172,7 @@ describe GraphQL::Upgrader::Member do
         field :name, -> { String }, null: true do
         end
       }
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
 
       old = %{
         field :name do
@@ -183,7 +183,7 @@ describe GraphQL::Upgrader::Member do
         field :name, String, null: false do
         end
       }
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
 
       old = %{
         field :name, -> { types.String },
@@ -194,7 +194,7 @@ describe GraphQL::Upgrader::Member do
         field :name, -> { String }, "newline description", null: true do
         end
       }
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
 
       old = %{
         field :name, -> { !types.String },
@@ -205,7 +205,7 @@ describe GraphQL::Upgrader::Member do
         field :name, -> { String }, "newline description", null: false do
         end
       }
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
 
       old = %{
        field :name, String,
@@ -216,7 +216,7 @@ describe GraphQL::Upgrader::Member do
        field :name, String, field: SomeField, null: true do
        end
       }
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
     end
   end
 
@@ -231,7 +231,7 @@ describe GraphQL::Upgrader::Member do
           method: :example_field?
       }
 
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
     end
   end
 
@@ -246,7 +246,7 @@ describe GraphQL::Upgrader::Member do
           method: :example_connections
       }
 
-      assert_equal upgrade(old), new
+      assert_equal new, upgrade(old)
     end
   end
 end

--- a/spec/graphql/upgrader/member_spec.rb
+++ b/spec/graphql/upgrader/member_spec.rb
@@ -107,6 +107,14 @@ describe GraphQL::Upgrader::Member do
       old = %{UserEnum = GraphQL::EnumType.define do}
       new = %{class UserEnum < Types::BaseEnum}
       assert_equal new, upgrade(old)
+
+      old = %{UserInput = GraphQL::InputObjectType.define do}
+      new = %{class UserInput < Types::BaseInputObject}
+      assert_equal new, upgrade(old)
+
+      old = %{UserScalar = GraphQL::ScalarType.define do}
+      new = %{class UserScalar < Types::BaseScalar}
+      assert_equal new, upgrade(old)
     end
 
     it 'upgrades including the module' do

--- a/spec/graphql/upgrader/member_spec.rb
+++ b/spec/graphql/upgrader/member_spec.rb
@@ -278,4 +278,19 @@ describe GraphQL::Upgrader::Member do
       assert_equal new, upgrade(old)
     end
   end
+
+  describe 'implements' do
+    it 'upgrades interfaces to implements' do
+      old = %{
+        interfaces [Types::SearchableType, Types::CommentableType]
+        interfaces [Types::ShareableType]
+      }
+      new = %{
+        implements Types::SearchableType
+        implements Types::CommentableType
+        implements Types::ShareableType
+      }
+      assert_equal new, upgrade(old)
+    end
+  end
 end


### PR DESCRIPTION
See https://github.com/rmosolgo/graphql-ruby/issues/1177

- [x] NameError (uninitialized constant BaseObject)
- [x] Generate classes base on Types::Base* instead of Base*
- [x] Convert `input_field` to `argument`, convert `null:` to `required:`
- [x] Convert types base on InputObjectType, ScalarType
- [x] Convert `interfaces [...]` to `implemnts`
~- [ ] Convert `description`~
~- [ ] Allow definition of `resolve` within field block~