### PR TITLE
feat(Tracing) add Prometheus

### DIFF
--- a/guides/queries/tracing.md
+++ b/guides/queries/tracing.md
@@ -136,3 +136,29 @@ class MySchema < GraphQL::Schema
   use(GraphQL::Tracing::DataDogTracing)
 end
 ```
+
+## Prometheus
+
+To add [Prometheus](https://prometheus.io) instrumentation:
+
+```ruby
+require 'prometheus_exporter/client'
+
+class MySchema < GraphQL::Schema
+  use(GraphQL::Tracing::PrometheusTracing)
+end
+```
+
+The PrometheusExporter server must be run with a custom type collector that extends
+`GraphQL::Tracing::PrometheusTracing::GraphQLCollector`:
+
+```ruby
+# lib/graphql_collector.rb
+
+class GraphQLCollector < GraphQL::Tracing::PrometheusTracing::GraphQLCollector
+end
+```
+
+```sh
+bundle exec prometheus_exporter -a lib/graphql_collector.rb
+```

--- a/lib/graphql/tracing.rb
+++ b/lib/graphql/tracing.rb
@@ -6,6 +6,7 @@ require "graphql/tracing/data_dog_tracing"
 require "graphql/tracing/new_relic_tracing"
 require "graphql/tracing/scout_tracing"
 require "graphql/tracing/skylight_tracing"
+require "graphql/tracing/prometheus_tracing"
 
 module GraphQL
   # Library entry point for performance metric reporting.

--- a/lib/graphql/tracing/prometheus_tracing.rb
+++ b/lib/graphql/tracing/prometheus_tracing.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module Tracing
+    class PrometheusTracing < PlatformTracing
+      DEFAULT_WHITELIST = ['execute_field', 'execute_field_lazy'].freeze
+      DEFAULT_COLLECTOR_TYPE = 'graphql'.freeze
+
+      self.platform_keys = {
+        'lex' => "graphql.lex",
+        'parse' => "graphql.parse",
+        'validate' => "graphql.validate",
+        'analyze_query' => "graphql.analyze",
+        'analyze_multiplex' => "graphql.analyze",
+        'execute_multiplex' => "graphql.execute",
+        'execute_query' => "graphql.execute",
+        'execute_query_lazy' => "graphql.execute",
+        'execute_field' => "graphql.execute",
+        'execute_field_lazy' => "graphql.execute"
+      }
+
+      def initialize(opts = {})
+        @client = opts[:client] || PrometheusExporter::Client.default
+        @keys_whitelist = opts[:keys_whitelist] || DEFAULT_WHITELIST
+        @collector_type = opts[:collector_type] || DEFAULT_COLLECTOR_TYPE
+
+        super opts
+      end
+
+      def platform_trace(platform_key, key, data, &block)
+        return yield unless @keys_whitelist.include?(key)
+        instrument_execution(platform_key, key, data, &block)
+      end
+
+      def platform_field_key(type, field)
+        "#{type.name}.#{field.name}"
+      end
+
+      private
+
+      def instrument_execution(platform_key, key, data, &block)
+        start = ::Process.clock_gettime ::Process::CLOCK_MONOTONIC
+        result = block.call
+        duration = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) - start
+        observe platform_key, key, duration
+        result
+      end
+
+      def observe(platform_key, key, duration)
+        @client.send_json(
+          type: @collector_type,
+          duration: duration,
+          platform_key: platform_key,
+          key: key
+        )
+      end
+    end
+  end
+end

--- a/lib/graphql/tracing/prometheus_tracing/graphql_collector.rb
+++ b/lib/graphql/tracing/prometheus_tracing/graphql_collector.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module Tracing
+    class PrometheusTracing < PlatformTracing
+      class GraphQLCollector < ::PrometheusExporter::Server::TypeCollector
+        def initialize
+          @graphql_gauge = PrometheusExporter::Metric::Summary.new(
+            'graphql_duration_seconds',
+            'Time spent in GraphQL operations, in seconds'
+          )
+        end
+
+        def type
+          'graphql'
+        end
+
+        def collect(object)
+          labels = { key: object['key'], platform_key: object['platform_key'] }
+          @graphql_gauge.observe object['duration'], labels
+        end
+
+        def metrics
+          [@graphql_gauge]
+        end
+      end
+    end
+  end
+end

--- a/spec/graphql/tracing/prometheus_tracing_spec.rb
+++ b/spec/graphql/tracing/prometheus_tracing_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe GraphQL::Tracing::PrometheusTracing do
+  module PrometheusTracingTest
+    class Query < GraphQL::Schema::Object
+      field :int, Integer, null: false
+
+      def int
+        1
+      end
+    end
+
+    class Schema < GraphQL::Schema
+      query Query
+    end
+  end
+
+  describe "Observing" do
+    it "sends JSON to Prometheus client" do
+      client = Minitest::Mock.new
+
+      client.expect :send_json, true do |obj|
+        obj[:type] == 'graphql' &&
+          obj[:key] == 'execute_field' &&
+          obj[:platform_key] == 'Query.int'
+      end
+
+      PrometheusTracingTest::Schema.use(
+        GraphQL::Tracing::PrometheusTracing,
+        client: client,
+        trace_scalars: true
+      )
+
+      PrometheusTracingTest::Schema.execute "query X { int }"
+    end
+  end
+end


### PR DESCRIPTION
This commit adds Prometheus tracing
- Includes tracing implementation
- Adds a custom type collector for Prometheus exporter gem that can be used to collect observations