### PR TITLE
[JS] Add Apollo link for OperationStore

### DIFF
--- a/javascript_client/package.json
+++ b/javascript_client/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "apollo-link": "^1.0.3",
     "glob": "^7.1.2",
-    "graphql": "^0.10.5"
+    "graphql": "^0.10.5",
+    "minimist": "^1.2.0"
   }
 }

--- a/javascript_client/sync/outfileGenerators/js.js
+++ b/javascript_client/sync/outfileGenerators/js.js
@@ -44,6 +44,26 @@ function generateOutfile(type, clientName, keyValuePairs) {
       },
 
       /**
+       * Satisfy the Apollo Link API.
+       * This link checks for an operation name, and if it's present,
+       * sets the HTTP context to _not_ include the query,
+       * and instead, include \`extensions.operationId\`.
+       * (This is inspired by apollo-link-persisted-queries.)
+      */
+      apolloLink: function(operation, forward) {
+        if (operation.operationName) {
+          const operationId = OperationStoreClient.getOperationId(operation.operationName)
+          operation.setContext({
+            http: {
+              includeQuery: false,
+              includeExtensions: true,
+            }
+          })
+          operation.extensions.operationId = operationId
+        }
+        return forward(operation)
+      },
+      /**
        * Satisfy the Apollo middleware API.
        * Replace the query with an operationId
       */

--- a/javascript_client/yarn.lock
+++ b/javascript_client/yarn.lock
@@ -1377,7 +1377,7 @@ minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.1:
+minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 


### PR DESCRIPTION
This adds apollo link support to graphql-pro's persisted query system 🎉  

TODO: 

- [ ] Add a test for the generated function 
- [ ] Add a test that the cli's dependencies are present (apparently `minimist` was missing?) 