### PR TITLE
Deprecate 'resolves?' in favour of 'abstract?' in TypeKind

### DIFF
--- a/lib/graphql/introspection/type_type.rb
+++ b/lib/graphql/introspection/type_type.rb
@@ -60,7 +60,7 @@ module GraphQL
       end
 
       def possible_types
-        if @object.kind.resolves?
+        if @object.kind.abstract?
           @context.warden.possible_types(@object)
         else
           nil

--- a/lib/graphql/schema/validation.rb
+++ b/lib/graphql/schema/validation.rb
@@ -131,7 +131,7 @@ module GraphQL
         }
 
         SCHEMA_CAN_RESOLVE_TYPES = ->(schema) {
-          if schema.types.values.any? { |type| type.kind.resolves? } && schema.resolve_type_proc.nil?
+          if schema.types.values.any? { |type| type.kind.abstract? } && schema.resolve_type_proc.nil?
             "schema contains Interfaces or Unions, so you must define a `resolve_type -> (obj, ctx) { ... }` function"
           else
             # :+1:

--- a/lib/graphql/type_kinds.rb
+++ b/lib/graphql/type_kinds.rb
@@ -5,18 +5,21 @@ module GraphQL
     # These objects are singletons, eg `GraphQL::TypeKinds::UNION`, `GraphQL::TypeKinds::SCALAR`.
     class TypeKind
       attr_reader :name, :description
-      def initialize(name, resolves: false, fields: false, wraps: false, input: false, description: nil)
+      def initialize(name, abstract: false, fields: false, wraps: false, input: false, description: nil)
         @name = name
-        @resolves = resolves
+        @abstract = abstract
         @fields = fields
         @wraps = wraps
         @input = input
-        @composite = fields? || resolves?
+        @composite = fields? || abstract?
         @description = description
       end
 
       # Does this TypeKind have multiple possible implementors?
-      def resolves?;  @resolves;  end
+      # @deprecated Use `abstract?` instead of `resolves?`.
+      def resolves?;  @abstract;  end
+      # Is this TypeKind abstract?
+      def abstract?; @abstract; end
       # Does this TypeKind have queryable fields?
       def fields?;    @fields;    end
       # Does this TypeKind modify another type?
@@ -31,8 +34,8 @@ module GraphQL
     TYPE_KINDS = [
       SCALAR =        TypeKind.new("SCALAR", input: true, description: 'Indicates this type is a scalar.'),
       OBJECT =        TypeKind.new("OBJECT", fields: true, description: 'Indicates this type is an object. `fields` and `interfaces` are valid fields.'),
-      INTERFACE =     TypeKind.new("INTERFACE", resolves: true, fields: true, description: 'Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.'),
-      UNION =         TypeKind.new("UNION", resolves: true, description: 'Indicates this type is a union. `possibleTypes` is a valid field.'),
+      INTERFACE =     TypeKind.new("INTERFACE", abstract: true, fields: true, description: 'Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.'),
+      UNION =         TypeKind.new("UNION", abstract: true, description: 'Indicates this type is a union. `possibleTypes` is a valid field.'),
       ENUM =          TypeKind.new("ENUM", input: true, description: 'Indicates this type is an enum. `enumValues` is a valid field.'),
       INPUT_OBJECT =  TypeKind.new("INPUT_OBJECT", input: true, description: 'Indicates this type is an input object. `inputFields` is a valid field.'),
       LIST =          TypeKind.new("LIST", wraps: true, description: 'Indicates this type is a list. `ofType` is a valid field.'),


### PR DESCRIPTION
This is a proposal and implementation to deprecate 'resolves?' in favour of adding 'abstract?' to `TypeKind`. The reason for this proposal is because I found that that the language 'resolves?' to be a bit misleading and 'abstract?' to be more explicit in what the check is actually doing.

I understand that abstract types need to provide a resolve type, but this might not be apparent to everyone at first glance, as it wasn't for me. It can also be easily confused with whether or not a type can actually resolve at all.