### PR TITLE
Include directives in InputObjectTypeDefinition's children

### DIFF
--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -539,13 +539,16 @@ module GraphQL
         include Scalars::Name
 
         attr_accessor :name, :fields, :directives, :description
-        alias :children :fields
 
         def initialize_node(name:, fields:, directives: [], description: nil)
           @name = name
           @fields = fields
           @directives = directives
           @description = description
+        end
+
+        def children
+          fields + directives
         end
       end
     end

--- a/spec/graphql/language/visitor_spec.rb
+++ b/spec/graphql/language/visitor_spec.rb
@@ -72,4 +72,23 @@ describe GraphQL::Language::Visitor do
       assert_equal(0, counts[:fields_entered])
     end
   end
+
+  it "can visit InputObjectTypeDefinition directives" do
+    schema_sdl = <<-GRAPHQL
+    input Test @directive {
+      id: ID!
+    }
+    GRAPHQL
+
+    document = GraphQL.parse(schema_sdl)
+
+    visitor = GraphQL::Language::Visitor.new(document)
+
+    visited_directive = false
+    visitor[GraphQL::Language::Nodes::Directive] << ->(node, parent) { visited_directive = true }
+
+    visitor.visit
+
+    assert visited_directive
+  end
 end


### PR DESCRIPTION
When using `GraphQL::Language::Visitor`, each node will be visited and then its child nodes (defined by the `children` method) will be visited. 

Currently the `children` of `InputObjectTypeDefinition` is only its fields. This means it is not possible to visit the directives of an `InputObjectTypeDefinition`.

This PR fixes this.