### PR TITLE
Fix method inheritance for interfaces

### DIFF
--- a/lib/graphql/schema/interface.rb
+++ b/lib/graphql/schema/interface.rb
@@ -47,7 +47,7 @@ module GraphQL
             child_class.extend(Schema::Interface::DefinitionMethods)
 
             child_class.own_interfaces << self
-            child_class.interfaces.each do |interface_defn|
+            child_class.interfaces.reverse_each do |interface_defn|
               child_class.extend(interface_defn::DefinitionMethods)
             end
 

--- a/spec/graphql/schema/interface_spec.rb
+++ b/spec/graphql/schema/interface_spec.rb
@@ -187,6 +187,10 @@ describe GraphQL::Schema::Interface do
       end
     end
 
+    module InterfaceE
+      include InterfaceD
+    end
+
     class ObjectA < GraphQL::Schema::Object
       implements InterfaceA
     end
@@ -210,8 +214,12 @@ describe GraphQL::Schema::Interface do
       assert_equal(ObjectA.some_method, InterfaceA.some_method)
     end
 
-    it "follows the normal Ruby inheritance chain" do
+    it "follows the normal Ruby inheritance chain for objects implementing interfaces" do
       assert_equal(ObjectB.some_method, InterfaceD.some_method)
+    end
+
+    it "follows the normal Ruby inheritance chain interfaces including other interfaces" do
+      assert_equal(InterfaceD.some_method, InterfaceE.some_method)
     end
   end
 end


### PR DESCRIPTION
When interfaces include other interfaces, their own interfaces are iterated over to extend each of their `DefinitionMethods`. This was happening in the reverse order than the usual Ruby object model.

Now `interfaces` is reversed when iterating to properly give precedence to interfaces higher in the chain.

This is another part of fixing behaviour described in #1674.