### PR TITLE
[docs] Change one field name in an example

### DIFF
--- a/lib/graphql/schema/mutation.rb
+++ b/lib/graphql/schema/mutation.rb
@@ -17,7 +17,7 @@ module GraphQL
     #    argument :post_id, ID, required: true
     #
     #    field :comment, Types::Comment, null: true
-    #    field :error_messages, [String], null: false
+    #    field :errors, [String], null: false
     #
     #    def resolve(body:, post_id:)
     #      post = Post.find(post_id)


### PR DESCRIPTION
This PR updates the documentation example for defining a mutation.
The `resolve` method uses the `errors` variable. However, the field is declared as `error_messages` above.