### PR TITLE
[1.8, breaking] Use hashes for fields, arguments, enum values

### DIFF
--- a/lib/graphql/schema/interface.rb
+++ b/lib/graphql/schema/interface.rb
@@ -20,7 +20,7 @@ module GraphQL
           type_defn = GraphQL::InterfaceType.new
           type_defn.name = graphql_name
           type_defn.description = description
-          fields.each do |field_inst|
+          fields.each do |field_name, field_inst|
             field_defn = field_inst.graphql_definition
             type_defn.fields[field_defn.name] = field_defn
           end

--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -13,25 +13,18 @@ module GraphQL
           nil
         end
 
-        # @return [Array<GraphQL::Schema::Field>] Fields on this object, including inherited fields
+        # @return [Hash<String => GraphQL::Schema::Field>] Fields on this object, keyed by name, including inherited fields
         def fields
-          all_fields = own_fields
-          inherited_fields = (superclass.is_a?(HasFields) ? superclass.fields : [])
-          # Remove any inherited fields which were overridden on this class:
-          inherited_fields.each do |inherited_f|
-            if all_fields.none? {|f| f.name == inherited_f.name}
-              all_fields << inherited_f
-            end
-          end
-          all_fields
+          inherited_fields = (superclass.is_a?(HasFields) ? superclass.fields : {})
+          # Local overrides take precedence over inherited fields
+          inherited_fields.merge(own_fields)
         end
 
         # Register this field with the class, overriding a previous one if needed
         # @param field_defn [GraphQL::Schema::Field]
         # @return [void]
         def add_field(field_defn)
-          own_fields.reject! {|f| f.name == field_defn.name}
-          own_fields << field_defn
+          own_fields[field_defn.name] = field_defn
           nil
         end
 
@@ -48,7 +41,7 @@ module GraphQL
 
         # @return [Array<GraphQL::Schema::Field>] Fields defined on this class _specifically_, not parent classes
         def own_fields
-          @own_fields ||= []
+          @own_fields ||= {}
         end
       end
     end

--- a/lib/graphql/schema/object.rb
+++ b/lib/graphql/schema/object.rb
@@ -17,7 +17,7 @@ module GraphQL
           new_interfaces.each do |int|
             if int.is_a?(Class) && int < GraphQL::Schema::Interface
               # Add the graphql field defns
-              int.fields.each do |field|
+              int.fields.each do |_name, field|
                 add_field(field)
               end
               # And call the implemented hook
@@ -47,7 +47,7 @@ module GraphQL
           obj_type.interfaces = interfaces
           obj_type.introspection = introspection
 
-          fields.each do |field_inst|
+          fields.each do |field_name, field_inst|
             field_defn = field_inst.to_graphql
             obj_type.fields[field_defn.name] = field_defn
           end

--- a/spec/graphql/schema/enum_spec.rb
+++ b/spec/graphql/schema/enum_spec.rb
@@ -21,7 +21,7 @@ describe GraphQL::Schema::Enum do
       # values were inherited without modifying the parent
       assert_equal 6, enum.values.size
       assert_equal 7, new_enum.values.size
-      perc_value = new_enum.values.find { |v| v.name == "PERCUSSION" }
+      perc_value = new_enum.values["PERCUSSION"]
       assert_equal "new description", perc_value.description
     end
   end

--- a/spec/graphql/schema/field_spec.rb
+++ b/spec/graphql/schema/field_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 describe GraphQL::Schema::Field do
   describe "graphql definition" do
     let(:object_class) { Jazz::Query }
-    let(:field) { object_class.fields.find { |f| f.name == "inspect_input" } }
+    let(:field) { object_class.fields["inspect_input"] }
 
     it "uses the argument class" do
       arg_defn = field.graphql_definition.arguments.values.first

--- a/spec/graphql/schema/object_spec.rb
+++ b/spec/graphql/schema/object_spec.rb
@@ -24,9 +24,9 @@ describe GraphQL::Schema::Object do
       # inherited interfaces are present
       assert_equal 2, new_object_class.interfaces.size
       # The new field is present
-      assert new_object_class.fields.find { |f| f.name == "newField" }
+      assert new_object_class.fields.key?("newField")
       # The overridden field is present:
-      name_field = new_object_class.fields.find { |f| f.name == "name" }
+      name_field = new_object_class.fields["name"]
       assert_equal "The new description", name_field.description
     end
 


### PR DESCRIPTION
I previously used an array, just because I wasn't thinking about it carefully. @cjoudrey suggested this refactor because:

- Easier to lookup a value by name 
- More compatibility with previous schema objects 

I think it's worth the breaking change for both those reasons, please leave a comment here if you disagree or if you'd like to talk about migrating some existing code to this new structure!