### PR TITLE
Only connect to MongoDB when required

### DIFF
--- a/spec/graphql/relay/mongo_relation_connection_spec.rb
+++ b/spec/graphql/relay/mongo_relation_connection_spec.rb
@@ -1,7 +1,18 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe GraphQL::Relay::RelationConnection do
+if MONGO_DETECTED
+  require "support/star_trek/data"
+  require "support/star_trek/schema"
+end
+
+describe GraphQL::Relay::MongoRelationConnection do
+  before do
+    if !MONGO_DETECTED
+      skip("Mongo not detected")
+    end
+  end
+
   def get_names(result)
     ships = result["data"]["federation"]["bases"]["edges"]
     ships.map { |e| e["node"]["name"] }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,7 @@ require "minitest/focus"
 require "minitest/reporters"
 
 MONGO_DETECTED = begin
+  require "mongo"
   Mongo::Client.new('mongodb://127.0.0.1:27017/graphql_ruby_test',
       connect_timeout: 1,
       socket_timeout: 1,
@@ -37,8 +38,8 @@ MONGO_DETECTED = begin
     )
     .database
     .collections
-rescue Mongo::Error => err
-  puts err.message, err.backtrace
+rescue StandardError, LoadError => err
+  # puts err.message, err.backtrace
   false
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,21 @@ require "pry"
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/reporters"
+
+MONGO_DETECTED = begin
+  Mongo::Client.new('mongodb://127.0.0.1:27017/graphql_ruby_test',
+      connect_timeout: 1,
+      socket_timeout: 1,
+      server_selection_timeout: 1,
+      logger: Logger.new(nil)
+    )
+    .database
+    .collections
+rescue Mongo::Error => err
+  puts err.message, err.backtrace
+  false
+end
+
 Minitest::Reporters.use! Minitest::Reporters::DefaultReporter.new(color: true)
 
 Minitest::Spec.make_my_diffs_pretty!
@@ -62,9 +77,12 @@ NO_OP_RESOLVE_TYPE = ->(type, obj, ctx) {
 
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each do |f|
+  # These require mongodb in order to run,
+  # so only load them in the specific tests that require them.
+  next if f.include?("star_trek")
+
   unless rails_should_be_installed?
     next if f.end_with?('star_wars/data.rb')
-    next if f.end_with?('star_trek/data.rb')
     next if f.end_with?('base_generator_test.rb')
   end
   require f

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,7 +38,7 @@ MONGO_DETECTED = begin
     )
     .database
     .collections
-rescue StandardError, LoadError => err
+rescue StandardError, LoadError => err # rubocop:disable Lint/UselessAssignment
   # puts err.message, err.backtrace
   false
 end


### PR DESCRIPTION
We have mongodb support now (:tada:) but making it required for _all_ tests can be a damper on developing the gem. This change makes it so it's: 

- Only loaded when needed
- Skipped when not found 

For example, when it's absent, you get: 

```
SSSSSSSSSSSSSSSSSSSSS

Finished tests in 0.004816s, 4360.4652 tests/s, 0.0000 assertions/s.


Skipped:
GraphQL::Relay::MongoRelationConnection::results#test_0007_handles cursors below the bounds of the array [/Users/rmosolgo/code/graphql-ruby/spec/graphql/relay/mongo_relation_connection_spec.rb:12]:
Mongo not detected
```

Fixes #1522 