### PR TITLE
Conditional Analyzers

### DIFF
--- a/guides/queries/analysis.md
+++ b/guides/queries/analysis.md
@@ -40,6 +40,11 @@ A query analyzer has the same basic parts. Here's the scaffold for an analyzer:
 
 ```ruby
 class MyQueryAnalyzer
+  # Called before initializing the analyzer.
+  # Returns true to run this analyzer, or false to skip it.
+  def analyze?(query)
+  end
+
   # Called before the visit.
   # Returns the initial value for `memo`
   def initial_value(query)
@@ -58,6 +63,7 @@ class MyQueryAnalyzer
 end
 ```
 
+- `#analyze?` is called before initializing any analyzer if it is defined. When `#analyze?` returns false, the analyzer won't be ran.
 - `#initial_value` is a chance to initialize the state for your analysis. For example, you can return a hash with keys for the query, schema, and any other values you want to store.
 - `#call` is called for each node in the query. `memo` is the analyzer state. `visit_type` is either `:enter` or `:leave`. `irep_node` is the {{ "GraphQL::InternalRepresentation::Node" | api_doc }} for the current field in the query. (It is like `item` in the `Array#reduce` callback.)
 - `#final_value` is called _after_ the visit. It provides a chance to write to your log or return a {{ "GraphQL::AnalysisError" | api_doc }} to halt query execution.

--- a/spec/graphql/analysis/query_depth_spec.rb
+++ b/spec/graphql/analysis/query_depth_spec.rb
@@ -4,7 +4,9 @@ require "spec_helper"
 describe GraphQL::Analysis::QueryDepth do
   let(:depths) { [] }
   let(:query_depth) { GraphQL::Analysis::QueryDepth.new { |query, max_depth|  depths << query << max_depth } }
-  let(:reduce_result) { GraphQL::Analysis.analyze_query(query, [query_depth]) }
+  let(:reduce_result) {
+    GraphQL::Analysis.analyze_query(query, [query_depth])
+  }
   let(:query) { GraphQL::Query.new(Dummy::Schema, query_string, variables: variables) }
   let(:variables) { {} }
 
@@ -75,7 +77,7 @@ describe GraphQL::Analysis::QueryDepth do
 
     it "finds the max depth" do
       reduce_result
-      assert_equal depths, [query, 4]
+      assert_equal [query, 4], depths
     end
   end
 end

--- a/spec/graphql/analysis/query_depth_spec.rb
+++ b/spec/graphql/analysis/query_depth_spec.rb
@@ -4,9 +4,7 @@ require "spec_helper"
 describe GraphQL::Analysis::QueryDepth do
   let(:depths) { [] }
   let(:query_depth) { GraphQL::Analysis::QueryDepth.new { |query, max_depth|  depths << query << max_depth } }
-  let(:reduce_result) {
-    GraphQL::Analysis.analyze_query(query, [query_depth])
-  }
+  let(:reduce_result) { GraphQL::Analysis.analyze_query(query, [query_depth]) }
   let(:query) { GraphQL::Query.new(Dummy::Schema, query_string, variables: variables) }
   let(:variables) { {} }
 
@@ -77,7 +75,7 @@ describe GraphQL::Analysis::QueryDepth do
 
     it "finds the max depth" do
       reduce_result
-      assert_equal [query, 4], depths
+      assert_equal depths, [query, 4]
     end
   end
 end


### PR DESCRIPTION
This PR adds an optional `analyze?` method to the analyzer API. The method gets the `query` as an argument and returns true or false to run the analyzer or not. This can be useful for example to only run analyzers (which can currently be quite costly)  only when needed.

We've been running a very similar API at GitHub and has been working pretty well.

It's a bit harder to have this condition apply to built in analyzers, maybe these can offer an additional hook? Another solution could be to allow overriding something similar to `build_analyzers` which would let users return the list of analyzers they want?