### PR TITLE
Allow definition_methods defined in interfaces to be applied onto classes

### DIFF
--- a/lib/graphql/schema/interface.rb
+++ b/lib/graphql/schema/interface.rb
@@ -61,6 +61,12 @@ module GraphQL
               child_class.extend(interface_defn::DefinitionMethods)
             end
           elsif child_class < GraphQL::Schema::Object
+            # Add all definition methods of this interface and the interfaces it
+            # includes onto the child class.
+            (own_interfaces + [self]).each do |interface_defn|
+              child_class.extend(interface_defn::DefinitionMethods)
+            end
+
             # This is being included into an object type, make sure it's using `implements(...)`
             backtrace_line = caller(0, 10).find { |line| line.include?("schema/object.rb") && line.include?("in `implements'")}
             if !backtrace_line

--- a/spec/graphql/schema/interface_spec.rb
+++ b/spec/graphql/schema/interface_spec.rb
@@ -161,6 +161,12 @@ describe GraphQL::Schema::Interface do
   describe ':DefinitionMethods' do
     module InterfaceA
       include GraphQL::Schema::Interface
+
+      definition_methods do
+        def some_method
+          42
+        end
+      end
     end
 
     module InterfaceB
@@ -169,6 +175,10 @@ describe GraphQL::Schema::Interface do
 
     module InterfaceC
       include GraphQL::Schema::Interface
+    end
+
+    class ObjectA < GraphQL::Schema::Object
+      implements InterfaceA
     end
 
     it "doesn't overwrite them when including multiple interfaces" do
@@ -180,6 +190,10 @@ describe GraphQL::Schema::Interface do
       end
 
       assert_equal(InterfaceC::DefinitionMethods, def_methods)
+    end
+
+    it "extends classes with the defined methods" do
+      assert_equal(ObjectA.some_method, InterfaceA.some_method)
     end
   end
 end


### PR DESCRIPTION
This PR allows methods defined in `definition_methods do ... end` blocks within interfaces to be used within classes implementing these interfaces. The change is simple enough, but I'm not entirely familiar with this project's codebase, so I may be missing some cases here. However, the changes proposed here do enable my own use case without hiccups.