### PR TITLE
Fix scalar coercion errors in variable values (including defaults) not being handled

### DIFF
--- a/lib/graphql/query/variables.rb
+++ b/lib/graphql/query/variables.rb
@@ -33,7 +33,7 @@ module GraphQL
             begin
               validation_result = variable_type.validate_input(provided_value, ctx)
             rescue GraphQL::CoercionError => ex
-              validation_result = Query::InputValidationResult.new
+              validation_result = GraphQL::Query::InputValidationResult.new
               validation_result.add_problem(ex.message)
             end
 

--- a/lib/graphql/query/variables.rb
+++ b/lib/graphql/query/variables.rb
@@ -30,7 +30,13 @@ module GraphQL
             provided_value = @provided_variables[variable_name]
             value_was_provided =  @provided_variables.key?(variable_name)
 
-            validation_result = variable_type.validate_input(provided_value, ctx)
+            begin
+              validation_result = variable_type.validate_input(provided_value, ctx)
+            rescue GraphQL::CoercionError => ex
+              validation_result = Query::InputValidationResult.new
+              validation_result.add_problem(ex.message)
+            end
+
             if !validation_result.valid?
               # This finds variables that were required but not provided
               @errors << GraphQL::Query::VariableValidationError.new(ast_variable, variable_type, provided_value, validation_result)

--- a/lib/graphql/static_validation/rules/variable_default_values_are_correctly_typed.rb
+++ b/lib/graphql/static_validation/rules/variable_default_values_are_correctly_typed.rb
@@ -27,9 +27,8 @@ module GraphQL
               error_message = err.message
             end
 
-            error_message ||= "Default value for $#{node.name} doesn't match type #{type}"
-
             if !valid
+              error_message ||= "Default value for $#{node.name} doesn't match type #{type}"
               context.errors << message(error_message, node, context: context)
             end
           end

--- a/lib/graphql/static_validation/rules/variable_default_values_are_correctly_typed.rb
+++ b/lib/graphql/static_validation/rules/variable_default_values_are_correctly_typed.rb
@@ -20,8 +20,18 @@ module GraphQL
           type = context.schema.type_from_ast(node.type)
           if type.nil?
             # This is handled by another validator
-          elsif !context.valid_literal?(value, type)
-            context.errors << message("Default value for $#{node.name} doesn't match type #{type}", node, context: context)
+          else
+            begin
+              valid = context.valid_literal?(value, type)
+            rescue GraphQL::CoercionError => err
+              error_message = err.message
+            end
+
+            error_message ||= "Default value for $#{node.name} doesn't match type #{type}"
+
+            if !valid
+              context.errors << message(error_message, node, context: context)
+            end
           end
         end
       end

--- a/spec/graphql/query/variables_spec.rb
+++ b/spec/graphql/query/variables_spec.rb
@@ -110,6 +110,26 @@ describe GraphQL::Query::Variables do
           assert_equal expected, variables.errors.first.message
         end
       end
+
+      describe "when provided input cannot be coerced" do
+        let(:query_string) {%|
+        query searchMyDairy (
+          $time: Time
+        ) {
+          searchDairy(expiresAfter: $time) {
+            ... on Cheese {
+              flavor
+            }
+          }
+        }
+        |}
+        let(:provided_variables) { { "time" => "a" } }
+
+        it "validates invalid input objects" do
+          expected = "Variable time of type Time was provided invalid value"
+          assert_equal expected, variables.errors.first.message
+        end
+      end
     end
 
     describe "nullable variables" do

--- a/spec/graphql/static_validation/rules/variable_default_values_are_correctly_typed_spec.rb
+++ b/spec/graphql/static_validation/rules/variable_default_values_are_correctly_typed_spec.rb
@@ -134,4 +134,56 @@ describe GraphQL::StaticValidation::VariableDefaultValuesAreCorrectlyTyped do
       end
     end
   end
+
+  describe "custom error messages" do
+    let(:schema) {
+      TimeType = GraphQL::ScalarType.define do
+        name "Time"
+        description "Time since epoch in seconds"
+
+        coerce_input ->(value, ctx) do
+          begin
+            Time.at(Float(value))
+          rescue ArgumentError
+            raise GraphQL::CoercionError, 'cannot coerce to Float'
+          end
+        end
+
+        coerce_result ->(value, ctx) { value.to_f }
+      end
+
+      QueryType = GraphQL::ObjectType.define do
+        name "Query"
+        description "The query root of this schema"
+
+        field :time do
+          type TimeType
+          argument :value, !TimeType
+          resolve ->(obj, args, ctx) { args[:value] }
+        end
+      end
+
+      GraphQL::Schema.define do
+        query QueryType
+      end
+    }
+
+    let(:query_string) {%|
+      query(
+        $value: Time = "a"
+      ) {
+        time(value: $value)
+      }
+    |}
+
+    it "sets error message from a CoercionError if raised" do
+      assert_equal 1, errors.length
+
+      assert_includes errors, {
+        "message"=> "cannot coerce to Float",
+        "locations"=>[{"line"=>3, "column"=>9}],
+        "fields"=>["query"]
+      }
+    end
+  end
 end

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -248,6 +248,21 @@ module Dummy
     end
   end
 
+  TimeType = GraphQL::ScalarType.define do
+    name "Time"
+    description "Time since epoch in seconds"
+
+    coerce_input ->(value, ctx) do
+      begin
+        Time.at(Float(value))
+      rescue ArgumentError
+        raise GraphQL::CoercionError, 'cannot coerce to Float'
+      end
+    end
+
+    coerce_result ->(value, ctx) { value.to_f }
+  end
+
   class FetchItem < GraphQL::Function
     attr_reader :type, :description, :arguments
 
@@ -312,6 +327,7 @@ module Dummy
       type !DairyProductUnion
       # This is a list just for testing 😬
       argument :product, types[DairyProductInputType], default_value: [{"source" => "SHEEP"}]
+      argument :expiresAfter, TimeType
       resolve ->(t, args, c) {
         source = args["product"][0][:source] # String or Sym is ok
         products = CHEESES.values + MILKS.values


### PR DESCRIPTION
Currently, if a variable value for a scalar cannot be coerced, it results in an exception getting raised rather than being tracked in the `errors` array of the response.  This same thing happens when a default value for a variable is provided that cannot be coerced.

This fixes that problem by handling `GraphQL::CoercionError` in the same way we see here: https://github.com/rmosolgo/graphql-ruby/blob/bf29cde08e9707100703d0bef9464c92aced65e3/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb#L10-L14

Example scenarios where this problem presents itself are shown in the specs.

This should also fix https://github.com/rmosolgo/graphql-ruby/issues/1269