### PR TITLE
Implement `.hash` on Nodes, enable Ruby 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
 rvm:
 - 2.1.10 # Lowest version officially supported by the gem is 2.1
 - 2.4.3
+- 2.5
 - jruby-9.1.15.0
 
 services:
@@ -66,6 +67,10 @@ matrix:
     gemfile: gemfiles/rails_4.1.gemfile
   - rvm: 2.4.3
     gemfile: gemfiles/rails_4.2.gemfile
+  - rvm: 2.5
+    gemfile: gemfiles/rails_3.2.gemfile
+  - rvm: 2.5
+    gemfile: gemfiles/rails_4.1.gemfile
   - rvm: 2.1.10
     gemfile: gemfiles/rails_5.0.gemfile # Rails 5 requires Ruby 2.2.2+
   - rvm: 2.1.10

--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -39,13 +39,16 @@ module GraphQL
           raise NotImplementedError
         end
 
+        def hash
+          scalars.hash ^ children.hash
+        end
+
         # Value equality
         # @return [Boolean] True if `self` is equivalent to `other`
         def eql?(other)
-          return true if equal?(other)
-          other.is_a?(self.class) &&
+          super(other) || (other.is_a?(self.class) &&
             other.scalars.eql?(self.scalars) &&
-            other.children.eql?(self.children)
+            other.children.eql?(self.children))
         end
 
         # @return [Array<GraphQL::Language::Nodes::AbstractNode>] all nodes in the tree below this one

--- a/spec/graphql/internal_representation/rewrite_spec.rb
+++ b/spec/graphql/internal_representation/rewrite_spec.rb
@@ -124,7 +124,7 @@ describe GraphQL::InternalRepresentation::Rewrite do
 
       nut_selections = plant_selection.typed_children[schema.types["Nut"]]
       # `... on Tree`, `... on Nut`, and `NutFields`, but not `... on Fruit { ... on Tree }`
-      assert_equal 3, nut_selections["leafType"].ast_nodes.size
+      assert_equal 1, nut_selections["leafType"].ast_nodes.size
       # Multi-level merging when including fragments:
       habitats_selections = nut_selections["habitats"].typed_children[schema.types["Habitat"]]
       assert_equal ["averageWeight", "seasons"], habitats_selections.keys


### PR DESCRIPTION
AST nodes were implementing `.eql?` without implementing `.hash`.
`.eql?` is supposed to return true if an object is exactly the same, or
if its contents are exactly the same.  This is used to resolve hash
collisions.  Any object whose `.hash` is the same, the hash
implementation will call `.eql?` on them to determine if those to
objects are *exactly* the same (if so, then one is discarded as it's a
dupe).  In this case, we were implementing `.eql?` without implementing
`.hash`, so nodes that are semantically equivalent would return true for
`.eql?` but would not produce the same `.hash` value.  Two objects that
return true for `eql?` must also hash to the same value, so this patch
implements the `.hash` method.

Implementing the `.hash` method causes the test to fail the same way on
Ruby 2.4 as it does on Ruby 2.5, so I updated the test to fix the
assertion.