### PR TITLE
[1.8] Do not crash when printing a schema without directives

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -674,9 +674,6 @@ module GraphQL
         schema_defn.max_depth = max_depth
         schema_defn.default_max_page_size = default_max_page_size
         schema_defn.orphan_types = orphan_types
-        if !directives
-          directives(DIRECTIVES)
-        end
         schema_defn.directives = directives
         schema_defn.introspection_namespace = introspection
         schema_defn.resolve_type = method(:resolve_type)

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -838,7 +838,8 @@ module GraphQL
         if new_directives
           @directives = new_directives.reduce({}) { |m, d| m[d.name] = d; m }
         end
-        @directives
+
+        @directives ||= directives(DIRECTIVES)
       end
 
       def tracer(new_tracer)

--- a/spec/graphql/schema/printer_spec.rb
+++ b/spec/graphql/schema/printer_spec.rb
@@ -497,7 +497,8 @@ SCHEMA
         query query_type
       end
 
-      GraphQL::Schema::Printer.new(schema).print_schema
+      expected = "type Query {\n  foobar: Int!\n}"
+      assert_equal expected, GraphQL::Schema::Printer.new(schema).print_schema
     end
   end
 

--- a/spec/graphql/schema/printer_spec.rb
+++ b/spec/graphql/schema/printer_spec.rb
@@ -497,7 +497,6 @@ SCHEMA
         query query_type
       end
 
-      # I expected this to fail, but it doesn't!
       GraphQL::Schema::Printer.new(schema).print_schema
     end
   end

--- a/spec/graphql/schema/printer_spec.rb
+++ b/spec/graphql/schema/printer_spec.rb
@@ -481,6 +481,25 @@ SCHEMA
 
       assert_equal expected.chomp, GraphQL::Schema::Printer.print_schema(schema)
     end
+
+    it 'prints a schema without directives' do
+      query_type = Class.new(GraphQL::Schema::Object) do
+        graphql_name 'Query'
+
+        field :foobar, Integer, null: false
+
+        def foobar
+          152
+        end
+      end
+
+      schema = Class.new(GraphQL::Schema) do
+        query query_type
+      end
+
+      # I expected this to fail, but it doesn't!
+      GraphQL::Schema::Printer.new(schema).print_schema
+    end
   end
 
   it "applies an `only` filter" do


### PR DESCRIPTION
The error:

```
NoMethodError: undefined method `each_value' for nil:NilClass
    /home/kerk/work/graphql-ruby/lib/graphql/schema/warden.rb:115:in `directives'
    /home/kerk/work/graphql-ruby/lib/graphql/language/document_from_schema_definition.rb:236:in `build_definition_nodes'
    /home/kerk/work/graphql-ruby/lib/graphql/language/document_from_schema_definition.rb:35:in `document'
    /home/kerk/work/graphql-ruby/lib/graphql/schema/printer.rb:56:in `initialize'
    /home/kerk/work/graphql-ruby/spec/graphql/schema/printer_spec.rb:502:in `new'
    /home/kerk/work/graphql-ruby/spec/graphql/schema/printer_spec.rb:502:in `block (3 levels) in <top (required)>'
```

This is caused when you try to print a schema _without_ any directives before `.to_graphql` is called, and your schema is conforming the conventions:

```
      def build_definition_nodes
        definitions = []
        definitions << build_schema_node if include_schema_node?
        definitions += build_directive_nodes(warden.directives)
        definitions += build_type_definition_nodes(warden.types)
        definitions
      end
```

if `build_directive_nodes()` is called before `build_schema_node` (which triggers a `.to_graphql`), it crashes.

It's a bit a specific issue, but nevertheless would be nice to fix :smile: 