### PR TITLE
Fix printing object type definitions

### DIFF
--- a/lib/graphql/language/printer.rb
+++ b/lib/graphql/language/printer.rb
@@ -154,8 +154,8 @@ module GraphQL
       def print_object_type_definition(object_type)
         out = print_description(object_type)
         out << "type #{object_type.name}"
-        out << print_directives(object_type.directives)
         out << " implements " << object_type.interfaces.map(&:name).join(", ") unless object_type.interfaces.empty?
+        out << print_directives(object_type.directives)
         out << print_field_definitions(object_type.fields)
       end
 

--- a/spec/graphql/language/printer_spec.rb
+++ b/spec/graphql/language/printer_spec.rb
@@ -105,7 +105,7 @@ describe GraphQL::Language::Printer do
       end
 
       describe "full featured schema" do
-        # From: https://github.com/graphql/graphql-js/blob/bc96406ab44453a120da25a0bd6e2b0237119ddf/src/language/__tests__/schema-kitchen-sink.graphql
+        # Based on: https://github.com/graphql/graphql-js/blob/bc96406ab44453a120da25a0bd6e2b0237119ddf/src/language/__tests__/schema-kitchen-sink.graphql
         let(:query_string) {<<-schema
           schema {
             query: QueryType
@@ -128,7 +128,7 @@ describe GraphQL::Language::Printer do
           # Scalar description
           scalar CustomScalar
 
-          type AnnotatedObject @onObject(arg: "value") {
+          type AnnotatedObject implements Bar @onObject(arg: "value") {
             annotatedField(arg: Type = "default" @onArg): Type @onField
           }
 


### PR DESCRIPTION
Directives come after the implemented interfaces.

See
https://github.com/graphql/graphql-js/blob/360fa06e43fed32b63fba99b353515e7b56eee20/src/language/printer.js#L117-L129
for the canonical printer.

This is pretty difficult to add a test for (I think?) and likely why there wasn't any to begin with.

@xuorig any suggestions for how to test this? Since right now we're building a document by parsing it but I don't think it supports directives like this?