### PR TITLE
Give introspection fields a complexity of 0

### DIFF
--- a/lib/graphql/field.rb
+++ b/lib/graphql/field.rb
@@ -185,7 +185,6 @@ module GraphQL
     attr_accessor :arguments_class
 
     attr_writer :connection
-    attr_writer :introspection
 
     # @return [nil, String] Prefix for subscription names from this field
     attr_accessor :subscription_scope
@@ -231,6 +230,11 @@ module GraphQL
     # @return [Boolean] Is this field a predefined introspection field?
     def introspection?
       @introspection
+    end
+
+    def introspection=(new_introspection_value)
+      @introspection = new_introspection_value
+      @complexity = 0 if introspection?
     end
 
     # Get a value for this field

--- a/spec/graphql/field_spec.rb
+++ b/spec/graphql/field_spec.rb
@@ -243,4 +243,13 @@ describe GraphQL::Field do
       assert_respond_to field_with_class.resolve_proc, :call
     end
   end
+
+  describe "#introspection" do
+    it "sets complexity to 0 when introspection" do
+      field = GraphQL::Field.define do
+        introspection true
+      end
+      assert_equal 0, field.complexity
+    end
+  end
 end


### PR DESCRIPTION
I think typically users wouldn't expect introspection fields such as `__typename` to contribute to a query's complexity, this PR will have those fields given a complexity of 0 rather than the default of 1. Since these fields are automatically defined by the gem, users of the gem also have no way of changing their complexity, so 0 seems like a better default for them.