### PR TITLE
Support grouping by "endpoint" with skylight instrumentation

### DIFF
--- a/lib/graphql/tracing/skylight_tracing.rb
+++ b/lib/graphql/tracing/skylight_tracing.rb
@@ -14,15 +14,31 @@ module GraphQL
         "execute_query_lazy" => "graphql.execute",
       }
 
+      # @param set_endpoint_name [Boolean] If true, the GraphQL operation name will be used as the endpoint name.
+      #   This is not advised if you run more than one query per HTTP request, for example, with `graphql-client` or multiplexing.
+      #   It can also be specified per-query with `context[:set_skylight_endpoint_name]`.
+      def initialize(set_endpoint_name: false)
+        @set_endpoint_name = set_endpoint_name
+        super
+      end
+
       def platform_trace(platform_key, key, data)
-        if (query = data[:query])
+        if key == "execute_query"
+          query = data[:query]
           title = query.selected_operation_name || "<anonymous>"
           category = platform_key
-          # Assign the endpoint so that queries will be grouped
-          current_instance = Skylight::Instrumenter.instance
-          if current_instance
-            endpoint = "GraphQL/#{query.operation_type}.#{title}"
-            current_instance.current_trace.endpoint = endpoint
+          set_endpoint_name_override = query.context[:set_skylight_endpoint_name]
+          if set_endpoint_name_override == true || (set_endpoint_name_override.nil? && @set_endpoint_name)
+            # Assign the endpoint so that queries will be grouped
+            instrumenter = Skylight.instrumenter
+            if instrumenter
+              current_trace = instrumenter.current_trace
+              if current_trace
+                op_type = query.selected_operation ? query.selected_operation.operation_type : "query"
+                endpoint = "GraphQL/#{op_type}.#{title}"
+                current_trace.endpoint = endpoint
+              end
+            end
           end
         elsif key.start_with?("execute_field")
           title = platform_key

--- a/lib/graphql/tracing/skylight_tracing.rb
+++ b/lib/graphql/tracing/skylight_tracing.rb
@@ -18,6 +18,12 @@ module GraphQL
         if (query = data[:query])
           title = query.selected_operation_name || "<anonymous>"
           category = platform_key
+          # Assign the endpoint so that queries will be grouped
+          current_instance = Skylight::Instrumenter.instance
+          if current_instance
+            endpoint = "GraphQL/#{query.operation_type}.#{title}"
+            current_instance.current_trace.endpoint = endpoint
+          end
         elsif key.start_with?("execute_field")
           title = platform_key
           category = key

--- a/spec/graphql/tracing/skylight_tracing_spec.rb
+++ b/spec/graphql/tracing/skylight_tracing_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::Tracing::SkylightTracing do
+  module SkylightTest
+    class Query < GraphQL::Schema::Object
+      field :int, Integer, null: false
+
+      def int
+        1
+      end
+    end
+
+    class SchemaWithoutTransactionName < GraphQL::Schema
+      query(Query)
+      use(GraphQL::Tracing::SkylightTracing)
+    end
+
+    class SchemaWithTransactionName < GraphQL::Schema
+      query(Query)
+      use(GraphQL::Tracing::SkylightTracing, set_endpoint_name: true)
+    end
+  end
+
+  before do
+    Skylight.clear_all
+  end
+
+  it "can leave the transaction name in place" do
+    SkylightTest::SchemaWithoutTransactionName.execute "query X { int }"
+    assert_equal [], Skylight::ENDPOINT_NAMES
+  end
+
+  it "can override the transaction name" do
+    SkylightTest::SchemaWithTransactionName.execute "query X { int }"
+    assert_equal ["GraphQL/query.X"], Skylight::ENDPOINT_NAMES
+  end
+
+  it "can override the transaction name per query" do
+    # Override with `false`
+    SkylightTest::SchemaWithTransactionName.execute "{ int }", context: { set_skylight_endpoint_name: false }
+    assert_equal [], Skylight::ENDPOINT_NAMES
+    # Override with `true`
+    SkylightTest::SchemaWithoutTransactionName.execute "{ int }", context: { set_skylight_endpoint_name: true }
+    assert_equal ["GraphQL/query.<anonymous>"], Skylight::ENDPOINT_NAMES
+  end
+end

--- a/spec/support/skylight.rb
+++ b/spec/support/skylight.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+# A stub for the Skylight agent, so we can make assertions about how it is used
+# Based on:
+#  - https://www.rubydoc.info/gems/skylight-core/2.0.2
+#  - https://www.rubydoc.info/gems/skylight/2.0.2
+if defined?(Skylight)
+  raise "Expected Skylight to be undefined, so that we could define a stub for it."
+end
+
+module Skylight
+  ENDPOINT_NAMES = []
+  # Reset state between tests
+  def self.clear_all
+    ENDPOINT_NAMES.clear
+  end
+
+  def self.instrumenter
+    Instrumenter
+  end
+
+  def self.instrument(category:, title:)
+    yield
+  end
+
+  module Instrumenter
+    def self.current_trace
+      CurrentTrace
+    end
+  end
+
+  module CurrentTrace
+    def self.endpoint=(endpoint)
+      ENDPOINT_NAMES << endpoint
+    end
+  end
+end


### PR DESCRIPTION
This will cause queries with the same name to be grouped together.

~~TODO: make this opt-in?~~, done, use `set_endpoint_name: true` at schema-level, and/or `context[:set_skylight_endpoint_name]` at query-level.