### PR TITLE
Unwrap values in InputObject#to_h

### DIFF
--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -27,7 +27,28 @@ module GraphQL
       attr_reader :arguments
 
       # Ruby-like hash behaviors, read-only
-      def_delegators :@ruby_style_hash, :to_h, :keys, :values, :each, :any?
+      def_delegators :@ruby_style_hash, :keys, :values, :each, :any?
+
+      def to_h
+        @ruby_style_hash.inject({}) do |h, (key, value)|
+          h.merge(key => unwrap_value(value))
+        end
+      end
+
+      def unwrap_value(value)
+        case value
+        when Array
+          value.map { |item| unwrap_value(item) }
+        when Hash
+          value.inject({}) do |h, (key, value)|
+            h.merge(key => unwrap_value(value))
+          end
+        when InputObject
+          value.to_h
+        else
+          value
+        end
+      end
 
       # Lookup a key on this object, it accepts new-style underscored symbols
       # Or old-style camelized identifiers.

--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -108,4 +108,36 @@ describe GraphQL::Schema::InputObject do
       assert_equal expected_info, res["data"]["inspectInput"]
     end
   end
+
+  describe "#to_h" do
+    module InputObjectToHTest
+      class TestInput1 < GraphQL::Schema::InputObject
+        graphql_name "TestInput1"
+        argument :d, Int, required: true
+        argument :e, Int, required: true
+      end
+
+      class TestInput2 < GraphQL::Schema::InputObject
+        graphql_name "TestInput2"
+        argument :a, Int, required: true
+        argument :b, Int, required: true
+        argument :c, TestInput1, as: :inputObject, required: true
+      end
+
+      TestInput1.to_graphql
+      TestInput2.to_graphql
+    end
+
+    it "returns a stringified, aliased, ruby keyword style hash" do
+      arg_values = {a: 1, b: 2, c: { d: 3, e: 4 }}
+
+      input_object = InputObjectToHTest::TestInput2.new(
+        arg_values,
+        context: nil,
+        defaults_used: Set.new
+      )
+
+      assert_equal({ a: 1, b: 2, input_object: { d: 3, e: 4 } }, input_object.to_h)
+    end
+  end
 end

--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -128,7 +128,7 @@ describe GraphQL::Schema::InputObject do
       TestInput2.to_graphql
     end
 
-    it "returns a stringified, aliased, ruby keyword style hash" do
+    it "returns a symbolized, aliased, ruby keyword style hash" do
       arg_values = {a: 1, b: 2, c: { d: 3, e: 4 }}
 
       input_object = InputObjectToHTest::TestInput2.new(


### PR DESCRIPTION
recursively unwraps values in `InputObject#to_h` in a way that's consistent with `Arguments`

fixes #1281 