### PR TITLE
Revert "Remove JRuby from build"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ node_js: "7"
 env:
   global:
     - CODECLIMATE_REPO_TOKEN=f5b27b2e25d3f4e199bb2566fb4fd4507144a004c71d4aa33a32c2df5f940333
+    - JRUBY_OPTS="-Xir.reading.debug=true --debug" # Coverage may be inaccurate without debug flag
 before_install:
   - gem update --system --no-doc
   - gem install bundler
@@ -16,6 +17,7 @@ before_install:
 rvm:
 - 2.2.8 # Lowest version officially supported by the gem is 2.2
 - 2.4.3
+- jruby-9.1.16.0
 
 services:
   - postgresql
@@ -64,3 +66,13 @@ matrix:
     gemfile: gemfiles/rails_4.1.gemfile
   - rvm: 2.4.3
     gemfile: gemfiles/rails_4.2.gemfile
+  - rvm: jruby-9.1.16.0
+    gemfile: gemfiles/rails_3.2.gemfile # JRuby + latest Rails only
+  - rvm: jruby-9.1.16.0
+    gemfile: gemfiles/rails_4.0.gemfile # JRuby + latest Rails only
+  - rvm: jruby-9.1.16.0
+    gemfile: gemfiles/rails_4.1.gemfile # JRuby + latest Rails only
+  - rvm: jruby-9.1.16.0
+    gemfile: gemfiles/rails_4.2.gemfile # JRuby + latest Rails only
+  - rvm: jruby-9.1.16.0
+    gemfile: gemfiles/rails_5.0.gemfile # JRuby + latest Rails only


### PR DESCRIPTION
I removed JRuby from the build during #1372 because of this issue: https://github.com/jruby/jruby/issues/3680#issuecomment-380143537

The build passes locally, and I don't really know what to do with the debug output, so ... here we are.

I actually don't know what to do with this but I figured I'd put it here in case an JRuby wizards have insight.