### PR TITLE
Remove duplicated object_class method

### DIFF
--- a/lib/graphql/schema/mutation.rb
+++ b/lib/graphql/schema/mutation.rb
@@ -86,16 +86,6 @@ module GraphQL
         alias :type :payload_type
         alias :type_expr :payload_type
 
-        # An object class to use for deriving payload types
-        # @param new_class [Class, nil] Defaults to {GraphQL::Schema::Object}
-        # @return [Class]
-        def object_class(new_class = nil)
-          if new_class
-            @object_class = new_class
-          end
-          @object_class || (superclass.respond_to?(:object_class) ? superclass.object_class : GraphQL::Schema::Object)
-        end
-
         def field_class(new_class = nil)
           if new_class
             @field_class = new_class


### PR DESCRIPTION
Noticed this when reading through the code, opted to keep the newer version of the method but there is no difference other than the documentation. I'm not sure if there is a purpose in having them both in there, thoughts?