### PR TITLE
Revert extending interface methods onto Objects

### DIFF
--- a/lib/graphql/schema/interface.rb
+++ b/lib/graphql/schema/interface.rb
@@ -61,12 +61,6 @@ module GraphQL
               child_class.extend(child_class::DefinitionMethods)
             end
           elsif child_class < GraphQL::Schema::Object
-            # Add all definition methods of this interface and the interfaces it
-            # includes onto the child class.
-            (interfaces + [self] - [GraphQL::Schema::Interface]).each do |interface_defn|
-              child_class.extend(interface_defn::DefinitionMethods)
-            end
-
             # This is being included into an object type, make sure it's using `implements(...)`
             backtrace_line = caller(0, 10).find { |line| line.include?("schema/object.rb") && line.include?("in `implements'")}
             if !backtrace_line

--- a/spec/graphql/schema/interface_spec.rb
+++ b/spec/graphql/schema/interface_spec.rb
@@ -191,14 +191,6 @@ describe GraphQL::Schema::Interface do
       include InterfaceD
     end
 
-    class ObjectA < GraphQL::Schema::Object
-      implements InterfaceA
-    end
-
-    class ObjectB < GraphQL::Schema::Object
-      implements InterfaceD
-    end
-
     it "doesn't overwrite them when including multiple interfaces" do
       def_methods = InterfaceC::DefinitionMethods
 
@@ -210,16 +202,8 @@ describe GraphQL::Schema::Interface do
       assert_equal(InterfaceC::DefinitionMethods, def_methods)
     end
 
-    it "extends classes with the defined methods" do
-      assert_equal(ObjectA.some_method, InterfaceA.some_method)
-    end
-
-    it "follows the normal Ruby inheritance chain for objects implementing interfaces" do
-      assert_equal(ObjectB.some_method, InterfaceD.some_method)
-    end
-
-    it "follows the normal Ruby inheritance chain interfaces including other interfaces" do
-      assert_equal(InterfaceD.some_method, InterfaceE.some_method)
+    it "follows the normal Ruby ancestor chain when including other interfaces" do
+      assert_equal('not 42', InterfaceE.some_method)
     end
   end
 end

--- a/spec/graphql/schema/object_spec.rb
+++ b/spec/graphql/schema/object_spec.rb
@@ -41,30 +41,6 @@ describe GraphQL::Schema::Object do
       assert_equal object_class.description, new_subclass_2.description
     end
 
-    it "does not inherit singleton methods from base interface when implementing base interface" do
-      object_type = Class.new(GraphQL::Schema::Object)
-      methods = object_type.singleton_methods
-      method_defs = Hash[methods.zip(methods.map{|method| object_type.method(method.to_sym)})]
-
-      object_type.implements(GraphQL::Schema::Interface)
-      new_method_defs = Hash[methods.zip(methods.map{|method| object_type.method(method.to_sym)})]
-      assert_equal method_defs, new_method_defs
-    end
-
-    it "does not inherit singleton methods from base interface when implementing another interface" do
-      object_type = Class.new(GraphQL::Schema::Object)
-      methods = object_type.singleton_methods
-      method_defs = Hash[methods.zip(methods.map{|method| object_type.method(method.to_sym)})]
-
-      module InterfaceType
-        include GraphQL::Schema::Interface
-      end
-
-      object_type.implements(InterfaceType)
-      new_method_defs = Hash[methods.zip(methods.map{|method| object_type.method(method.to_sym)})]
-      assert_equal method_defs, new_method_defs
-    end
-
     it "should take Ruby name (without Type suffix) as default graphql name" do
       TestingClassType = Class.new(GraphQL::Schema::Object)
       assert_equal "TestingClass", TestingClassType.graphql_name


### PR DESCRIPTION
This is effectively a revert of #1635.

When an Object Type would implement an Interface, the interface's `DefinitionMethods` were being extended.

However this causes unexpected ancestor chain issues when dealing with common methods (such as `to_graphql`) which are common to both interfaces and objects.

This simply removes this feature. Objects no longer extend the definition methods of the interfaces they implement.

Note: this is obviously a breaking change however I can't think of a better solution. This wasn't a core/fundamental feature of 1.8 either since it was introduced in 1.8.5 (and itself was technically a breaking change).