### PR TITLE
memoize field instances in default resolve

### DIFF
--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -119,7 +119,8 @@ ERR
           end
           default_resolve_module.module_eval <<-RUBY, __FILE__, __LINE__ + 1
             def #{method_name}(**args)
-              field_inst = self.class.fields[#{field_key}] || raise(%|Failed to find field #{field_key} for \#{self.class} among \#{self.class.fields.keys}|)
+              @field_instances ||= self.class.fields
+              field_inst = @field_instances[#{field_key}] || raise(%|Failed to find field #{field_key} for \#{self.class} among \#{self.class.fields.keys}|)
               field_inst.resolve_field_method(self, args, context)
             end
           RUBY

--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -120,7 +120,7 @@ ERR
           default_resolve_module.module_eval <<-RUBY, __FILE__, __LINE__ + 1
             def #{method_name}(**args)
               @field_instances ||= self.class.fields
-              field_inst = @field_instances[#{field_key}] || raise(%|Failed to find field #{field_key} for \#{self.class} among \#{self.class.fields.keys}|)
+              field_inst = @field_instances[#{field_key}] || raise(%|Failed to find field #{field_key} for \#{self.class} among \#{@field_instances.keys}|)
               field_inst.resolve_field_method(self, args, context)
             end
           RUBY


### PR DESCRIPTION
Another small perf improvement. For a large query on a large schema, we spend quite a bit of time computing `#fields` since it's not memoized. We have a few options:

  - Memoize in the resolve method (This PR). We still have to compute fields once at resolve time for every object.

  - Memoize at boot time, that would be the most efficient, but it has implications, or we have to do cache invalidation on ancestor add + field add.

  - I tried to get the current field def from `context` instead, using `irep_node.definition.metadata[:type_class]`, but somehow this was called when irep_node was the query root, which didnt work 🤔 

Thoughts?