### PR TITLE
1.8 upgrade fix; interface Implementation module fix 

### DIFF
--- a/lib/graphql/schema/interface.rb
+++ b/lib/graphql/schema/interface.rb
@@ -7,13 +7,20 @@ module GraphQL
       field_class GraphQL::Schema::Field
 
       class << self
+        # Always set up a `self::Implementation` module,
+        # which may or may not be added to.
+        def inherited(child_cls)
+          # This module will be mixed in to each object class,
+          # so it can contain methods to implement fields.
+          # It's always added to interfaces, but sometimes it's left empty.
+          child_cls.const_set(:Implementation, Module.new)
+        end
+
         # When this interface is added to a `GraphQL::Schema::Object`,
         # it calls this method. We add methods to the object by convention,
         # a nested module named `Implementation`
-        def apply_implemented(object_class)
-          if defined?(self::Implementation)
-            object_class.include(self::Implementation)
-          end
+        def implemented(object_class)
+          object_class.include(self::Implementation)
         end
 
         def orphan_types(*types)

--- a/lib/graphql/schema/object.rb
+++ b/lib/graphql/schema/object.rb
@@ -28,7 +28,7 @@ module GraphQL
                 own_fields[name] = field
               end
               # And call the implemented hook
-              int.apply_implemented(self)
+              int.implemented(self)
             else
               int.all_fields.each do |f|
                 field(f.name, field: f)

--- a/lib/graphql/upgrader/member.rb
+++ b/lib/graphql/upgrader/member.rb
@@ -334,10 +334,10 @@ module GraphQL
           # This is not good, it will hit false positives
           # Should use AST to make this substitution
           if obj_arg_name != "_"
-            proc_body.gsub!(/([^\w:.]|^)#{obj_arg_name}([^\w]|$)/, '\1@object\2')
+            proc_body.gsub!(/([^\w:.]|^)#{obj_arg_name}([^\w:]|$)/, '\1@object\2')
           end
           if ctx_arg_name != "_"
-            proc_body.gsub!(/([^\w:.]|^)#{ctx_arg_name}([^\w]|$)/, '\1@context\2')
+            proc_body.gsub!(/([^\w:.]|^)#{ctx_arg_name}([^\w:]|$)/, '\1@context\2')
           end
 
           method_def_indent = " " * (processor.resolve_indent - 2)
@@ -543,7 +543,8 @@ module GraphQL
       end
 
       def apply(input_text)
-        if input_text =~ @interface_file_pattern && input_text =~ /\n *def /
+        # See if it its an interface file with any instance methods
+        if input_text =~ @interface_file_pattern && input_text =~ /\n *def (?!(self|[A-Z]))/
           # Extract the method bodies and figure out where the module should be inserted
           method_bodies = []
           processor = apply_processor(input_text, InterfaceMethodProcessor.new)

--- a/spec/graphql/schema/interface_spec.rb
+++ b/spec/graphql/schema/interface_spec.rb
@@ -11,6 +11,10 @@ describe GraphQL::Schema::Interface do
     end
 
     class NewInterface1 < Jazz::GloballyIdentifiableType
+      # TODO not great
+      module Implementation
+        include Jazz::GloballyIdentifiableType::Implementation
+      end
     end
 
     class NewInterface2 < Jazz::GloballyIdentifiableType

--- a/spec/graphql/schema/interface_spec.rb
+++ b/spec/graphql/schema/interface_spec.rb
@@ -21,7 +21,6 @@ describe GraphQL::Schema::Interface do
     end
 
     it "can override Implementation" do
-
       new_object_1 = Class.new(GraphQL::Schema::Object) do
         implements NewInterface1
       end


### PR DESCRIPTION
- better handling for some upgrader substitutions 
- always define an `Implementation` module in interfaces classes, simplifies metaprogramming because it's always present. (maybe this will 🔥  later, but it's good for now)