### PR TITLE
Fix typo mutation/resolve

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -65,7 +65,7 @@ module GraphQL
             raise ArgumentError, "missing keyword argument null:"
           end
         end
-        if (field || function || resolve || resolve) && extras.any?
+        if (field || function || resolve || mutation) && extras.any?
           raise ArgumentError, "keyword `extras:` may only be used with method-based resolve, please remove `field:`, `function:`, `resolve:`, or `mutation:`"
         end
         if return_type_expr.is_a?(GraphQL::Field)


### PR DESCRIPTION
In file `lib/graphql/schema/field.rb`, there're 2 `resolve` in the or condition. Based on what's described in the error below, one of it should be `mutation` instead