### PR TITLE
Propagate null for list type of non-null types

### DIFF
--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -198,8 +198,6 @@ module GraphQL
               result = []
               field_ctx.value = result
 
-              non_null_inner_type = inner_type.non_null?
-
               value.each do |inner_value|
                 inner_ctx = field_ctx.spawn_child(
                   key: i,
@@ -213,11 +211,11 @@ module GraphQL
                   inner_ctx,
                 )
 
+                return PROPAGATE_NULL if inner_result == PROPAGATE_NULL
+
                 inner_ctx.value = inner_result
                 result << inner_ctx
                 i += 1
-
-                return PROPAGATE_NULL if non_null_inner_type && inner_ctx.value.nil?
               end
 
               result

--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -198,6 +198,8 @@ module GraphQL
               result = []
               field_ctx.value = result
 
+              non_null_inner_type = inner_type.non_null?
+
               value.each do |inner_value|
                 inner_ctx = field_ctx.spawn_child(
                   key: i,
@@ -214,13 +216,11 @@ module GraphQL
                 inner_ctx.value = inner_result
                 result << inner_ctx
                 i += 1
+
+                return PROPAGATE_NULL if non_null_inner_type && inner_ctx.value.nil?
               end
 
-              if inner_type.non_null? && result.any? { |result| result.value.nil? }
-                PROPAGATE_NULL
-              else
-                result
-              end
+              result
             when GraphQL::TypeKinds::NON_NULL
               inner_type = field_type.of_type
               resolve_value(

--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -215,7 +215,12 @@ module GraphQL
                 result << inner_ctx
                 i += 1
               end
-              result
+
+              if inner_type.non_null? && result.any? { |result| result.value.nil? }
+                PROPAGATE_NULL
+              else
+                result
+              end
             when GraphQL::TypeKinds::NON_NULL
               inner_type = field_type.of_type
               resolve_value(

--- a/spec/graphql/execution/execute_spec.rb
+++ b/spec/graphql/execution/execute_spec.rb
@@ -99,6 +99,12 @@ describe GraphQL::Execution::Execute do
             [nil]
           }
         end
+
+        field :nonNullList, !types[!types.String], "" do
+          resolve ->(obj, args, ctx) {
+            [nil]
+          }
+        end
       end
 
       GraphQL::Schema.define do
@@ -122,6 +128,12 @@ describe GraphQL::Execution::Execute do
       assert_equal ["nonNullListWithNullElementsLazy"], result["data"].keys
 
       assert_equal nil, result["data"]["nonNullListWithNullElements"]
+    end
+
+    it "propagates null for non-null lists of non-null types" do
+      result = schema.execute("{ nonNullList }").to_h
+
+      assert_equal nil, result["data"]
     end
   end
 


### PR DESCRIPTION
Fixes #1510 

This is my first time playing in the executor code so I'm not sure if other changes need to be made.

I believe this fixes the issue reported by @joshjcarrier. I've tried with the repro script attached to the issue and have added similar code in our tests.

As a precaution I also confirmed this behaviour in the reference implementation:

```js
var graphql = require("graphql");

var schema = new graphql.GraphQLSchema({
  query: new graphql.GraphQLObjectType({
    name: 'RootQueryType',
    fields: {
      hello: {
        type: graphql.GraphQLList(graphql.GraphQLNonNull(graphql.GraphQLString)),
        resolve() {
          return [null];
        }
      }
    }
  })
});

var query = '{ hello }';

graphql.graphql(schema, query).then(result => {
  console.log(result);
});

// { errors:
//    [ { message: 'Cannot return null for non-nullable field RootQueryType.hello.',
//        locations: [Array],
//        path: [Array] } ],
//   data: { hello: null } }
```