### PR TITLE
lazy method map: Dont aquire lock on get

### DIFF
--- a/lib/graphql/execution/lazy/lazy_method_map.rb
+++ b/lib/graphql/execution/lazy/lazy_method_map.rb
@@ -70,9 +70,13 @@ module GraphQL
           end
 
           def compute_if_absent(key)
-            @semaphore.synchronize {
-              @storage.fetch(key) { @storage[key] = yield }
-            }
+            if stored_value = @storage[key]
+              stored_value
+            else
+              @semaphore.synchronize {
+                @storage.fetch(key) { @storage[key] = yield }
+              }
+            end
           end
 
           def initialize_copy(other)


### PR DESCRIPTION
Context:
  - https://github.com/rmosolgo/graphql-ruby/issues/628
  - https://github.com/rmosolgo/graphql-ruby/pull/631

It appears the #synchronize on every object check is starting to be quite expensive on large queries.

I noticed we always synchronize before doing gets even if the key was always computed. Do we need to? I checked the MRI implementation for concurrent ruby and it sounds like they make this optimization: https://github.com/ruby-concurrency/concurrent-ruby/blob/master/lib/concurrent/collection/map/mri_map_backend.rb#L21-L23

If this only works with MRI, maybe we can have a conditional map implementation here? 

@rmosolgo and @ivoanjo, Can you let me know if this would break the existing fix?  💌 