### PR TITLE
Update subscription#instrumentation to call original resolver

### DIFF
--- a/lib/graphql/subscriptions/instrumentation.rb
+++ b/lib/graphql/subscriptions/instrumentation.rb
@@ -44,7 +44,7 @@ module GraphQL
 
         # Wrap the proc with subscription registration logic
         def call(obj, args, ctx)
-          @inner_proc.call(obj, args, ctx) if @inner_proc
+          @inner_proc.call(obj, args, ctx) if @inner_proc && !@inner_proc.is_a?(GraphQL::Field::Resolve::BuiltInResolve)
 
           events = ctx.namespace(:subscriptions)[:events]
 

--- a/lib/graphql/subscriptions/instrumentation.rb
+++ b/lib/graphql/subscriptions/instrumentation.rb
@@ -44,7 +44,10 @@ module GraphQL
 
         # Wrap the proc with subscription registration logic
         def call(obj, args, ctx)
+          @inner_proc.call(obj, args, ctx) if @inner_proc
+
           events = ctx.namespace(:subscriptions)[:events]
+
           if events
             # This is the first execution, so gather an Event
             # for the backend to register:

--- a/spec/graphql/subscriptions_spec.rb
+++ b/spec/graphql/subscriptions_spec.rb
@@ -132,6 +132,10 @@ class ClassBasedInMemoryBackend < InMemoryBackend
     def my_event(type: nil)
       object
     end
+
+    field :failed_event, Payload, null: false, resolve: -> (o, a, c) { raise GraphQL::ExecutionError.new("unauthorized") }  do
+      argument :id, ID, required: true
+    end
   end
 
   class Query < GraphQL::Schema::Object
@@ -151,6 +155,7 @@ class FromDefinitionInMemoryBackend < InMemoryBackend
     payload(id: ID!): Payload!
     event(stream: StreamInput): Payload
     myEvent(type: PayloadType): Payload
+    failedEvent(id: ID!): Payload
   }
 
   type Payload {
@@ -180,6 +185,7 @@ class FromDefinitionInMemoryBackend < InMemoryBackend
       "payload" => ->(o,a,c) { o },
       "myEvent" => ->(o,a,c) { o },
       "event" => ->(o,a,c) { o },
+      "failedEvent" => ->(o,a,c) { raise GraphQL::ExecutionError.new("unauthorized") },
     },
   }
   Schema = GraphQL::Schema.from_definition(SchemaDefinition, default_resolve: Resolvers).redefine do
@@ -408,6 +414,20 @@ describe GraphQL::Subscriptions do
             def str
               raise GraphQL::ExecutionError.new("This is handled")
             end
+          end
+
+          it "avoid subscription on resolver error" do
+            res = schema.execute(<<-GRAPHQL, context: { socket: "1" }, variables: { "id" => "100" })
+          subscription ($id: ID!){
+            failedEvent(id: $id) { str, int }
+          }
+            GRAPHQL
+
+            # assert_equal nil, res["data"] # TODO: data is not nil for `FromDefinitionInMemoryBackend`
+            assert_equal "unauthorized", res["errors"][0]["message"]
+
+            # this is to make sure nothing actually got subscribed.. but I don't have any idea better than checking its instance variable
+            assert_equal 0, schema.subscriptions.instance_variable_get(:@subscriptions).size
           end
 
           it "lets unhandled errors crash "do

--- a/spec/graphql/subscriptions_spec.rb
+++ b/spec/graphql/subscriptions_spec.rb
@@ -133,7 +133,7 @@ class ClassBasedInMemoryBackend < InMemoryBackend
       object
     end
 
-    field :failed_event, Payload, null: false, resolve: -> (o, a, c) { raise GraphQL::ExecutionError.new("unauthorized") }  do
+    field :failed_event, Payload, null: false, resolve: ->(o, a, c) { raise GraphQL::ExecutionError.new("unauthorized") }  do
       argument :id, ID, required: true
     end
   end
@@ -430,7 +430,7 @@ describe GraphQL::Subscriptions do
             assert_equal 0, schema.subscriptions.instance_variable_get(:@subscriptions).size
           end
 
-          it "lets unhandled errors crash "do
+          it "lets unhandled errors crash" do
             query_str = <<-GRAPHQL
           subscription($type: PayloadType) {
             myEvent(type: $type) { int }

--- a/spec/graphql/subscriptions_spec.rb
+++ b/spec/graphql/subscriptions_spec.rb
@@ -155,7 +155,7 @@ class FromDefinitionInMemoryBackend < InMemoryBackend
     payload(id: ID!): Payload!
     event(stream: StreamInput): Payload
     myEvent(type: PayloadType): Payload
-    failedEvent(id: ID!): Payload
+    failedEvent(id: ID!): Payload!
   }
 
   type Payload {
@@ -423,7 +423,7 @@ describe GraphQL::Subscriptions do
           }
             GRAPHQL
 
-            # assert_equal nil, res["data"] # TODO: data is not nil for `FromDefinitionInMemoryBackend`
+            assert_equal nil, res["data"]
             assert_equal "unauthorized", res["errors"][0]["message"]
 
             # this is to make sure nothing actually got subscribed.. but I don't have any idea better than checking its instance variable


### PR DESCRIPTION
As discussed in #1427 , the resolver in subscription needs to be called for authorization checking.

This PR adds in the logic for calling resolver defined.

This should also close #1341 