### PR TITLE
Fix argument def

### DIFF
--- a/lib/graphql/argument.rb
+++ b/lib/graphql/argument.rb
@@ -58,8 +58,13 @@ module GraphQL
     end
 
     def default_value=(new_default_value)
-      @has_default_value = true
-      @default_value = new_default_value
+      if new_default_value == NO_DEFAULT_VALUE
+        @has_default_value = false
+        @default_value = nil
+      else
+        @has_default_value = true
+        @default_value = new_default_value
+      end
     end
 
     # @!attribute name
@@ -102,29 +107,23 @@ module GraphQL
       # Move some positional args into keywords if they're present
       description && kwargs[:description] ||= description
       name && kwargs[:name] ||= name_s
+      default_value && kwargs[:default_value] ||= default_value
+      as && kwargs[:as] ||= as
+
+      unless prepare == DefaultPrepare
+        prepare && kwargs[:prepare] ||= prepare
+      end
 
       if !type_or_argument.nil? && !type_or_argument.is_a?(GraphQL::Argument)
         # Maybe a string, proc or BaseType
         kwargs[:type] = type_or_argument
       end
 
-      argument = if type_or_argument.is_a?(GraphQL::Argument)
+      if type_or_argument.is_a?(GraphQL::Argument)
         type_or_argument.redefine(kwargs, &block)
       else
         GraphQL::Argument.define(kwargs, &block)
       end
-
-      if default_value != NO_DEFAULT_VALUE
-        argument.default_value = default_value
-      end
-
-      as && argument.as = as
-
-      if prepare != DefaultPrepare
-        argument.prepare = prepare
-      end
-
-      argument
     end
   end
 end

--- a/lib/graphql/argument.rb
+++ b/lib/graphql/argument.rb
@@ -106,12 +106,12 @@ module GraphQL
 
       # Move some positional args into keywords if they're present
       description && kwargs[:description] ||= description
-      name && kwargs[:name] ||= name_s
-      default_value && kwargs[:default_value] ||= default_value
-      as && kwargs[:as] ||= as
+      kwargs[:name] ||= name_s
+      kwargs[:default_value] ||= default_value
+      kwargs[:as] ||= as
 
       unless prepare == DefaultPrepare
-        prepare && kwargs[:prepare] ||= prepare
+        kwargs[:prepare] ||= prepare
       end
 
       if !type_or_argument.nil? && !type_or_argument.is_a?(GraphQL::Argument)

--- a/lib/graphql/argument.rb
+++ b/lib/graphql/argument.rb
@@ -100,7 +100,7 @@ module GraphQL
       name_s = name.to_s
 
       # Move some positional args into keywords if they're present
-      desc && kwargs[:description] ||= description
+      description && kwargs[:description] ||= description
       name && kwargs[:name] ||= name_s
 
       if !type_or_argument.nil? && !type_or_argument.is_a?(GraphQL::Argument)
@@ -108,12 +108,23 @@ module GraphQL
         kwargs[:type] = type_or_argument
       end
 
-
-      if type_or_argument.is_a?(GraphQL::Argument)
+      argument = if type_or_argument.is_a?(GraphQL::Argument)
         type_or_argument.redefine(kwargs, &block)
       else
         GraphQL::Argument.define(kwargs, &block)
       end
+
+      if default_value != NO_DEFAULT_VALUE
+        argument.default_value = default_value
+      end
+
+      as && argument.as = as
+
+      if prepare != DefaultPrepare
+        argument.prepare = prepare
+      end
+
+      argument
     end
   end
 end

--- a/lib/graphql/argument.rb
+++ b/lib/graphql/argument.rb
@@ -97,28 +97,23 @@ module GraphQL
     NO_DEFAULT_VALUE = Object.new
     # @api private
     def self.from_dsl(name, type_or_argument = nil, description = nil, default_value: NO_DEFAULT_VALUE, as: nil, prepare: DefaultPrepare, **kwargs, &block)
+      name_s = name.to_s
+
+      # Move some positional args into keywords if they're present
+      desc && kwargs[:description] ||= description
+      name && kwargs[:name] ||= name_s
+
+      if !type_or_argument.nil? && !type_or_argument.is_a?(GraphQL::Argument)
+        # Maybe a string, proc or BaseType
+        kwargs[:type] = type_or_argument
+      end
+
+
       if type_or_argument.is_a?(GraphQL::Argument)
-        return type_or_argument.redefine(name: name.to_s)
-      end
-
-      argument = if block_given?
-        GraphQL::Argument.define(&block)
+        type_or_argument.redefine(kwargs, &block)
       else
-        GraphQL::Argument.define(**kwargs)
+        GraphQL::Argument.define(kwargs, &block)
       end
-
-      argument.name = name.to_s
-      type_or_argument && argument.type = type_or_argument
-      description && argument.description = description
-      if default_value != NO_DEFAULT_VALUE
-        argument.default_value = default_value
-      end
-      as && argument.as = as
-      if prepare != DefaultPrepare
-        argument.prepare = prepare
-      end
-
-      argument
     end
   end
 end

--- a/spec/graphql/argument_spec.rb
+++ b/spec/graphql/argument_spec.rb
@@ -32,6 +32,14 @@ describe GraphQL::Argument do
       assert_equal GraphQL::STRING_TYPE, arg.type
     end
 
+    it "accepts a definition block after defining kwargs" do
+      arg = GraphQL::Argument.from_dsl(:foo, GraphQL::STRING_TYPE) do
+        description "my type is #{target.type}"
+      end
+
+      assert_equal "my type is String", arg.description
+    end
+
     it "creates an argument from dsl arguments" do
       arg = GraphQL::Argument.from_dsl(
         :foo,

--- a/spec/graphql/argument_spec.rb
+++ b/spec/graphql/argument_spec.rb
@@ -40,6 +40,21 @@ describe GraphQL::Argument do
       assert_equal "my type is String", arg.description
     end
 
+    it "accepts a definition block with existing arg" do
+      existing = GraphQL::Argument.define do
+        name "bar"
+        type GraphQL::STRING_TYPE
+      end
+
+      arg = GraphQL::Argument.from_dsl(:foo, existing) do
+        description "Description for an existing field."
+      end
+
+
+      assert_equal "Description for an existing field.", arg.description
+    end
+
+
     it "creates an argument from dsl arguments" do
       arg = GraphQL::Argument.from_dsl(
         :foo,

--- a/spec/graphql/argument_spec.rb
+++ b/spec/graphql/argument_spec.rb
@@ -54,7 +54,6 @@ describe GraphQL::Argument do
       assert_equal "Description for an existing field.", arg.description
     end
 
-
     it "creates an argument from dsl arguments" do
       arg = GraphQL::Argument.from_dsl(
         :foo,

--- a/spec/graphql/argument_spec.rb
+++ b/spec/graphql/argument_spec.rb
@@ -50,7 +50,6 @@ describe GraphQL::Argument do
         description "Description for an existing field."
       end
 
-
       assert_equal "Description for an existing field.", arg.description
     end
 

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -223,10 +223,7 @@ module Dummy
       description "Where it came from"
     end
 
-    input_field :originDairy, types.String, "Dairy which produced it", default_value: "Sugar Hollow Dairy" do
-      description   "Ignored because arg takes precedence"
-      default_value "Ignored because keyword arg takes precedence"
-    end
+    input_field :originDairy, types.String, "Dairy which produced it", default_value: "Sugar Hollow Dairy"
 
     input_field :fatContent, types.Float, "How much fat it has" do
       # ensure we can define default in block


### PR DESCRIPTION
Fixes: https://github.com/rmosolgo/graphql-ruby/issues/1349

Changes `Argument.from_dsl` to be a bit more like `GraphQL::Field`. Definition proc takes precedence over kwargs, and kwargs are defined before the proc is called, safer for extensions.