### PR TITLE
Improve ability to debug errors in development environment

### DIFF
--- a/lib/generators/graphql/templates/graphql_controller.erb
+++ b/lib/generators/graphql/templates/graphql_controller.erb
@@ -9,6 +9,9 @@ class GraphqlController < ApplicationController
     }
     result = <%= schema_name %>.execute(query, variables: variables, context: context, operation_name: operation_name)
     render json: result
+  rescue => e
+    raise e unless Rails.env.development?
+    handle_error_in_development e
   end
 
   private
@@ -29,5 +32,12 @@ class GraphqlController < ApplicationController
     else
       raise ArgumentError, "Unexpected parameter: #{ambiguous_param}"
     end
+  end
+
+  def handle_error_in_development(e)
+    logger.error e.message
+    logger.error e.backtrace.join("\n")
+
+    render json: { error: { message: e.message, backtrace: e.backtrace }, data: {} }, status: 500
   end
 end


### PR DESCRIPTION
This pull request borrows some logic from https://github.com/howtographql/graphql-ruby/blob/master/app/controllers/graphql_controller.rb that allows for much easier debugging of errors when using tools such as graphiql.

It basically overrides the default Rails error handling for the development environment, which shows an HTML page by default, and instead returns the stack trace in a json response.

I think these are pretty good defaults to use for scaffolding when first creating a project with this gem.

Before:
![21-59-yddnv-bzih1](https://user-images.githubusercontent.com/684669/41781207-ec1cd85a-7604-11e8-8fa3-5810ddf172c6.jpg)

After:
![21-02-ww5b2-8bt2t](https://user-images.githubusercontent.com/684669/41781484-b87136bc-7605-11e8-88f2-907752b7b718.jpg)
