### PR TITLE
Paging back to beginning sets hasNextPage to true

### DIFF
--- a/lib/graphql/relay/relation_connection.rb
+++ b/lib/graphql/relay/relation_connection.rb
@@ -27,7 +27,7 @@ module GraphQL
         if first
           paged_nodes.length >= first && sliced_nodes_count > first
         elsif GraphQL::Relay::ConnectionType.bidirectional_pagination && last
-          sliced_nodes_count > last
+          sliced_nodes_count >= last
         else
           false
         end

--- a/spec/graphql/relay/relation_connection_spec.rb
+++ b/spec/graphql/relay/relation_connection_spec.rb
@@ -117,6 +117,13 @@ describe GraphQL::Relay::RelationConnection do
       assert_equal true, get_page_info(result)["hasNextPage"]
       assert_equal true, get_page_info(result)["hasPreviousPage"]
 
+      last_cursor = get_last_cursor(result)
+      result = with_bidirectional_pagination {
+        star_wars_query(query_string, "last" => 1, "before" => last_cursor)
+      }
+      assert_equal true, get_page_info(result)["hasNextPage"]
+      assert_equal false, get_page_info(result)["hasPreviousPage"]
+
       result = star_wars_query(query_string, "first" => 100)
       last_cursor = get_last_cursor(result)
 
@@ -129,7 +136,6 @@ describe GraphQL::Relay::RelationConnection do
       }
       assert_equal true, get_page_info(result)["hasNextPage"]
       assert_equal true, get_page_info(result)["hasPreviousPage"]
-
     end
 
     it 'slices the result' do


### PR DESCRIPTION
When querying a connection with first, then to the next "page" with
first+after, and then back to the previous "page" with last+before
(which is the first page), the `hasNextPage` field was set to false.

The expectation is that it would be set to true (when there are more
pages). Without this change, you could page forward then back, and get
into a situation where `hasPreviousPage` and `hasNextPage` are both
false, when `hasNextPage` should be true.

Fixes https://github.com/rmosolgo/graphql-ruby/issues/1318