### PR TITLE
Fix NO_TYPED_CHILDREN compatibility

### DIFF
--- a/lib/graphql/internal_representation/node.rb
+++ b/lib/graphql/internal_representation/node.rb
@@ -6,19 +6,8 @@ module GraphQL
       DEFAULT_TYPED_CHILDREN = Proc.new { |h, k| h[k] = {} }
 
       # A specialized, reusable object for leaf nodes.
-      # Behaves like a Hash, but doesn't copy itself.
-      # @api private
-      class NoTypedChildren < Hash
-        def initialize
-          super
-          freeze
-        end
-        CHILDREN = [].freeze
-        def [](k); CHILDREN; end
-        def dup; self; end
-      end
-
-      NO_TYPED_CHILDREN = NoTypedChildren.new
+      NO_TYPED_CHILDREN = Hash.new([].freeze).freeze
+      def NO_TYPED_CHILDREN.dup; self; end;
 
       # @return [String] the name this node has in the response
       attr_reader :name

--- a/lib/graphql/internal_representation/node.rb
+++ b/lib/graphql/internal_representation/node.rb
@@ -6,8 +6,9 @@ module GraphQL
       DEFAULT_TYPED_CHILDREN = Proc.new { |h, k| h[k] = {} }
 
       # A specialized, reusable object for leaf nodes.
-      NO_TYPED_CHILDREN = Hash.new([].freeze).freeze
+      NO_TYPED_CHILDREN = Hash.new([].freeze)
       def NO_TYPED_CHILDREN.dup; self; end;
+      NO_TYPED_CHILDREN.freeze
 
       # @return [String] the name this node has in the response
       attr_reader :name

--- a/lib/graphql/internal_representation/node.rb
+++ b/lib/graphql/internal_representation/node.rb
@@ -8,23 +8,16 @@ module GraphQL
       # A specialized, reusable object for leaf nodes.
       # Behaves like a Hash, but doesn't copy itself.
       # @api private
-      class NoTypedChildren
-        CHILDREN = {}.freeze
-        def dup; self; end
-        def any?; false; end
-        def none?; true; end
-        def [](key); CHILDREN; end
-        def each; end
-
-        # Compatibility for when this was an Array:
-        def method_missing(method_name, *args, &block)
-          if CHILDREN.respond_to?(method_name)
-            CHILDREN.send(method_name, *args, &block)
-          else
-            raise NotImplementedError
-          end
+      class NoTypedChildren < Hash
+        def initialize
+          super
+          freeze
         end
+        CHILDREN = [].freeze
+        def [](k); CHILDREN; end
+        def dup; self; end
       end
+
       NO_TYPED_CHILDREN = NoTypedChildren.new
 
       # @return [String] the name this node has in the response


### PR DESCRIPTION
My wacky object in 1.7.10 was a bit broken, this is a simpler and better solution which is just as fast. 

I used `be rake bench:validate` to confirm that performance is the same.