### PR TITLE
Eval argument block when provided

### DIFF
--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -18,7 +18,7 @@ module GraphQL
       # @param description [String]
       # @param default_value [Object]
       # @param camelize [Boolean] if true, the name will be camelized when building the schema
-      def initialize(arg_name, type_expr, desc = nil, required:, description: nil, default_value: NO_DEFAULT, camelize: true, owner:)
+      def initialize(arg_name, type_expr, desc = nil, required:, description: nil, default_value: NO_DEFAULT, camelize: true, owner:, &definition_block)
         @name = arg_name.to_s
         @type_expr = type_expr
         @description = desc || description
@@ -26,6 +26,18 @@ module GraphQL
         @default_value = default_value
         @camelize = camelize
         @owner = owner
+
+        if definition_block
+          instance_eval(&definition_block)
+        end
+      end
+
+      def description(text = nil)
+        if text
+          @description = text
+        else
+          @description
+        end
       end
 
       def to_graphql

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -87,9 +87,9 @@ module GraphQL
       end
 
       # This is the `argument(...)` DSL for class-based field definitons
-      def argument(*args, **kwargs)
+      def argument(*args, **kwargs, &block)
         kwargs[:owner] = self
-        arg_defn = self.class.argument_class.new(*args, **kwargs)
+        arg_defn = self.class.argument_class.new(*args, **kwargs, &block)
         arguments[arg_defn.name] = arg_defn
       end
 

--- a/spec/graphql/schema/argument_spec.rb
+++ b/spec/graphql/schema/argument_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::Schema::Argument do
+  class SchemaArgumentTest < GraphQL::Schema::Object
+    field :field, String, null: false do
+      argument :arg, String, description: "test", required: false
+
+      argument :argWithBlock, String, required: false do
+        description "test"
+      end
+    end
+  end
+
+  describe "graphql definition" do
+    it "calls block" do
+      assert_equal "test", SchemaArgumentTest.fields["field"].arguments["argWithBlock"].description
+    end
+  end
+
+  describe "#description" do
+    it "sets description" do
+      SchemaArgumentTest.fields["field"].arguments["arg"].description "new description"
+      assert_equal "new description", SchemaArgumentTest.fields["field"].arguments["arg"].description
+    end
+
+    it "returns description" do
+      assert_equal "test", SchemaArgumentTest.fields["field"].arguments["argWithBlock"].description
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1347

`GraphQL::Schema::Field.argument` method appears to silently ignore blocks passed to it.