### PR TITLE
Stop using patched delegate

### DIFF
--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -3,33 +3,10 @@ require "delegate"
 require "json"
 require "set"
 require "singleton"
+require "forwardable"
 require_relative "./graphql/railtie" if defined? Rails::Railtie
 
 module GraphQL
-  if RUBY_VERSION == "2.4.0"
-    # Ruby stdlib was pretty busted until this fix:
-    # https://bugs.ruby-lang.org/issues/13111
-    # https://github.com/ruby/ruby/commit/46c0e79bb5b96c45c166ef62f8e585f528862abb#diff-43adf0e587a50dbaf51764a262008d40
-    module Delegate
-      def def_delegators(accessor, *method_names)
-        method_names.each do |method_name|
-          class_eval <<-RUBY
-          def #{method_name}(*args)
-            if block_given?
-              #{accessor}.#{method_name}(*args, &Proc.new)
-            else
-              #{accessor}.#{method_name}(*args)
-            end
-          end
-          RUBY
-        end
-      end
-    end
-  else
-    require "forwardable"
-    Delegate = Forwardable
-  end
-
   class Error < StandardError
   end
 

--- a/lib/graphql/backtrace.rb
+++ b/lib/graphql/backtrace.rb
@@ -19,7 +19,7 @@ module GraphQL
   #
   class Backtrace
     include Enumerable
-    extend GraphQL::Delegate
+    extend Forwardable
 
     def_delegators :to_a, :each, :[]
 

--- a/lib/graphql/execution/lazy/lazy_method_map.rb
+++ b/lib/graphql/execution/lazy/lazy_method_map.rb
@@ -51,7 +51,7 @@ module GraphQL
 
         # Mock the Concurrent::Map API
         class ConcurrentishMap
-          extend GraphQL::Delegate
+          extend Forwardable
           # Technically this should be under the mutex too,
           # but I know it's only used when the lock is already acquired.
           def_delegators :@storage, :each_pair, :size

--- a/lib/graphql/non_null_type.rb
+++ b/lib/graphql/non_null_type.rb
@@ -33,7 +33,7 @@ module GraphQL
   #
   class NonNullType < GraphQL::BaseType
     include GraphQL::BaseType::ModifiesAnotherType
-    extend GraphQL::Delegate
+    extend Forwardable
 
     attr_reader :of_type
     def initialize(of_type:)

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -16,7 +16,7 @@ module GraphQL
   # A combination of query string and {Schema} instance which can be reduced to a {#result}.
   class Query
     include Tracing::Traceable
-    extend GraphQL::Delegate
+    extend Forwardable
 
     class OperationNameMissingError < GraphQL::ExecutionError
       def initialize(name)

--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -5,7 +5,7 @@ module GraphQL
     #
     # {Arguments} recursively wraps the input in {Arguments} instances.
     class Arguments
-      extend GraphQL::Delegate
+      extend Forwardable
 
       def self.construct_arguments_class(argument_owner)
         argument_definitions = argument_owner.arguments

--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -99,7 +99,7 @@ module GraphQL
       end
 
       include SharedMethods
-      extend GraphQL::Delegate
+      extend Forwardable
 
       attr_reader :execution_strategy
       # `strategy` is required by GraphQL::Batch
@@ -189,7 +189,7 @@ module GraphQL
       class FieldResolutionContext
         include SharedMethods
         include Tracing::Traceable
-        extend GraphQL::Delegate
+        extend Forwardable
 
         attr_reader :irep_node, :field, :parent_type, :query, :schema, :parent, :key, :type
         alias :selection :irep_node

--- a/lib/graphql/query/null_context.rb
+++ b/lib/graphql/query/null_context.rb
@@ -22,7 +22,7 @@ module GraphQL
       end
 
       class << self
-        extend GraphQL::Delegate
+        extend Forwardable
 
         def instance
           @instance = self.new

--- a/lib/graphql/query/result.rb
+++ b/lib/graphql/query/result.rb
@@ -6,7 +6,7 @@ module GraphQL
     # It provides the requested data and
     # access to the {Query} and {Query::Context}.
     class Result
-      extend GraphQL::Delegate
+      extend Forwardable
 
       def initialize(query:, values:)
         @query = query

--- a/lib/graphql/query/variables.rb
+++ b/lib/graphql/query/variables.rb
@@ -3,7 +3,7 @@ module GraphQL
   class Query
     # Read-only access to query variables, applying default values if needed.
     class Variables
-      extend GraphQL::Delegate
+      extend Forwardable
 
       # @return [Array<GraphQL::Query::VariableValidationError>]  Any errors encountered when parsing the provided variables and literal values
       attr_reader :errors

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -634,7 +634,7 @@ module GraphQL
     end
 
     class << self
-      extend GraphQL::Delegate
+      extend Forwardable
       # For compatibility, these methods all:
       # - Cause the Schema instance to be created, if it hasn't been created yet
       # - Delegate to that instance

--- a/lib/graphql/schema/enum.rb
+++ b/lib/graphql/schema/enum.rb
@@ -23,7 +23,7 @@ module GraphQL
       extend GraphQL::Schema::Member::AcceptsDefinition
 
       class << self
-        extend GraphQL::Delegate
+        extend Forwardable
         def_delegators :graphql_definition, :coerce_isolated_input, :coerce_isolated_result
 
         # Define a value for this enum

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -3,7 +3,7 @@ module GraphQL
   class Schema
     class InputObject < GraphQL::Schema::Member
       extend GraphQL::Schema::Member::AcceptsDefinition
-      extend GraphQL::Delegate
+      extend Forwardable
       extend GraphQL::Schema::Member::HasArguments
 
       def initialize(values, context:, defaults_used:)

--- a/lib/graphql/schema/middleware_chain.rb
+++ b/lib/graphql/schema/middleware_chain.rb
@@ -5,7 +5,7 @@ module GraphQL
     #
     # Steps should call `next_step.call` to continue the chain, or _not_ call it to stop the chain.
     class MiddlewareChain
-      extend GraphQL::Delegate
+      extend Forwardable
 
       # @return [Array<#call(*args)>] Steps in this chain, will be called with arguments and `next_middleware`
       attr_reader :steps, :final_step

--- a/lib/graphql/schema/scalar.rb
+++ b/lib/graphql/schema/scalar.rb
@@ -5,7 +5,7 @@ module GraphQL
       extend GraphQL::Schema::Member::AcceptsDefinition
 
       class << self
-        extend GraphQL::Delegate
+        extend Forwardable
         def_delegators :graphql_definition, :coerce_isolated_input, :coerce_isolated_result
 
         def coerce_input(val, ctx)

--- a/lib/graphql/static_validation/definition_dependencies.rb
+++ b/lib/graphql/static_validation/definition_dependencies.rb
@@ -103,7 +103,7 @@ module GraphQL
       end
 
       class NodeWithPath
-        extend GraphQL::Delegate
+        extend Forwardable
         attr_reader :node, :path
         def initialize(node, path)
           @node = node

--- a/lib/graphql/static_validation/validation_context.rb
+++ b/lib/graphql/static_validation/validation_context.rb
@@ -12,7 +12,7 @@ module GraphQL
     # It also provides limited access to the {TypeStack} instance,
     # which tracks state as you climb in and out of different fields.
     class ValidationContext
-      extend GraphQL::Delegate
+      extend Forwardable
 
       attr_reader :query, :schema,
         :document, :errors, :visitor,


### PR DESCRIPTION
This patch was required for 2.4.0, I'm going to remove it and include a recommendation to use another version.

Also, fixes #1438 because the patch was busted 😩 