### PR TITLE
Make Schema#as_json return an instance of Hash

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -554,7 +554,7 @@ module GraphQL
     # @param except [<#call(member, ctx)>]
     # @return [Hash] GraphQL result
     def as_json(only: nil, except: nil, context: {})
-      execute(Introspection::INTROSPECTION_QUERY, only: only, except: except, context: context)
+      execute(Introspection::INTROSPECTION_QUERY, only: only, except: except, context: context).to_h
     end
 
     # Returns the JSON response of {Introspection::INTROSPECTION_QUERY}.

--- a/spec/graphql/rake_task_spec.rb
+++ b/spec/graphql/rake_task_spec.rb
@@ -34,7 +34,9 @@ describe GraphQL::RakeTask do
       end
       dumped_json = File.read("./schema.json")
       expected_json = JSON.pretty_generate(RakeTaskSchema.execute(GraphQL::Introspection::INTROSPECTION_QUERY))
-      assert_equal(expected_json, dumped_json)
+
+      # Test that that JSON is logically equivalent, not serialized the same
+      assert_equal(JSON.parse(expected_json), JSON.parse(dumped_json))
 
       dumped_idl = File.read("./schema.graphql")
       expected_idl = rake_task_schema_defn.chomp

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -425,6 +425,13 @@ type Query {
     end
   end
 
+  describe "#as_json" do
+    it "returns a hash" do
+      result = schema.execute(GraphQL::Introspection::INTROSPECTION_QUERY)
+      assert_equal result.as_json.class, Hash
+    end
+  end
+
   describe "#get_field" do
     it "returns fields by type or type name" do
       field = schema.get_field("Cheese", "id")


### PR DESCRIPTION
Certain JSON encoders (namely, Oj) were previously serializing `GraphQL::Query::Result` incorrectly. Instead of returning a schema definition, it would return serialize the output of `GraphQL::Query::Result#inspect` as a string. In order to have better compatibility, this patch opts to represent the schema as a Hash when calling `#as_json`.