### PR TITLE
Add support for extensions in `CoercionError`s

### DIFF
--- a/lib/graphql/coercion_error.rb
+++ b/lib/graphql/coercion_error.rb
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 module GraphQL
   class CoercionError < GraphQL::Error
+    # @return [Hash] Optional custom data for error objects which will be added
+    # under the `extensions` key.
+    attr_accessor :extensions
+
+    def initialize(message, extensions: nil)
+      @extensions = extensions
+      super(message)
+    end
   end
 end

--- a/lib/graphql/query/input_validation_result.rb
+++ b/lib/graphql/query/input_validation_result.rb
@@ -3,6 +3,7 @@ module GraphQL
   class Query
     class InputValidationResult
       attr_accessor :problems
+      attr_accessor :extensions
 
       def valid?
         @problems.nil?
@@ -13,12 +14,26 @@ module GraphQL
         @problems.push({ "path" => path || [], "explanation" => explanation })
       end
 
+      def add_extensions(extensions)
+        @extensions ||= []
+        @extensions.push(extensions)
+      end
+
       def merge_result!(path, inner_result)
         return if inner_result.valid?
 
         inner_result.problems.each do |p|
           item_path = [path, *p["path"]]
           add_problem(p["explanation"], item_path)
+        end
+
+        # extensions are optional so don't attempt to
+        # merge them if they don't exist
+        if inner_result.extensions
+          inner_result.extensions.each do |e|
+            item_path = [path, *e["path"]]
+            add_extensions(e, item_path)
+          end
         end
       end
     end

--- a/lib/graphql/query/variable_validation_error.rb
+++ b/lib/graphql/query/variable_validation_error.rb
@@ -9,7 +9,12 @@ module GraphQL
         @validation_result = validation_result
 
         msg = "Variable #{variable_ast.name} of type #{type} was provided invalid value"
-        super(msg)
+
+        # Note: by merging the extensions we introduce the possibility that
+        # if two extensions contain the same key then the last one in the
+        # array will be the value chosen.
+        extensions = validation_result.extensions ? validation_result.extensions.inject(&:merge) : nil
+        super(msg, extensions: extensions)
         self.ast_node = variable_ast
       end
 

--- a/lib/graphql/query/variables.rb
+++ b/lib/graphql/query/variables.rb
@@ -35,6 +35,7 @@ module GraphQL
             rescue GraphQL::CoercionError => ex
               validation_result = GraphQL::Query::InputValidationResult.new
               validation_result.add_problem(ex.message)
+              validation_result.add_extensions(ex.extensions) if ex.extensions
             end
 
             if !validation_result.valid?

--- a/lib/graphql/static_validation/message.rb
+++ b/lib/graphql/static_validation/message.rb
@@ -6,19 +6,20 @@ module GraphQL
       # Convenience for validators
       module MessageHelper
         # Error `message` is located at `node`
-        def message(message, nodes, context: nil, path: nil)
+        def message(message, nodes, context: nil, path: nil, extensions: nil)
           path ||= context.path
           nodes = Array(nodes)
-          GraphQL::StaticValidation::Message.new(message, nodes: nodes, path: path)
+          GraphQL::StaticValidation::Message.new(message, nodes: nodes, path: path, extensions: extensions)
         end
       end
 
-      attr_reader :message, :path
+      attr_reader :message, :path, :extensions
 
-      def initialize(message, path: [], nodes: [])
+      def initialize(message, path: [], nodes: [], extensions: nil)
         @message = message
         @nodes = nodes
         @path = path
+        @extensions = extensions
       end
 
       # A hash representation of this Message
@@ -27,7 +28,7 @@ module GraphQL
           "message" => message,
           "locations" => locations,
           "fields" => path,
-        }
+        }.tap { |h| h["extensions"] = @extensions if @extensions }
       end
 
       private

--- a/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb
+++ b/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb
@@ -7,10 +7,12 @@ module GraphQL
         arg_defn = defn.arguments[node.name]
         return unless arg_defn
 
+        error_extensions = nil
         begin
           valid = context.valid_literal?(node.value, arg_defn.type)
         rescue GraphQL::CoercionError => err
           error_message = err.message
+          error_extensions = err.extensions
         end
 
         return if valid
@@ -21,7 +23,7 @@ module GraphQL
           "Argument '#{node.name}' on #{kind_of_node} '#{error_arg_name}' has an invalid value. Expected type '#{arg_defn.type}'."
         end
 
-        context.errors << message(error_message, parent, context: context)
+        context.errors << message(error_message, parent, context: context, extensions: error_extensions)
       end
     end
   end

--- a/lib/graphql/static_validation/rules/variable_default_values_are_correctly_typed.rb
+++ b/lib/graphql/static_validation/rules/variable_default_values_are_correctly_typed.rb
@@ -25,11 +25,12 @@ module GraphQL
               valid = context.valid_literal?(value, type)
             rescue GraphQL::CoercionError => err
               error_message = err.message
+              error_extensions = err.extensions
             end
 
             if !valid
               error_message ||= "Default value for $#{node.name} doesn't match type #{type}"
-              context.errors << message(error_message, node, context: context)
+              context.errors << message(error_message, node, context: context, extensions: error_extensions)
             end
           end
         end

--- a/spec/graphql/coercion_error_spec.rb
+++ b/spec/graphql/coercion_error_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::CoercionError do
+  let(:result) { Dummy::Schema.execute(query_string, variables: provided_variables) }
+  describe "extensions in CoercionError" do
+    let(:query_string) {%|
+      query searchMyDairy (
+              $time: Time
+            ) {
+        searchDairy(expiresAfter: $time) {
+          ... on Cheese {
+            flavor
+          }
+        }
+      }
+      |}
+
+    let(:provided_variables) { { "time" => "a" } }
+
+    it "the error is inserted into the errors key with custom data set in `extensions`" do
+      errors = result['errors']
+      assert_includes errors, {
+                        "message"=>"Variable time of type Time was provided invalid value",
+                        "locations"=>[{"line"=>3, "column"=>15}],
+                        "value"=>"a",
+                        "extensions"=>{"error"=>"invalid_format"},
+                        "problems"=>[{"path"=>[], "explanation"=>"cannot coerce to Float"}]
+                      }
+
+    end
+  end
+end

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 require "graphql"
 require_relative "./data"
@@ -256,7 +257,7 @@ module Dummy
       begin
         Time.at(Float(value))
       rescue ArgumentError
-        raise GraphQL::CoercionError, 'cannot coerce to Float'
+        raise GraphQL::CoercionError.new('cannot coerce to Float', extensions: {'error' => 'invalid_format'})
       end
     end
 


### PR DESCRIPTION
This change adds an `extensions` attribute to `CoercionError` in order
to make it consistent with the [GraphQL
Specification](http://facebook.github.io/graphql/June2018/#example-fce18)

Fixes #1621