### PR TITLE
Update hint in UnresolvedTypeError to use resolve_type

### DIFF
--- a/lib/graphql/unresolved_type_error.rb
+++ b/lib/graphql/unresolved_type_error.rb
@@ -26,7 +26,7 @@ module GraphQL
       @possible_types = possible_types
       message = "The value from \"#{field.name}\" on \"#{parent_type}\" could not be resolved to \"#{field.type}\". " \
         "(Received: `#{resolved_type.inspect}`, Expected: [#{possible_types.map(&:inspect).join(", ")}]) " \
-        "Make sure you have defined a `type_from_object` proc on your schema and that value `#{value.inspect}` " \
+        "Make sure you have defined a `resolve_type` proc on your schema and that value `#{value.inspect}` " \
         "gets resolved to a valid type."
       super(message)
     end

--- a/spec/graphql/query/serial_execution/value_resolution_spec.rb
+++ b/spec/graphql/query/serial_execution/value_resolution_spec.rb
@@ -88,7 +88,7 @@ describe GraphQL::Query::SerialExecution::ValueResolution do
         err = assert_raises(GraphQL::UnresolvedTypeError) { result }
         expected_message = "The value from \"resolvesToNilInterface\" on \"Query\" could not be resolved to \"SomeInterface\". " \
           "(Received: `nil`, Expected: [SomeObject]) " \
-          "Make sure you have defined a `type_from_object` proc on your schema and that value `1337` " \
+          "Make sure you have defined a `resolve_type` proc on your schema and that value `1337` " \
           "gets resolved to a valid type."
         assert_equal expected_message, err.message
       end
@@ -105,7 +105,7 @@ describe GraphQL::Query::SerialExecution::ValueResolution do
         err = assert_raises(GraphQL::UnresolvedTypeError) { result }
         expected_message = "The value from \"resolvesToWrongTypeInterface\" on \"Query\" could not be resolved to \"SomeInterface\". " \
           "(Received: `OtherObject`, Expected: [SomeObject]) " \
-          "Make sure you have defined a `type_from_object` proc on your schema and that value `:something` " \
+          "Make sure you have defined a `resolve_type` proc on your schema and that value `:something` " \
           "gets resolved to a valid type."
         assert_equal expected_message, err.message
       end


### PR DESCRIPTION
`type_from_object` was previously deprecated in favour of `resolve_type`.