### PR TITLE
Set all introspection types and fields as introspection

### DIFF
--- a/lib/graphql/introspection/dynamic_fields.rb
+++ b/lib/graphql/introspection/dynamic_fields.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module GraphQL
   module Introspection
-    class DynamicFields < GraphQL::Schema::Object
+    class DynamicFields < Introspection::BaseObject
       field :__typename, String, "The name of this type", null: false, extras: [:irep_node]
       def __typename(irep_node:)
         irep_node.owner_type.name

--- a/lib/graphql/introspection/entry_points.rb
+++ b/lib/graphql/introspection/entry_points.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module GraphQL
   module Introspection
-    class EntryPoints < GraphQL::Schema::Object
+    class EntryPoints < Introspection::BaseObject
       field :__schema, GraphQL::Schema::LateBoundType.new("__Schema"), "This GraphQL schema", null: false
       field :__type, GraphQL::Schema::LateBoundType.new("__Type"), "A type in the GraphQL system", null: true do
         argument :name, String, required: true

--- a/lib/graphql/introspection/type_type.rb
+++ b/lib/graphql/introspection/type_type.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module GraphQL
   module Introspection
-    class TypeType < GraphQL::Schema::Object
+    class TypeType < Introspection::BaseObject
       graphql_name "__Type"
       description "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in "\
                   "GraphQL as represented by the `__TypeKind` enum.\n\n"\
@@ -24,7 +24,6 @@ module GraphQL
       end
       field :input_fields, [GraphQL::Schema::LateBoundType.new("__InputValue")], null: true
       field :of_type, GraphQL::Schema::LateBoundType.new("__Type"), null: true
-      introspection true
 
       def kind
         @object.kind.name


### PR DESCRIPTION
Some introspection object types weren't marked as `introspection true`. I'm assuming this was just an oversight? These can just inherit from `Introspection::BaseObject` to ensure the types and their fields are marked as introspection.