### PR TITLE
Revert "fix(Relay::Node) use consistent description for id fields"

### DIFF
--- a/lib/graphql/define/assign_global_id_field.rb
+++ b/lib/graphql/define/assign_global_id_field.rb
@@ -4,11 +4,7 @@ module GraphQL
     module AssignGlobalIdField
       def self.call(type_defn, field_name)
         resolve = GraphQL::Relay::GlobalIdResolve.new(type: type_defn)
-        GraphQL::Define::AssignObjectField.call(type_defn, field_name,
-          description: GraphQL::Relay::Node::ID_FIELD_DESCRIPTION,
-          type: GraphQL::ID_TYPE.to_non_null_type,
-          resolve: resolve
-        )
+        GraphQL::Define::AssignObjectField.call(type_defn, field_name, type: GraphQL::ID_TYPE.to_non_null_type, resolve: resolve)
       end
     end
   end

--- a/lib/graphql/relay/node.rb
+++ b/lib/graphql/relay/node.rb
@@ -44,12 +44,10 @@ module GraphQL
         @interface ||= GraphQL::InterfaceType.define do
           name("Node")
           description("An object with an ID.")
-          field(:id, !types.ID, ID_FIELD_DESCRIPTION)
+          field(:id, !types.ID, "ID of the object.")
           default_relay(true)
         end
       end
-
-      ID_FIELD_DESCRIPTION = "ID of the object."
 
       # A field resolve for finding objects by IDs
       module FindNodes

--- a/lib/graphql/schema/object.rb
+++ b/lib/graphql/schema/object.rb
@@ -58,7 +58,7 @@ module GraphQL
         end
 
         def global_id_field(field_name)
-          field field_name, "ID", GraphQL::Relay::Node::ID_FIELD_DESCRIPTION, null: false, resolve: GraphQL::Relay::GlobalIdResolve.new(type: self)
+          field field_name, "ID", null: false, resolve: GraphQL::Relay::GlobalIdResolve.new(type: self)
         end
       end
     end

--- a/spec/graphql/relay/node_spec.rb
+++ b/spec/graphql/relay/node_spec.rb
@@ -6,19 +6,6 @@ describe GraphQL::Relay::Node do
     it "is a default relay type" do
       assert_equal true, GraphQL::Relay::Node.interface.default_relay?
     end
-
-    it "has a matching description to global_id_field" do
-      node_desc = GraphQL::Relay::Node.interface.fields["id"].description
-      # class API
-      class_global_id_desc = StarWars::Ship.fields["id"].description
-      assert_equal node_desc, class_global_id_desc
-      # .define API
-      defined_global_id_desc = GraphQL::ObjectType.define {
-        name "T"
-        global_id_field :id
-      }.fields["id"].description
-      assert_equal node_desc, defined_global_id_desc
-    end
   end
 
   describe ".field" do


### PR DESCRIPTION
Reverts rmosolgo/graphql-ruby#1252