### PR TITLE
Missing resource names for DataDog tracing

### DIFF
--- a/lib/graphql/tracing/data_dog_tracing.rb
+++ b/lib/graphql/tracing/data_dog_tracing.rb
@@ -19,13 +19,15 @@ module GraphQL
 
         pin = Datadog::Pin.get_from(self)
         unless pin
-          pin = Datadog::Pin.new(service)
+          pin = Datadog::Pin.new(service, app: 'ruby-graphql', app_type: Datadog::Ext::AppTypes::WEB)
           pin.onto(self)
         end
 
         pin.tracer.trace(platform_key, service: pin.service) do |span|
+          span.span_type = 'custom'
           if key == 'execute_multiplex'
-            span.resource = data[:multiplex].queries.map(&:selected_operation_name).join(', ')
+            operations = data[:multiplex].queries.map(&:selected_operation_name).join(', ')
+            span.resource = operations unless operations.empty?
           end
 
           if key == 'execute_query'


### PR DESCRIPTION
First off, wanted to say thanks for adding DataDog tracing support! Really cool to see support for this in GraphQL.

I was trying to setup and test out `graphql-ruby` with DataDog tracing enabled, but ran into some issues with the traces, which were being generated incorrectly, causing them not to display in DataDog.

When the `GraphQL::Tracing::DataDogTracing` receives an `execute_multiplex` operation to trace, and none of its queries have `selected_operation_name`s, it sets the resource name to an empty string. Although this doesn't raise an error in the Ruby application, when this trace gets sent through the DataDog agent, the agent prunes out 'bad looking' traces, including ones without resource names. Thus, the trace never makes it to DataDog.

The issue should be reproducible with default boilerplate code, and the following:

**dd_rails_test_schema.rb**

```
DdRailsTestSchema = GraphQL::Schema.define do
  query(Types::QueryType)
  use(GraphQL::Tracing::DataDogTracing)
end
```

**types/query_type.rb**

```
Types::QueryType = GraphQL::ObjectType.define do
  name "Query"

  field :foo do
    type Types::FooType
    argument :id, !types.ID
    description "Find a Foo by ID"
    resolve ->(obj, args, ctx) { Foo.find(args['id']) }
  end
end
```

**types/foo_type.rb**

```
Types::FooType = GraphQL::ObjectType.define do
  name "Foo"
  field :id, !types.ID
  field :name, types.String
  field :created_at, !types.String
  field :updated_at, !types.String
end
```

Then assuming a `Foo` record with ID 1 exists, running a query with:

```
curl \
  -X POST \
  -H "Content-Type: application/json" \
  --data '{ "query": "{ foo(id: 1) { name } }" }' \
  localhost:3000/graphql
```

The workaround for this issue, without the changes included in this PR, involve adding the following to the `datadog.rb` initializer, which leverages the pipeline feature in the DataDog tracing library to modify the incorrectly generated GraphQL traces:

```
# Temporary fix for GraphQL.
# If spans are generated without resource names,
# then the agent will automatically filter the trace out.
# Remove this when the issue has been fixed in GraphQL.
Datadog::Pipeline.before_flush(
  Datadog::Pipeline::SpanProcessor.new do |span|
    if span.name == 'execute.graphql'
      span.resource = 'execute.graphql' if span.resource.to_s.length == 0
      span.span_type = Datadog::Ext::HTTP::TYPE if span.span_type.to_s.length == 0
    end
  end
)
```

This pull request sets a span type (for better presentation in DataDog), and sets a custom resource name for `execute_multiplex` operations only if the sub queries have `selected_operation_name`s. Otherwise it uses the span default, which is the span name (e.g. `execute.graphql` in this case.) Open to suggestions if we think there might be a better default name to use in this particular case!

This issue is reproducible on `master` at least still as of `2782cc6343280fb68b1184b05aa18951e1d820e6`, with the latest versions of Rails, Ruby, and the `ddtrace` gem.

Let me know if there's anything else I can do on my end to help with this issue!