### PR TITLE
Allows defining custom directives to modify runtime query execution

### DIFF
--- a/lib/graphql/directive.rb
+++ b/lib/graphql/directive.rb
@@ -8,11 +8,12 @@ module GraphQL
   #
   class Directive
     include GraphQL::Define::InstanceDefinable
-    accepts_definitions :locations, :name, :description, :arguments, :default_directive, :resolve_execution, argument: GraphQL::Define::AssignArgument
+    accepts_definitions :locations, :name, :description, :arguments, :default_directive, :resolve_execution, :resolve_field_rewrite, argument: GraphQL::Define::AssignArgument
 
     attr_accessor :locations, :arguments, :name, :description, :arguments_class
     attr_accessor :ast_node
     attr_accessor :resolve_execution
+    attr_accessor :resolve_field_rewrite
     # @api private
     attr_writer :default_directive
     ensure_defined(:locations, :arguments, :name, :description, :default_directive?)

--- a/lib/graphql/directive.rb
+++ b/lib/graphql/directive.rb
@@ -8,10 +8,11 @@ module GraphQL
   #
   class Directive
     include GraphQL::Define::InstanceDefinable
-    accepts_definitions :locations, :name, :description, :arguments, :default_directive, argument: GraphQL::Define::AssignArgument
+    accepts_definitions :locations, :name, :description, :arguments, :default_directive, :resolve_execution, argument: GraphQL::Define::AssignArgument
 
     attr_accessor :locations, :arguments, :name, :description, :arguments_class
     attr_accessor :ast_node
+    attr_accessor :resolve_execution
     # @api private
     attr_writer :default_directive
     ensure_defined(:locations, :arguments, :name, :description, :default_directive?)

--- a/lib/graphql/directive/include_directive.rb
+++ b/lib/graphql/directive/include_directive.rb
@@ -5,4 +5,12 @@ GraphQL::Directive::IncludeDirective = GraphQL::Directive.define do
   locations([GraphQL::Directive::FIELD, GraphQL::Directive::FRAGMENT_SPREAD, GraphQL::Directive::INLINE_FRAGMENT])
   argument :if, !GraphQL::BOOLEAN_TYPE, 'Included when true.'
   default_directive true
+
+  resolve_field_rewrite ->(directive_args, ast_node, query) {
+    if directive_args[:if]
+      return ast_node
+    else
+      return nil
+    end
+  }
 end

--- a/lib/graphql/directive/skip_directive.rb
+++ b/lib/graphql/directive/skip_directive.rb
@@ -6,4 +6,12 @@ GraphQL::Directive::SkipDirective = GraphQL::Directive.define do
 
   argument :if, !GraphQL::BOOLEAN_TYPE, 'Skipped when true.'
   default_directive true
+
+  resolve_field_rewrite ->(directive_args, ast_node, query) {
+    if directive_args[:if]
+      return nil
+    else
+      return ast_node
+    end
+  }
 end


### PR DESCRIPTION
I'm opening this PR as an exploratory suggestion for custom directives: at Flexport we're using this library and have a bunch of use cases that custom directives could really help with.

This PR doesn't yet have specs or docs and certainly isn't complete, but I wanted to throw it out there as at least a strawman for a possible direction for this feature: from reading the associated issues, it seems that custom directives has stalled out a little?

The high level is that we allow a directive to define specific hooks, and at the appropriate points in parsing and executing a query we can then call into those hooks. In this PR, we allow directives to define a hook to be called at query execution time, such that when when resolving a field the directive is inserted and can return some other value, call into the original resolve proc, modify the arguments to the inner resolve proc, etc.

A minimal example of use would be as follows:

```
Graph::Directive::NullIfFooDirective = GraphQL::Directive.define do
  name "null_if_foo"
  description "Directs the executor to make this field null if the provided argument is the string 'foo'"
  locations([GraphQL::Directive::FIELD])

  argument :special_string, GraphQL::STRING_TYPE, "Skipped if this value is the string 'foo'"
  default_directive false

  resolve_execution ->(directive_args, object, field_args, context, inner_proc) {
    roles = directive_args[:roles]
    if directive_args[:special_string] == "foo"
      return nil
    else
      return inner_proc.call(object, field_args, context)
    end
  }
end
```

In this case, given a query like
```
hero {
  name
  friends @null_if_foo(special_string: "foo") {
    name
  }
}
```

we would receive
```
{
  "data": {
    "hero": {
      "name": "R2-D2"
    }
  }
}
```

But with a query like
```
hero {
  name
  friends @null_if_foo(special_string: "bar") {
    name
  }
}
```

we would receive
```
{
  "data": {
    "hero": {
      "name": "R2-D2",
      "friends": [
        {
          "name": "Luke Skywalker"
        }
      ]
    }
  }
}
```

I think an approach that allows defining hook points on directives would be a pretty powerful way to provide flexibility. I would imagine that the two key points one would want to hook in at would be during AST generation (as skip and include do) and during query execution (as I've implemented here). I think we'd also want to ensure that these hook points are appropriately implemented for fragments as well as fields.

I guess the high level question I have here: do you consider this to be a plausible approach, and would you be receptive to me pursuing it further? And if so, what are the areas you'd like to see focused on (setting aside obvious details here like documentation and testing)?