### PR TITLE
index.html page: Link to an existing article for explaining Types

### DIFF
--- a/guides/index.html
+++ b/guides/index.html
@@ -31,7 +31,7 @@ rails generate graphql:install
       <div class="teaser">
         <p>
           Describe your application with the
-          <a href="{{ site.baseurl }}/types/introduction">GraphQL type system</a>
+          <a href="{{ site.baseurl }}/schema/definition">GraphQL type system</a>
           to create a self-documenting, strongly-typed API.
         </p>
       </div>


### PR DESCRIPTION
  - the types/introduction text is no longer in there
  - the schema definition text is _perhaps_ where to begin, now?