### PR TITLE
[1.8] more upgrader fixes

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -19,7 +19,7 @@ module GraphQL
       # @return [Symbol]
       attr_reader :method
 
-      def initialize(name, return_type_expr = nil, desc = nil, null: nil, field: nil, function: nil, description: nil, deprecation_reason: nil, method: nil, connection: nil, max_page_size: nil, resolve: nil, introspection: false, extras: [], &definition_block)
+      def initialize(name, return_type_expr = nil, desc = nil, null: nil, field: nil, function: nil, description: nil, deprecation_reason: nil, method: nil, connection: nil, max_page_size: nil, resolve: nil, introspection: false, hash_key: nil, extras: [], &definition_block)
         if !(field || function)
           if return_type_expr.nil?
             raise ArgumentError, "missing positional argument `type`"
@@ -40,7 +40,11 @@ module GraphQL
         @function = function
         @resolve = resolve
         @deprecation_reason = deprecation_reason
+        if method && hash_key
+          raise ArgumentError, "Provide `method:` _or_ `hash_key:`, not both. (called with: `method: #{method.inspect}, hash_key: #{hash_key.inspect}`)"
+        end
         @method = method
+        @hash_key = hash_key
         @return_type_expr = return_type_expr
         @return_type_null = null
         @connection = connection
@@ -70,7 +74,7 @@ module GraphQL
 
       # @return [GraphQL::Field]
       def to_graphql
-        method_name = @method || Member::BuildType.underscore(@name)
+        method_name = @method || @hash_key || Member::BuildType.underscore(@name)
 
         field_defn = if @field
           @field.dup

--- a/lib/graphql/upgrader/member.rb
+++ b/lib/graphql/upgrader/member.rb
@@ -11,7 +11,6 @@ module GraphQL
 
     class Transform
       # @param input_text [String] Untransformed GraphQL-Ruby code
-      # @param rewrite_options [Hash] Used during rewrite
       # @return [String] The input text, with a transformation applied if necessary
       def apply(input_text)
         raise NotImplementedError, "Return transformed text here"
@@ -569,11 +568,11 @@ module GraphQL
         ConfigurationToKwargTransform.new(kwarg: "deprecation_reason"),
         ConfigurationToKwargTransform.new(kwarg: "hash_key"),
         PropertyToMethodTransform,
-        RemoveRedundantKwargTransform.new(kwarg: "hash_key"),
-        RemoveRedundantKwargTransform.new(kwarg: "method"),
         UnderscoreizeFieldNameTransform,
         ResolveProcToMethodTransform,
         UpdateMethodSignatureTransform,
+        RemoveRedundantKwargTransform.new(kwarg: "hash_key"),
+        RemoveRedundantKwargTransform.new(kwarg: "method"),
       ]
 
       DEFAULT_CLEAN_UP_TRANSFORMS = [

--- a/lib/graphql/upgrader/member.rb
+++ b/lib/graphql/upgrader/member.rb
@@ -19,11 +19,11 @@ module GraphQL
 
       # Recursively transform a `.define`-DSL-based type expression into a class-ready expression, for example:
       #
-      # - `types[X]` -> `[X]`
+      # - `types[X]` -> `[X, null: true]`
       # - `Int` -> `Integer`
       # - `X!` -> `X`
       #
-      # Notice that `!` is removed entirely, because it doesn't exist in the class API.
+      # Notice that `!` is removed sometimes, because it doesn't exist in the class API.
       #
       # @param type_expr [String] A `.define`-ready expression of a return type or input type
       # @return [String] A class-ready expression of the same type`
@@ -34,7 +34,15 @@ module GraphQL
           "#{preserve_bang ? "!" : ""}#{normalize_type_expression(type_expr[1..-1], preserve_bang: preserve_bang)}"
         when /\Atypes\[.*\]\Z/
           # Unwrap the brackets, normalize, then re-wrap
-          "[#{normalize_type_expression(type_expr[6..-2], preserve_bang: preserve_bang)}]"
+          inner_type = type_expr[6..-2]
+          if inner_type.start_with?("!")
+            nullable = false
+            inner_type = inner_type[1..-1]
+          else
+            nullable = true
+          end
+
+          "[#{normalize_type_expression(inner_type, preserve_bang: preserve_bang)}#{nullable ? ", null: true" : ""}]"
         when /\Atypes\./
           # Remove the prefix
           normalize_type_expression(type_expr[6..-1], preserve_bang: preserve_bang)
@@ -458,7 +466,6 @@ module GraphQL
               non_nullable = return_type.sub! /(^|[^\[])!/, '\1'
               nullable = !non_nullable
               return_type = normalize_type_expression(return_type)
-              return_type = return_type.gsub ',', ''
             else
               non_nullable = nil
               nullable = nil

--- a/spec/fixtures/upgrader/type_x.original.rb
+++ b/spec/fixtures/upgrader/type_x.original.rb
@@ -49,6 +49,8 @@ module Platform
       field :f7, field: SomeField
       field :f8, function: SomeFunction
       field :f9, types[Objects::O2]
+      field :fieldField, types.String, hash_key: "fieldField"
+      field :fieldField2, types.String, property: :field_field2
     end
   end
 end

--- a/spec/fixtures/upgrader/type_x.original.rb
+++ b/spec/fixtures/upgrader/type_x.original.rb
@@ -48,6 +48,7 @@ module Platform
 
       field :f7, field: SomeField
       field :f8, function: SomeFunction
+      field :f9, types[Objects::O2]
     end
   end
 end

--- a/spec/fixtures/upgrader/type_x.transformed.rb
+++ b/spec/fixtures/upgrader/type_x.transformed.rb
@@ -39,6 +39,7 @@ module Platform
 
       field :f7, field: SomeField
       field :f8, function: SomeFunction
+      field :f9, [Objects::O2, null: true], null: true
     end
   end
 end

--- a/spec/fixtures/upgrader/type_x.transformed.rb
+++ b/spec/fixtures/upgrader/type_x.transformed.rb
@@ -40,6 +40,8 @@ module Platform
       field :f7, field: SomeField
       field :f8, function: SomeFunction
       field :f9, [Objects::O2, null: true], null: true
+      field :field_field, String, hash_key: "fieldField", null: true
+      field :field_field2, String, null: true
     end
   end
 end

--- a/spec/graphql/schema/object_spec.rb
+++ b/spec/graphql/schema/object_spec.rb
@@ -7,7 +7,7 @@ describe GraphQL::Schema::Object do
     it "tells type data" do
       assert_equal "Ensemble", object_class.graphql_name
       assert_equal "A group of musicians playing together", object_class.description
-      assert_equal 5, object_class.fields.size
+      assert_equal 6, object_class.fields.size
       assert_equal 2, object_class.interfaces.size
       # Compatibility methods are delegated to the underlying BaseType
       assert object_class.respond_to?(:connection_type)
@@ -20,7 +20,7 @@ describe GraphQL::Schema::Object do
       end
 
       # one more than the parent class
-      assert_equal 6, new_object_class.fields.size
+      assert_equal 7, new_object_class.fields.size
       # inherited interfaces are present
       assert_equal 2, new_object_class.interfaces.size
       # The new field is present
@@ -49,6 +49,7 @@ describe GraphQL::Schema::Object do
         hashyEnsemble {
           name
           musicians { name }
+          formedAt
         }
       }
       GRAPHQL
@@ -56,6 +57,7 @@ describe GraphQL::Schema::Object do
       ensemble = res["data"]["hashyEnsemble"]
       assert_equal "The Grateful Dead", ensemble["name"]
       assert_equal ["Jerry Garcia"], ensemble["musicians"].map { |m| m["name"] }
+      assert_equal "May 5, 1965", ensemble["formedAt"]
     end
   end
 
@@ -64,7 +66,7 @@ describe GraphQL::Schema::Object do
     it "returns a matching GraphQL::ObjectType" do
       assert_equal "Ensemble", obj_type.name
       assert_equal "A group of musicians playing together", obj_type.description
-      assert_equal 5, obj_type.all_fields.size
+      assert_equal 6, obj_type.all_fields.size
 
       name_field = obj_type.all_fields[2]
       assert_equal "name", name_field.name

--- a/spec/graphql/upgrader/member_spec.rb
+++ b/spec/graphql/upgrader/member_spec.rb
@@ -300,12 +300,12 @@ describe GraphQL::Upgrader::Member do
       new = %{field :name, Name.connection_type, "names", null: false, connection: true}
       assert_equal new, upgrade(old)
 
-      old = %{field :names, types[types.String]}
+      old = %{field :names, types[!types.String]}
       new = %{field :names, [String], null: true}
       assert_equal new, upgrade(old)
 
       old = %{field :names, !types[types.String]}
-      new = %{field :names, [String], null: false}
+      new = %{field :names, [String, null: true], null: false}
       assert_equal new, upgrade(old)
 
       old = %{

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -168,6 +168,7 @@ module Jazz
     # Test string type names:
     field :name, "String", null: false
     field :musicians, "[Jazz::Musician]", null: false
+    field :formed_at, String, null: true, hash_key: "formedAtDate"
   end
 
   class Family < BaseEnum
@@ -347,6 +348,7 @@ module Jazz
           "musicians" => [
             OpenStruct.new(name: "Jerry Garcia"),
           ],
+          "formedAtDate" => "May 5, 1965",
       }
     end
   end


### PR DESCRIPTION
- Properly convert `[A]` to `[A, null: true]`. I have been stupidly applying that change by hand, and I'm tired of it 😆 
