### PR TITLE
Remove delegate for `FieldResolutionContext#schema`

### DIFF
--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -221,7 +221,7 @@ module GraphQL
 
         def_delegators :@context,
           :[], :[]=, :key?, :fetch, :to_h, :namespace,
-          :spawn, :schema, :warden, :errors,
+          :spawn, :warden, :errors,
           :execution_strategy, :strategy
 
         # @return [GraphQL::Language::Nodes::Field] The AST node for the currently-executing field


### PR DESCRIPTION
It's already cached via an ivar in the initializer.

Bonus: A tiny improvement in performance.

Refs 9a36a6fd7a26b7c01c9c556529caa1f0b2c878cc