### PR TITLE
Fix Warnings for Multiple Interface Inheritance

### DIFF
--- a/spec/graphql/schema/interface_spec.rb
+++ b/spec/graphql/schema/interface_spec.rb
@@ -157,4 +157,29 @@ describe GraphQL::Schema::Interface do
       assert_equal(expected_data, res["data"]["find"])
     end
   end
+
+  describe ':DefinitionMethods' do
+    module InterfaceA
+      include GraphQL::Schema::Interface
+    end
+
+    module InterfaceB
+      include GraphQL::Schema::Interface
+    end
+
+    module InterfaceC
+      include GraphQL::Schema::Interface
+    end
+
+    it "doesn't overwrite them when including multiple interfaces" do
+      def_methods = InterfaceC::DefinitionMethods
+      
+      InterfaceC.module_eval do
+        include InterfaceA
+        include InterfaceB
+      end
+
+      assert_equal(InterfaceC::DefinitionMethods, def_methods)
+    end
+  end
 end

--- a/spec/graphql/schema/interface_spec.rb
+++ b/spec/graphql/schema/interface_spec.rb
@@ -173,7 +173,7 @@ describe GraphQL::Schema::Interface do
 
     it "doesn't overwrite them when including multiple interfaces" do
       def_methods = InterfaceC::DefinitionMethods
-      
+
       InterfaceC.module_eval do
         include InterfaceA
         include InterfaceB


### PR DESCRIPTION
If you have an interface that includes multiple other interfaces:
```ruby
module MyInterface
  include GraphQL::Schema::Interface
  include SomeInterface
  include SomeOtherInterface
end
```

You get error messages about the `DefinitionMethods` constant being overridden. 😬