### PR TITLE
Allow resolvers to return multiple errors

### DIFF
--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -178,6 +178,12 @@ module GraphQL
             else
               nil
             end
+          elsif value.is_a?(Array) && value.any? && value.all? {|v| v.is_a?(GraphQL::ExecutionError)}
+            if field_type.kind.non_null?
+              PROPAGATE_NULL
+            else
+              nil
+            end
           elsif value.is_a?(Skip)
             field_ctx.value = value
           else

--- a/spec/graphql/execution_error_spec.rb
+++ b/spec/graphql/execution_error_spec.rb
@@ -271,4 +271,22 @@ describe GraphQL::ExecutionError do
       assert_equal(expected_result, result)
     end
   end
+  
+  describe "more than one ExecutionError" do
+    let(:query_string) { %|{ multipleErrorsOnNonNullableField} |}
+    it "the errors are inserted into the errors key and the data is nil even for a NonNullable field " do
+      expected_result = {
+          "data"=>nil,
+          "errors"=>
+              [{"message"=>"This is an error message for some error.",
+                "locations"=>[{"line"=>1, "column"=>3}],
+                "path"=>["multipleErrorsOnNonNullableField", 0]},
+               {"message"=>"This is another error message for a different error.",
+                "locations"=>[{"line"=>1, "column"=>3}],
+                "path"=>["multipleErrorsOnNonNullableField", 1]}]
+      }
+      assert_equal(expected_result, result)
+    end
+  end
+
 end

--- a/spec/graphql/introspection/schema_type_spec.rb
+++ b/spec/graphql/introspection/schema_type_spec.rb
@@ -35,6 +35,7 @@ describe GraphQL::Introspection::SchemaType do
             {"name"=>"fromSource"},
             {"name"=>"maybeNull"},
             {"name"=>"milk"},
+            {"name"=>"multipleErrorsOnNonNullableField"},
             {"name"=>"root"},
             {"name"=>"searchDairy"},
             {"name"=>"tracingScalar"},

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -369,6 +369,14 @@ module Dummy
       }
     end
 
+    field :multipleErrorsOnNonNullableField do
+      type !GraphQL::STRING_TYPE
+      resolve ->(t, a, c) {
+        [GraphQL::ExecutionError.new("This is an error message for some error."),
+         GraphQL::ExecutionError.new("This is another error message for a different error.")]
+      }
+    end
+
     field :executionErrorWithOptions do
       type GraphQL::INT_TYPE
       resolve ->(t, a, c) {


### PR DESCRIPTION
This PR is to enable resolvers to return an **array** of `GraphQL::ExecutionError`s and to have the same behavior we see when a single GraphQL::ExecutionError is returned from a resolver.

More detailed description here: https://github.com/rmosolgo/graphql-ruby/issues/1230