### PR TITLE
Minor fix to end block in example

### DIFF
--- a/guides/relay/object_identification.md
+++ b/guides/relay/object_identification.md
@@ -29,7 +29,7 @@ class MySchema < GraphQL::Schema
     class_name, item_id = MyApp::GlobalId.decrypt(id)
     # "Post" => Post.find(item_id)
     Object.const_get(class_name).find(item_id)
-  }
+  end
 end
 ```
 


### PR DESCRIPTION
Fixes an example, to use block `end` instead of `}`