### PR TITLE
Created files should end with newline

### DIFF
--- a/lib/graphql/railtie.rb
+++ b/lib/graphql/railtie.rb
@@ -40,7 +40,7 @@ module GraphQL
             unless File.exists?(destination_file)
               FileUtils.mkdir_p(File.dirname(destination_file))
               File.open(destination_file, 'w') do |f|
-                f.write "class Types::BaseScalar < GraphQL::Schema::Scalar\nend"
+                f.puts "class Types::BaseScalar < GraphQL::Schema::Scalar\nend"
               end
             end
 
@@ -48,7 +48,7 @@ module GraphQL
             unless File.exists?(destination_file)
               FileUtils.mkdir_p(File.dirname(destination_file))
               File.open(destination_file, 'w') do |f|
-                f.write "class Types::BaseInputObject < GraphQL::Schema::InputObject\nend"
+                f.puts "class Types::BaseInputObject < GraphQL::Schema::InputObject\nend"
               end
             end
 
@@ -56,7 +56,7 @@ module GraphQL
             unless File.exists?(destination_file)
               FileUtils.mkdir_p(File.dirname(destination_file))
               File.open(destination_file, 'w') do |f|
-                f.write "class Types::BaseEnum < GraphQL::Schema::Enum\nend"
+                f.puts "class Types::BaseEnum < GraphQL::Schema::Enum\nend"
               end
             end
 
@@ -64,7 +64,7 @@ module GraphQL
             unless File.exists?(destination_file)
               FileUtils.mkdir_p(File.dirname(destination_file))
               File.open(destination_file, 'w') do |f|
-                f.write "class Types::BaseUnion < GraphQL::Schema::Union\nend"
+                f.puts "class Types::BaseUnion < GraphQL::Schema::Union\nend"
               end
             end
 
@@ -72,14 +72,14 @@ module GraphQL
             unless File.exists?(destination_file)
               FileUtils.mkdir_p(File.dirname(destination_file))
               File.open(destination_file, 'w') do |f|
-                f.write "module Types::BaseInterface\n  include GraphQL::Schema::Interface\nend"
+                f.puts "module Types::BaseInterface\n  include GraphQL::Schema::Interface\nend"
               end
             end
 
             destination_file = File.join(base_dir, "types", "base_object.rb")
             unless File.exists?(destination_file)
               File.open(destination_file, 'w') do |f|
-                f.write "class Types::BaseObject < GraphQL::Schema::Object\nend"
+                f.puts "class Types::BaseObject < GraphQL::Schema::Object\nend"
               end
             end
           end


### PR DESCRIPTION
I got the following warning from git when I commited created base files:

![image](https://user-images.githubusercontent.com/1796864/40380718-d6e8fbfe-5e34-11e8-85c9-08cebc420946.png)

According to this article https://robots.thoughtbot.com/no-newline-at-end-of-file, I think we should add newline at the end of the files.

> So, it turns out that, according to POSIX, every text file (including Ruby and JavaScript source files) should end with a \n, or “newline” (not “a new line”) character. 