### PR TITLE
Fix/validate enum and input names

### DIFF
--- a/lib/graphql/enum_type.rb
+++ b/lib/graphql/enum_type.rb
@@ -85,6 +85,11 @@ module GraphQL
       self.values = other.values.values
     end
 
+    def name=(name)
+      GraphQL::NameValidator.validate!(name)
+      @name = name
+    end
+
     # @param new_values [Array<EnumValue>] The set of values contained in this type
     def values=(new_values)
       @values_by_name = {}

--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -51,6 +51,11 @@ module GraphQL
       @arguments = other.arguments.dup
     end
 
+    def name=(name)
+      GraphQL::NameValidator.validate!(name)
+      @name = name
+    end
+
     def kind
       GraphQL::TypeKinds::INPUT_OBJECT
     end

--- a/spec/graphql/enum_type_spec.rb
+++ b/spec/graphql/enum_type_spec.rb
@@ -37,18 +37,31 @@ describe GraphQL::EnumType do
     end
   end
 
-  describe "invalid names" do
-    it "rejects names with a space" do
+  describe "invalid values" do
+    it "rejects value names with a space" do
       assert_raises(GraphQL::InvalidNameError) {
-        InvalidEnumTest = GraphQL::EnumType.define do
-          name "InvalidEnumTest"
+        InvalidEnumValueTest = GraphQL::EnumType.define do
+          name "InvalidEnumValueTest"
 
           value("SPACE IN VALUE", "Invalid enum because it contains spaces", value: 1)
         end
 
         # Force evaluation
-        InvalidEnumTest.name
+        InvalidEnumValueTest.name
       }
+    end
+  end
+
+  describe "invalid name" do
+    it "reject names with invalid format" do
+      assert_raises(GraphQL::InvalidNameError) do
+        InvalidEnumNameTest = GraphQL::EnumType.define do
+          name "Some::Invalid::Name"
+        end
+
+        # Force evaluation
+        InvalidEnumNameTest.name
+      end
     end
   end
 

--- a/spec/graphql/input_object_type_spec.rb
+++ b/spec/graphql/input_object_type_spec.rb
@@ -218,6 +218,19 @@ describe GraphQL::InputObjectType do
           assert_equal(expected, actual)
         end
       end
+
+      describe 'with invalid name' do
+        it 'raises the correct error' do
+          assert_raises(GraphQL::InvalidNameError) do
+            InvalidInputTest = GraphQL::InputObjectType.define do
+              name "Some::Invalid Name"
+            end
+
+            # Force evaluation
+            InvalidInputTest.name
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
#### What's New?
We add the missing `name` validation for `GraphQL::EnumType` & `GraphQL::InputObjectType`. After applying this fix I'm wondering if we should just move this validation to the parent `GraphQL::BaseType` since I presume we want all type names to be validated (created an alternative PR for this https://github.com/rmosolgo/graphql-ruby/pull/1340).

**Issue**
https://github.com/rmosolgo/graphql-ruby/issues/1292