### PR TITLE
Accept symbol-keyed hashes in variables

### DIFF
--- a/lib/graphql/query/variables.rb
+++ b/lib/graphql/query/variables.rb
@@ -77,7 +77,6 @@ module GraphQL
         case arg_owner
         when GraphQL::Field, GraphQL::InputObjectType
           normalized_args = {}
-          missing_arg_names = []
           args.each do |k, v|
             arg_name = k.to_s
             arg_defn = arg_owner.arguments[arg_name]

--- a/lib/graphql/query/variables.rb
+++ b/lib/graphql/query/variables.rb
@@ -13,16 +13,8 @@ module GraphQL
       def initialize(ctx, ast_variables, provided_variables)
         schema = ctx.schema
         @context = ctx
-        @provided_variables = provided_variables
-        normalized_provided_variables = if provided_variables.is_a?(Hash)
-          provided_variables.reduce({}) do |h, (k, v)|
-            normalized_k = GraphQL::Schema::Member::BuildType.camelize(k.to_s)
-            h[normalized_k] = v
-            h
-          end
-        else
-          {}
-        end
+
+        @provided_variables = deep_stringify(provided_variables)
         @errors = []
         @storage = ast_variables.each_with_object({}) do |ast_variable, memo|
           # Find the right value for this variable:
@@ -35,16 +27,8 @@ module GraphQL
           else
             variable_name = ast_variable.name
             default_value = ast_variable.default_value
-            if @provided_variables.key?(variable_name)
-              provided_value = @provided_variables[variable_name]
-              value_was_provided = true
-            elsif normalized_provided_variables.key?(variable_name)
-              provided_value = normalize_arguments(variable_type, normalized_provided_variables[variable_name])
-              value_was_provided = true
-            else
-              provided_value = nil
-              value_was_provided = false
-            end
+            provided_value = @provided_variables[variable_name]
+            value_was_provided =  @provided_variables.key?(variable_name)
 
             validation_result = variable_type.validate_input(provided_value, ctx)
             if !validation_result.valid?
@@ -65,40 +49,18 @@ module GraphQL
 
       private
 
-      # TODO dedup with subscription
-      #
-      # Recursively normalize `args` as belonging to `arg_owner`:
-      # - convert symbols to strings,
-      # - if needed, camelize the string (using {#normalize_name})
-      # @param arg_owner [GraphQL::Field, GraphQL::BaseType]
-      # @param args [Hash, Array, Any] some GraphQL input value to coerce as `arg_owner`
-      # @return [Any] normalized arguments value
-      def normalize_arguments(arg_owner, args)
-        case arg_owner
-        when GraphQL::Field, GraphQL::InputObjectType
-          normalized_args = {}
-          args.each do |k, v|
-            arg_name = k.to_s
-            arg_defn = arg_owner.arguments[arg_name]
-            if arg_defn
-              normalized_arg_name = arg_name
-            else
-              normalized_arg_name = GraphQL::Schema::Member::BuildType.camelize(arg_name)
-              arg_defn = arg_owner.arguments[normalized_arg_name]
-            end
-
-            if arg_defn
-              normalized_args[normalized_arg_name] = normalize_arguments(arg_defn.type, v)
-            end
+      def deep_stringify(val)
+        case val
+        when Array
+          val.map { |v| deep_stringify(v) }
+        when Hash
+          new_val = {}
+          val.each do |k, v|
+            new_val[k.to_s] = deep_stringify(v)
           end
-
-          normalized_args
-        when GraphQL::ListType
-          args.map { |a| normalize_arguments(arg_owner.of_type, a) }
-        when GraphQL::NonNullType
-          normalize_arguments(arg_owner.of_type, args)
+          new_val
         else
-          args
+          val
         end
       end
     end

--- a/lib/graphql/query/variables.rb
+++ b/lib/graphql/query/variables.rb
@@ -14,6 +14,15 @@ module GraphQL
         schema = ctx.schema
         @context = ctx
         @provided_variables = provided_variables
+        normalized_provided_variables = if provided_variables.is_a?(Hash)
+          provided_variables.reduce({}) do |h, (k, v)|
+            normalized_k = GraphQL::Schema::Member::BuildType.camelize(k.to_s)
+            h[normalized_k] = v
+            h
+          end
+        else
+          {}
+        end
         @errors = []
         @storage = ast_variables.each_with_object({}) do |ast_variable, memo|
           # Find the right value for this variable:
@@ -26,8 +35,16 @@ module GraphQL
           else
             variable_name = ast_variable.name
             default_value = ast_variable.default_value
-            provided_value = @provided_variables[variable_name]
-            value_was_provided = @provided_variables.key?(variable_name)
+            if @provided_variables.key?(variable_name)
+              provided_value = @provided_variables[variable_name]
+              value_was_provided = true
+            elsif normalized_provided_variables.key?(variable_name)
+              provided_value = normalize_arguments(variable_type, normalized_provided_variables[variable_name])
+              value_was_provided = true
+            else
+              provided_value = nil
+              value_was_provided = false
+            end
 
             validation_result = variable_type.validate_input(provided_value, ctx)
             if !validation_result.valid?
@@ -45,6 +62,46 @@ module GraphQL
       end
 
       def_delegators :@storage, :length, :key?, :[], :fetch, :to_h
+
+      private
+
+      # TODO dedup with subscription
+      #
+      # Recursively normalize `args` as belonging to `arg_owner`:
+      # - convert symbols to strings,
+      # - if needed, camelize the string (using {#normalize_name})
+      # @param arg_owner [GraphQL::Field, GraphQL::BaseType]
+      # @param args [Hash, Array, Any] some GraphQL input value to coerce as `arg_owner`
+      # @return [Any] normalized arguments value
+      def normalize_arguments(arg_owner, args)
+        case arg_owner
+        when GraphQL::Field, GraphQL::InputObjectType
+          normalized_args = {}
+          missing_arg_names = []
+          args.each do |k, v|
+            arg_name = k.to_s
+            arg_defn = arg_owner.arguments[arg_name]
+            if arg_defn
+              normalized_arg_name = arg_name
+            else
+              normalized_arg_name = GraphQL::Schema::Member::BuildType.camelize(arg_name)
+              arg_defn = arg_owner.arguments[normalized_arg_name]
+            end
+
+            if arg_defn
+              normalized_args[normalized_arg_name] = normalize_arguments(arg_defn.type, v)
+            end
+          end
+
+          normalized_args
+        when GraphQL::ListType
+          args.map { |a| normalize_arguments(arg_owner.of_type, a) }
+        when GraphQL::NonNullType
+          normalize_arguments(arg_owner.of_type, args)
+        else
+          args
+        end
+      end
     end
   end
 end

--- a/spec/graphql/query/variables_spec.rb
+++ b/spec/graphql/query/variables_spec.rb
@@ -48,13 +48,11 @@ describe GraphQL::Query::Variables do
       end
     end
 
-    describe "symbol/underscored keys" do
+    describe "symbol keys" do
       let(:query_string) { <<-GRAPHQL
         query testVariables(
-          $camelizedInt: Int!
-          $dairyProduct1: DairyProductInput!
-          $dairyProduct2: DairyProductInput!
-          $dairy_product_3: DairyProductInput!
+          $dairy_product_1: DairyProductInput!
+          $dairy_product_2: DairyProductInput!
         ) {
           __typename
         }
@@ -63,16 +61,12 @@ describe GraphQL::Query::Variables do
 
       let(:provided_variables) {
         {
-          camelized_int: 1,
-          dairy_product_1: { source: "COW", fat_content: 0.99 },
-          "dairy_product_2" => { "source": "DONKEY", "fatContent": 0.89 },
-          "dairy_product_3" => { "source" => "COW", "fatContent" => 0.79 },
+          dairy_product_1: { source: "COW", fatContent: 0.99 },
+          "dairy_product_2" => { source: "DONKEY", "fatContent": 0.89 },
         }
       }
 
-      it "checks for string/camelized matches" do
-        assert_equal 1, variables["camelizedInt"]
-
+      it "checks for string matches" do
         # These get merged into all the values above
         default_values = {
           "originDairy"=>"Sugar Hollow Dairy",
@@ -84,19 +78,14 @@ describe GraphQL::Query::Variables do
           "source" => 1,
           "fatContent" => 0.99,
         }.merge(default_values)
-        assert_equal(expected_input_1, variables["dairyProduct1"].to_h)
+
+        assert_equal(expected_input_1, variables["dairy_product_1"].to_h)
 
         expected_input_2 = {
           "source" => :donkey,
           "fatContent" => 0.89,
         }.merge(default_values)
-        assert_equal(expected_input_2, variables["dairyProduct2"].to_h)
-
-        expected_input_3 = {
-          "source" => 1,
-          "fatContent" => 0.79,
-        }.merge(default_values)
-        assert_equal(expected_input_3, variables["dairy_product_3"].to_h)
+        assert_equal(expected_input_2, variables["dairy_product_2"].to_h)
       end
     end
 

--- a/spec/graphql/schema/enum_spec.rb
+++ b/spec/graphql/schema/enum_spec.rb
@@ -67,7 +67,7 @@ describe GraphQL::Schema::Enum do
     it "works as input" do
       query_str = "query($family: Family!) { instruments(family: $family) { name } }"
       expected_names = ["Piano", "Organ"]
-      result = Jazz::Schema.execute(query_str, variables: { "family" => "KEYS" })
+      result = Jazz::Schema.execute(query_str, variables: { family: "KEYS" })
       assert_equal expected_names, result["data"]["instruments"].map { |i| i["name"] }
     end
   end

--- a/spec/graphql/schema/object_spec.rb
+++ b/spec/graphql/schema/object_spec.rb
@@ -127,10 +127,10 @@ describe GraphQL::Schema::Object do
       }
       GRAPHQL
 
-      res = Jazz::Schema.execute(mutation_str, variables: { "name" => "Miles Davis Quartet" })
+      res = Jazz::Schema.execute(mutation_str, variables: { name: "Miles Davis Quartet" })
       new_id = res["data"]["addEnsemble"]["id"]
 
-      res2 = Jazz::Schema.execute(query_str, variables: { "id" => new_id })
+      res2 = Jazz::Schema.execute(query_str, variables: { id: new_id })
       assert_equal "Miles Davis Quartet", res2["data"]["find"]["name"]
     end
 


### PR DESCRIPTION
I think this will go along nicely with symbol-oriented changes in 1.8. 

When in a Rails controller, it doesn't really matter, but when hand-writing queries, I sometimes forget that before this, only strings are accepted. 
