### PR TITLE
[1.8] Backport accepts_definition, add cursor_encoder

### DIFF
--- a/guides/schema/class_based_api.md
+++ b/guides/schema/class_based_api.md
@@ -46,7 +46,7 @@ Parts of your schema can be converted one-by-one, so you can convert definitions
 
 In general, each `.define { ... }` block will be converted to a class.
 
-- Instead of a `GraphQL::{X}Type`, classes inherit from `GraphQL::Schema:{X}`. For example, instead of `GraphQL::ObjectType.define { ... }`, a definition is made by extending `GraphQL::Schema::Object`
+- Instead of a `GraphQL::{X}Type`, classes inherit from `GraphQL::Schema::{X}`. For example, instead of `GraphQL::ObjectType.define { ... }`, a definition is made by extending `GraphQL::Schema::Object`
 - Any class hierarchy is supported; It's recommended to create a base class for your application, then extend the base class for each of your types (like `ApplicationController` in Rails, see [Customizing Definitions](#customizing-defintions)).
 
 See sections below for specific information about each schema definition class.

--- a/guides/type_definitions/extensions.md
+++ b/guides/type_definitions/extensions.md
@@ -146,6 +146,29 @@ Then, in your custom argument class, you can use:
 
 Inevitably, this will result in some duplication while you migrate from one definition API to the other. Here are a couple of ways to re-use _old_ customizations with the new framework:
 
+__Pass-through with `accepts_definition`__. New schema classes have an `accepts_definition` method. They set up a configuration method which will pass the provided value to the existing (legacy-style) configuration function, for example:
+
+```ruby
+# Given a legacy-style configuration function:
+GraphQL::ObjectType.accepts_definitions({ permission_level: ->(...) { ... } })
+
+# Prepare the config method in the base class:
+class BaseObject < GraphQL::Schema::Object
+  accepts_definition :permission_level
+end
+
+# Call the config method in the object class:
+class Account < BaseObject
+  permission_level 1
+end
+
+# Then, the runtime object will have the configured value, for example:
+MySchema.find("Account").metadata[:permission_level]
+# => 1
+```
+
+See {{ "GraphQL::Schema::Member::AcceptsDefinition" | api_doc }} for the implementation.
+
 __Invoke `.call` directly__. If you defined a module with a `.call` method, you can invoke that method during `.to_graphql`. For example:
 
 ```ruby

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -64,6 +64,7 @@ module GraphQL
   #   end
   #
   class Schema
+    extend GraphQL::Schema::Member::AcceptsDefinition
     include GraphQL::Define::InstanceDefinable
     accepts_definitions \
       :query, :mutation, :subscription,

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -681,6 +681,7 @@ module GraphQL
         schema_defn.id_from_object = method(:id_from_object)
         schema_defn.type_error = method(:type_error)
         schema_defn.context_class = context_class
+        schema_defn.cursor_encoder = cursor_encoder
         schema_defn.tracers.concat(defined_tracers)
         schema_defn.query_analyzers.concat(defined_query_analyzers)
         schema_defn.multiplex_analyzers.concat(defined_multiplex_analyzers)
@@ -747,6 +748,13 @@ module GraphQL
         else
           @introspection
         end
+      end
+
+      def cursor_encoder(new_encoder = nil)
+        if new_encoder
+          @cursor_encoder = new_encoder
+        end
+        @cursor_encoder || Base64Encoder
       end
 
       def default_max_page_size(new_default_max_page_size = nil)

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -197,6 +197,9 @@ module GraphQL
       rescue_middleware.remove_handler(*args, &block)
     end
 
+    # For forwards-compatibility with Schema classes
+    alias :graphql_definition :itself
+
     # Validate a query string according to this schema.
     # @param string_or_document [String, GraphQL::Language::Nodes::Document]
     # @return [Array<GraphQL::StaticValidation::Message>]

--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -3,6 +3,7 @@ module GraphQL
   class Schema
     class Argument
       include GraphQL::Schema::Member::CachedGraphQLDefinition
+      include GraphQL::Schema::Member::AcceptsDefinition
 
       NO_DEFAULT = :__no_default__
 

--- a/lib/graphql/schema/enum.rb
+++ b/lib/graphql/schema/enum.rb
@@ -20,6 +20,8 @@ module GraphQL
   #   end
   class Schema
     class Enum < GraphQL::Schema::Member
+      extend GraphQL::Schema::Member::AcceptsDefinition
+
       class << self
         # Define a value for this enum
         # @param graphql_name [String, Symbol] the GraphQL value for this, usually `SCREAMING_CASE`

--- a/lib/graphql/schema/enum_value.rb
+++ b/lib/graphql/schema/enum_value.rb
@@ -26,6 +26,8 @@ module GraphQL
     #     enum_value_class CustomEnumValue
     #   end
     class EnumValue < GraphQL::Schema::Member
+      include GraphQL::Schema::Member::AcceptsDefinition
+
       attr_reader :graphql_name
 
       # @return [Class] The enum type that owns this value

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -6,6 +6,7 @@ module GraphQL
   class Schema
     class Field
       include GraphQL::Schema::Member::CachedGraphQLDefinition
+      include GraphQL::Schema::Member::AcceptsDefinition
 
       # @return [String]
       attr_reader :name

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -2,6 +2,7 @@
 module GraphQL
   class Schema
     class InputObject < GraphQL::Schema::Member
+      extend GraphQL::Schema::Member::AcceptsDefinition
       extend GraphQL::Delegate
 
       def initialize(values, context:, defaults_used:)

--- a/lib/graphql/schema/interface.rb
+++ b/lib/graphql/schema/interface.rb
@@ -3,6 +3,7 @@ module GraphQL
   class Schema
     class Interface < GraphQL::Schema::Member
       extend GraphQL::Schema::Member::HasFields
+      extend GraphQL::Schema::Member::AcceptsDefinition
       field_class GraphQL::Schema::Field
 
       class << self

--- a/lib/graphql/schema/member.rb
+++ b/lib/graphql/schema/member.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'graphql/schema/member/accepts_definition'
 require "graphql/relay/type_extensions"
 
 module GraphQL
@@ -27,7 +28,7 @@ module GraphQL
       # These constants are interpreted as GraphQL types
       #
       # @example
-      #   field :isDraft, Boolean, null: false
+      #   field :is_draft, Boolean, null: false
       #   field :id, ID, null: false
       #   field :score, Int, null: false
       module GraphQLTypeNames

--- a/lib/graphql/schema/member/accepts_definition.rb
+++ b/lib/graphql/schema/member/accepts_definition.rb
@@ -5,85 +5,112 @@ module GraphQL
     class Member
       # Support for legacy `accepts_definitions` functions.
       #
+      # Keep the legacy handler hooked up. Class-based types and fields
+      # will call those legacy handlers during their `.to_graphql`
+      # methods.
+      #
+      # This can help out while transitioning from one to the other.
+      # Eventually, `GraphQL::{X}Type` objects will be removed entirely,
+      # But this can help during the transition.
+      #
       # @example Applying a function to base object class
+      #   # Here's the legacy-style config, which we're calling back to:
+      #   GraphQL::ObjectType.accepts_definition({
+      #     permission_level: ->(defn, value) { defn.metadata[:permission_level] = value }
+      #   })
+      #
       #   class BaseObject < GraphQL::Schema::Object
-      #     accepts_definition :permission_level, -> (defn, level) {
-      #       defn.metadata[:permission_level] = level
-      #     }
+      #     # Setup a named pass-through to the legacy config functions
+      #     accepts_definition :permission_level
       #   end
       #
       #   class Account < BaseObject
+      #     # This value will be passed to the legacy handler:
       #     permission_level 1
       #   end
       #
-      #   Account.permission_level # => 1
+      #   # The class gets a reader method which returns the args,
+      #   # only marginally useful.
+      #   Account.permission_level # => [1]
+      #
+      #   # The legacy handler is called, as before:
       #   Account.graphql_definition.metadata[:permission_level] # => 1
       module AcceptsDefinition
+        def self.included(child)
+          child.extend(ClassMethods)
+          child.prepend(ToGraphQLExtension)
+          child.prepend(InitializeExtension)
+        end
+
         def self.extended(child)
+          child.extend(ClassMethods)
           # I tried to use `super`, but super isn't quite right
           # since the method is defined in the same class itself,
           # not the superclass
           child.class_eval do
-            if child.respond_to?(:to_graphql)
-              class << self
-                alias :to_graphql_without_accepts_definitions :to_graphql
-                alias :to_graphql :to_graphql_with_accepts_definitions
+            class << self
+              prepend(ToGraphQLExtension)
+            end
+          end
+        end
+
+        module ClassMethods
+          def accepts_definition(name)
+            @accepts_definition_methods ||= []
+            @accepts_definition_methods << name
+            ivar_name = "@#{name}_args"
+            define_singleton_method(name) do |*args|
+              if args.any?
+                instance_variable_set(ivar_name, args)
               end
-            else
-              include(AcceptsDefinition)
-              alias :initialize_without_accepts_definitions :initialize
-              alias :initialize :initialize_with_accepts_definitions
-
-              alias :to_graphql_without_accepts_definitions :to_graphql
-              alias :to_graphql :to_graphql_with_accepts_definitions
+              instance_variable_get(ivar_name)
             end
+
+            define_method(name) do |*args|
+              if args.any?
+                instance_variable_set(ivar_name, args)
+              end
+              instance_variable_get(ivar_name)
+            end
+          end
+
+          def accepts_definition_methods
+            @accepts_definition_methods ||= []
+            sc = self.is_a?(Class) ? superclass : self.class.superclass
+            @accepts_definition_methods + (sc.respond_to?(:accepts_definition_methods) ? sc.accepts_definition_methods : [])
           end
         end
 
-        def initialize_with_accepts_definitions(*args, **kwargs, &block)
-          self.class.accepts_definition_methods.each do |method_name|
-            if kwargs.key?(method_name)
-              value = kwargs.delete(method_name)
-              instance_variable_set("@#{method_name}_args", [value])
+        module ToGraphQLExtension
+          def to_graphql
+            defn = super
+            accepts_definition_methods.each do |method_name|
+              value = instance_variable_get("@#{method_name}_args")
+              if !value.nil?
+                defn = defn.redefine { public_send(method_name, *value) }
+              end
             end
-          end
-          initialize_without_accepts_definitions(*args, **kwargs, &block)
-        end
-
-        def accepts_definition(name)
-          @accepts_definition_methods ||= []
-          @accepts_definition_methods << name
-          ivar_name = "@#{name}_args"
-          define_singleton_method(name) do |*args|
-            if args.any?
-              instance_variable_set(ivar_name, args)
-            end
-            instance_variable_get(ivar_name)
-          end
-
-          define_method(name) do |*args|
-            if args.any?
-              instance_variable_set(ivar_name, args)
-            end
-            instance_variable_get(ivar_name)
+            defn
           end
         end
 
-        def to_graphql_with_accepts_definitions
-          defn = to_graphql_without_accepts_definitions
-          accepts_definition_methods.each do |method_name|
-            value = instance_variable_get("@#{method_name}_args")
-            if !value.nil?
-              defn = defn.redefine { public_send(method_name, *value) }
+        module InitializeExtension
+          def initialize(*args, **kwargs, &block)
+            self.class.accepts_definition_methods.each do |method_name|
+              if kwargs.key?(method_name)
+                value = kwargs.delete(method_name)
+                if !value.is_a?(Array)
+                  value = [value]
+                end
+                instance_variable_set("@#{method_name}_args", value)
+              end
             end
+            super(*args, **kwargs, &block)
           end
-          defn
-        end
 
-        def accepts_definition_methods
-          @accepts_definition_methods ||= []
-          sc = self.is_a?(Class) ? superclass : self.class.superclass
-          @accepts_definition_methods + (sc.respond_to?(:accepts_definition_methods) ? sc.accepts_definition_methods : [])
+          def accepts_definition_methods
+            self.class.accepts_definition_methods
+          end
         end
       end
     end

--- a/lib/graphql/schema/member/accepts_definition.rb
+++ b/lib/graphql/schema/member/accepts_definition.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+module GraphQL
+  class Schema
+    class Member
+      # Support for legacy `accepts_definitions` functions.
+      #
+      # @example Applying a function to base object class
+      #   class BaseObject < GraphQL::Schema::Object
+      #     accepts_definition :permission_level, -> (defn, level) {
+      #       defn.metadata[:permission_level] = level
+      #     }
+      #   end
+      #
+      #   class Account < BaseObject
+      #     permission_level 1
+      #   end
+      #
+      #   Account.permission_level # => 1
+      #   Account.graphql_definition.metadata[:permission_level] # => 1
+      module AcceptsDefinition
+        def self.extended(child)
+          # I tried to use `super`, but super isn't quite right
+          # since the method is defined in the same class itself,
+          # not the superclass
+          child.class_eval do
+            if child.respond_to?(:to_graphql)
+              class << self
+                alias :to_graphql_without_accepts_definitions :to_graphql
+                alias :to_graphql :to_graphql_with_accepts_definitions
+              end
+            else
+              include(AcceptsDefinition)
+              alias :initialize_without_accepts_definitions :initialize
+              alias :initialize :initialize_with_accepts_definitions
+
+              alias :to_graphql_without_accepts_definitions :to_graphql
+              alias :to_graphql :to_graphql_with_accepts_definitions
+            end
+          end
+        end
+
+        def initialize_with_accepts_definitions(*args, **kwargs, &block)
+          self.class.accepts_definition_methods.each do |method_name|
+            if kwargs.key?(method_name)
+              value = kwargs.delete(method_name)
+              instance_variable_set("@#{method_name}_args", [value])
+            end
+          end
+          initialize_without_accepts_definitions(*args, **kwargs, &block)
+        end
+
+        def accepts_definition(name)
+          @accepts_definition_methods ||= []
+          @accepts_definition_methods << name
+          ivar_name = "@#{name}_args"
+          define_singleton_method(name) do |*args|
+            if args.any?
+              instance_variable_set(ivar_name, args)
+            end
+            instance_variable_get(ivar_name)
+          end
+
+          define_method(name) do |*args|
+            if args.any?
+              instance_variable_set(ivar_name, args)
+            end
+            instance_variable_get(ivar_name)
+          end
+        end
+
+        def to_graphql_with_accepts_definitions
+          defn = to_graphql_without_accepts_definitions
+          accepts_definition_methods.each do |method_name|
+            value = instance_variable_get("@#{method_name}_args")
+            if !value.nil?
+              defn = defn.redefine { public_send(method_name, *value) }
+            end
+          end
+          defn
+        end
+
+        def accepts_definition_methods
+          @accepts_definition_methods ||= []
+          sc = self.is_a?(Class) ? superclass : self.class.superclass
+          @accepts_definition_methods + (sc.respond_to?(:accepts_definition_methods) ? sc.accepts_definition_methods : [])
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/schema/object.rb
+++ b/lib/graphql/schema/object.rb
@@ -3,6 +3,8 @@
 module GraphQL
   class Schema
     class Object < GraphQL::Schema::Member
+      extend GraphQL::Schema::Member::AcceptsDefinition
+
       # @return [Object] the application object this type is wrapping
       attr_reader :object
 

--- a/lib/graphql/schema/scalar.rb
+++ b/lib/graphql/schema/scalar.rb
@@ -2,6 +2,8 @@
 module GraphQL
   class Schema
     class Scalar < GraphQL::Schema::Member
+      extend GraphQL::Schema::Member::AcceptsDefinition
+
       class << self
         def coerce_input(val, ctx)
           raise NotImplementedError, "#{self.name}.coerce_input(val, ctx) must prepare GraphQL input (#{val.inspect}) for Ruby processing"

--- a/lib/graphql/schema/union.rb
+++ b/lib/graphql/schema/union.rb
@@ -2,6 +2,8 @@
 module GraphQL
   class Schema
     class Union < GraphQL::Schema::Member
+      extend GraphQL::Schema::Member::AcceptsDefinition
+
       class << self
         def possible_types(*types)
           if types.any?

--- a/spec/graphql/relay/range_add_spec.rb
+++ b/spec/graphql/relay/range_add_spec.rb
@@ -70,7 +70,11 @@ describe GraphQL::Relay::RangeAdd do
       field :add_item, add_item.field
     end
 
-    GraphQL::Schema.define(query: query, mutation: mutation, cursor_encoder: PassThroughEncoder)
+    Class.new(GraphQL::Schema) do
+      self.query(query)
+      self.mutation(mutation)
+      self.cursor_encoder(PassThroughEncoder)
+    end
   }
 
 

--- a/spec/graphql/schema/member/accepts_definition_spec.rb
+++ b/spec/graphql/schema/member/accepts_definition_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::Schema::Member::AcceptsDefinition do
+  class AcceptsDefinitionSchema < GraphQL::Schema
+    accepts_definition :set_metadata
+    set_metadata :a, 999
+
+    class Option < GraphQL::Schema::Enum
+      class EnumValue < GraphQL::Schema::EnumValue
+        accepts_definition :metadata
+      end
+      enum_value_class EnumValue
+      accepts_definition :metadata
+      metadata :a, 123
+      value "A", metadata: [:a, 456]
+      value "B"
+    end
+
+    class Query < GraphQL::Schema::Object
+      class Field < GraphQL::Schema::Field
+        class Argument < GraphQL::Schema::Argument
+          accepts_definition :metadata
+        end
+        argument_class Argument
+        accepts_definition :metadata
+      end
+      field_class Field
+      accepts_definition :metadata
+      metadata :a, :abc
+
+      field :option, Option, null: false do
+        metadata :a, :def
+        argument :value, Integer, required: true, metadata: [:a, :ghi]
+      end
+    end
+
+    query(Query)
+  end
+
+
+  it "passes along configs for types" do
+    assert_equal [:a, 123], AcceptsDefinitionSchema::Option.metadata
+    assert_equal 123, AcceptsDefinitionSchema::Option.graphql_definition.metadata[:a]
+    assert_equal [:a, :abc], AcceptsDefinitionSchema::Query.metadata
+    assert_equal :abc, AcceptsDefinitionSchema::Query.graphql_definition.metadata[:a]
+  end
+
+  it "passes along configs for fields and arguments" do
+    assert_equal :def, AcceptsDefinitionSchema.find("Query.option").metadata[:a]
+    assert_equal :ghi, AcceptsDefinitionSchema.find("Query.option.value").metadata[:a]
+  end
+
+  it "passes along configs for enum values" do
+    assert_equal 456, AcceptsDefinitionSchema.find("Option.A").metadata[:a]
+    assert_nil AcceptsDefinitionSchema.find("Option.B").metadata[:a]
+  end
+
+  it "passes along configs for schemas" do
+    assert_equal 999, AcceptsDefinitionSchema.graphql_definition.metadata[:a]
+  end
+end

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -6,6 +6,12 @@ describe GraphQL::Schema do
   let(:relay_schema)  { StarWars::Schema }
   let(:empty_schema) { GraphQL::Schema.define }
 
+  describe "#graphql_definition" do
+    it "returns itself" do
+      assert_equal empty_schema, empty_schema.graphql_definition
+    end
+  end
+
   describe "#rescue_from" do
     it "adds handlers to the rescue middleware" do
       schema_defn = schema.graphql_definition

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,7 @@ Minitest.backtrace_filter = Minitest::BacktraceFilter.new
 # This is for convenient access to metadata in test definitions
 assign_metadata_key = ->(target, key, value) { target.metadata[key] = value }
 assign_metadata_flag = ->(target, flag) { target.metadata[flag] = true }
+GraphQL::Schema.accepts_definitions(set_metadata: assign_metadata_key)
 GraphQL::BaseType.accepts_definitions(metadata: assign_metadata_key)
 GraphQL::Field.accepts_definitions(metadata: assign_metadata_key)
 GraphQL::Argument.accepts_definitions(metadata: assign_metadata_key)


### PR DESCRIPTION
This will make the transition a bit easier. I'll use it for graphql-pro, as well as the cursor_encoder fix.