### PR TITLE
[1.8] Add GraphQL::Schema::Interface.orphan_types configuration

### DIFF
--- a/guides/type_definitions/interfaces.md
+++ b/guides/type_definitions/interfaces.md
@@ -149,11 +149,20 @@ Specifically, in the example above, `CarType` would get a field named `price` an
 
 ## Orphan Types
 
-If you add an object type which implements an interface, but that object type doesn't properly appear in your schema, then you need to add that object to the schema's `orphan_types`, for example:
+If you add an object type which implements an interface, but that object type doesn't properly appear in your schema, then you need to add that object to the interfaces's `orphan_types`, for example:
+
+```ruby
+class Types::RetailItem < Types::BaseInterface
+  # ...
+  orphan_types Types::Comment
+end
+```
+
+Alternatively you can add the object types to the schema's `orphan_types`:
 
 ```ruby
 class MySchema < GraphQL::Schema
-  orphan_types [Types::Comment, ...]
+  orphan_types Types::Comment
 end
 ```
 

--- a/lib/graphql/interface_type.rb
+++ b/lib/graphql/interface_type.rb
@@ -23,20 +23,22 @@ module GraphQL
   #   end
   #
   class InterfaceType < GraphQL::BaseType
-    accepts_definitions :fields, :resolve_type, field: GraphQL::Define::AssignObjectField
+    accepts_definitions :fields, :orphan_types, :resolve_type, field: GraphQL::Define::AssignObjectField
 
-    attr_accessor :fields, :resolve_type_proc
-    ensure_defined :fields, :resolve_type_proc, :resolve_type
+    attr_accessor :fields, :orphan_types, :resolve_type_proc
+    ensure_defined :fields, :orphan_types, :resolve_type_proc, :resolve_type
 
     def initialize
       super
       @fields = {}
+      @orphan_types = []
       @resolve_type_proc = nil
     end
 
     def initialize_copy(other)
       super
       @fields = other.fields.dup
+      @orphan_types = other.orphan_types.dup
     end
 
     def kind

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -773,9 +773,9 @@ module GraphQL
         end
       end
 
-      def orphan_types(new_orphan_types = nil)
-        if new_orphan_types
-          @orphan_types = new_orphan_types
+      def orphan_types(*new_orphan_types)
+        if new_orphan_types.any?
+          @orphan_types = new_orphan_types.flatten
         else
           @orphan_types || []
         end

--- a/lib/graphql/schema/interface.rb
+++ b/lib/graphql/schema/interface.rb
@@ -15,10 +15,21 @@ module GraphQL
           end
         end
 
+        def orphan_types(*types)
+          if types.any?
+            @orphan_types = types
+          else
+            all_orphan_types = @orphan_types || []
+            all_orphan_types += super if defined?(super)
+            all_orphan_types.uniq
+          end
+        end
+
         def to_graphql
           type_defn = GraphQL::InterfaceType.new
           type_defn.name = graphql_name
           type_defn.description = description
+          type_defn.orphan_types = orphan_types
           fields.each do |field_name, field_inst|
             field_defn = field_inst.graphql_definition
             type_defn.fields[field_defn.name] = field_defn

--- a/lib/graphql/schema/traversal.rb
+++ b/lib/graphql/schema/traversal.rb
@@ -136,6 +136,9 @@ Some late-bound types couldn't be resolved:
               visit_fields(schema, type_defn)
             when GraphQL::InterfaceType
               visit_fields(schema, type_defn)
+              type_defn.orphan_types.each do |t|
+                visit(schema, t, "Orphan type for #{type_defn.name}")
+              end
             when GraphQL::UnionType
               type_defn.possible_types.each do |t|
                 @union_memberships[t.name] << type_defn

--- a/lib/graphql/schema/union.rb
+++ b/lib/graphql/schema/union.rb
@@ -5,17 +5,12 @@ module GraphQL
       class << self
         def possible_types(*types)
           if types.any?
-            @own_possible_types = types
+            @possible_types = types
           else
-            all_possible_types = own_possible_types
-            inherited_possible_types = (superclass < GraphQL::Schema::Union ? superclass.possible_types : [])
-            all_possible_types += inherited_possible_types
+            all_possible_types = @possible_types || []
+            all_possible_types += super if defined?(super)
             all_possible_types.uniq
           end
-        end
-
-        def own_possible_types
-          @own_possible_types ||= []
         end
 
         def to_graphql

--- a/spec/graphql/interface_type_spec.rb
+++ b/spec/graphql/interface_type_spec.rb
@@ -92,6 +92,18 @@ describe GraphQL::InterfaceType do
       assert_equal 3, interface.fields.size
       assert_equal 4, interface_2.fields.size
     end
+
+    it "copies orphan types without affecting the original" do
+      interface = GraphQL::InterfaceType.define do
+        name "AInterface"
+        orphan_types [Dummy::HoneyType]
+      end
+
+      interface_2 = interface.dup
+      interface_2.orphan_types << Dummy::CheeseType
+      assert_equal 1, interface.orphan_types.size
+      assert_equal 2, interface_2.orphan_types.size
+    end
   end
 
   describe "#resolve_type" do

--- a/spec/graphql/schema/interface_spec.rb
+++ b/spec/graphql/schema/interface_spec.rb
@@ -50,6 +50,7 @@ describe GraphQL::Schema::Interface do
       assert_equal GraphQL::ID_TYPE.to_non_null_type, field.type
       assert_equal "A unique identifier for this object", field.description
       assert_nil interface_type.resolve_type_proc
+      assert_empty interface_type.orphan_types
     end
 
     it "can specify a resolve_type method" do
@@ -64,6 +65,19 @@ describe GraphQL::Schema::Interface do
       end
       interface_type = interface.to_graphql
       assert_equal "MyType", interface_type.resolve_type_proc.call(nil, nil)
+    end
+
+    it "can specify orphan types" do
+      interface = Class.new(GraphQL::Schema::Interface) do
+        def self.name
+          "MyInterface"
+        end
+
+        orphan_types Dummy::CheeseType, Dummy::HoneyType
+      end
+
+      interface_type = interface.to_graphql
+      assert_equal [Dummy::CheeseType, Dummy::HoneyType], interface_type.orphan_types
     end
   end
 

--- a/spec/graphql/schema/traversal_spec.rb
+++ b/spec/graphql/schema/traversal_spec.rb
@@ -188,4 +188,35 @@ describe GraphQL::Schema::Traversal do
     }
     assert_equal expected, result
   end
+
+  it "finds orphan types from interfaces" do
+    b_type = GraphQL::ObjectType.define do
+      name "B"
+    end
+
+    c_type = GraphQL::ObjectType.define do
+      name "C"
+    end
+
+    interface = GraphQL::InterfaceType.define do
+      name "AInterface"
+      orphan_types [b_type]
+    end
+
+    another_interface = GraphQL::InterfaceType.define do
+      name "AnotherIterface"
+      orphan_types [b_type, c_type]
+    end
+
+    result = traversal([interface, another_interface]).type_map
+    expected = {
+      "Boolean" => GraphQL::BOOLEAN_TYPE,
+      "String" => GraphQL::STRING_TYPE,
+      "AInterface" => interface,
+      "AnotherIterface" => another_interface,
+      "B" => b_type,
+      "C" => c_type
+    }
+    assert_equal expected, result
+  end
 end

--- a/spec/graphql/union_type_spec.rb
+++ b/spec/graphql/union_type_spec.rb
@@ -150,7 +150,7 @@ describe GraphQL::UnionType do
   end
 
   describe "#dup" do
-    it "copies possible types without affecting the orginal" do
+    it "copies possible types without affecting the original" do
       union.possible_types # load the internal cache
       union_2 = union.dup
       union_2.possible_types << type_3


### PR DESCRIPTION
As discussed in #1335 this PR implements a method for registering "orphaned" interface implementations which leads to better encapsulation than registering this information with the schema:

```ruby
# Old way (but still supported)
class MySchema < GraphQL::Schema
  mutation Types::MutationType
  query Types::QueryType

  orphan_types Types::CircleType, Types::SquareType
end

# New way
class Types::Shape < GraphQL::Schema::Interface
  orphan_types Types::CircleType, Types::SquareType
end
```

I went with the terminology "orphan types" vs. "implementations" to be consistent with the existing orphan types API on `GraphQL::Schema` and to avoid confusion about being required to register all implementations vs. just ones that are unreachable from the schema roots. This does introduce a cyclic dependency between the types and the interfaces they implement but Rails auto-loading or the appropriate require statements should handle this.

The implementation is a mix of code inspired (i.e. copied) from `GraphQL::Schema::Union.possible_types` and `GraphQL::Schema.orphan_types`. For consistency between `GraphQL::Schema::Union.possible_types`, `GraphQL::Schema::Interface.orphan_types` and `GraphQL::Schema.orphan_types` I modified `GraphQL::Schema.orphan_types` to accept either an array or splatted array.
