### PR TITLE
Fix Interface inheritance chain

### DIFF
--- a/lib/graphql/schema/interface.rb
+++ b/lib/graphql/schema/interface.rb
@@ -43,6 +43,14 @@ module GraphQL
             # In this case, it's been included into another interface.
             # This is how interface inheritance is implemented
 
+            # We need this before we can call `own_interfaces`
+            child_class.extend(Schema::Interface::DefinitionMethods)
+
+            child_class.own_interfaces << self
+            child_class.interfaces.each do |interface_defn|
+              child_class.extend(interface_defn::DefinitionMethods)
+            end
+
             # Use an instance variable to tell whether it's been included previously or not;
             # You can't use constant detection because constants are brought into scope
             # by `include`, which has already happened at this point.
@@ -51,14 +59,6 @@ module GraphQL
               child_class.instance_variable_set(:@_definition_methods, defn_methods_module)
               child_class.const_set(:DefinitionMethods, defn_methods_module)
               child_class.extend(child_class::DefinitionMethods)
-            end
-
-            # We need this before we can call `own_interfaces`
-            child_class.extend(Schema::Interface::DefinitionMethods)
-
-            child_class.own_interfaces << self
-            child_class.interfaces.each do |interface_defn|
-              child_class.extend(interface_defn::DefinitionMethods)
             end
           elsif child_class < GraphQL::Schema::Object
             # Add all definition methods of this interface and the interfaces it

--- a/spec/graphql/schema/interface_spec.rb
+++ b/spec/graphql/schema/interface_spec.rb
@@ -177,8 +177,22 @@ describe GraphQL::Schema::Interface do
       include GraphQL::Schema::Interface
     end
 
+    module InterfaceD
+      include InterfaceA
+
+      definition_methods do
+        def some_method
+          'not 42'
+        end
+      end
+    end
+
     class ObjectA < GraphQL::Schema::Object
       implements InterfaceA
+    end
+
+    class ObjectB < GraphQL::Schema::Object
+      implements InterfaceD
     end
 
     it "doesn't overwrite them when including multiple interfaces" do
@@ -194,6 +208,10 @@ describe GraphQL::Schema::Interface do
 
     it "extends classes with the defined methods" do
       assert_equal(ObjectA.some_method, InterfaceA.some_method)
+    end
+
+    it "follows the normal Ruby inheritance chain" do
+      assert_equal(ObjectB.some_method, InterfaceD.some_method)
     end
   end
 end


### PR DESCRIPTION
Currently an interface's `definition_methods` will not take precedence over another interface it includes which is the opposite of Ruby's normal object model.

This simply moves extending the interface's own `DefinitionMethods` *after* the base `Schema::Interface::DefinitionMethods` and any other interfaces it already includes.

The tests include a test which previously failed on master/1.8.5.

This solution seems slightly naive to me, so I'm not 100% confident it won't have any other side effects; however, all tests are passing.

edit: this would mostly close #1674.