### PR TITLE
Update object_identification.md

### DIFF
--- a/guides/relay/object_identification.md
+++ b/guides/relay/object_identification.md
@@ -26,7 +26,7 @@ MySchema = GraphQL::Schema.define do
 
   object_from_id ->(id, query_ctx) {
     class_name, item_id = MyApp::GlobalId.decrypt(id)
-    # "Post" => Post.find(id)
+    # "Post" => Post.find(item_id)
     Object.const_get(class_name).find(item_id)
   }
 end


### PR DESCRIPTION
- Use `item_id` instead of `id` when decrypting object from ID.