### PR TITLE
Fix graphql:interface generator

### DIFF
--- a/lib/generators/graphql/templates/interface.erb
+++ b/lib/generators/graphql/templates/interface.erb
@@ -1,3 +1,4 @@
-class <%= type_ruby_name %> < Types::BaseInterface
+module <%= type_ruby_name %>
+  include Types::BaseInterface
 <% normalized_fields.each do |f| %>  <%= f.to_ruby %>
 <% end %>end

--- a/spec/generators/graphql/interface_generator_spec.rb
+++ b/spec/generators/graphql/interface_generator_spec.rb
@@ -16,7 +16,8 @@ class GraphQLGeneratorsInterfaceGeneratorTest < BaseGeneratorTest
     ]
 
     expected_content = <<-RUBY
-class Types::BirdType < Types::BaseInterface
+module Types::BirdType
+  include Types::BaseInterface
   field :wingspan, Integer, null: false
   field :foliage, [Types::ColorType], null: true
 end


### PR DESCRIPTION
changed generated class implementation to module

related to https://github.com/rmosolgo/graphql-ruby/issues/1576