### PR TITLE
Use `super` to collect nodes when accessing `children` or `scalars`

### DIFF
--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -42,35 +42,27 @@ module GraphQL
 
         # @return [Array<GraphQL::Language::Nodes::AbstractNode>] all nodes in the tree below this one
         def children
-          self.class.child_attributes
-            .map { |attr_name| public_send(attr_name) }
-            .flatten
+          []
         end
 
         # @return [Array<Integer, Float, String, Boolean, Array>] Scalar values attached to this node
         def scalars
-          self.class.scalar_attributes
-            .map { |attr_name| public_send(attr_name) }
+          []
         end
 
         class << self
-          # A node subclass inherits `scalar_attributes`
-          # and `child_attributes` from its parent
-          def inherited(subclass)
-            subclass.scalar_attributes(*@scalar_attributes)
-            subclass.child_attributes(*@child_attributes)
-          end
-
           # define `attr_names` as places where scalars may be attached to this node
           def scalar_attributes(*attr_names)
-            @scalar_attributes ||= []
-            @scalar_attributes += attr_names
+            define_method :scalars do
+              super() + attr_names.map { |attr_name| public_send(attr_name) }
+            end
           end
 
           # define `attr_names` as places where child nodes may be attached to this node
           def child_attributes(*attr_names)
-            @child_attributes ||= []
-            @child_attributes += attr_names
+            define_method :children do
+              super() + attr_names.map { |attr_name| public_send(attr_name) }.flatten
+            end
           end
         end
 

--- a/spec/graphql/language/nodes_spec.rb
+++ b/spec/graphql/language/nodes_spec.rb
@@ -4,13 +4,24 @@ require "spec_helper"
 describe GraphQL::Language::Nodes::AbstractNode do
   describe "child and scalar attributes" do
     it "are inherited by node subclasses" do
-      subclassed_directive = Class.new(GraphQL::Language::Nodes::Directive)
+      subclassed_directive = Class.new(GraphQL::Language::Nodes::AbstractNode) do
+        scalar_attributes :foo
+        child_attributes :bar
 
-      assert_equal GraphQL::Language::Nodes::Directive.scalar_attributes,
-        subclassed_directive.scalar_attributes
+        def initialize
+        end
 
-      assert_equal GraphQL::Language::Nodes::Directive.child_attributes,
-        subclassed_directive.child_attributes
+        def foo; __method__; end
+        def bar; __method__; end
+      end
+
+      sub_subclass = Class.new(subclassed_directive)
+
+      bob = subclassed_directive.new
+      alice = sub_subclass.new
+
+      assert_equal bob.children, alice.children
+      assert_equal bob.scalars, alice.scalars
     end
   end
 


### PR DESCRIPTION
We can avoid copying information between parent and child classes by
leveraging `super` and inheritance.  This means that each class only
needs to know about it's particular information, and can just ask it's
parent class for any information it has.