### PR TITLE
Validation: Don't traverse irep if no handlers are registered

### DIFF
--- a/lib/graphql/internal_representation/visit.rb
+++ b/lib/graphql/internal_representation/visit.rb
@@ -5,6 +5,7 @@ module GraphQL
     module Visit
       module_function
       def visit_each_node(operations, handlers)
+        return if handlers.empty?
         # Post-validation: make some assertions about the rewritten query tree
         operations.each do |op_name, op_node|
           # Yield each node to listeners which were attached by validators

--- a/lib/graphql/static_validation/validator.rb
+++ b/lib/graphql/static_validation/validator.rb
@@ -37,9 +37,12 @@ module GraphQL
           end
 
           context.visitor.visit
-          # Post-validation: allow validators to register handlers on rewritten query nodes
           rewrite_result = rewrite.document
-          GraphQL::InternalRepresentation::Visit.visit_each_node(rewrite_result.operation_definitions, context.each_irep_node_handlers)
+
+          if context.each_irep_node_handlers.any?
+            # Post-validation: allow validators to register handlers on rewritten query nodes
+            GraphQL::InternalRepresentation::Visit.visit_each_node(rewrite_result.operation_definitions, context.each_irep_node_handlers)
+          end
 
           {
             errors: context.errors,

--- a/lib/graphql/static_validation/validator.rb
+++ b/lib/graphql/static_validation/validator.rb
@@ -39,10 +39,8 @@ module GraphQL
           context.visitor.visit
           rewrite_result = rewrite.document
 
-          if context.each_irep_node_handlers.any?
-            # Post-validation: allow validators to register handlers on rewritten query nodes
-            GraphQL::InternalRepresentation::Visit.visit_each_node(rewrite_result.operation_definitions, context.each_irep_node_handlers)
-          end
+          # Post-validation: allow validators to register handlers on rewritten query nodes
+          GraphQL::InternalRepresentation::Visit.visit_each_node(rewrite_result.operation_definitions, context.each_irep_node_handlers)
 
           {
             errors: context.errors,


### PR DESCRIPTION
While investigating performance on validation and analysis on queries with `validate: false`, I noticed a pretty important part was spent in: https://github.com/xuorig/graphql-ruby/blame/master/lib/graphql/internal_representation/visit.rb#L7-L21

What I realized is that even if `validate` is `false`, the way `Visit` works is that it will traverse the whole irep and call these "post-rewrite" validators. The way it was setup, even though there were no handlers to run, we would still pay the cost for traversal.

Super simple fix that I think will improve very large queries by quite a bit: don't run the visit when no handlers are registered.