### PR TITLE
Fix AST node on input field

### DIFF
--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -237,7 +237,7 @@ module GraphQL
               **kwargs,
             )
 
-            argument.ast_node = input_object_type_definition
+            argument.ast_node = input_argument
 
             [
               input_argument.name,

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -668,7 +668,7 @@ type Type implements Interface {
       assert_equal [18, 1], schema.types["Union"].ast_node.position
       assert_equal [20, 1], schema.types["Scalar"].ast_node.position
       assert_equal [22, 1], schema.types["Input"].ast_node.position
-      assert_equal [22, 1], schema.types["Input"].arguments["argument"].ast_node.position
+      assert_equal [23, 3], schema.types["Input"].arguments["argument"].ast_node.position
       assert_equal [26, 1], schema.directives["Directive"].ast_node.position
       assert_equal [28, 3], schema.directives["Directive"].arguments["argument"].ast_node.position
       assert_equal [31, 22], schema.types["Type"].ast_node.interfaces[0].position


### PR DESCRIPTION
Fixes a bug in schema parsing which was setting input field AST nodes to the input object AST node.

cc @cjoudrey @rmosolgo 