### PR TITLE
Fix accessible_by link is documentation

### DIFF
--- a/guides/pro/authorization.md
+++ b/guides/pro/authorization.md
@@ -409,6 +409,6 @@ For list types, each item of the list is authorized individually.
 
 Database query objects (`ActiveRecord::Relation`s and `Mongoid::Criteria`s) get special treatment. They get passed to _scope handlers_ so that they can be filtered at database level (eg, SQL `WHERE`) instead of Ruby level (eg, `.select`).
 
-`ActiveRecord::Relation`s can be scoped with SQL by authorization strategies. The Pundit integration uses [policy scopes](#policy-scopes) and the CanCan integration uses [`accessible_by`](#accessibleby). [Custom authorization strategies](#custom-authorization-strategy) can implement `#scope(gate, relation)` to apply scoping to `ActiveRecord::Relation`s.
+`ActiveRecord::Relation`s can be scoped with SQL by authorization strategies. The Pundit integration uses [policy scopes](#policy-scopes) and the CanCan integration uses [`accessible_by`](#accessible_by). [Custom authorization strategies](#custom-authorization-strategy) can implement `#scope(gate, relation)` to apply scoping to `ActiveRecord::Relation`s.
 
 `Mongoid::Criteria`s are supported in the same way by Pundit [policy scopes](#policy-scopes)) and [custom strategy]((#custom-authorization-strategy))'s  `#scope(gate, relation)` methods, but they aren't supported by CanCan (which doesn't support Mongoid, as far as I can tell!).


### PR DESCRIPTION
The markdown link was broken so because the underscore is missing.

![](https://media.giphy.com/media/OyLTqcHtYLDoI/giphy.gif)