### PR TITLE
Fix `test:system` for Rails 5.1

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -31,7 +31,7 @@ appraise 'rails_5.1' do
   # Required for testing action cable
   gem 'puma'
   # Required for system tests
-  gem 'capybara'
+  gem 'capybara', '~> 2.13'
   gem 'selenium-webdriver'
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -96,7 +96,7 @@ namespace :test do
     success = Dir.chdir("spec/dummy") do
       system("bin/rails test:system")
     end
-    success || exit(0)
+    success || abort
   end
 
   task js: "js:test"

--- a/Rakefile
+++ b/Rakefile
@@ -110,7 +110,7 @@ namespace :js do
     success = Dir.chdir(client_dir) do
       system("yarn run test")
     end
-    success || exit(0)
+    success || abort
   end
 
   desc "Install JS dependencies"

--- a/gemfiles/rails_3.2.gemfile
+++ b/gemfiles/rails_3.2.gemfile
@@ -16,7 +16,8 @@ gem "actionpack", "~> 3.2.21"
 gem "test-unit"
 
 group :jekyll_plugins do
-  gem "algoliasearch-jekyll"
+  gem "jekyll-algolia"
+  gem "jekyll-redirect-from"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_3.2.gemfile
+++ b/gemfiles/rails_3.2.gemfile
@@ -15,9 +15,4 @@ gem "activerecord", "~> 3.2.21"
 gem "actionpack", "~> 3.2.21"
 gem "test-unit"
 
-group :jekyll_plugins do
-  gem "jekyll-algolia"
-  gem "jekyll-redirect-from"
-end
-
 gemspec path: "../"

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -16,7 +16,8 @@ gem "actionpack", "~> 4.1.10"
 gem "test-unit"
 
 group :jekyll_plugins do
-  gem "algoliasearch-jekyll"
+  gem "jekyll-algolia"
+  gem "jekyll-redirect-from"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -15,9 +15,4 @@ gem "activerecord", "~> 4.1.10"
 gem "actionpack", "~> 4.1.10"
 gem "test-unit"
 
-group :jekyll_plugins do
-  gem "jekyll-algolia"
-  gem "jekyll-redirect-from"
-end
-
 gemspec path: "../"

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -16,7 +16,8 @@ gem "actionpack", "~> 4.2.4"
 gem "concurrent-ruby", "1.0.0"
 
 group :jekyll_plugins do
-  gem "algoliasearch-jekyll"
+  gem "jekyll-algolia"
+  gem "jekyll-redirect-from"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -15,9 +15,4 @@ gem "activerecord", "~> 4.2.4"
 gem "actionpack", "~> 4.2.4"
 gem "concurrent-ruby", "1.0.0"
 
-group :jekyll_plugins do
-  gem "jekyll-algolia"
-  gem "jekyll-redirect-from"
-end
-
 gemspec path: "../"

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -15,7 +15,8 @@ gem "activerecord", "~> 5.0.0"
 gem "actionpack", "~> 5.0.0"
 
 group :jekyll_plugins do
-  gem "algoliasearch-jekyll"
+  gem "jekyll-algolia"
+  gem "jekyll-redirect-from"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -12,7 +12,7 @@ gem "pry"
 gem "pry-stack_explorer", platform: :ruby
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "puma"
-gem "capybara"
+gem "capybara", "~> 2.13"
 gem "selenium-webdriver"
 
 group :jekyll_plugins do

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -16,7 +16,8 @@ gem "capybara", "~> 2.13"
 gem "selenium-webdriver"
 
 group :jekyll_plugins do
-  gem "algoliasearch-jekyll"
+  gem "jekyll-algolia"
+  gem "jekyll-redirect-from"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -13,7 +13,8 @@ gem "pry-stack_explorer", platform: :ruby
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 
 group :jekyll_plugins do
-  gem "algoliasearch-jekyll"
+  gem "jekyll-algolia"
+  gem "jekyll-redirect-from"
 end
 
 gemspec path: "../"

--- a/gemfiles/without_rails.gemfile
+++ b/gemfiles/without_rails.gemfile
@@ -16,7 +16,8 @@ gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "globalid"
 
 group :jekyll_plugins do
-  gem "algoliasearch-jekyll"
+  gem "jekyll-algolia"
+  gem "jekyll-redirect-from"
 end
 
 gemspec path: "../"


### PR DESCRIPTION
Hello. I noticed that a system test task failed on Travis CI but the build was marked as "passed" on the CI. It does not seem to be an intended result. So I changed the Rakefile so the CI fails if the tests fail. Then, I fixed Capybara's version since Rails 5.1 depends on Capybara ~> 2.13.

* Before (an example of failing builds): https://travis-ci.org/rmosolgo/graphql-ruby/jobs/409088307
*  After: https://travis-ci.org/hibariya/graphql-ruby/jobs/409165615