### PR TITLE
Yield argument for definition block with arity of one

### DIFF
--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -42,7 +42,11 @@ module GraphQL
         @prepare = prepare
 
         if definition_block
-          instance_eval(&definition_block)
+          if definition_block.arity == 1
+            instance_exec(self, &definition_block)
+          else
+            instance_eval(&definition_block)
+          end
         end
       end
 

--- a/spec/graphql/argument_spec.rb
+++ b/spec/graphql/argument_spec.rb
@@ -40,6 +40,14 @@ describe GraphQL::Argument do
       assert_equal "my type is String", arg.description
     end
 
+    it "accepts a definition block and yields the argument if the block has an arity of one" do
+      arg = GraphQL::Argument.from_dsl(:foo, GraphQL::STRING_TYPE) do |argument|
+        argument.description "my type is #{target.type}"
+      end
+
+      assert_equal "my type is String", arg.description
+    end
+
     it "accepts a definition block with existing arg" do
       existing = GraphQL::Argument.define do
         name "bar"


### PR DESCRIPTION
## Proposal

To mirror the addition to `Field` in #1712.

To improve flexibility I want to propose that we provide the option to yield the argument to the argument definition block if there is a block provided. 

## How?

Utilize `instance_exec` in place of `instance_eval` if the definition block has an arity of one, otherwise we will default to `instance_eval` which does not yield the argument.

## Why?

Improves flexibility!

Added a test to cover the case of yield the argument.

