### PR TITLE
[1.8] Validation is run for wrong field

### DIFF
--- a/lib/graphql/schema/member/build_type.rb
+++ b/lib/graphql/schema/member/build_type.rb
@@ -109,8 +109,8 @@ module GraphQL
           return string unless string.include?("_")
           camelized = string.split('_').map(&:capitalize).join
           camelized[0] = camelized[0].downcase
-          if string.start_with?("__")
-            camelized = "__#{camelized}"
+          if (match_data = string.match(/\A(_+)/))
+            camelized = "#{match_data[0]}#{camelized}"
           end
           camelized
         end

--- a/spec/graphql/object_type_spec.rb
+++ b/spec/graphql/object_type_spec.rb
@@ -61,7 +61,6 @@ describe GraphQL::ObjectType do
       assert_raises(ArgumentError) { type.name }
     end
 
-    focus
     it "doesnt convolute field names that differ with underscore" do
       interface = Class.new(GraphQL::Schema::Interface) do
         graphql_name 'TestInterface'

--- a/spec/graphql/object_type_spec.rb
+++ b/spec/graphql/object_type_spec.rb
@@ -74,6 +74,8 @@ describe GraphQL::ObjectType do
         implements interface
         global_id_field :id
 
+        # When the validation for `id` is run for `_id`, it will fail because
+        # GraphQL::STRING_TYPE cannot be transformed into a GraphQL::ID_TYPE
         field :_id, String, description: 'database id', null: true
       end
 

--- a/spec/graphql/object_type_spec.rb
+++ b/spec/graphql/object_type_spec.rb
@@ -60,6 +60,26 @@ describe GraphQL::ObjectType do
 
       assert_raises(ArgumentError) { type.name }
     end
+
+    focus
+    it "doesnt convolute field names that differ with underscore" do
+      interface = Class.new(GraphQL::Schema::Interface) do
+        graphql_name 'TestInterface'
+        description 'Requires an id'
+
+        field :id, GraphQL::ID_TYPE, null: false
+      end
+
+      object = Class.new(GraphQL::Schema::Object) do
+        graphql_name 'TestObject'
+        implements interface
+        global_id_field :id
+
+        field :_id, String, description: 'database id', null: true
+      end
+
+      assert_equal nil, GraphQL::Schema::Validation.validate(object.to_graphql)
+    end
   end
 
   it "accepts fields definition" do


### PR DESCRIPTION
Hey, I found this weird error that I'm not sure how to deal with. It looks like the validation for the `id` field declared in the interface is run for the `_id` in the object. The error message is:

```
TestObject failed to implement some interfaces: "id" is required by TestInterface to return ID! but TestObject.id returns String
```

I'm afraid this might be a bug!