### PR TITLE
fix enum example plural to singular

### DIFF
--- a/lib/graphql/enum_type.rb
+++ b/lib/graphql/enum_type.rb
@@ -12,8 +12,8 @@ module GraphQL
   #
   # @example An enum of programming languages
   #   LanguageEnum = GraphQL::EnumType.define do
-  #     name "Languages"
-  #     description "Programming languages for Web projects"
+  #     name "Language"
+  #     description "Programming language for Web projects"
   #     value("PYTHON", "A dynamic, function-oriented language")
   #     value("RUBY", "A very dynamic language aimed at programmer happiness")
   #     value("JAVASCRIPT", "Accidental lingua franca of the web")


### PR DESCRIPTION
Enum name is singular form name. so this is example is better to `Languages` -> `Language`
https://github.com/rmosolgo/graphql-ruby/blob/3e8295cb2c65bf2cf2675b2330d804d78629a815/lib/graphql/enum_type.rb#L13-L20

https://stackoverflow.com/questions/15755955/naming-of-enums-in-java-singular-or-plural