### PR TITLE
Pass along context in Query#result

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -157,7 +157,7 @@ module GraphQL
     def result
       if !@executed
         with_prepared_ast {
-          Execution::Multiplex.run_queries(@schema, [self])
+          Execution::Multiplex.run_queries(@schema, [self], context: @context)
         }
       end
       @result ||= Query::Result.new(query: self, values: @result_values)

--- a/spec/graphql/backtrace_spec.rb
+++ b/spec/graphql/backtrace_spec.rb
@@ -126,6 +126,16 @@ describe GraphQL::Backtrace do
       assert_includes err.message, "more lines"
     end
 
+    it "annotates errors from Query#result" do
+      query_str = "query StrField { field2 { strField } __typename }"
+      context = { backtrace: true }
+      query = GraphQL::Query.new(schema, query_str, context: context)
+      err = assert_raises(GraphQL::Backtrace::TracedError) {
+        query.result
+      }
+      assert_instance_of RuntimeError, err.cause
+    end
+
     it "annotates errors inside lazy resolution" do
       # Test context-based flag
       err = assert_raises(GraphQL::Backtrace::TracedError) {


### PR DESCRIPTION
Should fix #1121.

I looked for a place to add a test for this and couldn't figure out a good one.