### PR TITLE
Support replacement values from unauthorized_object hook

### DIFF
--- a/guides/authorization/authorization.md
+++ b/guides/authorization/authorization.md
@@ -54,3 +54,5 @@ end
 ```
 
 Now, the custom hook will be called instead of the default one.
+
+If `.unauthorized_object` returns a non-`nil` object (and doesn't `raise` an error), then that object will be used in place of the unauthorized object.

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -871,6 +871,10 @@ module GraphQL
       #
       # By default, this hook just replaces the unauthorized object with `nil`.
       #
+      # Whatever value is returned from this method will be used instead of the
+      # unauthorized object (accessible ass `unauthorized_error.object`). If an
+      # error is raised, then `nil` will be used.
+      #
       # If you want to add an error to the `"errors"` key, raise a {GraphQL::ExecutionError}
       # in this hook.
       #

--- a/lib/graphql/schema/member/instrumentation.rb
+++ b/lib/graphql/schema/member/instrumentation.rb
@@ -78,8 +78,6 @@ module GraphQL
               ctx.wrapped_object = true
               proxy_to_depth(result, @list_depth, ctx)
             end
-          rescue GraphQL::UnauthorizedError => err
-            ctx.schema.unauthorized_object(err)
           end
 
           private

--- a/lib/graphql/schema/object.rb
+++ b/lib/graphql/schema/object.rb
@@ -39,7 +39,13 @@ module GraphQL
             if is_authorized
               self.new(object, context)
             else
-              raise GraphQL::UnauthorizedError.new(object: object, type: self, context: context)
+              # It failed the authorization check, so go to the schema's authorized object hook
+              err = GraphQL::UnauthorizedError.new(object: object, type: self, context: context)
+              # If a new value was returned, wrap that instead of the original value
+              new_obj = context.schema.unauthorized_object(err)
+              if new_obj
+                self.new(new_obj, context)
+              end
             end
           end
         end

--- a/spec/graphql/schema/object_spec.rb
+++ b/spec/graphql/schema/object_spec.rb
@@ -42,26 +42,26 @@ describe GraphQL::Schema::Object do
     end
 
     it "does not inherit singleton methods from base interface when implementing base interface" do
-      ObjectType = Class.new(GraphQL::Schema::Object)
-      methods = ObjectType.singleton_methods
-      method_defs = Hash[methods.zip(methods.map{|method| ObjectType.method(method.to_sym)})]
+      object_type = Class.new(GraphQL::Schema::Object)
+      methods = object_type.singleton_methods
+      method_defs = Hash[methods.zip(methods.map{|method| object_type.method(method.to_sym)})]
 
-      ObjectType.implements(GraphQL::Schema::Interface)
-      new_method_defs = Hash[methods.zip(methods.map{|method| ObjectType.method(method.to_sym)})]
+      object_type.implements(GraphQL::Schema::Interface)
+      new_method_defs = Hash[methods.zip(methods.map{|method| object_type.method(method.to_sym)})]
       assert_equal method_defs, new_method_defs
     end
 
     it "does not inherit singleton methods from base interface when implementing another interface" do
-      ObjectType = Class.new(GraphQL::Schema::Object)
-      methods = ObjectType.singleton_methods
-      method_defs = Hash[methods.zip(methods.map{|method| ObjectType.method(method.to_sym)})]
+      object_type = Class.new(GraphQL::Schema::Object)
+      methods = object_type.singleton_methods
+      method_defs = Hash[methods.zip(methods.map{|method| object_type.method(method.to_sym)})]
 
       module InterfaceType
         include GraphQL::Schema::Interface
       end
-      
-      ObjectType.implements(InterfaceType)
-      new_method_defs = Hash[methods.zip(methods.map{|method| ObjectType.method(method.to_sym)})]
+
+      object_type.implements(InterfaceType)
+      new_method_defs = Hash[methods.zip(methods.map{|method| object_type.method(method.to_sym)})]
       assert_equal method_defs, new_method_defs
     end
 


### PR DESCRIPTION
`Schema.unauthorized_object` may return a new value in case of an UnauthorizedError