### PR TITLE
Unique hash for fields so the union on Ruby 2.5 works as expected

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ rvm:
 - 2.1.10 # Lowest version officially supported by the gem is 2.1
 - 2.4.3
 - jruby-9.1.15.0
+- 2.5
 
 services:
   - postgresql

--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -40,6 +40,10 @@ module GraphQL
             other.children.eql?(self.children)
         end
 
+        def hash
+          line.hash ^ col.hash ^ filename.hash
+        end
+
         # @return [Array<GraphQL::Language::Nodes::AbstractNode>] all nodes in the tree below this one
         def children
           self.class.child_attributes
@@ -211,6 +215,14 @@ module GraphQL
           @arguments = arguments
           @directives = directives
           @selections = selections
+        end
+
+        def eql?(other)
+          hash == other.hash
+        end
+
+        def hash
+          super.hash ^ @name.hash ^ @arguments.hash ^ @alias.hash ^ @directives.hash ^ @selections.hash
         end
       end
 


### PR DESCRIPTION
A different approach to #1303, this change gives every `GraphQL::Language::Nodes::Field` a hash depending on its properties and uses this hash to compare objects. As `eql?` now uses the `hash`, Ruby's union (| and |=) gives the same result for big and small arrays (this issue https://bugs.ruby-lang.org/issues/14573).

If we go this route, this PR currently only implements the hash for the field node and I'm wondering if we should do the same for all other types since we probably run into the same problems when comparing those objects. 

What do you think @rmosolgo?