### PR TITLE
Add readers for context and object

### DIFF
--- a/guides/type_definitions/objects.md
+++ b/guides/type_definitions/objects.md
@@ -184,14 +184,14 @@ If you don't want to delegate to the underlying object, you can define a method 
 field :total_games_played, Integer, null: false
 
 def total_games_played
-  @object.games.count
+  object.games.count
 end
 ```
 
-Inside the method, you can access some instance variables:
+Inside the method, you can access some helper methods:
 
-- `@context` is the query context (formerly `ctx` to resolve functions)
-- `@object` is the underlying application object (formerly `obj` to resolve functions)
+- `object` is the underlying application object (formerly `obj` to resolve functions)
+- `context` is the query context (passed as `context:` when executing queries, formerly `ctx` to resolve functions)
 
 Additionally, when you define arguments (see below), they're passed to the method definition, for example:
 

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -9,6 +9,12 @@ module GraphQL
         @context = context
       end
 
+      # @return [GraphQL::Query::Context] The context for this query
+      attr_reader :context
+
+      # @return [GraphQL::Query::Arguments] The underlying arguments instance
+      attr_reader :arguments
+
       # A lot of methods work just like GraphQL::Arguments
       def_delegators :@arguments, :[], :key?, :to_h
       def_delegators :to_h, :keys, :values, :each, :any?

--- a/lib/graphql/schema/interface.rb
+++ b/lib/graphql/schema/interface.rb
@@ -6,7 +6,6 @@ module GraphQL
       field_class GraphQL::Schema::Field
 
       class << self
-
         # When this interface is added to a `GraphQL::Schema::Object`,
         # it calls this method. We add methods to the object by convention,
         # a nested module named `Implementation`

--- a/lib/graphql/schema/object.rb
+++ b/lib/graphql/schema/object.rb
@@ -3,12 +3,17 @@
 module GraphQL
   class Schema
     class Object < GraphQL::Schema::Member
+      # @return [Object] the application object this type is wrapping
       attr_reader :object
+
+      # @return [GraphQL::Query::Context] the context instance for this query
+      attr_reader :context
 
       def initialize(object, context)
         @object = object
         @context = context
       end
+
       extend GraphQL::Schema::Member::HasFields
       field_class GraphQL::Schema::Field
 

--- a/lib/graphql/schema/union.rb
+++ b/lib/graphql/schema/union.rb
@@ -2,11 +2,6 @@
 module GraphQL
   class Schema
     class Union < GraphQL::Schema::Member
-      def initialize(obj, ctx)
-        @object = obj
-        @context = ctx
-      end
-
       class << self
         def possible_types(*types)
           if types.any?
@@ -21,13 +16,6 @@ module GraphQL
 
         def own_possible_types
           @own_possible_types ||= []
-        end
-
-        # The class resolves type by:
-        # - make an instance
-        # - call the instance method
-        def resolve_type(value, ctx)
-          self.new(value, ctx).resolve_type
         end
 
         def to_graphql

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -156,7 +156,7 @@ module Jazz
     field :upcase_name, String, null: false, upcase: true
 
     def upcase_name
-      @object.name # upcase is applied by the superclass
+      object.name # upcase is applied by the superclass
     end
   end
 
@@ -245,9 +245,9 @@ module Jazz
     def helper_method
       [
         # Context is available in the InputObject
-        @context[:message],
+        context[:message],
         # A GraphQL::Query::Arguments instance is available
-        @arguments[:stringValue],
+        arguments[:stringValue],
         # Legacy inputs have underscored method access too
         legacy_input ? legacy_input.int_value : "-",
         # Access by method call is available
@@ -265,8 +265,8 @@ module Jazz
   class PerformingAct < GraphQL::Schema::Union
     possible_types Musician, Ensemble
 
-    def resolve_type
-      if @object.is_a?(Models::Ensemble)
+    def self.resolve_type(object, context)
+      if object.is_a?(Models::Ensemble)
         Ensemble
       else
         Musician
@@ -301,7 +301,7 @@ module Jazz
 
     def find(id:)
       if id == "MagicalSkipId"
-        @context.skip
+        context.skip
       else
         GloballyIdentifiableType.find(id)
       end
@@ -334,9 +334,9 @@ module Jazz
 
     def inspect_context
       [
-        @context.custom_method,
-        @context[:magic_key],
-        @context[:normal_key]
+        context.custom_method,
+        context[:magic_key],
+        context[:normal_key]
       ]
     end
 
@@ -392,7 +392,7 @@ module Jazz
   module Introspection
     class TypeType < GraphQL::Introspection::TypeType
       def name
-        @object.name.upcase
+        object.name.upcase
       end
     end
 
@@ -420,7 +420,7 @@ module Jazz
     class EntryPoints < GraphQL::Introspection::EntryPoints
       field :__classname, String, "The Ruby class name of the root object", null: false
       def __classname
-        @object.class.name
+        object.class.name
       end
     end
   end


### PR DESCRIPTION
Previously, the way to customize field resolution in a method involved ivars: 

```ruby 
field :comments, [Types::Comment]

def comments 
  @object.comments.visible_for(@context[:viewer])
end 
```

But this adds reader methods `#context` and `#object`: 

```ruby
def comments 
  object.comments.visible_for(context[:viewer])
end 
```

Cons: 

- Magic method 

Pros: 

- Is a magic method really worse than ivar? I don't think so 
- You get `NoMethodError` in case of a typo, instead of silent nil (eg `@contxte # => nil`)
- You can override the method if you want 

## TODO 

~~update docs (wait for #1274 )~~