### PR TITLE
Coerce input field defaults to support nested default values

### DIFF
--- a/lib/graphql/argument.rb
+++ b/lib/graphql/argument.rb
@@ -65,7 +65,7 @@ module GraphQL
         @default_value = nil
       else
         @has_default_value = true
-        @default_value = new_default_value
+        @default_value = GraphQL::Argument.deep_stringify(new_default_value)
       end
     end
 
@@ -125,6 +125,22 @@ module GraphQL
         type_or_argument.redefine(kwargs, &block)
       else
         GraphQL::Argument.define(kwargs, &block)
+      end
+    end
+
+    # @api private
+    def self.deep_stringify(val)
+      case val
+      when Array
+        val.map { |v| deep_stringify(v) }
+      when Hash
+        new_val = {}
+        val.each do |k, v|
+          new_val[k.to_s] = deep_stringify(v)
+        end
+        new_val
+      else
+        val
       end
     end
   end

--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -93,7 +93,8 @@ module GraphQL
           coerced_value = input_field_defn.type.coerce_input(field_value, ctx)
           input_values[input_key] = input_field_defn.prepare(coerced_value, ctx)
         elsif input_field_defn.default_value?
-          input_values[input_key] = input_field_defn.default_value
+          coerced_value = input_field_defn.type.coerce_input(input_field_defn.default_value, ctx)
+          input_values[input_key] = coerced_value
           defaults_used << input_key
         end
       end

--- a/lib/graphql/query/variables.rb
+++ b/lib/graphql/query/variables.rb
@@ -14,7 +14,7 @@ module GraphQL
         schema = ctx.schema
         @context = ctx
 
-        @provided_variables = deep_stringify(provided_variables)
+        @provided_variables = GraphQL::Argument.deep_stringify(provided_variables)
         @errors = []
         @storage = ast_variables.each_with_object({}) do |ast_variable, memo|
           # Find the right value for this variable:
@@ -52,23 +52,6 @@ module GraphQL
       end
 
       def_delegators :@storage, :length, :key?, :[], :fetch, :to_h
-
-      private
-
-      def deep_stringify(val)
-        case val
-        when Array
-          val.map { |v| deep_stringify(v) }
-        when Hash
-          new_val = {}
-          val.each do |k, v|
-            new_val[k.to_s] = deep_stringify(v)
-          end
-          new_val
-        else
-          val
-        end
-      end
     end
   end
 end

--- a/spec/graphql/input_object_type_spec.rb
+++ b/spec/graphql/input_object_type_spec.rb
@@ -254,6 +254,10 @@ describe GraphQL::InputObjectType do
         c: String = "Default"
         d: Boolean = false
       }
+
+      input SecondLevelInputObject {
+        example: ExampleInputObject = {b: 42, d: true}
+      }
     |) }
     let(:input_type) { schema.types['ExampleInputObject'] }
 
@@ -294,6 +298,13 @@ describe GraphQL::InputObjectType do
       result = input_type.coerce_isolated_input(input)
 
       assert_equal false, result['d']
+    end
+
+    it "merges defaults of nested input objects" do
+      result = schema.types['SecondLevelInputObject'].coerce_isolated_input({})
+      assert_equal 42, result['example']['b']
+      assert_equal "Default", result['example']['c']
+      assert_equal true, result['example']['d']
     end
   end
 


### PR DESCRIPTION
Given a schema like:

```graphql
input A {
  b: Int = 42
}

input B {
  a: A = {}
}
```

Prior to this change, constructing a `B` from defaults would result in a nil value for `a.b`, when instead it should have the value `42`. On this topic, [the spec says](http://facebook.github.io/graphql/June2018/#sec-Input-Objects):

> If a literal value is provided for an input object field, an entry in the coerced unordered map is given the result of coercing that value according to the input coercion rules for the type of that field.

Does it make sense to also call `input_field_defn.prepare` with default values? I haven't used that feature for anything yet.

@rmosolgo cc @jackychiu @michaelkipper