### PR TITLE
refactor(Schema) use explicit whitelist of delegated methods

### DIFF
--- a/lib/graphql/schema/member.rb
+++ b/lib/graphql/schema/member.rb
@@ -38,22 +38,6 @@ module GraphQL
       class << self
         include CachedGraphQLDefinition
         include GraphQL::Relay::TypeExtensions
-        # Delegate to the derived type definition if possible.
-        # This is tricky because missing methods cause the definition to be built & cached.
-        def method_missing(method_name, *args, &block)
-          if graphql_definition.respond_to?(method_name)
-            graphql_definition.public_send(method_name, *args, &block)
-          else
-            super
-          end
-        end
-
-        # Check if the derived type definition responds to the method
-        # @return [Boolean]
-        def respond_to_missing?(method_name, incl_private = false)
-          graphql_definition.respond_to?(method_name, incl_private) || super
-        end
-
         # Call this with a new name to override the default name for this schema member; OR
         # call it without an argument to get the name of this schema member
         #

--- a/spec/graphql/query/executor_spec.rb
+++ b/spec/graphql/query/executor_spec.rb
@@ -188,7 +188,8 @@ describe GraphQL::Query::Executor do
 
     describe "if the schema has a rescue handler" do
       before do
-        schema.rescue_from(RuntimeError) { "Error was handled!" }
+        # HACK: reach to the underlying instance to perform a side-effect
+        schema.graphql_definition.rescue_from(RuntimeError) { "Error was handled!" }
       end
 
       after do

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -7,12 +7,12 @@ describe GraphQL::Schema do
   let(:empty_schema) { GraphQL::Schema.define }
 
   describe "#rescue_from" do
-    let(:rescue_middleware) { schema.middleware.first }
-
     it "adds handlers to the rescue middleware" do
+      schema_defn = schema.graphql_definition
+      rescue_middleware = schema_defn.middleware.first
       assert_equal(1, rescue_middleware.rescue_table.length)
       # normally, you'd use a real class, not a symbol:
-      schema.rescue_from(:error_class) { "my custom message" }
+      schema_defn.rescue_from(:error_class) { "my custom message" }
       assert_equal(2, rescue_middleware.rescue_table.length)
     end
   end


### PR DESCRIPTION
`method_missing` is pretty confusing, it led to some very weird errors in development.