### PR TITLE
improve error messages in ActionCableSubscriptions

### DIFF
--- a/lib/graphql/subscriptions/action_cable_subscriptions.rb
+++ b/lib/graphql/subscriptions/action_cable_subscriptions.rb
@@ -92,7 +92,7 @@ module GraphQL
       # It will receive notifications when events come in
       # and re-evaluate the query locally.
       def write_subscription(query, events)
-        channel = query.context[:channel]
+        channel = query.context.fetch(:channel)
         subscription_id = query.context[:subscription_id] ||= build_id
         stream = query.context[:action_cable_stream] ||= SUBSCRIPTION_PREFIX + subscription_id
         channel.stream_from(stream)


### PR DESCRIPTION
`MySchema.execute("subscription { ... }")` does not work on Rails console / grahpqil, as repoted in  https://github.com/rmosolgo/graphql-ruby/issues/1045; it is the spec and I have no idea to fix it.

However, the error message, `NoMethodError (undefined method `stream_from' for nil:NilClass)` can be more understandable: `KeyError (key not found: :channel)`, which suggests the `context` requires `:channel`.

In fact, use of `Hash#fetch` is always better if the key must exist.


