### PR TITLE
[1.8] Support nullable list items

### DIFF
--- a/guides/schema/class_based_api.md
+++ b/guides/schema/class_based_api.md
@@ -69,7 +69,7 @@ Previously, list types were expressed with `types[T]` and non-null types were ex
 
 - List types are expressed with Ruby Arrays, `[T]`, for example, `field :owners, [Types::UserType]`
   - By default, list members are _non-null_, for example, `[Types::UserType]` becomes `[User!]`
-  - If your list members may be null, add `,nil` to the array: `[Types::UserType, nil]` becomes `[User]` (the list may include `nil`)
+  - If your list members may be null, add `, null: true` to the array: `[Types::UserType, null: true]` becomes `[User]` (the list may include `nil`)
 - Non-null types are expressed with keyword arguments `null:` or `required:`
   - `field` takes a keyword `null:`. `null: true` means the field is nullable, `null: false` means the field is non-null (equivalent to `!`)
   - `argument` takes a keyword `required:`. `required: true` means the argument is non-null (equivalent to `!`), `required: false` means that the argument is nullable

--- a/guides/schema/class_based_api.md
+++ b/guides/schema/class_based_api.md
@@ -68,6 +68,8 @@ As described below, `.to_graphql` can be overridden to customize the type system
 Previously, list types were expressed with `types[T]` and non-null types were expressed with `!T`. Now:
 
 - List types are expressed with Ruby Arrays, `[T]`, for example, `field :owners, [Types::UserType]`
+  - By default, list members are _non-null_, for example, `[Types::UserType]` becomes `[User!]`
+  - If your list members may be null, add `,nil` to the array: `[Types::UserType, nil]` becomes `[User]` (the list may include `nil`)
 - Non-null types are expressed with keyword arguments `null:` or `required:`
   - `field` takes a keyword `null:`. `null: true` means the field is nullable, `null: false` means the field is non-null (equivalent to `!`)
   - `argument` takes a keyword `required:`. `required: true` means the argument is non-null (equivalent to `!`), `required: false` means that the argument is nullable

--- a/lib/graphql/schema/member/build_type.rb
+++ b/lib/graphql/schema/member/build_type.rb
@@ -4,6 +4,8 @@ module GraphQL
     class Member
       # @api private
       module BuildType
+        LIST_TYPE_ERROR = "Use an array of [T] or [T, null: true] for list types; other arrays are not supported"
+
         module_function
         # @param type_expr [String, Class, GraphQL::BaseType]
         # @return [GraphQL::BaseType]
@@ -52,14 +54,14 @@ module GraphQL
               # List members are required by default
               parse_type(type_expr.first, null: false)
             when 2
-              inner_type, nullable_nil = type_expr
-              if !nullable_nil.nil?
-                raise "Use an array of [T] or [T, nil] for list types; other arrays are not supported"
+              inner_type, nullable_option = type_expr
+              if nullable_option.keys != [:null] || nullable_option.values != [true]
+                raise ArgumentError, LIST_TYPE_ERROR
               end
               list_type = true
               parse_type(type_expr.first, null: true)
             else
-              raise "Use an array of [T] or [T, nil] for list types; other arrays are not supported"
+              raise ArgumentError, LIST_TYPE_ERROR
             end
           when Class
             if Class < GraphQL::Schema::Member

--- a/spec/graphql/query/context_spec.rb
+++ b/spec/graphql/query/context_spec.rb
@@ -256,8 +256,9 @@ TABLE
       }'
       res = Jazz::Schema.execute(query_str, context: { magic_key: :ignored, normal_key: "normal_value" })
       expected_values = ["custom_method", "magic_value", "normal_value"]
+      expected_values_with_nil = expected_values + [nil]
       assert_equal expected_values, res["data"]["inspectContext"]
-      assert_equal expected_values, res["data"]["find"]["inspectContext"]
+      assert_equal expected_values_with_nil, res["data"]["find"]["inspectContext"]
     end
   end
 end

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -202,7 +202,7 @@ module Jazz
     end
     field :favorite_key, Key, null: true
     # Test lists with nullable members:
-    field :inspect_context, [String, nil], null: false
+    field :inspect_context, [String, null: true], null: false
 
     def inspect_context
       [

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -201,13 +201,15 @@ module Jazz
       description "An object played in order to produce music"
     end
     field :favorite_key, Key, null: true
-    field :inspect_context, [String], null: false
+    # Test lists with nullable members:
+    field :inspect_context, [String, nil], null: false
 
     def inspect_context
       [
         @context.custom_method,
         @context[:magic_key],
-        @context[:normal_key]
+        @context[:normal_key],
+        nil,
       ]
     end
   end


### PR DESCRIPTION
Previously, given type `T`, you could only create `[T!]`, not `[T]`. This is usually fine, but I want to keep compatibility with an existing schema.