### PR TITLE
Add ability to set nullability of mutations

### DIFF
--- a/guides/mutations/mutation_classes.md
+++ b/guides/mutations/mutation_classes.md
@@ -30,6 +30,8 @@ GraphQL-Ruby includes two classes to help you write mutations:
 
 Besides those, you can also use the plain {% internal_link "field API", "/type_definitions/objects#fields" %} to write mutation fields.
 
+An additional `null` helper method is provided on classes inheriting from `GraphQL::Schema::Mutation` to allow setting the nullability of the mutation. This is required when inheriting off of `GraphQL::Schema::Mutation` - `GraphQL::Schema::RelayClassicMutation` sets `null` to `true` for you.
+
 ## Example mutation class
 
 You should add a base class to your application, for example:
@@ -43,6 +45,8 @@ Then extend it for your mutations:
 
 ```ruby
 class Mutations::CreateComment < Mutations::BaseMutation
+  null true
+
   argument :body, String, required: true
   argument :post_id, ID, required: true
 

--- a/guides/mutations/mutation_classes.md
+++ b/guides/mutations/mutation_classes.md
@@ -30,7 +30,7 @@ GraphQL-Ruby includes two classes to help you write mutations:
 
 Besides those, you can also use the plain {% internal_link "field API", "/type_definitions/objects#fields" %} to write mutation fields.
 
-An additional `null` helper method is provided on classes inheriting from `GraphQL::Schema::Mutation` to allow setting the nullability of the mutation. This is required when inheriting off of `GraphQL::Schema::Mutation` - `GraphQL::Schema::RelayClassicMutation` sets `null` to `true` for you.
+An additional `null` helper method is provided on classes inheriting from `GraphQL::Schema::Mutation` to allow setting the nullability of the mutation. This is not required and defaults to `true`.
 
 ## Example mutation class
 

--- a/lib/graphql/schema/mutation.rb
+++ b/lib/graphql/schema/mutation.rb
@@ -187,7 +187,7 @@ module GraphQL
             resolve: self.method(:resolve_field),
             mutation_class: self,
             arguments: arguments,
-            null: self.null,
+            null: null,
           )
         end
 

--- a/lib/graphql/schema/mutation.rb
+++ b/lib/graphql/schema/mutation.rb
@@ -141,6 +141,17 @@ module GraphQL
           @extras || []
         end
 
+        # Specifies whether or not the mutation is nullable
+        # @param allow_null [Boolean] Whether or not the response can be null
+        def null(allow_null = nil)
+          unless allow_null.nil?
+            @null = allow_null
+          end
+
+          raise ArgumentError, "must set `null` on mutation classes" if @null.nil?
+          @null
+        end
+
         private
 
         # Build a subclass of {.object_class} based on `self`.
@@ -173,10 +184,10 @@ module GraphQL
             field_name,
             payload_type,
             description,
-            resolve: self.method(:resolve_field),\
+            resolve: self.method(:resolve_field),
             mutation_class: self,
             arguments: arguments,
-            null: true,
+            null: self.null,
           )
         end
 

--- a/lib/graphql/schema/mutation.rb
+++ b/lib/graphql/schema/mutation.rb
@@ -83,6 +83,10 @@ module GraphQL
       end
 
       class << self
+        def inherited(base)
+          base.null(null)
+        end
+
         # Override the method from HasFields to support `field: Mutation.field`, for backwards compat.
         #
         # If called without any arguments, returns a `GraphQL::Field`.
@@ -141,15 +145,14 @@ module GraphQL
           @extras || []
         end
 
-        # Specifies whether or not the mutation is nullable
+        # Specifies whether or not the mutation is nullable. Defaults to `true`
         # @param allow_null [Boolean] Whether or not the response can be null
         def null(allow_null = nil)
           unless allow_null.nil?
             @null = allow_null
           end
 
-          raise ArgumentError, "must set `null` on mutation classes" if @null.nil?
-          @null
+          @null.nil? ? true : @null
         end
 
         private

--- a/lib/graphql/schema/relay_classic_mutation.rb
+++ b/lib/graphql/schema/relay_classic_mutation.rb
@@ -24,6 +24,10 @@ module GraphQL
       field(:client_mutation_id, String, "A unique identifier for the client performing the mutation.", null: true)
 
       class << self
+        def inherited(base)
+          base.null(true)
+        end
+
         # The base class for generated input object types
         # @param new_class [Class] The base class to use for generating input object definitions
         # @return [Class] The base class for this mutation's generated input object (default is {GraphQL::Schema::InputObject})

--- a/spec/graphql/schema/mutation_spec.rb
+++ b/spec/graphql/schema/mutation_spec.rb
@@ -96,4 +96,29 @@ describe GraphQL::Schema::Mutation do
       assert_equal 7, response["data"]["addInstrument"]["entries"].size
     end
   end
+
+  describe ".null" do
+    it "overrides whether or not the field can be null" do
+      non_nullable_mutation_class = Class.new(GraphQL::Schema::Mutation) do
+        graphql_name "Thing1"
+        null(false)
+      end
+
+      nullable_mutation_class = Class.new(GraphQL::Schema::Mutation) do
+        graphql_name "Thing2"
+        null(true)
+      end
+
+      default_mutation_class = Class.new(GraphQL::Schema::Mutation) do
+        graphql_name "Thing3"
+      end
+
+      error = assert_raises(ArgumentError) do
+        default_mutation_class.graphql_field
+      end
+      assert_equal error.message, "must set `null` on mutation classes"
+      assert nullable_mutation_class.graphql_field.instance_variable_get("@return_type_null")
+      refute non_nullable_mutation_class.graphql_field.instance_variable_get("@return_type_null")
+    end
+  end
 end

--- a/spec/graphql/schema/mutation_spec.rb
+++ b/spec/graphql/schema/mutation_spec.rb
@@ -113,12 +113,27 @@ describe GraphQL::Schema::Mutation do
         graphql_name "Thing3"
       end
 
-      error = assert_raises(ArgumentError) do
-        default_mutation_class.graphql_field
-      end
-      assert_equal error.message, "must set `null` on mutation classes"
+      assert default_mutation_class.graphql_field.instance_variable_get("@return_type_null")
       assert nullable_mutation_class.graphql_field.instance_variable_get("@return_type_null")
       refute non_nullable_mutation_class.graphql_field.instance_variable_get("@return_type_null")
+    end
+
+    it "should inherit and override in subclasses" do
+      base_mutation = Class.new(GraphQL::Schema::Mutation) do
+        null(false)
+      end
+
+      inheriting_mutation = Class.new(base_mutation) do
+        graphql_name "Thing"
+      end
+
+      override_mutation = Class.new(base_mutation) do
+        graphql_name "Thing2"
+        null(true)
+      end
+
+      assert_equal false, inheriting_mutation.graphql_field.instance_variable_get("@return_type_null")
+      assert override_mutation.graphql_field.instance_variable_get("@return_type_null")
     end
   end
 end

--- a/spec/graphql/schema/relay_classic_mutation_spec.rb
+++ b/spec/graphql/schema/relay_classic_mutation_spec.rb
@@ -25,4 +25,14 @@ describe GraphQL::Schema::RelayClassicMutation do
       assert_equal mutation, mutation.input_type.graphql_definition.mutation
     end
   end
+
+  describe ".null" do
+    it "is inherited as true" do
+      mutation = Class.new(GraphQL::Schema::RelayClassicMutation) do
+        graphql_name "Test"
+      end
+
+      assert mutation.null
+    end
+  end
 end

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -365,6 +365,7 @@ module Jazz
   end
 
   class AddInstrument < GraphQL::Schema::Mutation
+    null true
     description "Register a new musical instrument in the database"
 
     argument :name, String, required: true


### PR DESCRIPTION
When using the class-based API for mutations (inheriting off of `GraphQL::Schema::Mutation`), there is no way to set whether or not the mutation field is nullable. This change adds a `null` helper method that subclasses can use to specify whether or not they should be nullable:

```
class MyMutation < GraphQL::Schema::Mutation
  null true
end
```

This will be inherited by any subclasses:

```
class AnotherMutation < MyMutation
end

AnotherMutation.null # => true
```

If it hasn't been set, it will raise an error when you attempt to use the mutation.

`GraphQL::Schema::RelayClassicMutation` sets `null` to `true`, so no need to worry when inheriting from it:

```
class MyRelayMutation < GraphQL::Schema::RelayClassicMutation
end

MyRelayMutation.null # => true
```

Any thoughts/critiques on this from @rmosolgo or any of the other more regular maintainers more than welcome!