### PR TITLE
Add extensions support for execution errors

### DIFF
--- a/lib/graphql/execution_error.rb
+++ b/lib/graphql/execution_error.rb
@@ -12,11 +12,19 @@ module GraphQL
     attr_accessor :path
 
     # @return [Hash] Optional data for error objects
+    # @deprecated Use `extensions` instead of `options`. The GraphQL spec
+    # recommends that any custom entries in an error be under the
+    # `extensions` key.
     attr_accessor :options
 
-    def initialize(message, ast_node: nil, options: nil)
+    # @return [Hash] Optional custom data for error objects which will be added
+    # under the `extensions` key.
+    attr_accessor :extensions
+
+    def initialize(message, ast_node: nil, options: nil, extensions: nil)
       @ast_node = ast_node
       @options = options
+      @extensions = extensions
       super(message)
     end
 
@@ -38,6 +46,10 @@ module GraphQL
       end
       if options
         hash.merge!(options)
+      end
+      if extensions
+        hash["extensions"] ||= {}
+        hash["extensions"].merge!(extensions)
       end
       hash
     end

--- a/spec/graphql/execution_error_spec.rb
+++ b/spec/graphql/execution_error_spec.rb
@@ -271,7 +271,26 @@ describe GraphQL::ExecutionError do
       assert_equal(expected_result, result)
     end
   end
-  
+
+  describe "extensions in ExecutionError" do
+    let(:query_string) {%|
+    {
+      executionErrorWithExtensions
+    }
+    |}
+    it "the error is inserted into the errors key and the rest of the query is fulfilled" do
+      expected_result = {
+        "data"=>{"executionErrorWithExtensions"=>nil},
+        "errors"=>
+            [{"message"=>"Permission Denied!",
+              "locations"=>[{"line"=>3, "column"=>7}],
+              "path"=>["executionErrorWithExtensions"],
+              "extensions"=>{"code"=>"permission_denied"}}]
+      }
+      assert_equal(expected_result, result)
+    end
+  end
+
   describe "more than one ExecutionError" do
     let(:query_string) { %|{ multipleErrorsOnNonNullableField} |}
     it "the errors are inserted into the errors key and the data is nil even for a NonNullable field " do

--- a/spec/graphql/execution_error_spec.rb
+++ b/spec/graphql/execution_error_spec.rb
@@ -278,7 +278,7 @@ describe GraphQL::ExecutionError do
       executionErrorWithExtensions
     }
     |}
-    it "the error is inserted into the errors key and the rest of the query is fulfilled" do
+    it "the error is inserted into the errors key with custom data set in `extensions`" do
       expected_result = {
         "data"=>{"executionErrorWithExtensions"=>nil},
         "errors"=>

--- a/spec/graphql/introspection/schema_type_spec.rb
+++ b/spec/graphql/introspection/schema_type_spec.rb
@@ -30,6 +30,7 @@ describe GraphQL::Introspection::SchemaType do
             {"name"=>"deepNonNull"},
             {"name"=>"error"},
             {"name"=>"executionError"},
+            {"name"=>"executionErrorWithExtensions"},
             {"name"=>"executionErrorWithOptions"},
             {"name"=>"favoriteEdible"},
             {"name"=>"fromSource"},

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -381,6 +381,13 @@ module Dummy
       }
     end
 
+    field :executionErrorWithExtensions do
+      type GraphQL::INT_TYPE
+      resolve ->(t, a, c) {
+        GraphQL::ExecutionError.new("Permission Denied!", extensions: { "code" => "permission_denied" })
+      }
+    end
+
     # To test possibly-null fields
     field :maybeNull, MaybeNullType do
       resolve ->(t, a, c) { OpenStruct.new(cheese: nil) }


### PR DESCRIPTION
`ExecutionError` already supports `options` to merge in custom data. However the GraphQL spec now recommends that all additions entries to an error be under the `extensions` key to avoid conflicts with any future spec changes.

Ref: http://facebook.github.io/graphql/draft/#sec-Errors

This adds the ability to specific `extensions` which will get merged into any existing `extensions` data.

`options` has also been marked as deprecated.