### PR TITLE
Fix: use an empty hash when variables: nil is provided

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -76,7 +76,9 @@ module GraphQL
     # @param max_complexity [Numeric] the maximum field complexity for this query (falls back to schema-level value)
     # @param except [<#call(schema_member, context)>] If provided, objects will be hidden from the schema when `.call(schema_member, context)` returns truthy
     # @param only [<#call(schema_member, context)>] If provided, objects will be hidden from the schema when `.call(schema_member, context)` returns false
-    def initialize(schema, query_string = nil, query: nil, document: nil, context: nil, variables: {}, validate: true, subscription_topic: nil, operation_name: nil, root_value: nil, max_depth: nil, max_complexity: nil, except: nil, only: nil)
+    def initialize(schema, query_string = nil, query: nil, document: nil, context: nil, variables: nil, validate: true, subscription_topic: nil, operation_name: nil, root_value: nil, max_depth: nil, max_complexity: nil, except: nil, only: nil)
+      # Even if `variables: nil` is passed, use an empty hash for simpler logic
+      variables ||= {}
       @schema = schema
       @filter = schema.default_filter.merge(except: except, only: only)
       @context = schema.context_class.new(query: self, object: root_value, values: context)

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -638,6 +638,20 @@ describe GraphQL::Query do
     end
   end
 
+  describe "validating with optional arguments and variables: nil" do
+    it "works" do
+      query_str = <<-GRAPHQL
+      query($expiresAfter: Time) {
+        searchDairy(expiresAfter: $expiresAfter) {
+          __typename
+        }
+      }
+      GRAPHQL
+      query = GraphQL::Query.new(schema, query_str, variables: nil)
+      assert query.valid?
+    end
+  end
+
   describe 'NullValue type arguments' do
     let(:schema_definition) {
       <<-GRAPHQL


### PR DESCRIPTION
Previously, passing `variables: nil` would cause a runtime error