### PR TITLE
Test on Rails 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ gemfile:
   - gemfiles/rails_4.2.gemfile
   - gemfiles/rails_5.0.gemfile
   - gemfiles/rails_5.1.gemfile
+  - gemfiles/rails_5.2.gemfile
 
 
 matrix:
@@ -64,3 +65,9 @@ matrix:
     gemfile: gemfiles/rails_4.1.gemfile
   - rvm: 2.4.3
     gemfile: gemfiles/rails_4.2.gemfile
+  - rvm: 2.2.8
+    gemfile: gemfiles/rails_5.0.gemfile
+  - rvm: 2.2.8
+    gemfile: gemfiles/rails_5.1.gemfile
+  - rvm: 2.2.8
+    gemfile: gemfiles/rails_5.2.gemfile

--- a/Appraisals
+++ b/Appraisals
@@ -35,6 +35,10 @@ appraise 'rails_5.1' do
   gem 'selenium-webdriver'
 end
 
+appraise "rails_5.2" do
+  gem 'rails', '~> 5.2.0'
+end
+
 appraise 'without_rails' do
   gem "globalid"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem 'rails'
+gem 'bootsnap' # required by the Rails apps generated in tests
 gem 'ruby-prof', platform: :ruby
 gem 'sqlite3', platform: :ruby
 gem 'pg', "< 1.0", platform: :ruby

--- a/gemfiles/rails_3.2.gemfile
+++ b/gemfiles/rails_3.2.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "3.2.22.5"
+gem "bootsnap"
 gem "ruby-prof", :platform => :ruby
 gem "sqlite3", :platform => :ruby
 gem "pg", "< 1.0", :platform => :ruby

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.1"
+gem "bootsnap"
 gem "ruby-prof", :platform => :ruby
 gem "sqlite3", :platform => :ruby
 gem "pg", "< 1.0", :platform => :ruby

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.2"
+gem "bootsnap"
 gem "ruby-prof", :platform => :ruby
 gem "sqlite3", :platform => :ruby
 gem "pg", "< 1.0", :platform => :ruby

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.1.0"
+gem "bootsnap"
 gem "ruby-prof", :platform => :ruby
 gem "sqlite3", :platform => :ruby
 gem "pg", "< 1.0", :platform => :ruby

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 5.0"
+gem "rails", "~> 5.2.0"
 gem "bootsnap"
 gem "ruby-prof", :platform => :ruby
 gem "sqlite3", :platform => :ruby
@@ -10,8 +10,6 @@ gem "pg", "< 1.0", :platform => :ruby
 gem "pry"
 gem "pry-stack_explorer", :platform => :ruby
 gem "activerecord-jdbcsqlite3-adapter", :platform => :jruby
-gem "activerecord", "~> 5.0.0"
-gem "actionpack", "~> 5.0.0"
 
 group :jekyll_plugins do
   gem "algoliasearch-jekyll"

--- a/lib/generators/graphql/install_generator.rb
+++ b/lib/generators/graphql/install_generator.rb
@@ -81,13 +81,6 @@ module Graphql
         type: :boolean,
         desc: "Preconfigure smaller stack for API only apps"
 
-
-      GRAPHIQL_ROUTE = <<-RUBY
-if Rails.env.development?
-    mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "/graphql"
-  end
-RUBY
-
       def create_folder_structure
         create_dir("#{options[:directory]}/types")
         template("schema.erb", schema_file_path)
@@ -115,7 +108,20 @@ RUBY
           # This is a little cheat just to get cleaner shell output:
           log :route, 'graphiql-rails'
           shell.mute do
-            route(GRAPHIQL_ROUTE)
+            # Rails 5.2 has better support for `route`?
+            if Rails::VERSION::STRING > "5"
+              route <<-RUBY
+if Rails.env.development?
+  mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "/graphql"
+end
+RUBY
+            else
+              route <<-RUBY
+if Rails.env.development?
+    mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "/graphql"
+  end
+RUBY
+            end
           end
         end
 

--- a/lib/generators/graphql/install_generator.rb
+++ b/lib/generators/graphql/install_generator.rb
@@ -109,7 +109,7 @@ module Graphql
           log :route, 'graphiql-rails'
           shell.mute do
             # Rails 5.2 has better support for `route`?
-            if Rails::VERSION::STRING > "5"
+            if Rails::VERSION::STRING > "5.2"
               route <<-RUBY
 if Rails.env.development?
   mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "/graphql"


### PR DESCRIPTION
The generated Rails apps now require bootsnap, and [AFAICT](https://blog.bigbinary.com/2018/01/01/rails-5-2-adds-bootsnap-to-the-app-to-speed-up-boot-time.html) there's no option to build without it, so we may as well just add it here.

Fixes #1425 