### PR TITLE
Validate argument names are unique

### DIFF
--- a/lib/graphql/static_validation/all_rules.rb
+++ b/lib/graphql/static_validation/all_rules.rb
@@ -24,6 +24,7 @@ module GraphQL
       GraphQL::StaticValidation::ArgumentsAreDefined,
       GraphQL::StaticValidation::ArgumentLiteralsAreCompatible,
       GraphQL::StaticValidation::RequiredArgumentsArePresent,
+      GraphQL::StaticValidation::ArgumentNamesAreUnique,
       GraphQL::StaticValidation::VariableNamesAreUnique,
       GraphQL::StaticValidation::VariablesAreInputTypes,
       GraphQL::StaticValidation::VariableDefaultValuesAreCorrectlyTyped,

--- a/lib/graphql/static_validation/rules/argument_names_are_unique.rb
+++ b/lib/graphql/static_validation/rules/argument_names_are_unique.rb
@@ -6,17 +6,25 @@ module GraphQL
 
       def validate(context)
         context.visitor[GraphQL::Language::Nodes::Field] << ->(node, parent) {
-          argument_defns = node.arguments
-          if argument_defns.any?
-            args_by_name = Hash.new { |h, k| h[k] = [] }
-            argument_defns.each { |a| args_by_name[a.name] << a }
-            args_by_name.each do |name, defns|
-              if defns.size > 1
-                context.errors << message("There can be only one argument named \"#{name}\"", defns, context: context)
-              end
+          validate_arguments(node, context)
+        }
+
+        context.visitor[GraphQL::Language::Nodes::Directive] << ->(node, parent) {
+          validate_arguments(node, context)
+        }
+      end
+
+      def validate_arguments(node, context)
+        argument_defns = node.arguments
+        if argument_defns.any?
+          args_by_name = Hash.new { |h, k| h[k] = [] }
+          argument_defns.each { |a| args_by_name[a.name] << a }
+          args_by_name.each do |name, defns|
+            if defns.size > 1
+              context.errors << message("There can be only one argument named \"#{name}\"", defns, context: context)
             end
           end
-        }
+        end
       end
     end
   end

--- a/lib/graphql/static_validation/rules/argument_names_are_unique.rb
+++ b/lib/graphql/static_validation/rules/argument_names_are_unique.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+module GraphQL
+  module StaticValidation
+    class ArgumentNamesAreUnique
+      include GraphQL::StaticValidation::Message::MessageHelper
+
+      def validate(context)
+        context.visitor[GraphQL::Language::Nodes::Field] << ->(node, parent) {
+          argument_defns = node.arguments
+          if argument_defns.any?
+            args_by_name = Hash.new { |h, k| h[k] = [] }
+            argument_defns.each { |a| args_by_name[a.name] << a }
+            args_by_name.each do |name, defns|
+              if defns.size > 1
+                context.errors << message("There can be only one argument named \"#{name}\"", defns, context: context)
+              end
+            end
+          end
+        }
+      end
+    end
+  end
+end

--- a/spec/graphql/static_validation/rules/argument_names_are_unique_spec.rb
+++ b/spec/graphql/static_validation/rules/argument_names_are_unique_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::StaticValidation::ArgumentNamesAreUnique do
+  include StaticValidationHelpers
+
+  let(:query_string) { <<-GRAPHQL
+  query GetStuff {
+    c1: cheese(id: 1, id: 2) { flavor }
+    c2: cheese(id: 2) { flavor }
+  }
+  GRAPHQL
+  }
+
+  it "finds duplicate argument names" do
+    assert_equal 1, errors.size
+
+    error = errors.first
+    assert_equal 'There can be only one argument named "id"', error["message"]
+    assert_equal [{ "line" => 2, "column" => 16}, { "line" => 2, "column" => 23 }], error["locations"]
+    assert_equal ["query GetStuff", "c1"], error["fields"]
+  end
+end

--- a/spec/graphql/static_validation/rules/argument_names_are_unique_spec.rb
+++ b/spec/graphql/static_validation/rules/argument_names_are_unique_spec.rb
@@ -4,20 +4,41 @@ require "spec_helper"
 describe GraphQL::StaticValidation::ArgumentNamesAreUnique do
   include StaticValidationHelpers
 
-  let(:query_string) { <<-GRAPHQL
-  query GetStuff {
-    c1: cheese(id: 1, id: 2) { flavor }
-    c2: cheese(id: 2) { flavor }
-  }
-  GRAPHQL
-  }
+  describe "field arguments" do
+    let(:query_string) { <<-GRAPHQL
+    query GetStuff {
+      c1: cheese(id: 1, id: 2) { flavor }
+      c2: cheese(id: 2) { flavor }
+    }
+    GRAPHQL
+    }
 
-  it "finds duplicate argument names" do
-    assert_equal 1, errors.size
+    it "finds duplicate names" do
+      assert_equal 1, errors.size
 
-    error = errors.first
-    assert_equal 'There can be only one argument named "id"', error["message"]
-    assert_equal [{ "line" => 2, "column" => 16}, { "line" => 2, "column" => 23 }], error["locations"]
-    assert_equal ["query GetStuff", "c1"], error["fields"]
+      error = errors.first
+      assert_equal 'There can be only one argument named "id"', error["message"]
+      assert_equal [{ "line" => 2, "column" => 18}, { "line" => 2, "column" => 25 }], error["locations"]
+      assert_equal ["query GetStuff", "c1"], error["fields"]
+    end
+  end
+
+  describe "directive arguments" do
+    let(:query_string) { <<-GRAPHQL
+    query GetStuff {
+      c1: cheese(id: 1) @include(if: true, if: true) { flavor }
+      c2: cheese(id: 2) @include(if: true) { flavor }
+    }
+    GRAPHQL
+    }
+
+    it "finds duplicate names" do
+      assert_equal 1, errors.size
+
+      error = errors.first
+      assert_equal 'There can be only one argument named "if"', error["message"]
+      assert_equal [{ "line" => 2, "column" => 34}, { "line" => 2, "column" => 44 }], error["locations"]
+      assert_equal ["query GetStuff", "c1"], error["fields"]
+    end
   end
 end


### PR DESCRIPTION
[As per the spec](http://facebook.github.io/graphql/October2016/#sec-Argument-Uniqueness):

> Fields and directives treat arguments as a mapping of argument name to value. More than one argument with the same name in an argument set is ambiguous and invalid.

This PR adds extra validation to adhere to the spec and remove ambiguity.

/cc @d12 @nickvanw as they discovered this