### PR TITLE
Add add_argument to GraphQL::Schema::Member::HasArguments

### DIFF
--- a/lib/graphql/schema/member/has_arguments.rb
+++ b/lib/graphql/schema/member/has_arguments.rb
@@ -16,6 +16,13 @@ module GraphQL
         def argument(*args, **kwargs, &block)
           kwargs[:owner] = self
           arg_defn = self.argument_class.new(*args, **kwargs, &block)
+          add_argument(arg_defn)
+        end
+
+        # Register this argument with the class.
+        # @param arg_defn [GraphQL::Schema::Argument]
+        # @return [GraphQL::Schema::Argument]
+        def add_argument(arg_defn)
           own_arguments[arg_defn.name] = arg_defn
           arg_defn
         end

--- a/spec/graphql/schema/field_spec.rb
+++ b/spec/graphql/schema/field_spec.rb
@@ -11,6 +11,15 @@ describe GraphQL::Schema::Field do
       assert_equal :ok, arg_defn.metadata[:custom]
     end
 
+    it "can add argument directly with add_argument" do
+      argument = Jazz::Query.fields["instruments"].arguments["family"]
+
+      field.add_argument(argument)
+
+      assert_equal "family", field.arguments["family"].name
+      assert_equal Jazz::Family, field.arguments["family"].type
+    end
+
     it "attaches itself to its graphql_definition as type_class" do
       assert_equal field, field.graphql_definition.metadata[:type_class]
     end


### PR DESCRIPTION
## Proposal

Add an `add_argument` method to `GraphQL::Schema::Member::HasArguments`. This functionality is similar to how `GraphQL::Schema::Member::HasFields` exposes an `add_field` method. 

## Why

Improve consistency and flexibility. (ex. Arguments can now be added to a field outside a field definition)

## How

Create the method `add_argument`, add a test and make use of the new method where applicable.