### PR TITLE
#1385 - better handling of boolean attributes

### DIFF
--- a/lib/graphql/name_validator.rb
+++ b/lib/graphql/name_validator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module GraphQL
   class NameValidator
-    VALID_NAME_REGEX = /^[_a-zA-Z][_a-zA-Z0-9]*$/
+    VALID_NAME_REGEX = /^[_a-zA-Z][_a-zA-Z0-9]*\??$/
 
     def self.validate!(name)
       raise GraphQL::InvalidNameError.new(name, VALID_NAME_REGEX) unless valid?(name)

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -111,6 +111,7 @@ module GraphQL
           raise ArgumentError, "keyword `extras:` may only be used with method-based resolve, please remove `field:`, `function:`, `resolve:`, or `mutation:`"
         end
         @name = camelize ? Member::BuildType.camelize(name.to_s) : name.to_s
+        @name.chop! if @name.end_with?('?')
         @description = description
         if field.is_a?(GraphQL::Schema::Field)
           @field_instance = field

--- a/spec/graphql/object_type_spec.rb
+++ b/spec/graphql/object_type_spec.rb
@@ -28,7 +28,7 @@ describe GraphQL::ObjectType do
       # Force evaluation
       InvalidNameObject.name
     }
-    assert_equal("Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but 'Three Word Query' does not", exception.message)
+    assert_equal("Names must match /^[_a-zA-Z][_a-zA-Z0-9]*\\??$/ but 'Three Word Query' does not", exception.message)
   end
 
   it "has a name" do

--- a/spec/graphql/schema/field_spec.rb
+++ b/spec/graphql/schema/field_spec.rb
@@ -29,6 +29,13 @@ describe GraphQL::Schema::Field do
       assert_equal 'underscored_arg', arg_defn.name
     end
 
+    it "removes `?` name suffix but preserve it in method name" do
+      boolean_field = GraphQL::Schema::Field.from_options(:boolean_field?, GraphQL::Types::Boolean, null: false, camelize: false, owner: nil)
+      assert_equal 'boolean_field', boolean_field.to_graphql.name
+      assert_equal 'boolean_field?', boolean_field.method_str
+      assert_equal :boolean_field?, boolean_field.method_sym
+    end
+
     it "exposes the method override" do
       object = Class.new(Jazz::BaseObject) do
         field :t, String, method: :tt, null: true


### PR DESCRIPTION
* This changes allows boolean field name with `?` suffix.
* stripped `?` suffix for the json member name

it is using the second solution of issue #1385