### PR TITLE
Add GraphQL::Types::ISO8601DateTime to documentation

### DIFF
--- a/guides/type_definitions/scalars.md
+++ b/guides/type_definitions/scalars.md
@@ -16,6 +16,7 @@ Scalars are "leaf" values in GraphQL. There are several built-in scalars, and yo
 - `Float`, like a JSON or Ruby floating point decimal
 - `Boolean`, like a JSON or Ruby boolean (`true` or `false`)
 - `ID`, which a specialized `String` for representing unique object identifiers
+- `ISO8601DateTime`, an ISO 8601-encoded datetime
 
 Fields can return built-in scalars by referencing them by name:
 
@@ -32,6 +33,8 @@ field :avg_points_per_game, Float, null: false
 field :is_top_ranked, Boolean, null: false
 # ID field
 field :id, ID, null: false
+# ISO8601DateTime field
+field :created_at, GraphQL::Types::ISO8601DateTime, null: false
 ```
 
 Custom scalars (see below) can also be used by name:


### PR DESCRIPTION
I couldn't find `GraphQL::Types::ISO8601DateTime` anywhere in documentation.

This resolves rmosolgo/graphql-ruby-demo/issues/27