### PR TITLE
[1.8] Add camelize: false option

### DIFF
--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -8,17 +8,25 @@ module GraphQL
 
       attr_reader :name
 
-      def initialize(arg_name, type_expr, desc = nil, required:, description: nil, default_value: NO_DEFAULT)
+      # @param arg_name [Symbol]
+      # @param type_expr
+      # @param desc [String]
+      # @param required [Boolean] if true, this argument is non-null; if false, this argument is nullable
+      # @param description [String]
+      # @param default_value [Object]
+      # @param camelize [Boolean] if true, the name will be camelized when building the schema
+      def initialize(arg_name, type_expr, desc = nil, required:, description: nil, default_value: NO_DEFAULT, camelize: true)
         @name = arg_name.to_s
         @type_expr = type_expr
         @description = desc || description
         @null = !required
         @default_value = default_value
+        @camelize = camelize
       end
 
       def to_graphql
         argument = GraphQL::Argument.new
-        argument.name = Member::BuildType.camelize(@name)
+        argument.name = @camelize ? Member::BuildType.camelize(@name) : @name
         argument.type = -> {
           Member::BuildType.parse_type(@type_expr, null: @null)
         }

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -33,7 +33,8 @@ module GraphQL
       # @param resolve [<#call(obj, args, ctx)>] **deprecated** for compatibility with <1.8.0
       # @param field [GraphQL::Field] **deprecated** for compatibility with <1.8.0
       # @param function [GraphQL::Function] **deprecated** for compatibility with <1.8.0
-      def initialize(name, return_type_expr = nil, desc = nil, null: nil, field: nil, function: nil, description: nil, deprecation_reason: nil, method: nil, connection: nil, max_page_size: nil, resolve: nil, introspection: false, hash_key: nil, extras: [], &definition_block)
+      # @param camelize [Boolean] If true, the field name will be camelized when building the schema
+      def initialize(name, return_type_expr = nil, desc = nil, null: nil, field: nil, function: nil, description: nil, deprecation_reason: nil, method: nil, connection: nil, max_page_size: nil, resolve: nil, introspection: false, hash_key: nil, camelize: true, extras: [], &definition_block)
         if (field || function) && desc.nil? && return_type_expr.is_a?(String)
           # The return type should be copied from `field` or `function`, and the second positional argument is the description
           desc = return_type_expr
@@ -71,6 +72,7 @@ module GraphQL
         @introspection = introspection
         @extras = extras
         @arguments = {}
+        @camelize = camelize
 
         if definition_block
           instance_eval(&definition_block)
@@ -103,7 +105,7 @@ module GraphQL
           GraphQL::Field.new
         end
 
-        field_defn.name = Member::BuildType.camelize(name)
+        field_defn.name = @camelize ? Member::BuildType.camelize(name) : name
         if @return_type_expr
           return_type_name = Member::BuildType.to_type_name(@return_type_expr)
           connection = @connection.nil? ? return_type_name.end_with?("Connection") : @connection

--- a/spec/graphql/schema/field_spec.rb
+++ b/spec/graphql/schema/field_spec.rb
@@ -11,8 +11,17 @@ describe GraphQL::Schema::Field do
       assert_equal :ok, arg_defn.metadata[:custom]
     end
 
-    it "camelizes the field name" do
+    it "camelizes the field name, unless camelize: false" do
       assert_equal 'inspectInput', field.graphql_definition.name
+
+      underscored_field = GraphQL::Schema::Field.new(:underscored_field, String, null: false, camelize: false) do
+        argument :underscored_arg, String, required: true, camelize: false
+      end
+
+      assert_equal 'underscored_field', underscored_field.to_graphql.name
+      arg_name, arg_defn = underscored_field.to_graphql.arguments.first
+      assert_equal 'underscored_arg', arg_name
+      assert_equal 'underscored_arg', arg_defn.name
     end
 
     it "exposes the method override" do


### PR DESCRIPTION
This is for backwards compat; if your schema is _all_ underscore-case, then you can override the base classes and reset the default value to `true`.