### PR TITLE
Change deprecation arg from camel case to snake case

### DIFF
--- a/lib/graphql/introspection/fields_field.rb
+++ b/lib/graphql/introspection/fields_field.rb
@@ -6,7 +6,7 @@ GraphQL::Introspection::FieldsField = GraphQL::Field.define do
   resolve ->(object, arguments, context) {
     return nil if !object.kind.fields?
     fields = context.warden.fields(object)
-    if !arguments["includeDeprecated"]
+    if !arguments["include_deprecated"]
       fields = fields.select {|f| !f.deprecation_reason }
     end
     fields.sort_by(&:name)


### PR DESCRIPTION
This fixes an issue where deprecated fields were not showing for the Introspection query, therefore was not showing within Graphiql docs.