### PR TITLE
Improve RescueMiddleware error matching

### DIFF
--- a/lib/graphql/schema/rescue_middleware.rb
+++ b/lib/graphql/schema/rescue_middleware.rb
@@ -41,13 +41,14 @@ module GraphQL
       private
 
       def attempt_rescue(err)
-        handler = rescue_table[err.class]
-        if handler
-          message = handler.call(err)
-          GraphQL::ExecutionError.new(message)
-        else
-          raise(err)
-        end
+        rescue_table.each { |klass, handler|
+          if klass.is_a?(Class) && err.is_a?(klass) && handler
+            message = handler.call(err)
+            return GraphQL::ExecutionError.new(message)
+          end
+        }
+
+        raise(err)
       end
     end
   end

--- a/spec/graphql/schema/rescue_middleware_spec.rb
+++ b/spec/graphql/schema/rescue_middleware_spec.rb
@@ -25,6 +25,17 @@ describe GraphQL::Schema::RescueMiddleware do
       assert_equal(GraphQL::ExecutionError, result.class)
     end
 
+    describe "rescue_from superclass" do
+      class ChildSpecExampleError < SpecExampleError; end
+
+      let(:error_class) { ChildSpecExampleError }
+      it "handles them as execution errors" do
+        result = middleware_chain.invoke([])
+        assert_equal("there was an example error: ChildSpecExampleError", result.message)
+        assert_equal(GraphQL::ExecutionError, result.class)
+      end
+    end
+
     describe "with multiple error classes" do
       let(:error_class) { SecondSpecExampleError }
       let(:rescue_middleware) do


### PR DESCRIPTION
Support error matching by superclasses in rescue_table.

RescueMiddleware, when attempting to rescue the errors was only matching
against the exact class if it was present in the `rescue_table`. This PR
introduces the change where we can `rescue_from` a superclass and
RescueMiddleware will be able to handle all its descendants by checking
if either the error class provided or any of it's superclasses is in the
`rescue_table`.

Closes #1392