### PR TITLE
Yield field for definition blocks with arity of one

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -152,7 +152,11 @@ module GraphQL
         @subscription_scope = subscription_scope
 
         if definition_block
-          instance_eval(&definition_block)
+          if definition_block.arity == 1
+            instance_exec(self, &definition_block)
+          else
+            instance_eval(&definition_block)
+          end
         end
       end
 

--- a/spec/graphql/schema/field_spec.rb
+++ b/spec/graphql/schema/field_spec.rb
@@ -51,6 +51,20 @@ describe GraphQL::Schema::Field do
       assert_equal "A Description.", object.fields["test"].description
     end
 
+    it "accepts a block for defintion and yields the field if the block has an arity of one" do
+      object = Class.new(Jazz::BaseObject) do
+        graphql_name "JustAName"
+
+        field :test, String, null: true do |field|
+          field.argument :test, String, required: true
+          field.description "A Description."
+        end
+      end.to_graphql
+
+      assert_equal "test", object.fields["test"].arguments["test"].name
+      assert_equal "A Description.", object.fields["test"].description
+    end
+
     it "accepts anonymous classes as type" do
       type = Class.new(GraphQL::Schema::Object) do
         graphql_name 'MyType'


### PR DESCRIPTION
## Proposal

To improve backwards compatibility I want to propose that we provide the option to yield the field to the field definition block if there is a block provided. 

## How?

Utilize `instance_exec` in place of `instance_eval` if the definition block has an arity of one, otherwise we will default to `instance_eval` which does not yield the field.

## Why?

Improves compatibility with older versions.

Added a test to cover the case of yield the field.

