### PR TITLE
Add possible type helpers to abstract types

### DIFF
--- a/lib/graphql/interface_type.rb
+++ b/lib/graphql/interface_type.rb
@@ -64,5 +64,23 @@ module GraphQL
     def all_fields
       fields.values
     end
+
+    # Get a possible type of this {InterfaceType} by type name
+    # @param type_name [String]
+    # @param ctx [GraphQL::Query::Context] The context for the current query
+    # @return [GraphQL::ObjectType, nil] The type named `type_name` if it exists and implements this {InterfaceType}, (else `nil`)
+    def get_possible_type(type_name, ctx)
+      type = ctx.query.get_type(type_name)
+      type if type && ctx.query.schema.possible_types(self).include?(type)
+    end
+
+    # Check if a type is a possible type of this {InterfaceType}
+    # @param type [String, GraphQL::BaseType] Name of the type or a type definition
+    # @param ctx [GraphQL::Query::Context] The context for the current query
+    # @return [Boolean] True if the `type` exists and is a member of this {InterfaceType}, (else `nil`)
+    def possible_type?(type, ctx)
+      type_name = type.is_a?(String) ? type : type.graphql_name
+      !get_possible_type(type_name, ctx).nil?
+    end
   end
 end

--- a/lib/graphql/union_type.rb
+++ b/lib/graphql/union_type.rb
@@ -67,6 +67,24 @@ module GraphQL
       end
     end
 
+    # Get a possible type of this {UnionType} by type name
+    # @param type_name [String]
+    # @param ctx [GraphQL::Query::Context] The context for the current query
+    # @return [GraphQL::ObjectType, nil] The type named `type_name` if it exists and is a member of this {UnionType}, (else `nil`)
+    def get_possible_type(type_name, ctx)
+      type = ctx.query.get_type(type_name)
+      type if type && ctx.query.schema.possible_types(self).include?(type)
+    end
+
+    # Check if a type is a possible type of this {UnionType}
+    # @param type [String, GraphQL::BaseType] Name of the type or a type definition
+    # @param ctx [GraphQL::Query::Context] The context for the current query
+    # @return [Boolean] True if the `type` exists and is a member of this {UnionType}, (else `nil`)
+    def possible_type?(type, ctx)
+      type_name = type.is_a?(String) ? type : type.graphql_name
+      !get_possible_type(type_name, ctx).nil?
+    end
+
     def resolve_type(value, ctx)
       ctx.query.resolve_type(self, value)
     end

--- a/spec/graphql/interface_type_spec.rb
+++ b/spec/graphql/interface_type_spec.rb
@@ -149,4 +149,48 @@ describe GraphQL::InterfaceType do
       assert_equal expected_result, result["data"]
     end
   end
+
+  describe "#get_possible_type" do
+    let(:query_string) {%|
+      query fav {
+        favoriteEdible { fatContent }
+      }
+    |}
+
+    let(:query) { GraphQL::Query.new(Dummy::Schema, query_string) }
+
+    it "returns the type definition if the type exists and is a possible type of the interface" do
+      assert interface.get_possible_type("Cheese", query.context)
+    end
+
+    it "returns nil if the type is not found in the schema" do
+      assert_nil interface.get_possible_type("Foo", query.context)
+    end
+
+    it "returns nil if the type is not a possible type of the interface" do
+      assert_nil interface.get_possible_type("Beverage", query.context)
+    end
+  end
+
+  describe "#possible_type?" do
+    let(:query_string) {%|
+      query fav {
+        favoriteEdible { fatContent }
+      }
+    |}
+
+    let(:query) { GraphQL::Query.new(Dummy::Schema, query_string) }
+
+    it "returns true if the type exists and is a possible type of the interface" do
+      assert interface.possible_type?("Cheese", query.context)
+    end
+
+    it "returns false if the type is not found in the schema" do
+      refute interface.possible_type?("Foo", query.context)
+    end
+
+    it "returns false if the type is not a possible type of the interface" do
+      refute interface.possible_type?("Beverage", query.context)
+    end
+  end
 end

--- a/spec/graphql/union_type_spec.rb
+++ b/spec/graphql/union_type_spec.rb
@@ -158,4 +158,54 @@ describe GraphQL::UnionType do
       assert_equal 3, union_2.possible_types.size
     end
   end
+
+  describe "#get_possible_type" do
+    let(:query_string) {%|
+      {
+        __type(name: "Beverage") {
+          name
+        }
+      }
+    |}
+
+    let(:query) { GraphQL::Query.new(Dummy::Schema, query_string) }
+    let(:union) { Dummy::BeverageUnion }
+
+    it "returns the type definition if the type exists and is a possible type of the union" do
+      assert union.get_possible_type("Milk", query.context)
+    end
+
+    it "returns nil if the type is not found in the schema" do
+      assert_nil union.get_possible_type("Foo", query.context)
+    end
+
+    it "returns nil if the type is not a possible type of the union" do
+      assert_nil union.get_possible_type("Cheese", query.context)
+    end
+  end
+
+  describe "#possible_type?" do
+    let(:query_string) {%|
+      {
+        __type(name: "Beverage") {
+          name
+        }
+      }
+    |}
+
+    let(:query) { GraphQL::Query.new(Dummy::Schema, query_string) }
+    let(:union) { Dummy::BeverageUnion }
+
+    it "returns true if the type exists and is a possible type of the union" do
+      assert union.possible_type?("Milk", query.context)
+    end
+
+    it "returns false if the type is not found in the schema" do
+      refute union.possible_type?("Foo", query.context)
+    end
+
+    it "returns false if the type is not a possible type of the union" do
+      refute union.possible_type?("Cheese", query.context)
+    end
+  end
 end


### PR DESCRIPTION
This adds `get_possible_type` and `possible_type?` to `InterfaceType` and `UnionType`.

These methods differ from the static `Schema.possible_types` since they take into account the context and go through warden (for things like visibility).

`get_possible_type` returns the type if it exists and is a possible type from a type name.

`possible_type?` accepts with a type definition or a type name and returns a boolean.