### PR TITLE
Update link to Relay Global Object Identification spec

### DIFF
--- a/guides/relay/object_identification.md
+++ b/guides/relay/object_identification.md
@@ -7,7 +7,7 @@ desc: Working with Relay-style global IDs
 index: 0
 ---
 
-Relay uses [global object identification](https://facebook.github.io/relay/docs/graphql-object-identification.html) support some of its features:
+Relay uses [global object identification](https://facebook.github.io/relay/graphql/objectidentification.htm) support some of its features:
 
 - __Caching__: Unique IDs are used as primary keys in Relay's client-side cache.
 - __Refetching__: Relay uses unique IDs to refetch objects when it determines that its cache is stale. (It uses the `Query.node` field to refetch objects.)


### PR DESCRIPTION
The current link in [Object Identification](http://graphql-ruby.org/relay/object_identification) is 404ing, as the url for Facebook’s _Relay Global Object Identification Specification_ has changed.