### PR TITLE
Add graphql-cache link to related_projects.md

### DIFF
--- a/guides/related_projects.md
+++ b/guides/related_projects.md
@@ -14,6 +14,7 @@ Want to add something? Please open a pull request [on GitHub](https://github.com
 - `graphql-ruby` + Rails demo ([src](https://github.com/rmosolgo/graphql-ruby-demo) / [heroku](http://graphql-ruby-demo.herokuapp.com))
 - `graphql-ruby` + Sinatra demo ([src](https://github.com/robinjmurphy/ruby-graphql-server-example) / [heroku](https://ruby-graphql-server-example.herokuapp.com/))
 - [`graphql-batch`](https://github.com/shopify/graphql-batch), a batched query execution strategy
+- [`graphql-cache`](https://github.com/stackshareio/graphql-cache), a resolver-level caching solution
 - [`graphql-libgraphqlparser`](https://github.com/rmosolgo/graphql-libgraphqlparser-ruby), bindings to [libgraphqlparser](https://github.com/graphql/libgraphqlparser), a C-level parser.
 - [`graphql-docs`](https://github.com/gjtorikian/graphql-docs), a tool to automatically generate static HTML documentation from your GraphQL implementation
 - Rails Helpers:


### PR DESCRIPTION
Been working on the [graphql-cache](https://github.com/stackshareio/graphql-cache) gem for a little while and thought it would be a good addition to the "Related Projects" section of the site.