### PR TITLE
Fix deprecation reason regression in schema printer

### DIFF
--- a/lib/graphql/schema/printer.rb
+++ b/lib/graphql/schema/printer.rb
@@ -100,7 +100,7 @@ module GraphQL
           if reason.value == GraphQL::Directive::DEFAULT_DEPRECATION_REASON
             "@deprecated"
           else
-            "@deprecated(reason: \"#{reason.value}\")"
+            "@deprecated(reason: #{reason.value.to_s.inspect})"
           end
         else
           super


### PR DESCRIPTION
The use of `inspect` was removed in the schema printer refactor (https://github.com/rmosolgo/graphql-ruby/pull/1159).

This was causing an issue with multi-line deprecation reason strings. Previously it would be printed in the schema as a single line string including line breaks. After the refactor it would be printed as a multi-line string.

I don't know what the GraphQL spec itself says about this, but it was causing issues in JavaScript parsing the IDL since the string would be unterminated.

This just restores the old behaviour using `inspect`.

Also see https://github.com/rmosolgo/graphql-ruby/pull/1159/files#r155625238 for more specific discussion around this usage and escaping strings.

cc @xuorig @eapache 