### PR TITLE
Fix class based subscriptions

### DIFF
--- a/lib/graphql/subscriptions/instrumentation.rb
+++ b/lib/graphql/subscriptions/instrumentation.rb
@@ -56,7 +56,11 @@ module GraphQL
             ctx.skip
           elsif ctx.irep_node.subscription_topic == ctx.query.subscription_topic
             # The root object is _already_ the subscription update:
-            obj
+            if obj.respond_to?(:object)
+              obj.object
+            else
+              obj
+            end
           else
             # This is a subscription update, but this event wasn't triggered.
             ctx.skip

--- a/lib/graphql/subscriptions/instrumentation.rb
+++ b/lib/graphql/subscriptions/instrumentation.rb
@@ -56,7 +56,7 @@ module GraphQL
             ctx.skip
           elsif ctx.irep_node.subscription_topic == ctx.query.subscription_topic
             # The root object is _already_ the subscription update:
-            if obj.respond_to?(:object)
+            if obj.is_a?(GraphQL::Schema::Object)
               obj.object
             else
               obj

--- a/lib/graphql/subscriptions/serialize.rb
+++ b/lib/graphql/subscriptions/serialize.rb
@@ -33,8 +33,8 @@ module GraphQL
         case
         when obj.is_a?(Array)
           obj.map { |i| dump_recursive(i) }.join(':')
-        when obj.is_a?(Hash)
-          obj.map { |k, v| "#{dump_recursive(k)}:#{dump_recursive(v)}" }.join(":")
+        when obj.respond_to?(:to_h)
+          obj.to_h.map { |k, v| "#{dump_recursive(k)}:#{dump_recursive(v)}" }.join(":")
         when obj.respond_to?(:to_gid_param)
           obj.to_gid_param
         when obj.respond_to?(:to_param)

--- a/lib/graphql/subscriptions/serialize.rb
+++ b/lib/graphql/subscriptions/serialize.rb
@@ -33,8 +33,10 @@ module GraphQL
         case
         when obj.is_a?(Array)
           obj.map { |i| dump_recursive(i) }.join(':')
-        when obj.respond_to?(:to_h)
-          obj.to_h.map { |k, v| "#{dump_recursive(k)}:#{dump_recursive(v)}" }.join(":")
+        when obj.is_a?(Hash)
+          obj.map { |k, v| "#{dump_recursive(k)}:#{dump_recursive(v)}" }.join(":")
+        when obj.is_a?(GraphQL::Schema::InputObject)
+          dump_recursive(obj.to_h)
         when obj.respond_to?(:to_gid_param)
           obj.to_gid_param
         when obj.respond_to?(:to_param)

--- a/spec/graphql/subscriptions_spec.rb
+++ b/spec/graphql/subscriptions_spec.rb
@@ -75,7 +75,7 @@ class InMemoryBackend
     end
   end
   # Just a random stateful object for tracking what happens:
-  class Payload
+  class SubscriptionPayload
     attr_reader :str
 
     def initialize
@@ -87,7 +87,69 @@ class InMemoryBackend
       @counter += 1
     end
   end
+end
 
+class ClassBasedInMemoryBackend < InMemoryBackend
+  class Payload < GraphQL::Schema::Object
+    field :str, String, null: false
+    field :int, Integer, null: false
+  end
+
+  class PayloadType < GraphQL::Schema::Enum
+    graphql_name "PayloadType"
+    # Arbitrary "kinds" of payloads which may be
+    # subscribed to separately
+    value "ONE"
+    value "TWO"
+  end
+
+  class StreamInput < GraphQL::Schema::InputObject
+    argument :user_id, ID, required: true
+    argument :type, PayloadType, required: false, default_value: "ONE"
+  end
+
+  class Subscription < GraphQL::Schema::Object
+    field :payload, Payload, null: false do
+      argument :id, ID, required: true
+    end
+
+    def payload(id:)
+      object
+    end
+
+    field :event, Payload, null: true do
+      argument :stream, StreamInput, required: false
+    end
+
+    def event(stream: nil)
+      object
+    end
+
+    field :my_event, Payload, null: true do
+      argument :type, PayloadType, required: false
+    end
+
+    def my_event(type: nil)
+      object
+    end
+  end
+
+  class Query < GraphQL::Schema::Object
+    field :dummy, Integer, null: true
+  end
+
+  class Schema < GraphQL::Schema
+    query(Query)
+    subscription(Subscription)
+    use InMemoryBackend::Subscriptions, extra: 123
+  end
+
+
+  # TODO don't hack this (no way to add metadata from IDL parser right now)
+  Schema.get_field("Subscription", "myEvent").subscription_scope = :me
+end
+
+class FromDefinitionInMemoryBackend < InMemoryBackend
   SchemaDefinition = <<-GRAPHQL
   type Subscription {
     payload(id: ID!): Payload!
@@ -126,7 +188,7 @@ class InMemoryBackend
   }
   Schema = GraphQL::Schema.from_definition(SchemaDefinition, default_resolve: Resolvers).redefine do
     use InMemoryBackend::Subscriptions,
-      extra: 123
+        extra: 123
   end
 
   # TODO don't hack this (no way to add metadata from IDL parser right now)
@@ -162,260 +224,264 @@ describe GraphQL::Subscriptions do
     schema.subscriptions.reset
   end
 
-  let(:root_object) {
-    OpenStruct.new(
-      payload: InMemoryBackend::Payload.new,
-    )
-  }
+  [ClassBasedInMemoryBackend, FromDefinitionInMemoryBackend].each do |in_memory_backend_class|
+    describe "using #{in_memory_backend_class}" do
+      let(:root_object) {
+        OpenStruct.new(
+          payload: in_memory_backend_class::SubscriptionPayload.new,
+          )
+      }
 
-  let(:schema) { InMemoryBackend::Schema }
-  let(:implementation) { schema.subscriptions }
-  let(:deliveries) { implementation.deliveries }
-  describe "pushing updates" do
-    it "sends updated data" do
-      query_str = <<-GRAPHQL
+      let(:schema) { in_memory_backend_class::Schema }
+      let(:implementation) { schema.subscriptions }
+      let(:deliveries) { implementation.deliveries }
+      describe "pushing updates" do
+        it "sends updated data" do
+          query_str = <<-GRAPHQL
         subscription ($id: ID!){
           firstPayload: payload(id: $id) { str, int }
           otherPayload: payload(id: "900") { int }
         }
-      GRAPHQL
+          GRAPHQL
 
-      # Initial subscriptions
-      res_1 = schema.execute(query_str, context: { socket: "1" }, variables: { "id" => "100" }, root_value: root_object)
-      res_2 = schema.execute(query_str, context: { socket: "2" }, variables: { "id" => "200" }, root_value: root_object)
+          # Initial subscriptions
+          res_1 = schema.execute(query_str, context: { socket: "1" }, variables: { "id" => "100" }, root_value: root_object)
+          res_2 = schema.execute(query_str, context: { socket: "2" }, variables: { "id" => "200" }, root_value: root_object)
 
-      # Initial response is nil, no broadcasts yet
-      assert_equal(nil, res_1["data"])
-      assert_equal(nil, res_2["data"])
-      assert_equal [], deliveries["1"]
-      assert_equal [], deliveries["2"]
+          # Initial response is nil, no broadcasts yet
+          assert_equal(nil, res_1["data"])
+          assert_equal(nil, res_2["data"])
+          assert_equal [], deliveries["1"]
+          assert_equal [], deliveries["2"]
 
-      # Application stuff happens.
-      # The application signals graphql via `subscriptions.trigger`:
-      schema.subscriptions.trigger(:payload, {"id" => "100"}, root_object.payload)
-      schema.subscriptions.trigger("payload", {"id" => "200"}, root_object.payload)
-      # Symobls are OK too
-      schema.subscriptions.trigger(:payload, {:id => "100"}, root_object.payload)
-      schema.subscriptions.trigger("payload", {"id" => "300"}, nil)
+          # Application stuff happens.
+          # The application signals graphql via `subscriptions.trigger`:
+          schema.subscriptions.trigger(:payload, {"id" => "100"}, root_object.payload)
+          schema.subscriptions.trigger("payload", {"id" => "200"}, root_object.payload)
+          # Symobls are OK too
+          schema.subscriptions.trigger(:payload, {:id => "100"}, root_object.payload)
+          schema.subscriptions.trigger("payload", {"id" => "300"}, nil)
 
-      # Let's see what GraphQL sent over the wire:
-      assert_equal({"str" => "Update", "int" => 1}, deliveries["1"][0]["data"]["firstPayload"])
-      assert_equal({"str" => "Update", "int" => 2}, deliveries["2"][0]["data"]["firstPayload"])
-      assert_equal({"str" => "Update", "int" => 3}, deliveries["1"][1]["data"]["firstPayload"])
-    end
-  end
+          # Let's see what GraphQL sent over the wire:
+          assert_equal({"str" => "Update", "int" => 1}, deliveries["1"][0]["data"]["firstPayload"])
+          assert_equal({"str" => "Update", "int" => 2}, deliveries["2"][0]["data"]["firstPayload"])
+          assert_equal({"str" => "Update", "int" => 3}, deliveries["1"][1]["data"]["firstPayload"])
+        end
+      end
 
-  describe "subscribing" do
-    it "doesn't call the subscriptions for invalid queries" do
-      query_str = <<-GRAPHQL
+      describe "subscribing" do
+        it "doesn't call the subscriptions for invalid queries" do
+          query_str = <<-GRAPHQL
         subscription ($id: ID){
           payload(id: $id) { str, int }
         }
-      GRAPHQL
+          GRAPHQL
 
-      res = schema.execute(query_str, context: { socket: "1" }, variables: { "id" => "100" }, root_value: root_object)
-      assert_equal true, res.key?("errors")
-      assert_equal 0, implementation.size
-    end
-  end
+          res = schema.execute(query_str, context: { socket: "1" }, variables: { "id" => "100" }, root_value: root_object)
+          assert_equal true, res.key?("errors")
+          assert_equal 0, implementation.size
+        end
+      end
 
-  describe "trigger" do
-    it "uses the provided queue" do
-      query_str = <<-GRAPHQL
+      describe "trigger" do
+        it "uses the provided queue" do
+          query_str = <<-GRAPHQL
         subscription ($id: ID!){
           payload(id: $id) { str, int }
         }
-      GRAPHQL
+          GRAPHQL
 
-      schema.execute(query_str, context: { socket: "1" }, variables: { "id" => "8" }, root_value: root_object)
-      schema.subscriptions.trigger("payload", { "id" => "8"}, root_object.payload)
-      assert_equal ["1"], implementation.pushes
-    end
+          schema.execute(query_str, context: { socket: "1" }, variables: { "id" => "8" }, root_value: root_object)
+          schema.subscriptions.trigger("payload", { "id" => "8"}, root_object.payload)
+          assert_equal ["1"], implementation.pushes
+        end
 
-    it "pushes errors" do
-      query_str = <<-GRAPHQL
+        it "pushes errors" do
+          query_str = <<-GRAPHQL
         subscription ($id: ID!){
           payload(id: $id) { str, int }
         }
-      GRAPHQL
+          GRAPHQL
 
-      schema.execute(query_str, context: { socket: "1" }, variables: { "id" => "8" }, root_value: root_object)
-      schema.subscriptions.trigger("payload", { "id" => "8"}, OpenStruct.new(str: nil, int: nil))
-      delivery = deliveries["1"].first
-      assert_nil delivery.fetch("data")
-      assert_equal 1, delivery["errors"].length
-    end
+          schema.execute(query_str, context: { socket: "1" }, variables: { "id" => "8" }, root_value: root_object)
+          schema.subscriptions.trigger("payload", { "id" => "8"}, OpenStruct.new(str: nil, int: nil))
+          delivery = deliveries["1"].first
+          assert_nil delivery.fetch("data")
+          assert_equal 1, delivery["errors"].length
+        end
 
-    it "coerces args" do
-      query_str = <<-GRAPHQL
+        it "coerces args" do
+          query_str = <<-GRAPHQL
         subscription($type: PayloadType) {
           e1: event(stream: { userId: "3", type: $type }) { int }
         }
-      GRAPHQL
+          GRAPHQL
 
-      # Subscribe with explicit `TYPE`
-      schema.execute(query_str, context: { socket: "1" }, variables: { "type" => "ONE" }, root_value: root_object)
-      # Subscribe with default `TYPE`
-      schema.execute(query_str, context: { socket: "2" }, root_value: root_object)
-      # Subscribe with non-matching `TYPE`
-      schema.execute(query_str, context: { socket: "3" }, variables: { "type" => "TWO" }, root_value: root_object)
-      # Subscribe with explicit null
-      schema.execute(query_str, context: { socket: "4" }, variables: { "type" => nil }, root_value: root_object)
+          # Subscribe with explicit `TYPE`
+          schema.execute(query_str, context: { socket: "1" }, variables: { "type" => "ONE" }, root_value: root_object)
+          # Subscribe with default `TYPE`
+          schema.execute(query_str, context: { socket: "2" }, root_value: root_object)
+          # Subscribe with non-matching `TYPE`
+          schema.execute(query_str, context: { socket: "3" }, variables: { "type" => "TWO" }, root_value: root_object)
+          # Subscribe with explicit null
+          schema.execute(query_str, context: { socket: "4" }, variables: { "type" => nil }, root_value: root_object)
 
-      # Trigger the subscription with coerceable args, different orders:
-      schema.subscriptions.trigger("event", { "stream" => {"userId" => 3, "type" => "ONE"} }, OpenStruct.new(str: "", int: 1))
-      schema.subscriptions.trigger("event", { "stream" => {"type" => "ONE", "userId" => "3"} }, OpenStruct.new(str: "", int: 2))
-      # This is a non-trigger
-      schema.subscriptions.trigger("event", { "stream" => {"userId" => "3", "type" => "TWO"} }, OpenStruct.new(str: "", int: 3))
-      # These get default value of ONE (underscored / symbols are ok)
-      schema.subscriptions.trigger("event", { stream: { user_id: "3"} }, OpenStruct.new(str: "", int: 4))
-      # Trigger with null updates subscriptionss to null
-      schema.subscriptions.trigger("event", { "stream" => {"userId" => 3, "type" => nil} }, OpenStruct.new(str: "", int: 5))
+          # Trigger the subscription with coerceable args, different orders:
+          schema.subscriptions.trigger("event", { "stream" => {"userId" => 3, "type" => "ONE"} }, OpenStruct.new(str: "", int: 1))
+          schema.subscriptions.trigger("event", { "stream" => {"type" => "ONE", "userId" => "3"} }, OpenStruct.new(str: "", int: 2))
+          # This is a non-trigger
+          schema.subscriptions.trigger("event", { "stream" => {"userId" => "3", "type" => "TWO"} }, OpenStruct.new(str: "", int: 3))
+          # These get default value of ONE (underscored / symbols are ok)
+          schema.subscriptions.trigger("event", { stream: { user_id: "3"} }, OpenStruct.new(str: "", int: 4))
+          # Trigger with null updates subscriptionss to null
+          schema.subscriptions.trigger("event", { "stream" => {"userId" => 3, "type" => nil} }, OpenStruct.new(str: "", int: 5))
 
-      assert_equal [1,2,4], deliveries["1"].map { |d| d["data"]["e1"]["int"] }
+          assert_equal [1,2,4], deliveries["1"].map { |d| d["data"]["e1"]["int"] }
 
-      # Same as socket_1
-      assert_equal [1,2,4], deliveries["2"].map { |d| d["data"]["e1"]["int"] }
+          # Same as socket_1
+          assert_equal [1,2,4], deliveries["2"].map { |d| d["data"]["e1"]["int"] }
 
-      # Received the "non-trigger"
-      assert_equal [3], deliveries["3"].map { |d| d["data"]["e1"]["int"] }
+          # Received the "non-trigger"
+          assert_equal [3], deliveries["3"].map { |d| d["data"]["e1"]["int"] }
 
-      # Received the trigger with null
-      assert_equal [5], deliveries["4"].map { |d| d["data"]["e1"]["int"] }
-    end
+          # Received the trigger with null
+          assert_equal [5], deliveries["4"].map { |d| d["data"]["e1"]["int"] }
+        end
 
-    it "allows context-scoped subscriptions" do
-      query_str = <<-GRAPHQL
+        it "allows context-scoped subscriptions" do
+          query_str = <<-GRAPHQL
         subscription($type: PayloadType) {
           myEvent(type: $type) { int }
         }
-      GRAPHQL
+          GRAPHQL
 
-      # Subscriptions for user 1
-      schema.execute(query_str, context: { socket: "1", me: "1" }, variables: { "type" => "ONE" }, root_value: root_object)
-      schema.execute(query_str, context: { socket: "2", me: "1" }, variables: { "type" => "TWO" }, root_value: root_object)
-      # Subscription for user 2
-      schema.execute(query_str, context: { socket: "3", me: "2" }, variables: { "type" => "ONE" }, root_value: root_object)
+          # Subscriptions for user 1
+          schema.execute(query_str, context: { socket: "1", me: "1" }, variables: { "type" => "ONE" }, root_value: root_object)
+          schema.execute(query_str, context: { socket: "2", me: "1" }, variables: { "type" => "TWO" }, root_value: root_object)
+          # Subscription for user 2
+          schema.execute(query_str, context: { socket: "3", me: "2" }, variables: { "type" => "ONE" }, root_value: root_object)
 
-      schema.subscriptions.trigger("myEvent", { "type" => "ONE" }, OpenStruct.new(str: "", int: 1), scope: "1")
-      schema.subscriptions.trigger("myEvent", { "type" => "TWO" }, OpenStruct.new(str: "", int: 2), scope: "1")
-      schema.subscriptions.trigger("myEvent", { "type" => "ONE" }, OpenStruct.new(str: "", int: 3), scope: "2")
+          schema.subscriptions.trigger("myEvent", { "type" => "ONE" }, OpenStruct.new(str: "", int: 1), scope: "1")
+          schema.subscriptions.trigger("myEvent", { "type" => "TWO" }, OpenStruct.new(str: "", int: 2), scope: "1")
+          schema.subscriptions.trigger("myEvent", { "type" => "ONE" }, OpenStruct.new(str: "", int: 3), scope: "2")
 
-      # Delivered to user 1
-      assert_equal [1], deliveries["1"].map { |d| d["data"]["myEvent"]["int"] }
-      assert_equal [2], deliveries["2"].map { |d| d["data"]["myEvent"]["int"] }
-      # Delivered to user 2
-      assert_equal [3], deliveries["3"].map { |d| d["data"]["myEvent"]["int"] }
-    end
+          # Delivered to user 1
+          assert_equal [1], deliveries["1"].map { |d| d["data"]["myEvent"]["int"] }
+          assert_equal [2], deliveries["2"].map { |d| d["data"]["myEvent"]["int"] }
+          # Delivered to user 2
+          assert_equal [3], deliveries["3"].map { |d| d["data"]["myEvent"]["int"] }
+        end
 
-    if defined?(GlobalID)
-      it "allows complex object subscription scopes" do
-        query_str = <<-GRAPHQL
+        if defined?(GlobalID)
+          it "allows complex object subscription scopes" do
+            query_str = <<-GRAPHQL
           subscription($type: PayloadType) {
             myEvent(type: $type) { int }
           }
-        GRAPHQL
+            GRAPHQL
 
-        # Global ID Backed User
-        schema.execute(query_str, context: { socket: "1", me: GlobalIDUser.new(1) }, variables: { "type" => "ONE" }, root_value: root_object)
-        schema.execute(query_str, context: { socket: "2", me: GlobalIDUser.new(1) }, variables: { "type" => "TWO" }, root_value: root_object)
-        # ToParam Backed User
-        schema.execute(query_str, context: { socket: "3", me: ToParamUser.new(2) }, variables: { "type" => "ONE" }, root_value: root_object)
-        # Array of Objects
-        schema.execute(query_str, context: { socket: "4", me: [GlobalIDUser.new(4), ToParamUser.new(5)] }, variables: { "type" => "ONE" }, root_value: root_object)
+            # Global ID Backed User
+            schema.execute(query_str, context: { socket: "1", me: GlobalIDUser.new(1) }, variables: { "type" => "ONE" }, root_value: root_object)
+            schema.execute(query_str, context: { socket: "2", me: GlobalIDUser.new(1) }, variables: { "type" => "TWO" }, root_value: root_object)
+            # ToParam Backed User
+            schema.execute(query_str, context: { socket: "3", me: ToParamUser.new(2) }, variables: { "type" => "ONE" }, root_value: root_object)
+            # Array of Objects
+            schema.execute(query_str, context: { socket: "4", me: [GlobalIDUser.new(4), ToParamUser.new(5)] }, variables: { "type" => "ONE" }, root_value: root_object)
 
-        schema.subscriptions.trigger("myEvent", { "type" => "ONE" }, OpenStruct.new(str: "", int: 1), scope: GlobalIDUser.new(1))
-        schema.subscriptions.trigger("myEvent", { "type" => "TWO" }, OpenStruct.new(str: "", int: 2), scope: GlobalIDUser.new(1))
-        schema.subscriptions.trigger("myEvent", { "type" => "ONE" }, OpenStruct.new(str: "", int: 3), scope: ToParamUser.new(2))
-        schema.subscriptions.trigger("myEvent", { "type" => "ONE" }, OpenStruct.new(str: "", int: 4), scope: [GlobalIDUser.new(4), ToParamUser.new(5)])
+            schema.subscriptions.trigger("myEvent", { "type" => "ONE" }, OpenStruct.new(str: "", int: 1), scope: GlobalIDUser.new(1))
+            schema.subscriptions.trigger("myEvent", { "type" => "TWO" }, OpenStruct.new(str: "", int: 2), scope: GlobalIDUser.new(1))
+            schema.subscriptions.trigger("myEvent", { "type" => "ONE" }, OpenStruct.new(str: "", int: 3), scope: ToParamUser.new(2))
+            schema.subscriptions.trigger("myEvent", { "type" => "ONE" }, OpenStruct.new(str: "", int: 4), scope: [GlobalIDUser.new(4), ToParamUser.new(5)])
 
-        # Delivered to GlobalIDUser
-        assert_equal [1], deliveries["1"].map { |d| d["data"]["myEvent"]["int"] }
-        assert_equal [2], deliveries["2"].map { |d| d["data"]["myEvent"]["int"] }
-        # Delivered to ToParamUser
-        assert_equal [3], deliveries["3"].map { |d| d["data"]["myEvent"]["int"] }
-        # Delivered to Array of GlobalIDUser and ToParamUser
-        assert_equal [4], deliveries["4"].map { |d| d["data"]["myEvent"]["int"] }
-      end
-    end
-
-    describe "errors" do
-      class ErrorPayload
-        def int
-          raise "Boom!"
+            # Delivered to GlobalIDUser
+            assert_equal [1], deliveries["1"].map { |d| d["data"]["myEvent"]["int"] }
+            assert_equal [2], deliveries["2"].map { |d| d["data"]["myEvent"]["int"] }
+            # Delivered to ToParamUser
+            assert_equal [3], deliveries["3"].map { |d| d["data"]["myEvent"]["int"] }
+            # Delivered to Array of GlobalIDUser and ToParamUser
+            assert_equal [4], deliveries["4"].map { |d| d["data"]["myEvent"]["int"] }
+          end
         end
 
-        def str
-          raise GraphQL::ExecutionError.new("This is handled")
-        end
-      end
+        describe "errors" do
+          class ErrorPayload
+            def int
+              raise "Boom!"
+            end
 
-      it "lets unhandled errors crash "do
-        query_str = <<-GRAPHQL
+            def str
+              raise GraphQL::ExecutionError.new("This is handled")
+            end
+          end
+
+          it "lets unhandled errors crash "do
+            query_str = <<-GRAPHQL
           subscription($type: PayloadType) {
             myEvent(type: $type) { int }
           }
-        GRAPHQL
+            GRAPHQL
 
-        schema.execute(query_str, context: { socket: "1", me: "1" }, variables: { "type" => "ONE" }, root_value: root_object)
-        err = assert_raises(RuntimeError) {
-          schema.subscriptions.trigger("myEvent", { "type" => "ONE" }, ErrorPayload.new, scope: "1")
-        }
-        assert_equal "Boom!", err.message
-      end
-    end
+            schema.execute(query_str, context: { socket: "1", me: "1" }, variables: { "type" => "ONE" }, root_value: root_object)
+            err = assert_raises(RuntimeError) {
+              schema.subscriptions.trigger("myEvent", { "type" => "ONE" }, ErrorPayload.new, scope: "1")
+            }
+            assert_equal "Boom!", err.message
+          end
+        end
 
-    it "sends query errors to the subscriptions" do
-      query_str = <<-GRAPHQL
+        it "sends query errors to the subscriptions" do
+          query_str = <<-GRAPHQL
         subscription($type: PayloadType) {
           myEvent(type: $type) { str }
         }
-      GRAPHQL
+          GRAPHQL
 
-      schema.execute(query_str, context: { socket: "1", me: "1" }, variables: { "type" => "ONE" }, root_value: root_object)
-      schema.subscriptions.trigger("myEvent", { "type" => "ONE" }, ErrorPayload.new, scope: "1")
-      res = deliveries["1"].first
-      assert_equal "This is handled", res["errors"][0]["message"]
-    end
-  end
-
-  describe "implementation" do
-    it "is initialized with keywords" do
-      assert_equal 123, schema.subscriptions.extra
-    end
-  end
-
-  describe "#build_id" do
-    it "returns a unique ID string" do
-      assert_instance_of String, schema.subscriptions.build_id
-      refute_equal schema.subscriptions.build_id, schema.subscriptions.build_id
-    end
-  end
-
-  describe ".trigger" do
-    it "raises when event name is not found" do
-      err = assert_raises(GraphQL::Subscriptions::InvalidTriggerError) do
-        schema.subscriptions.trigger(:nonsense_field, {}, nil)
+          schema.execute(query_str, context: { socket: "1", me: "1" }, variables: { "type" => "ONE" }, root_value: root_object)
+          schema.subscriptions.trigger("myEvent", { "type" => "ONE" }, ErrorPayload.new, scope: "1")
+          res = deliveries["1"].first
+          assert_equal "This is handled", res["errors"][0]["message"]
+        end
       end
 
-      assert_includes err.message, "trigger: nonsense_field"
-      assert_includes err.message, "Subscription.nonsenseField"
-    end
-
-    it "raises when argument is not found" do
-      err = assert_raises(GraphQL::Subscriptions::InvalidTriggerError) do
-        schema.subscriptions.trigger(:event, { scream: {"userId" => "😱"} }, nil)
+      describe "implementation" do
+        it "is initialized with keywords" do
+          assert_equal 123, schema.subscriptions.extra
+        end
       end
 
-      assert_includes err.message, "arguments: scream"
-      assert_includes err.message, "arguments of Subscription.event"
-
-      err = assert_raises(GraphQL::Subscriptions::InvalidTriggerError) do
-        schema.subscriptions.trigger(:event, { stream: { user_id_number: "😱"} }, nil)
+      describe "#build_id" do
+        it "returns a unique ID string" do
+          assert_instance_of String, schema.subscriptions.build_id
+          refute_equal schema.subscriptions.build_id, schema.subscriptions.build_id
+        end
       end
 
-      assert_includes err.message, "arguments: user_id_number"
-      assert_includes err.message, "arguments of StreamInput"
+      describe ".trigger" do
+        it "raises when event name is not found" do
+          err = assert_raises(GraphQL::Subscriptions::InvalidTriggerError) do
+            schema.subscriptions.trigger(:nonsense_field, {}, nil)
+          end
+
+          assert_includes err.message, "trigger: nonsense_field"
+          assert_includes err.message, "Subscription.nonsenseField"
+        end
+
+        it "raises when argument is not found" do
+          err = assert_raises(GraphQL::Subscriptions::InvalidTriggerError) do
+            schema.subscriptions.trigger(:event, { scream: {"userId" => "😱"} }, nil)
+          end
+
+          assert_includes err.message, "arguments: scream"
+          assert_includes err.message, "arguments of Subscription.event"
+
+          err = assert_raises(GraphQL::Subscriptions::InvalidTriggerError) do
+            schema.subscriptions.trigger(:event, { stream: { user_id_number: "😱"} }, nil)
+          end
+
+          assert_includes err.message, "arguments: user_id_number"
+          assert_includes err.message, "arguments of StreamInput"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
*NOTE:* I'm not sure I feel this is done - I got all tests green, but this solution might not be "correct". There's a lot at play here that I don't fully understand.

### Issue

When using the class-based API with subscriptions, triggering the subscription blows up with the "Failed to implement" error that happens during resolve when your object doesn't implement the method/hash key being asked for.

### Tests

I took the original test plus the one Robert created to prove the failing code and merged them essentially by running each way of defining the schema through the same set of tests. This way I was able to verify that both ways still worked with the changes I made.

### Analysis

In `GraphQL::Schema::Field`, during execution of `resolve_field_method`, the `obj` is wrapped one more time than expected, where you would have to use `obj.object.object` to get the object in question.

The offending code that is performing the "double wrapping" is in `GraphQL::Schema::Member::Instrumentation#before_query`, which has this block of code:

```ruby
wrapper_class = root_type.metadata[:type_class]
if wrapper_class
  new_root_value = wrapper_class.new(query.root_value, query.context)
  query.root_value = new_root_value
end
```

where `new_root_value` is now the wrapped version. 

This method _never gets hit_ when not using the class-based API because `GraphQL::Schema::Member::Instrumentation` is *not* in the list of query instrumenters when we use the SDL (the only query instrumenter is `GraphQL::Subscription::Instrumentation`). so it never blows up.

However, when using the class-based API, what happens is that `schema.instrumenters[:query]` includes both `GraphQL::Subscription::Instrumentation` _and_ `GraphQL::Schema::Member::Instrumentation`, thus eventually wrapping the `root_value`. The difference is that the class-based API uses `GraphQL::Schema`, where `to_grapqhl` eventually gets called, and has this line:

```ruby
schema_defn.instrumenters[:query] << GraphQL::Schema::Member::Instrumentation
```

And presto - we now have the instrumenter that wraps the root value, blowing everything up eventually down the line.

Given all of that context, what I ended up doing is just checking to see if we need to drill into `obj` in `GraphQL::Subscriptions::Instrumentation` and I'm unsure if this was the best thing to do, or if we should be somehow removing the offending instrumenter, or something else entirely.

**This also surfaced a second bug** which was shown by another one of the subscription tests failing.

This bug had to do with the serialization of arguments not working correctly when one of the items was an `InputObject`. Essentially, it ended up just turning the object location into a string, so the key for the subscription looked something like `":event:stream:#<ClassBasedInMemoryBackend::StreamInput:0x00007f85cfb9b200>"`. Of course this means when trying to retrieve the subscription to deliver the message, it couldn't find the subscription, and tests failed.