### PR TITLE
Include 'filename' key in static validation error hash

### DIFF
--- a/lib/graphql/static_validation/message.rb
+++ b/lib/graphql/static_validation/message.rb
@@ -33,7 +33,11 @@ module GraphQL
       private
 
       def locations
-        @nodes.map{|node| {"line" => node.line, "column" => node.col}}
+        @nodes.map do |node|
+          h = {"line" => node.line, "column" => node.col}
+          h["filename"] = node.filename if node.filename
+          h
+        end
       end
     end
   end

--- a/spec/graphql/static_validation/validator_spec.rb
+++ b/spec/graphql/static_validation/validator_spec.rb
@@ -25,6 +25,21 @@ describe GraphQL::StaticValidation::Validator do
     end
   end
 
+  describe "error format" do
+    let(:query_string) { "{ cheese(id: $undefinedVar) { source } }" }
+    let(:document) { GraphQL.parse_with_racc(query_string, filename: "not_a_real.graphql") }
+    let(:query) { GraphQL::Query.new(Dummy::Schema, nil, document: document) }
+
+    it "includes message, locations, and fields keys" do
+      expected_errors = [{
+        "message" => "Variable $undefinedVar is used by  but not declared",
+        "locations" => [{"line" => 1, "column" => 14, "filename" => "not_a_real.graphql"}],
+        "fields" => ["query", "cheese", "id"]
+      }]
+      assert_equal expected_errors, errors
+    end
+  end
+
   describe "validation order" do
     let(:document) { GraphQL.parse(query_string)}
 


### PR DESCRIPTION
This may not be the best way of accomplishing this, but in our use-case we'd like to be able to pull the filename back out of the validation error, since we're concatenating definitions from multiple documents before running validation.

@rmosolgo 
cc @jackychiu @jpittis