### PR TITLE
Fix get field introspection

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -323,9 +323,9 @@ module GraphQL
           defined_field
         elsif field_name == "__typename"
           GraphQL::Introspection::TypenameField
-        elsif field_name == "__schema" && parent_type == query
+        elsif field_name == "__schema" && parent_type_name == query.name
           GraphQL::Introspection::SchemaField
-        elsif field_name == "__type" && parent_type == query
+        elsif field_name == "__type" && parent_type_name == query.name
           GraphQL::Introspection::TypeByNameField
         else
           nil

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -444,7 +444,7 @@ type Query {
       field = schema.get_field("Query", "__schema")
       assert_equal GraphQL::Introspection::SchemaField, field
       field_2 = schema.get_field(Dummy::DairyAppQueryType, "__schema")
-      assert_equal GraphQL::Introspection::SchemaField, field
+      assert_equal field2, field
     end
   end
 end

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -439,5 +439,12 @@ type Query {
       field_2 = schema.get_field(Dummy::CheeseType, "id")
       assert_equal field, field_2
     end
+
+    it "returns introspection fields by type or type name" do
+      field = schema.get_field("Query", "__schema")
+      assert_equal GraphQL::Introspection::SchemaField, field
+      field_2 = schema.get_field(Dummy::DairyAppQueryType, "__schema")
+      assert_equal GraphQL::Introspection::SchemaField, field
+    end
   end
 end


### PR DESCRIPTION
`schema.get_field("Query", "__schema")` would fail because we compared a string vs the query root object.