### PR TITLE
Mutation auth improvements

### DIFF
--- a/guides/mutations/mutation_authorization.md
+++ b/guides/mutations/mutation_authorization.md
@@ -74,14 +74,14 @@ If you don't want this behavior, don't use it. Instead, create arguments with ty
 argument :employee_id, ID, required: true
 ```
 
-## Can _this user_ modify _this thing_?
+## Can _this user_ perform _this action_?
 
-Sometimes you need to authorize a specific user-object-action combination. For example, `.admin?` users can't promote _all_ employees! They can only promote employees which they manage.
+Sometimes you need to authorize a specific user-object(s)-action combination. For example, `.admin?` users can't promote _all_ employees! They can only promote employees which they manage.
 
-You can add this check by implementing a `#validate_#{arg_name}` method, for example:
+You can add this check by implementing a `#authorized?` method, for example:
 
 ```ruby
-def validate_employee(employee)
+def authorized?(employee:)
   if !context[:current_user].manager_of?(employee)
     raise GraphQL::ExecutionError, "You can only promote your _own_ employees"
   end

--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -61,12 +61,14 @@ module GraphQL
           context.schema.after_lazy(load_arguments_val) do |loaded_args|
             # Then call `authorized?`, which may raise or may return a lazy object
             authorized_val = authorized?(loaded_args)
-            context.schema.after_lazy(authorized_val) do
-              # Finally, all the hooks have passed, so resolve it
-              if loaded_args.any?
-                public_send(self.class.resolve_method, **loaded_args)
-              else
-                public_send(self.class.resolve_method)
+            context.schema.after_lazy(authorized_val) do |authorized_result|
+              if authorized_result
+                # Finally, all the hooks have passed, so resolve it
+                if loaded_args.any?
+                  public_send(self.class.resolve_method, **loaded_args)
+                else
+                  public_send(self.class.resolve_method)
+                end
               end
             end
           end
@@ -97,7 +99,9 @@ module GraphQL
       # @param args [Hash] The input arguments
       # @raise [GraphQL::ExecutionError] To add an error to the response
       # @raise [GraphQL::UnauthorizedError] To signal an authorization failure
+      # @return [Boolean] if `false`, execution will stop
       def authorized?(**args)
+        true
       end
 
       private

--- a/spec/graphql/schema/resolver_spec.rb
+++ b/spec/graphql/schema/resolver_spec.rb
@@ -140,24 +140,6 @@ describe GraphQL::Schema::Resolver do
       end
     end
 
-    class PrepResolver7 < PrepResolver1
-      type Integer, null: true
-
-      def load_int(int)
-        int
-      end
-
-      def validate_int(int)
-        check_for_magic_number(int)
-      end
-    end
-
-    class PrepResolver8 < PrepResolver7
-      def validate_int(int)
-        LazyBlock.new { super }
-      end
-    end
-
     module HasValue
       include GraphQL::Schema::Interface
       field :value, Integer, null: false
@@ -192,6 +174,27 @@ describe GraphQL::Schema::Resolver do
       end
     end
 
+    class PrepResolver10 < BaseResolver
+      argument :int1, Integer, required: true
+      argument :int2, Integer, required: true
+      type Integer, null: false
+      def authorized?(int1:, int2:)
+        if int1 + int2 > context[:max_int]
+          raise GraphQL::ExecutionError, "Inputs too big"
+        end
+      end
+
+      def resolve(int1:, int2:)
+        int1 + int2
+      end
+    end
+
+    class PrepResolver11 < PrepResolver10
+      def authorized?(int1:, int2:)
+        LazyBlock.new { super(int1: int1 * 2, int2: int2) }
+      end
+    end
+
     class Query < GraphQL::Schema::Object
       class CustomField < GraphQL::Schema::Field
         def resolve_field(*args)
@@ -221,9 +224,9 @@ describe GraphQL::Schema::Resolver do
       field :prep_resolver_4, resolver: PrepResolver4
       field :prep_resolver_5, resolver: PrepResolver5
       field :prep_resolver_6, resolver: PrepResolver6
-      field :prep_resolver_7, resolver: PrepResolver7
-      field :prep_resolver_8, resolver: PrepResolver8
       field :prep_resolver_9, resolver: PrepResolver9
+      field :prep_resolver_10, resolver: PrepResolver10
+      field :prep_resolver_11, resolver: PrepResolver11
     end
 
     class Schema < GraphQL::Schema
@@ -355,16 +358,22 @@ describe GraphQL::Schema::Resolver do
     end
 
     describe "validating arguments" do
-      test_cases = {
-        "eager" => "prepResolver7",
-        "lazy" => "prepResolver8",
-      }
+      describe ".authorized?" do
+        it "can raise an error to halt" do
+          res = exec_query("{ prepResolver10(int1: 5, int2: 6) }", context: { max_int: 9 })
+          assert_equal ["Inputs too big"], res["errors"].map { |e| e["message"] }
 
-      test_cases.each do |mode, field_name|
-        it "supports raising #{mode} errors" do
-          res = exec_query("{ validatedInt: #{field_name}(int: 5) }")
-          assert_equal 5, res["data"]["validatedInt"]
-          add_error_assertions(field_name, "#{mode} validation")
+          res = exec_query("{ prepResolver10(int1: 5, int2: 6) }", context: { max_int: 90 })
+          assert_equal 11, res["data"]["prepResolver10"]
+        end
+
+        it "can return a lazy object" do
+          # This is too big because it's modified in the overridden authorized? hook:
+          res = exec_query("{ prepResolver11(int1: 3, int2: 5) }", context: { max_int: 9 })
+          assert_equal ["Inputs too big"], res["errors"].map { |e| e["message"] }
+
+          res = exec_query("{ prepResolver11(int1: 3, int2: 5) }", context: { max_int: 90 })
+          assert_equal 8, res["data"]["prepResolver11"]
         end
       end
     end


### PR DESCRIPTION
I'm trying this out in GitHub and tweaking things a bit. So far: 

- Add a `#object_from_id(type, id, ctx)` hook so that loading objects can be customized 
- Support lazy objects from that hook (promises)
- Remove `#validate_{arg}` hooks and replace them with a single `#authorized?(**inputs)` hook. This is a breaking change, but if you want to preserve the old behavior, you can implement authorized to do the same thing: 

  ```ruby 
  def authorized?(inputs) 
    inputs.each { |k, v|  public_send("validate_#{k}", v) } 
  end 
  ```
