### PR TITLE
Travis: jruby-9.1.15.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 rvm:
 - 2.1.10 # Lowest version officially supported by the gem is 2.1
 - 2.4.3
-- jruby-9.1.14.0
+- jruby-9.1.15.0
 
 services:
   - postgresql
@@ -70,13 +70,13 @@ matrix:
     gemfile: gemfiles/rails_5.0.gemfile # Rails 5 requires Ruby 2.2.2+
   - rvm: 2.1.10
     gemfile: gemfiles/rails_5.1.gemfile # Rails 5 requires Ruby 2.2.2+
-  - rvm: jruby-9.1.14.0
+  - rvm: jruby-9.1.15.0
     gemfile: gemfiles/rails_3.2.gemfile # JRuby + latest Rails only
-  - rvm: jruby-9.1.14.0
+  - rvm: jruby-9.1.15.0
     gemfile: gemfiles/rails_4.0.gemfile # JRuby + latest Rails only
-  - rvm: jruby-9.1.14.0
+  - rvm: jruby-9.1.15.0
     gemfile: gemfiles/rails_4.1.gemfile # JRuby + latest Rails only
-  - rvm: jruby-9.1.14.0
+  - rvm: jruby-9.1.15.0
     gemfile: gemfiles/rails_4.2.gemfile # JRuby + latest Rails only
-  - rvm: jruby-9.1.14.0
+  - rvm: jruby-9.1.15.0
     gemfile: gemfiles/rails_5.0.gemfile # JRuby + latest Rails only


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/12/07/jruby-9-1-15-0.html