### PR TITLE
Fix default_mask configuration not being compatible in the class-based API

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -652,6 +652,7 @@ module GraphQL
         # Configuration
         :max_complexity=, :max_depth=,
         :metadata,
+        :default_mask,
         :default_filter, :redefine,
         :id_from_object_proc, :object_from_id_proc,
         :id_from_object=, :object_from_id=, :type_error,


### PR DESCRIPTION
Prior to 1.8, I used to be able to do:

```ruby
GraphQL::Schema.define do
  # ...
  default_mask(...)
end
```

This doesn't work on the class-based API in 1.8:

```ruby
class MySchema < GraphQL::Schema
  # ...
  default_mask(...)
end
```

This PR adds support to be compatible between the old and new APIs.