### PR TITLE
Add nodes_field option to edge_type to hide nodes field

### DIFF
--- a/lib/graphql/types/relay/base_connection.rb
+++ b/lib/graphql/types/relay/base_connection.rb
@@ -48,7 +48,7 @@ module GraphQL
           # It's called when you subclass this base connection, trying to use the
           # class name to set defaults. You can call it again in the class definition
           # to override the default (or provide a value, if the default lookup failed).
-          def edge_type(edge_type_class, edge_class: GraphQL::Relay::Edge, node_type: edge_type_class.node_type)
+          def edge_type(edge_type_class, edge_class: GraphQL::Relay::Edge, node_type: edge_type_class.node_type, nodes_field: true)
             # Set this connection's graphql name
             node_type_name = node_type.graphql_name
 
@@ -61,9 +61,11 @@ module GraphQL
               method: :edge_nodes,
               edge_class: edge_class
 
-            field :nodes, [node_type, null: true],
-              null: true,
-              description: "A list of nodes."
+            if nodes_field
+              field :nodes, [node_type, null: true],
+                null: true,
+                description: "A list of nodes."
+            end
 
             description("The connection type for #{node_type_name}.")
           end

--- a/lib/graphql/types/relay/base_connection.rb
+++ b/lib/graphql/types/relay/base_connection.rb
@@ -61,18 +61,22 @@ module GraphQL
               method: :edge_nodes,
               edge_class: edge_class
 
-            if nodes_field
-              field :nodes, [node_type, null: true],
-                null: true,
-                description: "A list of nodes."
-            end
+            define_nodes_field if nodes_field
 
             description("The connection type for #{node_type_name}.")
           end
 
           # Add the shortcut `nodes` field to this connection and its subclasses
           def nodes_field
-            field :nodes, [@node_type, null: true], null: true
+            define_nodes_field
+          end
+
+          private
+
+          def define_nodes_field
+            field :nodes, [@node_type, null: true],
+              null: true,
+              description: "A list of nodes."
           end
         end
 

--- a/spec/graphql/relay/connection_type_spec.rb
+++ b/spec/graphql/relay/connection_type_spec.rb
@@ -41,7 +41,12 @@ describe GraphQL::Relay::ConnectionType do
       let(:query_string) {%|
         {
           rebels {
-            bases: basesWithCustomEdge {
+            bases {
+              nodes {
+                name
+              }
+            }
+            basesWithCustomEdge {
               nodes {
                 name
               }
@@ -54,9 +59,29 @@ describe GraphQL::Relay::ConnectionType do
         result = star_wars_query(query_string)
         bases = result["data"]["rebels"]["bases"]
         assert_equal ["Yavin", "Echo Base", "Secret Hideout"] , bases["nodes"].map { |e| e["name"] }
+        bases_with_custom_edge = result["data"]["rebels"]["basesWithCustomEdge"]
+        assert_equal ["Yavin", "Echo Base", "Secret Hideout"] , bases_with_custom_edge["nodes"].map { |e| e["name"] }
       end
     end
 
+    describe "connections without nodes field" do
+      let(:query_string) {%|
+        {
+          rebels {
+            basesWithoutNodes {
+              nodes {
+                name
+              }
+            }
+          }
+        }
+      |}
+
+      it "raises error" do
+        result = star_wars_query(query_string)
+        assert_includes result["errors"][0]["message"], "Field 'nodes' doesn't exist"
+      end
+    end
 
     describe "when an execution error is raised" do
       let(:query_string) {%|

--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -36,8 +36,12 @@ module StarWars
     edge_type(BaseEdge)
   end
 
+  class BaseConnectionWithoutNodes < GraphQL::Types::Relay::BaseConnection
+    edge_type(BaseEdge, nodes_field: false)
+  end
+
   class BasesConnectionWithTotalCountType < GraphQL::Types::Relay::BaseConnection
-    edge_type(BaseEdge)
+    edge_type(BaseEdge, nodes_field: false)
     nodes_field
 
     field :total_count, Integer, null: true
@@ -159,6 +163,7 @@ module StarWars
     field :basesWithDefaultMaxLimitRelation, BaseConnection, null: true, resolve: Proc.new { Base.all }
     field :basesWithDefaultMaxLimitArray, BaseConnection, null: true, resolve: Proc.new { Base.all.to_a }
     field :basesWithLargeMaxLimitRelation, BaseConnection, null: true, max_page_size: 1000, resolve: Proc.new { Base.all }
+    field :basesWithoutNodes, BaseConnectionWithoutNodes, null: true, resolve: Proc.new { Base.all.to_a }
 
     field :basesAsSequelDataset, BasesConnectionWithTotalCountType, null: true, connection: true, max_page_size: 1000 do
       argument :nameIncludes, String, required: false


### PR DESCRIPTION
Fix for https://github.com/rmosolgo/graphql-ruby/issues/1683

Add `nodes_field` option to `GraphQL::Types::Relay::BaseConnection#edge_type` to allow hiding `nodes` field.
I think `nodes_field` shouldn't be added by default but since it's already released behavior, I keep the compatibility by setting the option `true` by default.

It can be disabled like below.
```ruby
class Types::PostConnectionType < GraphQL::Types::Relay::BaseConnection
  edge_type(Types::PostEdge, nodes_field: false)

  field :total_count, Int, null: false

  def total_count
     # calculate count
  end
end
```

Also, add `"A list of nodes."` description to `nodes_field` helper method by consolidating defining nodes field method.