### PR TITLE
[1.8] Fix class based API for union and interface type resolution

### DIFF
--- a/lib/graphql/schema/interface.rb
+++ b/lib/graphql/schema/interface.rb
@@ -23,6 +23,9 @@ module GraphQL
             field_defn = field_inst.graphql_definition
             type_defn.fields[field_defn.name] = field_defn
           end
+          if respond_to?(:resolve_type)
+            type_defn.resolve_type = method(:resolve_type)
+          end
           type_defn
         end
       end

--- a/lib/graphql/schema/union.rb
+++ b/lib/graphql/schema/union.rb
@@ -23,9 +23,7 @@ module GraphQL
           type_defn.name = graphql_name
           type_defn.description = description
           type_defn.possible_types = possible_types
-          # If an instance method is defined, use it as a
-          # resolve type hook, via the class method
-          if method_defined?(:resolve_type)
+          if respond_to?(:resolve_type)
             type_defn.resolve_type = method(:resolve_type)
           end
           type_defn

--- a/spec/graphql/schema/interface_spec.rb
+++ b/spec/graphql/schema/interface_spec.rb
@@ -49,6 +49,21 @@ describe GraphQL::Schema::Interface do
       assert_equal "id", field.name
       assert_equal GraphQL::ID_TYPE.to_non_null_type, field.type
       assert_equal "A unique identifier for this object", field.description
+      assert_nil interface_type.resolve_type_proc
+    end
+
+    it "can specify a resolve_type method" do
+      interface = Class.new(GraphQL::Schema::Interface) do
+        def self.resolve_type(_object, _context)
+          "MyType"
+        end
+
+        def self.name
+          "MyInterface"
+        end
+      end
+      interface_type = interface.to_graphql
+      assert_equal "MyType", interface_type.resolve_type_proc.call(nil, nil)
     end
   end
 

--- a/spec/graphql/schema/union_spec.rb
+++ b/spec/graphql/schema/union_spec.rb
@@ -9,6 +9,36 @@ describe GraphQL::Schema::Union do
     end
   end
 
+  describe ".to_graphql" do
+    it "creates a UnionType" do
+      union = Class.new(GraphQL::Schema::Union) do
+        possible_types Jazz::Musician, Jazz::Ensemble
+
+        def self.name
+          "MyUnion"
+        end
+      end
+      union_type = union.to_graphql
+      assert_equal "MyUnion", union_type.name
+      assert_equal [Jazz::Musician.to_graphql, Jazz::Ensemble.to_graphql], union_type.possible_types
+      assert_nil union_type.resolve_type_proc
+    end
+
+    it "can specify a resolve_type method" do
+      union = Class.new(GraphQL::Schema::Union) do
+        def self.resolve_type(_object, _context)
+          "MyType"
+        end
+
+        def self.name
+          "MyUnion"
+        end
+      end
+      union_type = union.to_graphql
+      assert_equal "MyType", union_type.resolve_type_proc.call(nil, nil)
+    end
+  end
+
   describe "in queries" do
     it "works" do
       query_str = <<-GRAPHQL


### PR DESCRIPTION
This fixes the class based API for [union](https://github.com/rmosolgo/graphql-ruby/blob/1.8-dev/guides/type_definitions/unions.md#defining-union-types) and [interface](https://github.com/rmosolgo/graphql-ruby/blob/1.8-dev/guides/type_definitions/interfaces.md#resolve-type) type resolution to behave like the documentation. `GraphQL::Schema::Union` was mistakenly checking for the presence of a `resolve_type` instance method rather than class method. `GraphQL::Schema::Interface` was missing the necessary code altogether.  

Fixes #1336