### PR TITLE
fix args problem in ScoutTracing

### DIFF
--- a/lib/graphql/tracing/scout_tracing.rb
+++ b/lib/graphql/tracing/scout_tracing.rb
@@ -16,9 +16,9 @@ module GraphQL
         "execute_query_lazy" => "execute.graphql",
       }
 
-      def initialize
+      def initialize(options = {})
         self.class.include ScoutApm::Tracer
-        super
+        super(options)
       end
 
       def platform_trace(platform_key, key, data)


### PR DESCRIPTION
Hello, when I have added `use(GraphQL::Tracing::ScoutTracing)` to schema, i got an error.
Thanks

```ruby
 Failure/Error: use(GraphQL::Tracing::ScoutTracing)

     ArgumentError:
       wrong number of arguments (given 1, expected 0)
     # /Users/askingedik/.rvm/gems/ruby-2.4.2/gems/graphql-1.7.7/lib/graphql/tracing/scout_tracing.rb:19:in `initialize'
     # /Users/askingedik/.rvm/gems/ruby-2.4.2/gems/graphql-1.7.7/lib/graphql/tracing/platform_tracing.rb:63:in `new'
     # /Users/askingedik/.rvm/gems/ruby-2.4.2/gems/graphql-1.7.7/lib/graphql/tracing/platform_tracing.rb:63:in `use'
     # /Users/askingedik/.rvm/gems/ruby-2.4.2/gems/graphql-1.7.7/lib/graphql/define/defined_object_proxy.rb:28:in `use'
     # ./app/graphql/sofra_backend_schema.rb:65:in `block in <top (required)>'
     # /Users/askingedik/.rvm/gems/ruby-2.4.2/gems/graphql-1.7.7/lib/graphql/define/instance_definable.rb:161:in `instance_eval'
     # /Users/askingedik/.rvm/gems/ruby-2.4.2/gems/graphql-1.7.7/lib/graphql/define/instance_definable.rb:161:in `ensure_defined'
     # /Users/askingedik/.rvm/gems/ruby-2.4.2/gems/graphql-1.7.7/lib/graphql/schema.rb:196:in `define'
     # /Users/askingedik/.rvm/gems/ruby-2.4.2/gems/graphql-1.7.7/lib/graphql/define/instance_definable.rb:226:in `define'
```