### PR TITLE
Add default_graphql_name in BaseDSL methods

### DIFF
--- a/lib/graphql/schema/member/base_dsl_methods.rb
+++ b/lib/graphql/schema/member/base_dsl_methods.rb
@@ -10,8 +10,7 @@ module GraphQL
         # Call this with a new name to override the default name for this schema member; OR
         # call it without an argument to get the name of this schema member
         #
-        # The default name is the Ruby constant name,
-        # without any namespaces and with any `-Type` suffix removed
+        # The default name is implemented in default_graphql_name
         # @param new_name [String]
         # @return [String]
         def graphql_name(new_name = nil)
@@ -20,10 +19,10 @@ module GraphQL
             @graphql_name = new_name
           when overridden = overridden_graphql_name
             overridden
-          else # Fallback to Ruby constant name
-            raise NotImplementedError, 'Anonymous class should declare an `graphql_name`' if name.nil?
+          else
+            raise NotImplementedError, 'Anonymous class should declare a `graphql_name`' if name.nil?
 
-            name.split("::").last.sub(/Type\Z/, "")
+            default_graphql_name
           end
         end
 
@@ -76,6 +75,13 @@ module GraphQL
 
         def overridden_graphql_name
           @graphql_name || find_inherited_method(:overridden_graphql_name, nil)
+        end
+
+        # Creates the default name for a schema member.
+        # The default name is the Ruby constant name,
+        # without any namespaces and with any `-Type` suffix removed
+        def default_graphql_name
+          name.split("::").last.sub(/Type\Z/, "")
         end
 
         def visible?(context)

--- a/spec/graphql/schema/object_spec.rb
+++ b/spec/graphql/schema/object_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 describe GraphQL::Schema::Object do
   describe "class attributes" do
     let(:object_class) { Jazz::Ensemble }
+
     it "tells type data" do
       assert_equal "Ensemble", object_class.graphql_name
       assert_equal "A group of musicians playing together", object_class.description
@@ -51,6 +52,20 @@ describe GraphQL::Schema::Object do
       assert_raises NotImplementedError do
         anonymous_class.graphql_name
       end
+    end
+
+    class OverrideNameObject < GraphQL::Schema::Object
+      class << self
+        def default_graphql_name
+          "Override"
+        end
+      end
+    end
+
+    it "can override the default graphql_name" do
+      override_name_object = OverrideNameObject
+
+      assert_equal "Override", override_name_object.graphql_name
     end
   end
 


### PR DESCRIPTION
## Proposal

Create a `default_graphql_name` in `GraphQL::Schema::Member::BaseDSLMethods` method to be used in the base implementation of `graphql_name`. This will allow people to override just how default schema member name gets created without having to override the entire method.

## Why

Improves flexibility! 😃 

## How

Add `default_graphql_name` and make use of it in `graphql_name`.

## Questions

Is that a good place for my test to live?