### PR TITLE
Use an empty hash for response when an error propagates, so after_query hooks can use it

### DIFF
--- a/lib/graphql/execution/multiplex.rb
+++ b/lib/graphql/execution/multiplex.rb
@@ -93,7 +93,7 @@ module GraphQL
           end
         rescue StandardError
           # Assign values here so that the query's `@executed` becomes true
-          queries.map { |q| q.result_values ||= nil }
+          queries.map { |q| q.result_values ||= {} }
           raise
         end
 

--- a/spec/graphql/execution/multiplex_spec.rb
+++ b/spec/graphql/execution/multiplex_spec.rb
@@ -176,7 +176,7 @@ describe GraphQL::Execution::Multiplex do
       assert_raises(GraphQL::Error) do
         InspectSchema.execute("{ raiseError }")
       end
-      unhandled_err_json = 'null'
+      unhandled_err_json = '{}'
       assert_equal unhandled_err_json, InspectQueryInstrumentation.last_json
     end
   end

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -258,6 +258,7 @@ describe GraphQL::Query do
       module ExtensionsInstrumenter
         LOG = []
         def self.before_query(q); end;
+
         def self.after_query(q)
           q.result["extensions"] = { "a" => 1 }
           LOG << :ok

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -253,6 +253,31 @@ describe GraphQL::Query do
         assert_equal [nil], Instrumenter::ERROR_LOG
       end
     end
+
+    describe "when an error propagated through execution" do
+      module ExtensionsInstrumenter
+        LOG = []
+        def self.before_query(q); end;
+        def self.after_query(q)
+          q.result["extensions"] = { "a" => 1 }
+          LOG << :ok
+        end
+      end
+
+      let(:schema) {
+        Dummy::Schema.redefine {
+          instrument(:query, ExtensionsInstrumenter)
+        }
+      }
+
+      it "can add to extensions" do
+        ExtensionsInstrumenter::LOG.clear
+        assert_raises(RuntimeError) do
+          schema.execute "{ error }"
+        end
+        assert_equal [:ok], ExtensionsInstrumenter::LOG
+      end
+    end
   end
 
   it "uses root_value as the object for the root type" do


### PR DESCRIPTION
This might fix #1362 ... Let's see 😬 

It's a nice code improvement too, that you can count on `Query::Result` acting like a hash, regardless of the error state.