### PR TITLE
Track position of union member nodes

### DIFF
--- a/lib/graphql/compatibility/schema_parser_specification.rb
+++ b/lib/graphql/compatibility/schema_parser_specification.rb
@@ -78,6 +78,34 @@ module GraphQL
             assert_equal [], type.values[2].directives
           end
 
+          def test_it_parses_union_types
+            document = parse(
+              "union BagOfThings = \n" \
+              "A |\n" \
+              "B |\n" \
+              "C"
+            )
+
+            union = document.definitions.first
+
+            assert_equal GraphQL::Language::Nodes::UnionTypeDefinition, union.class
+            assert_equal 'BagOfThings', union.name
+            assert_equal 3, union.types.length
+            assert_equal [1, 1], union.position
+
+            assert_equal GraphQL::Language::Nodes::TypeName, union.types[0].class
+            assert_equal 'A', union.types[0].name
+            assert_equal [2, 1], union.types[0].position
+
+            assert_equal GraphQL::Language::Nodes::TypeName, union.types[1].class
+            assert_equal 'B', union.types[1].name
+            assert_equal [3, 1], union.types[1].position
+
+            assert_equal GraphQL::Language::Nodes::TypeName, union.types[2].class
+            assert_equal 'C', union.types[2].name
+            assert_equal [4, 1], union.types[2].position
+          end
+
           def test_it_parses_input_types
             document = parse('
               input EmptyMutationInput {

--- a/lib/graphql/language/parser.rb
+++ b/lib/graphql/language/parser.rb
@@ -1651,14 +1651,14 @@ module_eval(<<'.,.,', 'parser.y', 341)
 
 module_eval(<<'.,.,', 'parser.y', 345)
   def _reduce_141(val, _values, result)
-     return [make_node(:TypeName, name: val[0])]
+     return [make_node(:TypeName, name: val[0], position_source: val[0])]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 346)
   def _reduce_142(val, _values, result)
-     val[0] << make_node(:TypeName, name: val[2]) 
+     val[0] << make_node(:TypeName, name: val[2], position_source: val[2]) 
     result
   end
 .,.,

--- a/lib/graphql/language/parser.y
+++ b/lib/graphql/language/parser.y
@@ -343,8 +343,8 @@ rule
       }
 
   union_members:
-      name                    { return [make_node(:TypeName, name: val[0])]}
-    | union_members PIPE name { val[0] << make_node(:TypeName, name: val[2]) }
+      name                    { return [make_node(:TypeName, name: val[0], position_source: val[0])]}
+    | union_members PIPE name { val[0] << make_node(:TypeName, name: val[2], position_source: val[2]) }
 
   union_type_definition:
       UNION name directives_list_opt EQUALS union_members {


### PR DESCRIPTION
When parsing union type members, we were not tracking the position of the `TypeName` node.

This PR fixes that and adds some test coverage.