### PR TITLE
Exclude GraphQL::Schema::Interface::DefinitionMethods from extend

### DIFF
--- a/lib/graphql/schema/interface.rb
+++ b/lib/graphql/schema/interface.rb
@@ -63,7 +63,7 @@ module GraphQL
           elsif child_class < GraphQL::Schema::Object
             # Add all definition methods of this interface and the interfaces it
             # includes onto the child class.
-            (own_interfaces + [self]).each do |interface_defn|
+            (interfaces + [self] - [GraphQL::Schema::Interface]).each do |interface_defn|
               child_class.extend(interface_defn::DefinitionMethods)
             end
 

--- a/spec/graphql/schema/object_spec.rb
+++ b/spec/graphql/schema/object_spec.rb
@@ -41,6 +41,30 @@ describe GraphQL::Schema::Object do
       assert_equal object_class.description, new_subclass_2.description
     end
 
+    it "does not inherit singleton methods from base interface when implementing base interface" do
+      ObjectType = Class.new(GraphQL::Schema::Object)
+      methods = ObjectType.singleton_methods
+      method_defs = Hash[methods.zip(methods.map{|method| ObjectType.method(method.to_sym)})]
+
+      ObjectType.implements(GraphQL::Schema::Interface)
+      new_method_defs = Hash[methods.zip(methods.map{|method| ObjectType.method(method.to_sym)})]
+      assert_equal method_defs, new_method_defs
+    end
+
+    it "does not inherit singleton methods from base interface when implementing another interface" do
+      ObjectType = Class.new(GraphQL::Schema::Object)
+      methods = ObjectType.singleton_methods
+      method_defs = Hash[methods.zip(methods.map{|method| ObjectType.method(method.to_sym)})]
+
+      module InterfaceType
+        include GraphQL::Schema::Interface
+      end
+      
+      ObjectType.implements(InterfaceType)
+      new_method_defs = Hash[methods.zip(methods.map{|method| ObjectType.method(method.to_sym)})]
+      assert_equal method_defs, new_method_defs
+    end
+
     it "should take Ruby name (without Type suffix) as default graphql name" do
       TestingClassType = Class.new(GraphQL::Schema::Object)
       assert_equal "TestingClass", TestingClassType.graphql_name


### PR DESCRIPTION
See https://github.com/rmosolgo/graphql-ruby/issues/1649. Extending object classes with  `GraphQL::Schema::Interface::DefinitionMethods` will either override methods or include methods which should not be included. This PR ensures `GraphQL::Schema::Interface` is skipped.