### PR TITLE
Fix mutation guide example code

### DIFF
--- a/guides/mutations/mutation_classes.md
+++ b/guides/mutations/mutation_classes.md
@@ -54,7 +54,7 @@ class Mutations::CreateComment < Mutations::BaseMutation
   argument :post_id, ID, required: true
 
   field :comment, Types::Comment, null: true
-  field :error_messages, [String], null: false
+  field :errors, [String], null: false
 
   def resolve(body:, post_id:)
     post = Post.find(post_id)


### PR DESCRIPTION
Fixed inconsistency between field name defined with `field` macro and what's actually returned from `resolve` method.