### PR TITLE
[Language::Printer] Bug with custom object default values

### DIFF
--- a/lib/graphql/language/document_from_schema_definition.rb
+++ b/lib/graphql/language/document_from_schema_definition.rb
@@ -173,7 +173,7 @@ module GraphQL
 
         case type
         when GraphQL::ScalarType
-          default_value
+          type.coerce_isolated_result(default_value)
         when EnumType
           GraphQL::Language::Nodes::Enum.new(name: type.coerce_isolated_result(default_value))
         when InputObjectType

--- a/lib/graphql/language/printer.rb
+++ b/lib/graphql/language/printer.rb
@@ -339,7 +339,9 @@ module GraphQL
         when Hash
           "{#{node.map { |k, v| "#{k}: #{print_node(v)}" }.join(", ")}}".dup
         else
-          raise TypeError
+          # This case is used if there is some custom object that is used as a default value for an
+          # argument of input field.
+          GraphQL::Language.serialize(node.to_s)
         end
       end
 

--- a/lib/graphql/language/printer.rb
+++ b/lib/graphql/language/printer.rb
@@ -339,8 +339,6 @@ module GraphQL
         when Hash
           "{#{node.map { |k, v| "#{k}: #{print_node(v)}" }.join(", ")}}".dup
         else
-          # This case is used if there is some custom object that is used as a default value for an
-          # argument of input field.
           GraphQL::Language.serialize(node.to_s)
         end
       end

--- a/spec/graphql/schema/printer_spec.rb
+++ b/spec/graphql/schema/printer_spec.rb
@@ -612,14 +612,7 @@ SCHEMA
     end
 
     it "can print arguments that use non-standard Ruby objects as default values" do
-      backing_object = Struct.new(:value) do
-        # Before #1159: The Schema::Printer called `to_s.inspect` on your type to generate
-        # the public value for the `default_value`. Following that same pattern here:
-        
-        def to_s
-          value
-        end
-      end
+      backing_object = Struct.new(:value)
 
       scalar_type = GraphQL::ScalarType.define do
         name "SomeType"


### PR DESCRIPTION
This fixes a bug when you have an input field, or an argument, that uses some sort of custom object for its default value. I think it was introduced 1.7.8 with #1159.

The bug is that it will raise a `TypeError`, because the [`Language::Printer`](https://github.com/rmosolgo/graphql-ruby/blob/7929ce579b77a5d57b80829d00c131326e66712b/lib/graphql/language/printer.rb#L342) doesn't handle other kinds of objects.

Previously, it looks like `Schema::Printer` would call [`to_s.inspect`](https://github.com/rmosolgo/graphql-ruby/blob/v1.7.7/lib/graphql/schema/printer.rb#L219) on your custom object types.