### PR TITLE
Fixing typo in error handling

### DIFF
--- a/guides/queries/error_handling.md
+++ b/guides/queries/error_handling.md
@@ -107,8 +107,8 @@ If you don't want to `begin ... rescue ... end` in every field, you can wrap `re
 
 ```ruby
 # Wrap field resolver `resolve_func` with an error handler.
-# `RescueFrom` instances are valid field resolvers too.
-class RescueFrom
+# `Rescuable` instances are valid field resolvers too.
+class Rescuable
   def initialize(resolve_func)
     @resolve_func = resolve_func
   end


### PR DESCRIPTION
`RescueFrom` is used in the sample class definition but `Rescuable` is used in the sample use case.
Updated class definition to use `Rescuable`

https://github.com/rmosolgo/graphql-ruby/blob/df28b7da1451931f7dbafc9bd17395d775f11367/guides/queries/error_handling.md#error-handling-with-wrappers