### PR TITLE
Use .size instead of .count for connection counts

### DIFF
--- a/guides/relay/connections.md
+++ b/guides/relay/connections.md
@@ -77,7 +77,7 @@ PostConnectionWithTotalCountType = PostType.define_connection do
     type types.Int
     # - `obj` is the Connection
     # - `obj.nodes` is the collection of Posts
-    resolve ->(obj, args, ctx) { obj.nodes.count }
+    resolve ->(obj, args, ctx) { obj.nodes.size }
   end
 end
 


### PR DESCRIPTION
When you create a custom connection type using [this](https://github.com/rmosolgo/graphql-ruby/blob/master/guides/relay/connections.md#connection-types) example in Rails it creates a N+1 query, because `.count`is inherited from ActiveRecord and not from Array, whereas `.size` calls the array without refetching the query for each edge.