### PR TITLE
Support custom JSON scalar types

### DIFF
--- a/lib/graphql/scalar_type.rb
+++ b/lib/graphql/scalar_type.rb
@@ -117,6 +117,8 @@ module GraphQL
         value.to_h
       elsif value.is_a?(Array)
         value.map { |element| raw_coercion_input(element) }
+      elsif value.is_a?(GraphQL::Language::Nodes::Enum)
+        value.name
       else
         value
       end

--- a/lib/graphql/scalar_type.rb
+++ b/lib/graphql/scalar_type.rb
@@ -109,7 +109,17 @@ module GraphQL
     end
 
     def coerce_non_null_input(value, ctx)
-      @coerce_input_proc.call(value, ctx)
+      @coerce_input_proc.call(raw_coercion_input(value), ctx)
+    end
+
+    def raw_coercion_input(value)
+      if value.is_a?(GraphQL::Language::Nodes::InputObject)
+        value.to_h
+      elsif value.is_a?(Array)
+        value.map { |element| raw_coercion_input(element) }
+      else
+        value
+      end
     end
 
     def validate_non_null_input(value, ctx)

--- a/lib/graphql/static_validation/literal_validator.rb
+++ b/lib/graphql/static_validation/literal_validator.rb
@@ -16,7 +16,7 @@ module GraphQL
         elsif type.kind.list?
           item_type = type.of_type
           ensure_array(ast_value).all? { |val| validate(val, item_type) }
-        elsif type.kind.scalar? && !ast_value.is_a?(GraphQL::Language::Nodes::AbstractNode) && !ast_value.is_a?(Array)
+        elsif type.kind.scalar? && !ast_value.is_a?(GraphQL::Language::Nodes::VariableIdentifier)
           type.valid_input?(ast_value, @context)
         elsif type.kind.enum? && ast_value.is_a?(GraphQL::Language::Nodes::Enum)
           type.valid_input?(ast_value.name, @context)

--- a/lib/graphql/static_validation/literal_validator.rb
+++ b/lib/graphql/static_validation/literal_validator.rb
@@ -16,23 +16,35 @@ module GraphQL
         elsif type.kind.list?
           item_type = type.of_type
           ensure_array(ast_value).all? { |val| validate(val, item_type) }
-        elsif type.kind.scalar? && !ast_value.is_a?(GraphQL::Language::Nodes::VariableIdentifier)
+        elsif ast_value.is_a?(GraphQL::Language::Nodes::VariableIdentifier)
+          true
+        elsif type.kind.scalar? && constant_scalar?(ast_value)
           type.valid_input?(ast_value, @context)
         elsif type.kind.enum? && ast_value.is_a?(GraphQL::Language::Nodes::Enum)
           type.valid_input?(ast_value.name, @context)
         elsif type.kind.input_object? && ast_value.is_a?(GraphQL::Language::Nodes::InputObject)
           required_input_fields_are_present(type, ast_value) &&
             present_input_field_values_are_valid(type, ast_value)
-        elsif ast_value.is_a?(GraphQL::Language::Nodes::VariableIdentifier)
-          true
         else
           false
         end
       end
 
-
       private
 
+      # The GraphQL grammar supports variables embedded within scalars but graphql.js
+      # doesn't support it so we won't either for simplicity
+      def constant_scalar?(ast_value)
+        if ast_value.is_a?(GraphQL::Language::Nodes::VariableIdentifier)
+          false
+        elsif ast_value.is_a?(Array)
+          ast_value.all? { |element| constant_scalar?(element) }
+        elsif ast_value.is_a?(GraphQL::Language::Nodes::InputObject)
+          ast_value.arguments.all? { |arg| constant_scalar?(arg.value) }
+        else
+          true
+        end
+      end
 
       def required_input_fields_are_present(type, ast_node)
         required_field_names = @warden.arguments(type)

--- a/spec/graphql/schema/scalar_spec.rb
+++ b/spec/graphql/schema/scalar_spec.rb
@@ -69,5 +69,27 @@ describe GraphQL::Schema::Scalar do
       res = Jazz::Schema.execute(query_str)
       assert_equal([{"foo" => "bar"}], res["data"]["echoJson"])
     end
+
+    it "can be JSON with a nested enum" do
+      query_str = <<-GRAPHQL
+      {
+        echoJson(input: [{foo: WOODWIND}])
+      }
+      GRAPHQL
+
+      res = Jazz::Schema.execute(query_str)
+      assert_equal([{"foo" => "WOODWIND"}], res["data"]["echoJson"])
+    end
+
+    it "cannot be JSON with a nested variable" do
+      query_str = <<-GRAPHQL
+      {
+        echoJson(input: [{foo: $var}])
+      }
+      GRAPHQL
+
+      res = Jazz::Schema.execute(query_str)
+      assert_includes(res["errors"][0]["message"], "Argument 'input' on Field 'echoJson' has an invalid value")
+    end
   end
 end

--- a/spec/graphql/schema/scalar_spec.rb
+++ b/spec/graphql/schema/scalar_spec.rb
@@ -36,5 +36,38 @@ describe GraphQL::Schema::Scalar do
       assert_equal true, key_info["isSharp"]
       assert_equal false, key_info["isFlat"]
     end
+
+    it "can be nested JSON" do
+      query_str = <<-GRAPHQL
+      {
+        echoJson(input: {foo: [{bar: "baz"}]})
+      }
+      GRAPHQL
+
+      res = Jazz::Schema.execute(query_str)
+      assert_equal({"foo" => [{"bar" => "baz"}]}, res["data"]["echoJson"])
+    end
+
+    it "can be a JSON array" do
+      query_str = <<-GRAPHQL
+      {
+        echoFirstJson(input: [{foo: "bar"}, {baz: "boo"}])
+      }
+      GRAPHQL
+
+      res = Jazz::Schema.execute(query_str)
+      assert_equal({"foo" => "bar"}, res["data"]["echoFirstJson"])
+    end
+
+    it "can be a JSON array even if the GraphQL type is not an array" do
+      query_str = <<-GRAPHQL
+      {
+        echoJson(input: [{foo: "bar"}])
+      }
+      GRAPHQL
+
+      res = Jazz::Schema.execute(query_str)
+      assert_equal([{"foo" => "bar"}], res["data"]["echoJson"])
+    end
   end
 end

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -212,6 +212,16 @@ module Jazz
     end
   end
 
+  class RawJson < GraphQL::Schema::Scalar
+    def self.coerce_input(val, ctx)
+      val
+    end
+
+    def self.coerce_result(val, ctx)
+      val
+    end
+  end
+
   class Musician < BaseObject
     implements GloballyIdentifiableType
     implements NamedEntity
@@ -300,6 +310,14 @@ module Jazz
     field :inspect_context, [String], null: false
     field :hashyEnsemble, Ensemble, null: false
 
+    field :echo_json, RawJson, null: false do
+      argument :input, RawJson, required: true
+    end
+
+    field :echo_first_json, RawJson, null: false do
+      argument :input, [RawJson], required: true
+    end
+
     def ensembles
       Models.data["Ensemble"]
     end
@@ -357,6 +375,14 @@ module Jazz
           ],
           "formedAtDate" => "May 5, 1965",
       }
+    end
+
+    def echo_json(input:)
+      input
+    end
+
+    def echo_first_json(input:)
+      input.first
     end
   end
 


### PR DESCRIPTION
This PR adds support for building a custom JSON scalar type (i.e. actual JSON not JSON encoded in a string) that is similar to [graphql-type-json](https://github.com/taion/graphql-type-json) for [graphql.js](https://github.com/graphql/graphql-js). The custom scalar can be defined as:

```ruby
class JsonType < GraphQL::Schema::Scalar
  def self.coerce_input(value, _context)
    value
  end

  def self.coerce_result(value, _context)
    value
  end
end  
```
The parser was converting JSON arguments to a `GraphQL::Language::Nodes::InputObject` so I had to convert it back to it's more raw form before attempting scalar coercion. The changes to `GraphQL:: StaticValidation::LiteralValidator` could definitely use some extra scrutiny to ensure I didn't break anything :)

Fixes #146