### PR TITLE
Nest under common namespace for better autoloading availability

### DIFF
--- a/lib/generators/graphql/mutation_generator.rb
+++ b/lib/generators/graphql/mutation_generator.rb
@@ -38,7 +38,7 @@ module Graphql
         sentinel = /class .*MutationType\s*<\s*[^\s]+?\n/m
         in_root do
           gsub_file "#{options[:directory]}/types/mutation_type.rb", /  \# TODO\: Add Mutations as fields\s*\n/m, ""
-          inject_into_file "#{options[:directory]}/types/mutation_type.rb", "  field :#{field_name}, mutation: Mutations::#{mutation_name}\n", after: sentinel, verbose: false, force: false
+          inject_into_file "#{options[:directory]}/types/mutation_type.rb", "    field :#{field_name}, mutation: Mutations::#{mutation_name}\n", after: sentinel, verbose: false, force: false
         end
       end
 

--- a/lib/generators/graphql/templates/base_enum.erb
+++ b/lib/generators/graphql/templates/base_enum.erb
@@ -1,2 +1,4 @@
-class Types::BaseEnum < GraphQL::Schema::Enum
+module Types
+  class BaseEnum < GraphQL::Schema::Enum
+  end
 end

--- a/lib/generators/graphql/templates/base_input_object.erb
+++ b/lib/generators/graphql/templates/base_input_object.erb
@@ -1,2 +1,4 @@
-class Types::BaseInputObject < GraphQL::Schema::InputObject
+module Types
+  class BaseInputObject < GraphQL::Schema::InputObject
+  end
 end

--- a/lib/generators/graphql/templates/base_interface.erb
+++ b/lib/generators/graphql/templates/base_interface.erb
@@ -1,3 +1,5 @@
-module Types::BaseInterface
-  include GraphQL::Schema::Interface
+module Types
+  module BaseInterface
+    include GraphQL::Schema::Interface
+  end
 end

--- a/lib/generators/graphql/templates/base_object.erb
+++ b/lib/generators/graphql/templates/base_object.erb
@@ -1,2 +1,4 @@
-class Types::BaseObject < GraphQL::Schema::Object
+module Types
+  class BaseObject < GraphQL::Schema::Object
+  end
 end

--- a/lib/generators/graphql/templates/base_union.erb
+++ b/lib/generators/graphql/templates/base_union.erb
@@ -1,2 +1,4 @@
-class Types::BaseUnion < GraphQL::Schema::Union
+module Types
+  class BaseUnion < GraphQL::Schema::Union
+  end
 end

--- a/lib/generators/graphql/templates/enum.erb
+++ b/lib/generators/graphql/templates/enum.erb
@@ -1,3 +1,5 @@
-class <%= type_ruby_name %> < Types::BaseEnum
-<% prepared_values.each do |v| %>  value "<%= v[0] %>"<%= v.length > 1 ? ", value: #{v[1]}" : "" %>
-<% end %>end
+module Types
+  class <%= type_ruby_name.split('::')[-1] %> < Types::BaseEnum
+<% prepared_values.each do |v| %>    value "<%= v[0] %>"<%= v.length > 1 ? ", value: #{v[1]}" : "" %>
+<% end %>  end
+end

--- a/lib/generators/graphql/templates/interface.erb
+++ b/lib/generators/graphql/templates/interface.erb
@@ -1,4 +1,6 @@
-module <%= type_ruby_name %>
-  include Types::BaseInterface
-<% normalized_fields.each do |f| %>  <%= f.to_ruby %>
-<% end %>end
+module Types
+  class <%= type_ruby_name.split('::')[-1] %>
+    include Types::BaseInterface
+<% normalized_fields.each do |f| %>    <%= f.to_ruby %>
+<% end %>  end
+end

--- a/lib/generators/graphql/templates/interface.erb
+++ b/lib/generators/graphql/templates/interface.erb
@@ -1,5 +1,5 @@
 module Types
-  class <%= type_ruby_name.split('::')[-1] %>
+  module <%= type_ruby_name.split('::')[-1] %>
     include Types::BaseInterface
 <% normalized_fields.each do |f| %>    <%= f.to_ruby %>
 <% end %>  end

--- a/lib/generators/graphql/templates/loader.erb
+++ b/lib/generators/graphql/templates/loader.erb
@@ -1,15 +1,17 @@
-class Loaders::<%= class_name %> < GraphQL::Batch::Loader
-  # Define `initialize` to store grouping arguments, eg
-  #
-  #     Loaders::<%= class_name %>.for(group).load(value)
-  #
-  # def initialize()
-  # end
+module Loaders
+  class <%= class_name %> < GraphQL::Batch::Loader
+    # Define `initialize` to store grouping arguments, eg
+    #
+    #     Loaders::<%= class_name %>.for(group).load(value)
+    #
+    # def initialize()
+    # end
 
-  # `keys` contains each key from `.load(key)`.
-  # Find the corresponding values, then
-  # call `fulfill(key, value)` or `fulfill(key, nil)`
-  # for each key.
-  def perform(keys)
+    # `keys` contains each key from `.load(key)`.
+    # Find the corresponding values, then
+    # call `fulfill(key, value)` or `fulfill(key, nil)`
+    # for each key.
+    def perform(keys)
+    end
   end
 end

--- a/lib/generators/graphql/templates/mutation.erb
+++ b/lib/generators/graphql/templates/mutation.erb
@@ -1,11 +1,13 @@
-class Mutations::<%= mutation_name %> < GraphQL::Schema::RelayClassicMutation
-  # TODO: define return fields
-  # return_field :post, Types::PostType
+module Mutations
+  class <%= mutation_name %> < GraphQL::Schema::RelayClassicMutation
+    # TODO: define return fields
+    # return_field :post, Types::PostType
 
-  # TODO: define arguments
-  # input_field :name, !types.String
+    # TODO: define arguments
+    # input_field :name, !types.String
 
-  def resolve(**inputs)
-    # TODO: define resolve method
+    def resolve(**inputs)
+      # TODO: define resolve method
+    end
   end
 end

--- a/lib/generators/graphql/templates/mutation.erb
+++ b/lib/generators/graphql/templates/mutation.erb
@@ -1,13 +1,14 @@
 module Mutations
   class <%= mutation_name %> < GraphQL::Schema::RelayClassicMutation
     # TODO: define return fields
-    # return_field :post, Types::PostType
+    # field :post, Types::PostType, null: false
 
     # TODO: define arguments
-    # input_field :name, !types.String
+    # argument :name, String, required: true
 
-    def resolve(**inputs)
-      # TODO: define resolve method
-    end
+    # TODO: define resolve method
+    # def resolve(name:)
+    #   { post: ... }
+    # end
   end
 end

--- a/lib/generators/graphql/templates/mutation_type.erb
+++ b/lib/generators/graphql/templates/mutation_type.erb
@@ -1,8 +1,10 @@
-class Types::MutationType < Types::BaseObject
-  # TODO: remove me
-  field :test_field, String, null: false,
-    description: "An example field added by the generator"
-  def test_field
-    "Hello World"
+module Types
+  class MutationType < Types::BaseObject
+    # TODO: remove me
+    field :test_field, String, null: false,
+      description: "An example field added by the generator"
+    def test_field
+      "Hello World"
+    end
   end
 end

--- a/lib/generators/graphql/templates/object.erb
+++ b/lib/generators/graphql/templates/object.erb
@@ -1,4 +1,6 @@
-class <%= type_ruby_name %> < Types::BaseObject
-<% if options.node %>  implements GraphQL::Relay::Node.interface
-<% end %><% normalized_fields.each do |f| %>  <%= f.to_ruby %>
-<% end %>end
+module Types
+  class <%= type_ruby_name.split('::')[-1] %> < Types::BaseObject
+<% if options.node %>    implements GraphQL::Relay::Node.interface
+<% end %><% normalized_fields.each do |f| %>    <%= f.to_ruby %>
+<% end %>  end
+end

--- a/lib/generators/graphql/templates/query_type.erb
+++ b/lib/generators/graphql/templates/query_type.erb
@@ -1,13 +1,15 @@
-class Types::QueryType < Types::BaseObject
-  # Add root-level fields here.
-  # They will be entry points for queries on your schema.
+module Types
+  class QueryType < Types::BaseObject
+    # Add root-level fields here.
+    # They will be entry points for queries on your schema.
 
-  # TODO: remove me
-  field :test_field, String, null: false,
-    description: "An example field added by the generator"
-  def test_field
-    "Hello World!"
-  end
+    # TODO: remove me
+    field :test_field, String, null: false,
+      description: "An example field added by the generator"
+    def test_field
+      "Hello World!"
+    end
 <% if options[:relay] %>
-  field :node, field: GraphQL::Relay::Node.field
-<% end %>end
+    field :node, field: GraphQL::Relay::Node.field
+<% end %>  end
+end

--- a/lib/generators/graphql/templates/union.erb
+++ b/lib/generators/graphql/templates/union.erb
@@ -1,3 +1,5 @@
-class <%= type_ruby_name %> < Types::BaseUnion
-<% if possible_types.any? %>  possible_types [<%= normalized_possible_types.join(", ") %>]
-<% end %>end
+module Types
+  class <%= type_ruby_name.split('::')[-1] %> < Types::BaseUnion
+<% if possible_types.any? %>    possible_types [<%= normalized_possible_types.join(", ") %>]
+<% end %>  end
+end

--- a/spec/generators/graphql/enum_generator_spec.rb
+++ b/spec/generators/graphql/enum_generator_spec.rb
@@ -7,12 +7,14 @@ class GraphQLGeneratorsEnumGeneratorTest < BaseGeneratorTest
 
   test "it generate enums with values" do
     expected_content = <<-RUBY
-class Types::FamilyType < Types::BaseEnum
-  value "NIGHTSHADE"
-  value "BRASSICA", value: Family::COLE
-  value "UMBELLIFER", value: :umbellifer
-  value "LEGUME", value: "bean & friends"
-  value "CURCURBITS", value: 5
+module Types
+  class FamilyType < Types::BaseEnum
+    value "NIGHTSHADE"
+    value "BRASSICA", value: Family::COLE
+    value "UMBELLIFER", value: :umbellifer
+    value "LEGUME", value: "bean & friends"
+    value "CURCURBITS", value: 5
+  end
 end
 RUBY
 

--- a/spec/generators/graphql/install_generator_spec.rb
+++ b/spec/generators/graphql/install_generator_spec.rb
@@ -48,15 +48,17 @@ RUBY
 
 
     expected_query_type = <<-RUBY
-class Types::QueryType < Types::BaseObject
-  # Add root-level fields here.
-  # They will be entry points for queries on your schema.
+module Types
+  class QueryType < Types::BaseObject
+    # Add root-level fields here.
+    # They will be entry points for queries on your schema.
 
-  # TODO: remove me
-  field :test_field, String, null: false,
-    description: \"An example field added by the generator\"
-  def test_field
-    \"Hello World!\"
+    # TODO: remove me
+    field :test_field, String, null: false,
+      description: \"An example field added by the generator\"
+    def test_field
+      \"Hello World!\"
+    end
   end
 end
 RUBY
@@ -80,18 +82,20 @@ RUBY
     end
 
     expected_query_type = <<-RUBY
-class Types::QueryType < Types::BaseObject
-  # Add root-level fields here.
-  # They will be entry points for queries on your schema.
+module Types
+  class QueryType < Types::BaseObject
+    # Add root-level fields here.
+    # They will be entry points for queries on your schema.
 
-  # TODO: remove me
-  field :test_field, String, null: false,
-    description: \"An example field added by the generator\"
-  def test_field
-    \"Hello World!\"
+    # TODO: remove me
+    field :test_field, String, null: false,
+      description: \"An example field added by the generator\"
+    def test_field
+      \"Hello World!\"
+    end
+
+    field :node, field: GraphQL::Relay::Node.field
   end
-
-  field :node, field: GraphQL::Relay::Node.field
 end
 RUBY
 

--- a/spec/generators/graphql/interface_generator_spec.rb
+++ b/spec/generators/graphql/interface_generator_spec.rb
@@ -17,7 +17,7 @@ class GraphQLGeneratorsInterfaceGeneratorTest < BaseGeneratorTest
 
     expected_content = <<-RUBY
 module Types
-  class BirdType
+  module BirdType
     include Types::BaseInterface
     field :wingspan, Integer, null: false
     field :foliage, [Types::ColorType], null: true

--- a/spec/generators/graphql/interface_generator_spec.rb
+++ b/spec/generators/graphql/interface_generator_spec.rb
@@ -16,10 +16,12 @@ class GraphQLGeneratorsInterfaceGeneratorTest < BaseGeneratorTest
     ]
 
     expected_content = <<-RUBY
-module Types::BirdType
-  include Types::BaseInterface
-  field :wingspan, Integer, null: false
-  field :foliage, [Types::ColorType], null: true
+module Types
+  class BirdType
+    include Types::BaseInterface
+    field :wingspan, Integer, null: false
+    field :foliage, [Types::ColorType], null: true
+  end
 end
 RUBY
 

--- a/spec/generators/graphql/loader_generator_spec.rb
+++ b/spec/generators/graphql/loader_generator_spec.rb
@@ -9,19 +9,21 @@ class GraphQLGeneratorsLoaderGeneratorTest < BaseGeneratorTest
     run_generator(["RecordLoader"])
 
     expected_content = <<-RUBY
-class Loaders::RecordLoader < GraphQL::Batch::Loader
-  # Define `initialize` to store grouping arguments, eg
-  #
-  #     Loaders::RecordLoader.for(group).load(value)
-  #
-  # def initialize()
-  # end
+module Loaders
+  class RecordLoader < GraphQL::Batch::Loader
+    # Define `initialize` to store grouping arguments, eg
+    #
+    #     Loaders::RecordLoader.for(group).load(value)
+    #
+    # def initialize()
+    # end
 
-  # `keys` contains each key from `.load(key)`.
-  # Find the corresponding values, then
-  # call `fulfill(key, value)` or `fulfill(key, nil)`
-  # for each key.
-  def perform(keys)
+    # `keys` contains each key from `.load(key)`.
+    # Find the corresponding values, then
+    # call `fulfill(key, value)` or `fulfill(key, nil)`
+    # for each key.
+    def perform(keys)
+    end
   end
 end
 RUBY
@@ -33,19 +35,21 @@ RUBY
     run_generator(["active_record::record_loader"])
 
     expected_content = <<-RUBY
-class Loaders::ActiveRecord::RecordLoader < GraphQL::Batch::Loader
-  # Define `initialize` to store grouping arguments, eg
-  #
-  #     Loaders::ActiveRecord::RecordLoader.for(group).load(value)
-  #
-  # def initialize()
-  # end
+module Loaders
+  class ActiveRecord::RecordLoader < GraphQL::Batch::Loader
+    # Define `initialize` to store grouping arguments, eg
+    #
+    #     Loaders::ActiveRecord::RecordLoader.for(group).load(value)
+    #
+    # def initialize()
+    # end
 
-  # `keys` contains each key from `.load(key)`.
-  # Find the corresponding values, then
-  # call `fulfill(key, value)` or `fulfill(key, nil)`
-  # for each key.
-  def perform(keys)
+    # `keys` contains each key from `.load(key)`.
+    # Find the corresponding values, then
+    # call `fulfill(key, value)` or `fulfill(key, nil)`
+    # for each key.
+    def perform(keys)
+    end
   end
 end
 RUBY

--- a/spec/generators/graphql/mutation_generator_spec.rb
+++ b/spec/generators/graphql/mutation_generator_spec.rb
@@ -20,27 +20,31 @@ class GraphQLGeneratorsMutationGeneratorTest < BaseGeneratorTest
   end
 
   UPDATE_NAME_MUTATION = <<-RUBY
-class Mutations::UpdateName < GraphQL::Schema::RelayClassicMutation
-  # TODO: define return fields
-  # return_field :post, Types::PostType
+module Mutations
+  class UpdateName < GraphQL::Schema::RelayClassicMutation
+    # TODO: define return fields
+    # return_field :post, Types::PostType
 
-  # TODO: define arguments
-  # input_field :name, !types.String
+    # TODO: define arguments
+    # input_field :name, !types.String
 
-  def resolve(**inputs)
-    # TODO: define resolve method
+    def resolve(**inputs)
+      # TODO: define resolve method
+    end
   end
 end
 RUBY
 
   EXPECTED_MUTATION_TYPE = <<-RUBY
-class Types::MutationType < Types::BaseObject
-  field :updateName, mutation: Mutations::UpdateName
-  # TODO: remove me
-  field :test_field, String, null: false,
-    description: "An example field added by the generator"
-  def test_field
-    "Hello World"
+module Types
+  class MutationType < Types::BaseObject
+    field :updateName, mutation: Mutations::UpdateName
+    # TODO: remove me
+    field :test_field, String, null: false,
+      description: "An example field added by the generator"
+    def test_field
+      "Hello World"
+    end
   end
 end
 RUBY

--- a/spec/generators/graphql/mutation_generator_spec.rb
+++ b/spec/generators/graphql/mutation_generator_spec.rb
@@ -23,14 +23,15 @@ class GraphQLGeneratorsMutationGeneratorTest < BaseGeneratorTest
 module Mutations
   class UpdateName < GraphQL::Schema::RelayClassicMutation
     # TODO: define return fields
-    # return_field :post, Types::PostType
+    # field :post, Types::PostType, null: false
 
     # TODO: define arguments
-    # input_field :name, !types.String
+    # argument :name, String, required: true
 
-    def resolve(**inputs)
-      # TODO: define resolve method
-    end
+    # TODO: define resolve method
+    # def resolve(name:)
+    #   { post: ... }
+    # end
   end
 end
 RUBY

--- a/spec/generators/graphql/object_generator_spec.rb
+++ b/spec/generators/graphql/object_generator_spec.rb
@@ -16,9 +16,11 @@ class GraphQLGeneratorsObjectGeneratorTest < BaseGeneratorTest
     ]
 
     expected_content = <<-RUBY
-class Types::BirdType < Types::BaseObject
-  field :wingspan, Integer, null: false
-  field :foliage, [Types::ColorType], null: true
+module Types
+  class BirdType < Types::BaseObject
+    field :wingspan, Integer, null: false
+    field :foliage, [Types::ColorType], null: true
+  end
 end
 RUBY
 
@@ -32,7 +34,9 @@ RUBY
   test "it generates classifed file" do
     run_generator(["page"])
     assert_file "app/graphql/types/page_type.rb", <<-RUBY
-class Types::PageType < Types::BaseObject
+module Types
+  class PageType < Types::BaseObject
+  end
 end
 RUBY
   end
@@ -40,8 +44,10 @@ RUBY
   test "it makes Relay nodes" do
     run_generator(["Page", "--node"])
     assert_file "app/graphql/types/page_type.rb", <<-RUBY
-class Types::PageType < Types::BaseObject
-  implements GraphQL::Relay::Node.interface
+module Types
+  class PageType < Types::BaseObject
+    implements GraphQL::Relay::Node.interface
+  end
 end
 RUBY
   end

--- a/spec/generators/graphql/union_generator_spec.rb
+++ b/spec/generators/graphql/union_generator_spec.rb
@@ -14,8 +14,10 @@ class GraphQLGeneratorsUnionGeneratorTest < BaseGeneratorTest
     ]
 
     expected_content = <<-RUBY
-class Types::WingedCreatureType < Types::BaseUnion
-  possible_types [Types::InsectType, Types::BirdType]
+module Types
+  class WingedCreatureType < Types::BaseUnion
+    possible_types [Types::InsectType, Types::BirdType]
+  end
 end
 RUBY
 
@@ -35,7 +37,9 @@ RUBY
     ]
 
     expected_content = <<-RUBY
-class Types::WingedCreatureType < Types::BaseUnion
+module Types
+  class WingedCreatureType < Types::BaseUnion
+  end
 end
 RUBY
 
@@ -50,7 +54,9 @@ RUBY
     command = ["WingedCreature", "--directory", "app/mydirectory"]
 
     expected_content = <<-RUBY
-class Types::WingedCreatureType < Types::BaseUnion
+module Types
+  class WingedCreatureType < Types::BaseUnion
+  end
 end
 RUBY
 


### PR DESCRIPTION
To avoid confusion represented in #1591.

In Rails application, constant is resolved based on certain mechanism as
described in the [guide](https://guides.rubyonrails.org/v5.2/autoloading_and_reloading_constants.html#namespaces).
Essentially:

```
class Animal
end

class Animal::Dog
end

class Animal::Human
  Dog # => NameError
end
```
This fails to lookup constant `Dog`

Whereas:

```
module Animal
  class Dog
  end
end

module Animal
  class Human
    Dog # => Animal::Dog
  end
end
```
This works fine.