### PR TITLE
[1.8] Bug: Missing max_complexity class method in schema

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -641,6 +641,7 @@ module GraphQL
         schema_defn.query = query
         schema_defn.mutation = mutation
         schema_defn.subscription = subscription
+        schema_defn.max_complexity = max_complexity
         schema_defn.max_depth = max_depth
         schema_defn.default_max_page_size = default_max_page_size
         schema_defn.orphan_types = orphan_types
@@ -717,6 +718,14 @@ module GraphQL
           @default_max_page_size = new_default_max_page_size
         else
           @default_max_page_size
+        end
+      end
+
+      def max_complexity(max_complexity = nil)
+        if max_complexity
+          @max_complexity = max_complexity
+        else
+          @max_complexity
         end
       end
 


### PR DESCRIPTION
Trying to upgrade the [schema](https://github.com/rmosolgo/graphql-ruby/blob/1.8-dev/guides/schema/class_based_api.md#schema-class) I encountered this error:

`ArgumentError (wrong number of arguments (1 for 0)):` on line with `max_complexity` method definition, adding class method `max_complexity` to the schema fixes the issue.