### PR TITLE
Improve Arguments#to_h for nested input objects

### DIFF
--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -108,10 +108,14 @@ module GraphQL
         ruby_kwargs = {}
 
         keys.each do |key|
-          ruby_kwargs[Schema::Member::BuildType.underscore(key).to_sym] = self[key]
+          value = unwrap_value(self[key])
+          ruby_kwargs[Schema::Member::BuildType.underscore(key).to_sym] = value
         end
+        pp ruby_kwargs
 
-        ruby_kwargs
+        return ruby_kwargs
+        # puts "%" * 80
+        # pp Hash[to_h.map { |(key, value)| [Schema::Member::BuildType.underscore(key).to_sym, value] }]
       end
 
       private
@@ -168,7 +172,7 @@ module GraphQL
         when GraphQL::Query::Arguments
           value.to_h
         else
-          value
+          value.try(:to_h) || value
         end
       end
     end

--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -111,7 +111,6 @@ module GraphQL
           value = unwrap_value(self[key])
           ruby_kwargs[Schema::Member::BuildType.underscore(key).to_sym] = value
         end
-        pp ruby_kwargs
 
         return ruby_kwargs
         # puts "%" * 80
@@ -169,10 +168,10 @@ module GraphQL
             memo[key] = unwrap_value(value)
             memo
           end
-        when GraphQL::Query::Arguments
+        when GraphQL::Query::Arguments #, GraphQL::Schema::InputObject
           value.to_h
         else
-          value.try(:to_h) || value
+          value
         end
       end
     end

--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -112,7 +112,7 @@ module GraphQL
           ruby_kwargs[Schema::Member::BuildType.underscore(key).to_sym] = value
         end
 
-        return ruby_kwargs
+        ruby_kwargs
       end
 
       private

--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -113,8 +113,6 @@ module GraphQL
         end
 
         return ruby_kwargs
-        # puts "%" * 80
-        # pp Hash[to_h.map { |(key, value)| [Schema::Member::BuildType.underscore(key).to_sym, value] }]
       end
 
       private
@@ -168,7 +166,7 @@ module GraphQL
             memo[key] = unwrap_value(value)
             memo
           end
-        when GraphQL::Query::Arguments #, GraphQL::Schema::InputObject
+        when GraphQL::Query::Arguments, GraphQL::Schema::InputObject
           value.to_h
         else
           value

--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -147,6 +147,15 @@ module GraphQL
             wrap_value(value, arg_defn_type.of_type, context)
           when GraphQL::InputObjectType
             if value.is_a?(Hash)
+              # alternatively, make sure that stuff is wrapped as an instance of Arguments?
+              #
+              # see:
+              # https://github.com/rmosolgo/graphql-ruby/blob/022477fdb/lib/graphql/schema/input_object.rb#L74-L78
+              #
+              #
+              # klass = arg_defn_type.arguments_class.try(:arguments_class) || arg_defn_type.arguments_class
+              # return klass.new(value, context: context, defaults_used: Set.new)
+
               arg_defn_type.arguments_class.new(value, context: context, defaults_used: Set.new)
             else
               value

--- a/spec/graphql/query/arguments_spec.rb
+++ b/spec/graphql/query/arguments_spec.rb
@@ -261,34 +261,37 @@ describe GraphQL::Query::Arguments do
 
     it "returns nested values as hashes" do
       assert_instance_of Hash, arguments.to_kwargs[:input_object]
-      pp arguments.to_kwargs
     end
 
-    describe "recursive nested" do
+    describe "class based api" do
       let(:arguments) {
         class TestInputA < GraphQL::Schema::InputObject
-          graphql_name "TestInput1"
+          graphql_name "TestInputA"
           argument :d, Int, required: true
           argument :e, Int, required: true
         end
 
         class TestInputB < GraphQL::Schema::InputObject
-          graphql_name "TestInput2"
+          graphql_name "TestInputB"
           argument :a, Int, required: true
           argument :b, Int, required: true
           argument :c, [TestInputA], as: :inputObject, required: true
         end
 
-        GraphQL::Query::Arguments.construct_arguments_class(TestInputA)
-        GraphQL::Query::Arguments.construct_arguments_class(TestInputB)
+        TestInputA.to_graphql
+        TestInputB.to_graphql
+
         arg_values = {a: 1, b: 2, c: [{ d: 3, e: 4 }]}
-        TestInputB.arguments_class.new(arg_values, context: nil, defaults_used: Set.new)
+        TestInputB.new(arg_values, context: nil, defaults_used: Set.new)
       }
+
+      it "returns a hash with keys that are valid ruby keyword arguments" do
+        assert_equal([:a, :b, :input_object], arguments.to_kwargs.keys)
+      end
 
       it "returns nested values as hashes" do
         assert_instance_of Array, arguments.to_kwargs[:input_object]
         assert_instance_of Hash, arguments.to_kwargs[:input_object].first
-        pp arguments.to_kwargs
       end
     end
   end

--- a/spec/graphql/query/arguments_spec.rb
+++ b/spec/graphql/query/arguments_spec.rb
@@ -262,36 +262,37 @@ describe GraphQL::Query::Arguments do
     it "returns nested values as hashes" do
       assert_instance_of Hash, arguments.to_kwargs[:input_object]
     end
+  end
 
-    describe "class based api" do
-      let(:arguments) {
-        class TestInputA < GraphQL::Schema::InputObject
-          graphql_name "TestInputA"
-          argument :d, Int, required: true
-          argument :e, Int, required: true
-        end
+  describe "class based api" do
+    let(:arguments) {
+      class TestInput1 < GraphQL::Schema::InputObject
+        graphql_name "TestInput1"
+        argument :d, Int, required: true
+        argument :e, Int, required: true
+      end
 
-        class TestInputB < GraphQL::Schema::InputObject
-          graphql_name "TestInputB"
-          argument :a, Int, required: true
-          argument :b, Int, required: true
-          argument :c, [TestInputA], as: :inputObject, required: true
-        end
+      class TestInput2 < GraphQL::Schema::InputObject
+        graphql_name "TestInput2"
+        argument :a, Int, required: true
+        argument :b, Int, required: true
+        argument :c, TestInput1, as: :inputObject, required: true
+      end
 
-        TestInputA.to_graphql
-        TestInputB.to_graphql
+      TestInput2.to_graphql
 
-        arg_values = {a: 1, b: 2, c: [{ d: 3, e: 4 }]}
-        TestInputB.new(arg_values, context: nil, defaults_used: Set.new)
-      }
+      arg_values = {a: 1, b: 2, c: { d: 3, e: 4 }}
+      TestInput2.new(arg_values, context: nil, defaults_used: Set.new)
+    }
 
+    describe "#to_kwargs" do
       it "returns a hash with keys that are valid ruby keyword arguments" do
         assert_equal([:a, :b, :input_object], arguments.to_kwargs.keys)
       end
 
-      it "returns nested values as hashes" do
-        assert_instance_of Array, arguments.to_kwargs[:input_object]
-        assert_instance_of Hash, arguments.to_kwargs[:input_object].first
+      it "returns nested values as hashes with valid keyword arguments" do
+        assert_instance_of Hash, arguments.to_kwargs[:input_object]
+        assert_equal([:d, :e], arguments.to_kwargs[:input_object].keys)
       end
     end
   end


### PR DESCRIPTION
this is an attempt at fixing #1281 and does a few things:

- changes `Arguments#to_h` to recursively hit `unwrap_values` so that nested attributes have ruby style keyword args
- adds `GraphQL::Schema::InputObject` as a thing that gets unwrapped, since the nested arguments seem to be instances of those

i also added a commented out alternative approach, which keeps nested stuff as instances of `Arguments`. not sure which makes sense, this bit in `InputObject` confuses me:

https://github.com/rmosolgo/graphql-ruby/blob/022477fdb2f29467659f2009161329d7e87bf579/lib/graphql/schema/input_object.rb#L74-L78

anyway i'm very excited to have discovered the class based api! thanks for looking at this and i'd be grateful for any feedback 🙌🏻

update: oh no, i see this breaks things. i'll try to get things working.
