### PR TITLE
Static validation for deprecated fields in query

### DIFF
--- a/lib/graphql/static_validation/all_rules.rb
+++ b/lib/graphql/static_validation/all_rules.rb
@@ -33,5 +33,9 @@ module GraphQL
       GraphQL::StaticValidation::SubscriptionRootExists,
       GraphQL::StaticValidation::OperationNamesAreValid,
     ]
+
+    OPTIONAL_RULES = [
+      GraphQL::StaticValidation::NoDeprecatedFields
+    ]
   end
 end

--- a/lib/graphql/static_validation/rules/no_deprecated_fields.rb
+++ b/lib/graphql/static_validation/rules/no_deprecated_fields.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+module GraphQL
+  module StaticValidation
+    # Optional validation not included in default validator.
+    #
+    # @example Initialize validator with optional rules
+    #   validator = GraphQL::StaticValidation::Validator.new(schema: MySchema, rules: GraphQL::StaticValidation::OPTIONAL_RULES)
+    #
+    class NoDeprecatedFields
+      include GraphQL::StaticValidation::Message::MessageHelper
+
+      def validate(context)
+        v = context.visitor
+        v[GraphQL::Language::Nodes::Field] << ->(node, parent) { validate_field(node, context) }
+        v[GraphQL::Language::Nodes::Directive] << ->(node, parent) { validate_directive(node, context) }
+      end
+
+      private
+
+      def validate_directive(ast_directive, context)
+        directive_defn = context.schema.directives[ast_directive.name]
+        assert_deprecated_field(ast_directive, directive_defn, context)
+      end
+
+      def validate_field(ast_field, context)
+        defn = context.field_definition
+        assert_deprecated_field(ast_field, defn, context)
+      end
+
+      def assert_deprecated_field(ast_node, defn, context)
+        deprecation_reason = defn.deprecation_reason
+        if deprecation_reason
+          context.errors << message("#{ast_node.class.name.split("::").last} '#{ast_node.name}' is deprecated: '#{deprecation_reason}'", ast_node, context: context)
+        end
+      end
+    end
+  end
+end

--- a/spec/graphql/static_validation/rules/no_deprecated_fields_spec.rb
+++ b/spec/graphql/static_validation/rules/no_deprecated_fields_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::StaticValidation::NoDeprecatedFields do
+  include StaticValidationHelpers
+  let(:query_string) {"
+    query getCheese {
+      okCheese: cheese(id: 1) { flavor }
+      cheese(id: 1) { source fatContent }
+    }
+  "}
+
+  it "finds deprecated fields" do
+    assert_equal(1, errors_optional.length)
+
+    query_root_error = {
+      "message"=>"Field 'fatContent' is deprecated: 'Diet fashion has changed'",
+      "locations"=>[{"line"=>4, "column"=>30}],
+      "fields"=>["query getCheese", "cheese", "fatContent"],
+    }
+    assert_includes(errors_optional, query_root_error)
+  end
+
+  def errors_optional
+    errors(
+      validator: GraphQL::StaticValidation::Validator.new(schema: schema, rules: GraphQL::StaticValidation::OPTIONAL_RULES)
+    )
+  end
+end

--- a/spec/support/static_validation_helpers.rb
+++ b/spec/support/static_validation_helpers.rb
@@ -11,10 +11,11 @@
 #     assert_equal(error_messages, [ ... ])
 #   end
 module StaticValidationHelpers
-  def errors
-    target_schema = schema
-    validator = GraphQL::StaticValidation::Validator.new(schema: target_schema)
-    query = GraphQL::Query.new(target_schema, query_string)
+  def errors(
+        target_schema: schema,
+        validator: GraphQL::StaticValidation::Validator.new(schema: target_schema),
+        query: GraphQL::Query.new(target_schema, query_string)
+      )
     validator.validate(query)[:errors].map(&:to_h)
   end
 


### PR DESCRIPTION
This validation is optional. I find it useful to check if my queries are not using deprecated fields.