### PR TITLE
Correctly check for `null` argument when `mutation` argument used

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -52,7 +52,7 @@ module GraphQL
           desc = return_type_expr
           return_type_expr = nil
         end
-        if mutation && (return_type_expr || desc || description || function || field || null || deprecation_reason || method || resolve || introspection || hash_key)
+        if mutation && (return_type_expr || desc || description || function || field || !null.nil? || deprecation_reason || method || resolve || introspection || hash_key)
           raise ArgumentError, "when keyword `mutation:` is present, all arguments are ignored, please remove them"
         end
         if !(field || function || mutation)

--- a/spec/graphql/schema/field_spec.rb
+++ b/spec/graphql/schema/field_spec.rb
@@ -164,4 +164,35 @@ describe GraphQL::Schema::Field do
       assert_includes err.message, "Thing.stuff"
     end
   end
+
+  describe "mutation" do
+    let(:mutation) do
+      Class.new(GraphQL::Schema::Mutation) do
+        graphql_name "Thing"
+
+        field :stuff, String, null: false
+      end
+    end
+    let(:error_message) { "when keyword `mutation:` is present, all arguments are ignored, please remove them" }
+
+    it "fails when including null option as true" do
+      error = assert_raises(ArgumentError) do
+        GraphQL::Schema::Field.new(:my_field, mutation: mutation, null: true)
+      end
+
+      assert_equal error.message, error_message
+    end
+
+    it "fails when including null option as false" do
+      error = assert_raises(ArgumentError) do
+        GraphQL::Schema::Field.new(:my_field, mutation: mutation, null: false)
+      end
+
+      assert_equal error.message, error_message
+    end
+
+    it "passes when not including extra arguments" do
+      assert_equal GraphQL::Schema::Field.new(:my_field, mutation: mutation).mutation, mutation
+    end
+  end
 end


### PR DESCRIPTION
When using the `mutation` argument to set a mutation field and passing in `null: false`, it should blow up with an `ArgumentError` but doesn't because it's simply checking for presence (which evaluates to `false` on `false`).

This changes the code to check for a `null` argument that is anything other than `nil` instead when deciding to blow up.