### PR TITLE
Refactor wrapping types to use new Wrapper class

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -21,6 +21,7 @@ require "graphql/schema/build_from_definition"
 
 
 require "graphql/schema/member"
+require "graphql/schema/wrapper"
 require "graphql/schema/list"
 require "graphql/schema/non_null"
 require "graphql/schema/argument"

--- a/lib/graphql/schema/list.rb
+++ b/lib/graphql/schema/list.rb
@@ -5,29 +5,17 @@ module GraphQL
     # Represents a list type in the schema.
     # Wraps a {Schema::Member} as a list type.
     # @see {Schema::Member::TypeSystemHelpers#to_list_type}
-    class List
-      include GraphQL::Schema::Member::CachedGraphQLDefinition
-      include GraphQL::Schema::Member::TypeSystemHelpers
-
-      # @return [Class, Module] The inner type of this list, the type of which one or more objects may be present.
-      attr_reader :of_type
-
-      def initialize(of_type)
-        @of_type = of_type
-      end
-
+    class List < GraphQL::Schema::Wrapper
       def to_graphql
         @of_type.graphql_definition.to_list_type
       end
 
+      # @return [GraphQL::TypeKinds::LIST]
       def kind
         GraphQL::TypeKinds::LIST
       end
 
-      def unwrap
-        @of_type.unwrap
-      end
-
+      # @return [true]
       def list?
         true
       end

--- a/lib/graphql/schema/non_null.rb
+++ b/lib/graphql/schema/non_null.rb
@@ -2,18 +2,17 @@
 
 module GraphQL
   class Schema
+    # Represents a non null type in the schema.
     # Wraps a {Schema::Member} when it is required.
     # @see {Schema::Member::TypeSystemHelpers#to_non_null_type}
-    class NonNull
-      include GraphQL::Schema::Member::CachedGraphQLDefinition
-      include GraphQL::Schema::Member::TypeSystemHelpers
-      attr_reader :of_type
-      def initialize(of_type)
-        @of_type = of_type
-      end
-
+    class NonNull < GraphQL::Schema::Wrapper
       def to_graphql
         @of_type.graphql_definition.to_non_null_type
+      end
+
+       # @return [GraphQL::TypeKinds::NON_NULL]
+      def kind
+        GraphQL::TypeKinds::NON_NULL
       end
 
       # @return [true]
@@ -25,15 +24,7 @@ module GraphQL
       def list?
         @of_type.list?
       end
-
-      def kind
-        GraphQL::TypeKinds::NON_NULL
-      end
-
-      def unwrap
-        @of_type.unwrap
-      end
-
+      
       def to_type_signature
         "#{@of_type.to_type_signature}!"
       end

--- a/lib/graphql/schema/wrapper.rb
+++ b/lib/graphql/schema/wrapper.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module GraphQL
+  class Schema
+    class Wrapper
+      include GraphQL::Schema::Member::CachedGraphQLDefinition
+      include GraphQL::Schema::Member::TypeSystemHelpers
+      extend Forwardable
+
+      # @return [Class, Module] The inner type of this list, the type of which one or more objects may be present.
+      attr_reader :of_type
+
+      def initialize(of_type)
+        @of_type = of_type
+      end
+
+      def to_graphql
+        raise NotImplementedError
+      end
+
+      def unwrap
+        @of_type.unwrap
+      end
+
+      def ==(other)
+        self.class == other.class && of_type == other.of_type
+      end
+    end
+  end
+end

--- a/spec/graphql/schema/list_spec.rb
+++ b/spec/graphql/schema/list_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe GraphQL::Schema::List do
+  let(:of_type) { Jazz::Musician }
+  let(:list_type) { GraphQL::Schema::List.new(of_type) }
+
+  it "returns list? to be true" do
+    assert list_type.list?
+  end
+
+  it "returns non_null? to be false" do
+    refute list_type.non_null?
+  end
+
+  it "returns kind to be GraphQL::TypeKinds::LIST" do
+    assert_equal GraphQL::TypeKinds::LIST, list_type.kind
+  end
+
+  it "returns correct type signature" do
+    assert_equal "[Musician]", list_type.to_type_signature
+  end
+
+  describe "comparison operator" do
+    it "will return false if list types 'of_type' are different" do
+      new_of_type = Jazz::InspectableKey
+      new_list_type = GraphQL::Schema::List.new(new_of_type)
+
+      refute_equal list_type, new_list_type
+    end
+
+    it "will return true if list types 'of_type' are the same" do
+      new_of_type = Jazz::Musician
+      new_list_type = GraphQL::Schema::List.new(new_of_type)
+      
+      assert_equal list_type, new_list_type
+    end
+  end
+
+  describe "to_graphql" do
+    it "will return a list type" do
+      assert_kind_of GraphQL::ListType, list_type.to_graphql
+    end
+  end
+end

--- a/spec/graphql/schema/non_null_spec.rb
+++ b/spec/graphql/schema/non_null_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe GraphQL::Schema::NonNull do
+  let(:of_type) { Jazz::Musician }
+  let(:non_null_type) { GraphQL::Schema::NonNull.new(of_type) }
+
+  it "returns list? to be false" do
+    refute non_null_type.list?
+  end
+
+  it "returns non_null? to be true" do
+    assert non_null_type.non_null?
+  end
+
+  it "returns kind to be GraphQL::TypeKinds::NON_NULL" do
+    assert_equal GraphQL::TypeKinds::NON_NULL, non_null_type.kind
+  end
+
+  it "returns correct type signature" do
+    assert_equal "Musician!", non_null_type.to_type_signature
+  end
+
+  describe "comparison operator" do
+    it "will return false if list types 'of_type' are different" do
+      new_of_type = Jazz::InspectableKey
+      new_non_null_type = GraphQL::Schema::NonNull.new(new_of_type)
+
+      refute_equal non_null_type, new_non_null_type
+    end
+
+    it "will return true if list types 'of_type' are the same" do
+      new_of_type = Jazz::Musician
+      new_non_null_type = GraphQL::Schema::NonNull.new(new_of_type)
+      
+      assert_equal non_null_type, new_non_null_type
+    end
+  end
+
+  describe "to_graphql" do
+    it "will return a non null type" do
+      assert_kind_of GraphQL::NonNullType, non_null_type.to_graphql
+    end
+  end
+end


### PR DESCRIPTION
## Proposal

Introduce `GraphQL::Schema::Wrapper` to move out some common code in `GraphQL::Schema::NonNull` and `GraphQL::Schema::List`.

## Why

Reduces code and DRY. Adds a better equality operator for wrapping types.

Not sure if you welcome the new class but thought it was a nice refactor! 😄 