### PR TITLE
[1.8] Instance_eval the Field instead of a FieldProxy

### DIFF
--- a/spec/graphql/schema/field_spec.rb
+++ b/spec/graphql/schema/field_spec.rb
@@ -15,18 +15,18 @@ describe GraphQL::Schema::Field do
       assert_equal 'inspectInput', field.graphql_definition.name
     end
 
-    describe "description in block" do
-      it "will raise if description is defined both in the argument and in the block" do
-        assert_raises RuntimeError, "You're overriding the description of shouldRaise in the provided block!" do
-          Class.new(Jazz::BaseObject) do
-            graphql_name "JustAName"
+    it "accepts a block for definition" do
+      object = Class.new(Jazz::BaseObject) do
+        graphql_name "JustAName"
 
-            field :should_raise, Jazz::Key, "this should not raise", null: true do
-              description "This should raise"
-            end
-          end.to_graphql
+        field :test, String, null: true do
+          argument :test, String, required: true
+          description "A Description."
         end
-      end
+      end.to_graphql
+
+      assert_equal "test", object.fields["test"].arguments["test"].name
+      assert_equal "A Description.", object.fields["test"].description
     end
   end
 end


### PR DESCRIPTION
This PR takes another approach to Field definition blocks like this one:

```ruby
field :a, GraphQL::STRING_TYPE, null: true do
  argument :id, ID, required: true
end
```

The `FieldProxy` that powers this API is currently hard to customize, making it hard to extend with custom methods like this:

```ruby
field :a, GraphQL::STRING_TYPE, null: true do
  argument :id, ID, required: true
  my_custom_thing(true)
end
```

This PR remove `FieldProxy` and instead chooses a more explicit approach. Instead of using `FieldProxy`, the Field Class is passed to the block, letting users call `Field` methods directly on the object:

```ruby
field :a, GraphQL::STRING_TYPE, null: true do |f|
  f.argument :id, ID, required: true
  f.my_custom_thing(true)
end
``

  - First commit implements the change
  - Second commit fixes fixtures and tests

