### PR TITLE
Use the ID type for Relay connection cursors

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -243,8 +243,8 @@ module GraphQL
           # TODO: this could be a bit weird, because these fields won't be present
           # after initialization, only in the `to_graphql` response.
           # This calculation _could_ be moved up if need be.
-          argument :after, "String", "Returns the elements in the list that come after the specified cursor.", required: false
-          argument :before, "String", "Returns the elements in the list that come before the specified cursor.", required: false
+          argument :after, "ID", "Returns the elements in the list that come after the specified cursor.", required: false
+          argument :before, "ID", "Returns the elements in the list that come before the specified cursor.", required: false
           argument :first, "Int", "Returns the first _n_ elements from the list.", required: false
           argument :last, "Int", "Returns the last _n_ elements from the list.", required: false
         end

--- a/spec/graphql/relay/array_connection_spec.rb
+++ b/spec/graphql/relay/array_connection_spec.rb
@@ -17,7 +17,7 @@ describe GraphQL::Relay::ArrayConnection do
 
   describe "results" do
     let(:query_string) {%|
-      query getShips($first: Int, $after: String, $last: Int, $before: String, $nameIncludes: String){
+      query getShips($first: Int, $after: ID, $last: Int, $before: ID, $nameIncludes: String){
         rebels {
           ships(first: $first, after: $after, last: $last, before: $before, nameIncludes: $nameIncludes) {
             edges {
@@ -177,7 +177,7 @@ describe GraphQL::Relay::ArrayConnection do
       end
 
       let(:query_string) {%|
-        query getShips($first: Int, $after: String, $last: Int, $before: String){
+        query getShips($first: Int, $after: ID, $last: Int, $before: ID){
           rebels {
             bases: basesWithMaxLimitArray(first: $first, after: $after, last: $last, before: $before) {
               edges {
@@ -237,7 +237,7 @@ describe GraphQL::Relay::ArrayConnection do
       end
 
       let(:query_string) {%|
-        query getShips($first: Int, $after: String, $last: Int, $before: String){
+        query getShips($first: Int, $after: ID, $last: Int, $before: ID){
           rebels {
             bases: basesWithDefaultMaxLimitArray(first: $first, after: $after, last: $last, before: $before) {
               edges {

--- a/spec/graphql/relay/mongo_relation_connection_spec.rb
+++ b/spec/graphql/relay/mongo_relation_connection_spec.rb
@@ -32,7 +32,7 @@ describe GraphQL::Relay::MongoRelationConnection do
 
   describe "results" do
     let(:query_string) {%|
-      query getShips($first: Int, $after: String, $last: Int, $before: String,  $nameIncludes: String){
+      query getShips($first: Int, $after: ID, $last: Int, $before: ID,  $nameIncludes: String){
         federation {
           bases(first: $first, after: $after, last: $last, before: $before, nameIncludes: $nameIncludes) {
             ... basesConnection
@@ -222,7 +222,7 @@ describe GraphQL::Relay::MongoRelationConnection do
 
     describe "applying max_page_size" do
       let(:query_string) {%|
-        query getBases($first: Int, $after: String, $last: Int, $before: String){
+        query getBases($first: Int, $after: ID, $last: Int, $before: ID){
           federation {
             bases: basesWithMaxLimitRelation(first: $first, after: $after, last: $last, before: $before) {
               ... basesConnection
@@ -281,7 +281,7 @@ describe GraphQL::Relay::MongoRelationConnection do
 
     describe "applying default_max_page_size" do
       let(:query_string) {%|
-        query getBases($first: Int, $after: String, $last: Int, $before: String){
+        query getBases($first: Int, $after: ID, $last: Int, $before: ID){
           federation {
             bases: basesWithDefaultMaxLimitRelation(first: $first, after: $after, last: $last, before: $before) {
               ... basesConnection
@@ -341,7 +341,7 @@ describe GraphQL::Relay::MongoRelationConnection do
 
   describe "applying a max_page_size bigger than the results" do
     let(:query_string) {%|
-      query getBases($first: Int, $after: String, $last: Int, $before: String){
+      query getBases($first: Int, $after: ID, $last: Int, $before: ID){
         federation {
           bases: basesWithLargeMaxLimitRelation(first: $first, after: $after, last: $last, before: $before) {
             ... basesConnection

--- a/spec/graphql/relay/page_info_spec.rb
+++ b/spec/graphql/relay/page_info_spec.rb
@@ -20,7 +20,7 @@ describe GraphQL::Relay::PageInfo do
   }
 
   let(:query_string) {%|
-    query getShips($first: Int, $after: String, $last: Int, $before: String, $nameIncludes: String){
+    query getShips($first: Int, $after: ID, $last: Int, $before: ID, $nameIncludes: String){
       empire {
         bases(first: $first, after: $after, last: $last, before: $before, nameIncludes: $nameIncludes) {
           edges {

--- a/spec/graphql/relay/relation_connection_spec.rb
+++ b/spec/graphql/relay/relation_connection_spec.rb
@@ -21,7 +21,7 @@ describe GraphQL::Relay::RelationConnection do
 
   describe "results" do
     let(:query_string) {%|
-      query getShips($first: Int, $after: String, $last: Int, $before: String,  $nameIncludes: String){
+      query getShips($first: Int, $after: ID, $last: Int, $before: ID,  $nameIncludes: String){
         empire {
           bases(first: $first, after: $after, last: $last, before: $before, nameIncludes: $nameIncludes) {
             ... basesConnection
@@ -240,7 +240,7 @@ describe GraphQL::Relay::RelationConnection do
 
     describe "applying max_page_size" do
       let(:query_string) {%|
-        query getBases($first: Int, $after: String, $last: Int, $before: String){
+        query getBases($first: Int, $after: ID, $last: Int, $before: ID){
           empire {
             bases: basesWithMaxLimitRelation(first: $first, after: $after, last: $last, before: $before) {
               ... basesConnection
@@ -299,7 +299,7 @@ describe GraphQL::Relay::RelationConnection do
 
     describe "applying default_max_page_size" do
       let(:query_string) {%|
-        query getBases($first: Int, $after: String, $last: Int, $before: String){
+        query getBases($first: Int, $after: ID, $last: Int, $before: ID){
           empire {
             bases: basesWithDefaultMaxLimitRelation(first: $first, after: $after, last: $last, before: $before) {
               ... basesConnection
@@ -359,7 +359,7 @@ describe GraphQL::Relay::RelationConnection do
 
   describe "applying a max_page_size bigger than the results" do
     let(:query_string) {%|
-      query getBases($first: Int, $after: String, $last: Int, $before: String){
+      query getBases($first: Int, $after: ID, $last: Int, $before: ID){
         empire {
           bases: basesWithLargeMaxLimitRelation(first: $first, after: $after, last: $last, before: $before) {
             ... basesConnection
@@ -498,7 +498,7 @@ describe GraphQL::Relay::RelationConnection do
 
     describe "results" do
       let(:query_string) {%|
-        query getShips($first: Int, $after: String, $last: Int, $before: String,  $nameIncludes: String){
+        query getShips($first: Int, $after: ID, $last: Int, $before: ID,  $nameIncludes: String){
           empire {
             basesAsSequelDataset(first: $first, after: $after, last: $last, before: $before, nameIncludes: $nameIncludes) {
               ... basesConnection


### PR DESCRIPTION
I came across this error today: 

```
GraphQLParser: Variable `$cursor` was defined as type `ID`, but used in a location that expects type `String`.
```

This should solve it by using the graphql ID type instead of strings for cursors on Relay connections.