### PR TITLE
Change `eql?` to `===`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
 rvm:
 - 2.1.10 # Lowest version officially supported by the gem is 2.1
 - 2.4.3
+- 2.5
 - jruby-9.1.15.0
 
 services:

--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -41,7 +41,7 @@ module GraphQL
 
         # Value equality
         # @return [Boolean] True if `self` is equivalent to `other`
-        def eql?(other)
+        def ===(other)
           return true if equal?(other)
           other.is_a?(self.class) &&
             other.scalars.eql?(self.scalars) &&

--- a/spec/graphql/language/equality_spec.rb
+++ b/spec/graphql/language/equality_spec.rb
@@ -30,8 +30,8 @@ describe GraphQL::Language::Nodes::AbstractNode do
       let(:query_string2) { query_string1 }
 
       it "should be equal" do
-        assert document1.eql?(document2)
-        assert document2.eql?(document1)
+        assert document1 === document2
+        assert document2 === document1
       end
     end
 
@@ -40,8 +40,8 @@ describe GraphQL::Language::Nodes::AbstractNode do
       let(:query_string2) { "mutation { setField }" }
 
       it "should not be equal" do
-        refute document1.eql?(document2)
-        refute document2.eql?(document1)
+        refute document1 === document2
+        refute document2 === document1
       end
     end
 
@@ -50,8 +50,8 @@ describe GraphQL::Language::Nodes::AbstractNode do
       let(:query_string2) { "query { bar }" }
 
       it "should not be equal" do
-        refute document1.eql?(document2)
-        refute document2.eql?(document1)
+        refute document1 === document2
+        refute document2 === document1
       end
     end
 
@@ -76,8 +76,8 @@ describe GraphQL::Language::Nodes::AbstractNode do
       |}
 
       it "should not be equal" do
-        refute document1.eql?(document2)
-        refute document2.eql?(document1)
+        refute document1 === document2
+        refute document2 === document1
       end
     end
   end


### PR DESCRIPTION
If you implement `eql?`, you must also implement `hash`.  Otherwise
hashing will not work correctly as collisions won't resolve, or will
resolve in unexpected ways.

This commit changes `eql?` to `===` so that we have an easy way to do
tree comparison, but we don't mess up hashing semantics (or have to
implement our own hashing semantics).

Also enabling the Ruby 2.5 build.