### PR TITLE
Use class rather than names to lookup connection implementation

### DIFF
--- a/lib/graphql/relay/base_connection.rb
+++ b/lib/graphql/relay/base_connection.rb
@@ -27,7 +27,7 @@ module GraphQL
         def connection_for_nodes(nodes)
           # Check for class _names_ because classes can be redefined in Rails development
           nodes.class.ancestors.each do |ancestor|
-            conn_impl = CONNECTION_IMPLEMENTATIONS[ancestor.name]
+            conn_impl = CONNECTION_IMPLEMENTATIONS[ancestor]
             if conn_impl
               return conn_impl
             end
@@ -41,7 +41,7 @@ module GraphQL
         # @param nodes_class [Class] A class representing a collection (eg, Array, AR::Relation)
         # @param connection_class [Class] A class implementing Connection methods
         def register_connection_implementation(nodes_class, connection_class)
-          CONNECTION_IMPLEMENTATIONS[nodes_class.name] = connection_class
+          CONNECTION_IMPLEMENTATIONS[nodes_class] = connection_class
         end
       end
 


### PR DESCRIPTION
While debugging a (very) slow GraphQL query on our system, we noticed that we spend 451ms (2.98%) on `Module#name`.

<img width="1497" alt="screencapture" src="https://user-images.githubusercontent.com/102915/40132017-e6a13712-593b-11e8-8da2-bd0c9e9e014b.png">

A close up of this trace reveals it's being called by the `connection_for_nodes` operation
<img width="924" alt="screen shot 2018-05-16 at 19 45 48" src="https://user-images.githubusercontent.com/102915/40134118-d271ba04-5941-11e8-82f9-93bac47051a3.png">

We spend 459ms in the `connection_for_nodes` method doing mostly `Module#name`work. As `Module.name` is a Ruby method, I was surprised to see it shows up in this trace. After some google-ing, I found https://bugs.ruby-lang.org/issues/11119 where they describe poor performance of `.name` on anonymous modules/classes. As `connection_for_nodes` uses `.name` and an `AR` models ancestors have anonymous classes; I wondered what the difference would be if we use the class itself rather than the name of the class to look up the connection type.

Here's our benchmark using .name:
```
Timing:
  Real: 15.027346999995643 sec
Allocations:
  Total: 1668836
ActiveRecord results:
  Number of queries: 156
  Query dump: /tmp/86f55dfd2f98f563d5899303003cb6f7.txt
Profiler results:
  Written to /tmp/benchmark_profile
```

Here's our benchmark using the class as lookup key (this PR):
```
Timing:
  Real: 14.350659000017913 sec
Allocations:
  Total: 1667811
ActiveRecord results:
  Number of queries: 156
  Query dump: /tmp/0f3915032a6b77aa5feb33cc818a91d5.txt
Profiler results:
  Written to /tmp/benchmark_profile
```

We went from 15.027346999995643sec to 14.350659000017913 (yeah, this is _really_ a slow query but that is mostly our implementation 😄). After this change, the flame chart looks like:

<img width="1596" alt="test_svg" src="https://user-images.githubusercontent.com/102915/40136283-bbadbe20-5947-11e8-9a79-a4dad918cec8.png">

Zooming in on the `connection_for_nodes`:
<img width="658" alt="screen shot 2018-05-16 at 20 21 15" src="https://user-images.githubusercontent.com/102915/40135914-cfa37e16-5946-11e8-83af-1566717eac5e.png">

We went from 459ms to 6ms. 

I find this very interesting but I didn't figure out yet _why_ this happens. Is it `Module#name` being slow? Or can Ruby optimize/cache hash lookups? I've run some micro benchmarks but they didn't show a significant difference. I'd like to figure this out why there's such a difference when I use a real graphql query.

Another thing I have to figure out is the reason why `.name` is used in the first place. The comment above the .name hints to Rails' autoloader in development.

Also note that the response of the query I'm using is large (hence the 15sec response time)! Your mileage may vary.







