### PR TITLE
Support setting the new relic transaction name

### DIFF
--- a/guides/queries/tracing.md
+++ b/guides/queries/tracing.md
@@ -87,6 +87,8 @@ To add [New Relic](https://newrelic.com/) instrumentation:
 ```ruby
 MySchema = GraphQL::Schema.define do
   use(GraphQL::Tracing::NewRelicTracing)
+  # Optional, use the operation name to set the new relic transaction name:
+  # use GraphQL::Tracing::NewRelicTracing, set_transaction_name: true
 end
 ```
 

--- a/lib/graphql/tracing/new_relic_tracing.rb
+++ b/lib/graphql/tracing/new_relic_tracing.rb
@@ -16,25 +16,29 @@ module GraphQL
 
       # @param set_transaction_name [Boolean] If true, the GraphQL operation name will be used as the transaction name.
       #   This is not advised if you run more than one query per HTTP request, for example, with `graphql-client` or multiplexing.
+      #   It can also be specified per-query with `context[:set_new_relic_transaction_name]`.
       def initialize(set_transaction_name: false)
-
-        @set_transaction_name = true
+        @set_transaction_name = set_transaction_name
+        super
       end
 
       def platform_trace(platform_key, key, data)
-        if @set_transaction_name && platform_key == "execute_query"
-          query = data[:query]
-          # Set the transaction name based on the operation type and name
-          selected_op = query.selected_operation
-          if selected_op
-            op_type = selected_op.operation_type
-            op_name = selected_op.name || "anonymous"
-          else
-            op_type = "query"
-            op_name = "anonymous"
-          end
+        if key == "execute_query"
+          set_this_txn_name =  data[:query].context[:set_new_relic_transaction_name]
+          if set_this_txn_name == true || (set_this_txn_name.nil? && @set_transaction_name)
+            query = data[:query]
+            # Set the transaction name based on the operation type and name
+            selected_op = query.selected_operation
+            if selected_op
+              op_type = selected_op.operation_type
+              op_name = selected_op.name || "anonymous"
+            else
+              op_type = "query"
+              op_name = "anonymous"
+            end
 
-          NewRelic::Agent.set_transaction_name("GraphQL/#{op_type}.#{op_name}")
+            NewRelic::Agent.set_transaction_name("GraphQL/#{op_type}.#{op_name}")
+          end
         end
 
         NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped(platform_key) do

--- a/spec/graphql/tracing/new_relic_tracing_spec.rb
+++ b/spec/graphql/tracing/new_relic_tracing_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::Tracing::NewRelicTracing do
+  module NewRelicTest
+    class Query < GraphQL::Schema::Object
+      field :int, Integer, null: false
+
+      def int
+        1
+      end
+    end
+
+    class SchemaWithoutTransactionName < GraphQL::Schema
+      query(Query)
+      use(GraphQL::Tracing::NewRelicTracing)
+    end
+
+    class SchemaWithTransactionName < GraphQL::Schema
+      query(Query)
+      use(GraphQL::Tracing::NewRelicTracing, set_transaction_name: true)
+    end
+  end
+
+  before do
+    NewRelic.clear_all
+  end
+
+  it "can leave the transaction name in place" do
+    NewRelicTest::SchemaWithoutTransactionName.execute "query X { int }"
+    assert_equal [], NewRelic::TRANSACTION_NAMES
+  end
+
+  it "can override the transaction name" do
+    NewRelicTest::SchemaWithTransactionName.execute "query X { int }"
+    assert_equal ["GraphQL/query.X"], NewRelic::TRANSACTION_NAMES
+  end
+
+  it "can override the transaction name per query" do
+    # Override with `false`
+    NewRelicTest::SchemaWithTransactionName.execute "{ int }", context: { set_new_relic_transaction_name: false }
+    assert_equal [], NewRelic::TRANSACTION_NAMES
+    # Override with `true`
+    NewRelicTest::SchemaWithoutTransactionName.execute "{ int }", context: { set_new_relic_transaction_name: true }
+    assert_equal ["GraphQL/query.anonymous"], NewRelic::TRANSACTION_NAMES
+  end
+end

--- a/spec/support/new_relic.rb
+++ b/spec/support/new_relic.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+# A stub for the NewRelic agent, so we can make assertions about how it is used
+if defined?(NewRelic)
+  raise "Expected NewRelic to be undefined, so that we could define a stub for it."
+end
+
+module NewRelic
+  TRANSACTION_NAMES = []
+  # Reset state between tests
+  def self.clear_all
+    TRANSACTION_NAMES.clear
+  end
+  module Agent
+    def self.set_transaction_name(name)
+      TRANSACTION_NAMES << name
+    end
+
+    module MethodTracerHelpers
+      def self.trace_execution_scoped(trace_name)
+        yield
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds an option to new relic tracer to set the transaction name for all queries.