### PR TITLE
Call inspect on value when raising EnumType::UnresolvedValueError

### DIFF
--- a/lib/graphql/enum_type.rb
+++ b/lib/graphql/enum_type.rb
@@ -121,7 +121,7 @@ module GraphQL
       if enum_value
         enum_value.name
       else
-        raise(UnresolvedValueError, "Can't resolve enum #{name} for #{value}")
+        raise(UnresolvedValueError, "Can't resolve enum #{name} for #{value.inspect}")
       end
     end
 


### PR DESCRIPTION
If a value cannot be coerced to a value of an EnumType, an error is raised like the following:
```
raise(UnresolvedValueError, "Can't resolve enum #{name} for #{value}")
```
The output produced is not telling if the value is a symbol or a string. A simple call to `inspect` solves this problem:
```
raise(UnresolvedValueError, "Can't resolve enum #{name} for #{value.inspect}")
```