### PR TITLE
[1.8] Allow fields to use anonymous classes for types

### DIFF
--- a/lib/graphql/schema/member/build_type.rb
+++ b/lib/graphql/schema/member/build_type.rb
@@ -64,7 +64,7 @@ module GraphQL
               raise ArgumentError, LIST_TYPE_ERROR
             end
           when Class
-            if Class < GraphQL::Schema::Member
+            if type_expr < GraphQL::Schema::Member
               type_expr.graphql_definition
             else
               # Eg `String` => GraphQL::STRING_TYPE

--- a/spec/graphql/schema/field_spec.rb
+++ b/spec/graphql/schema/field_spec.rb
@@ -46,6 +46,14 @@ describe GraphQL::Schema::Field do
       assert_equal "A Description.", object.fields["test"].description
     end
 
+    it "accepts anonymous classes as type" do
+      type = Class.new(GraphQL::Schema::Object) do
+        graphql_name 'MyType'
+      end
+      field = GraphQL::Schema::Field.new(:my_field, type, owner: nil, null: true)
+      assert_equal type.to_graphql, field.to_graphql.type
+    end
+
     describe "extras" do
       it "can get errors, which adds path" do
         query_str = <<-GRAPHQL


### PR DESCRIPTION
I hit this bug while using some meta-programmed classes for field types. The test case shows a contrived example of this.