### PR TITLE
Resolve directive bug when using variable with default value of false

### DIFF
--- a/lib/graphql/query/variables.rb
+++ b/lib/graphql/query/variables.rb
@@ -43,7 +43,7 @@ module GraphQL
             elsif value_was_provided
               # Add the variable if a value was provided
               memo[variable_name] = variable_type.coerce_input(provided_value, ctx)
-            elsif default_value
+            elsif default_value != nil
               # Add the variable if it wasn't provided but it has a default value (including `null`)
               memo[variable_name] = GraphQL::Query::LiteralInput.coerce(variable_type, default_value, self)
             end

--- a/spec/graphql/directive_spec.rb
+++ b/spec/graphql/directive_spec.rb
@@ -48,6 +48,38 @@ describe GraphQL::Directive do
       end
     end
 
+    describe "when directive uses argument with default value" do
+      describe "with false" do
+        let(:query_string) { <<-GRAPHQL
+          query($f: Boolean = false) {
+            cheese(id: 1) {
+              dontIncludeFlavor: flavor @include(if: $f)
+            }
+          }
+        GRAPHQL
+        }
+
+        it "is not included" do
+          assert !result["data"]["cheese"].key?("dontIncludeFlavor")
+        end
+      end
+
+      describe "with true" do
+        let(:query_string) { <<-GRAPHQL
+          query($t: Boolean = true) {
+            cheese(id: 1) {
+              includeFlavor: flavor @include(if: $t)
+            }
+          }
+        GRAPHQL
+        }
+
+        it "is included" do
+          assert result["data"]["cheese"].key?("includeFlavor")
+        end
+      end
+    end
+
     it "intercepts fields" do
       expected = { "data" =>{
         "cheese" => {

--- a/spec/graphql/directive_spec.rb
+++ b/spec/graphql/directive_spec.rb
@@ -54,6 +54,7 @@ describe GraphQL::Directive do
           query($f: Boolean = false) {
             cheese(id: 1) {
               dontIncludeFlavor: flavor @include(if: $f)
+              dontSkipFlavor: flavor @skip(if: $f)
             }
           }
         GRAPHQL
@@ -62,6 +63,10 @@ describe GraphQL::Directive do
         it "is not included" do
           assert !result["data"]["cheese"].key?("dontIncludeFlavor")
         end
+
+        it "is not skipped" do
+          assert result["data"]["cheese"].key?("dontSkipFlavor")
+        end
       end
 
       describe "with true" do
@@ -69,6 +74,7 @@ describe GraphQL::Directive do
           query($t: Boolean = true) {
             cheese(id: 1) {
               includeFlavor: flavor @include(if: $t)
+              skipFlavor: flavor @skip(if: $t)
             }
           }
         GRAPHQL
@@ -76,6 +82,10 @@ describe GraphQL::Directive do
 
         it "is included" do
           assert result["data"]["cheese"].key?("includeFlavor")
+        end
+
+        it "is skipped" do
+          assert !result["data"]["cheese"].key?("skipFlavor")
         end
       end
     end


### PR DESCRIPTION
👋 Hi there,

This pull request resolves a bug that was originally reported in our site's [public Discourse](https://platform.github.community/t/include-with-default-false-behaves-like-it-received-true/6302). The reporter had mentioned that given a query like:

```graphql
query($showName: Boolean = false) { 
  viewer {
    login @include(if: $showName)
  }
}
```

Their response would include the field that was not to be included:

```json
{
  "data": {
    "viewer": {
      "login": "bswinnerton"
    }
  }
}
```

This ultimately boiled down to this `case` statement:

https://github.com/rmosolgo/graphql-ruby/blob/e0b3e728f38c73529cf68846ac9c2870526a1832/lib/graphql/query/variables.rb#L46

Which, in the query above, `default_value` would have been equal to `false`.

This pull request changes the behavior to specifically check for the presence of `nil`.