### PR TITLE
Add a flow for returning data early from Mutation#authorized?

### DIFF
--- a/guides/mutations/mutation_authorization.md
+++ b/guides/mutations/mutation_authorization.md
@@ -20,13 +20,16 @@ This guide describes how to accomplish that workflow with GraphQL-Ruby.
 
 Before loading any data from the database, you might want to see if the user has a certain permission level. For example, maybe only `.admin?` users can run `Mutation.promoteEmployee`.
 
-This check can be implemented using the `#before_prepare` method in a mutation:
+This check can be implemented using the `#ready?` method in a mutation:
 
 ```ruby
 class Mutations::PromoteEmployee < Mutations::BaseMutation
-  def before_prepare(**args)
+  def ready?(**args)
     if !context[:current_user].admin?
       raise GraphQL::ExecutionError, "Only admins can run this mutation"
+    else
+      # Return true to continue the mutation:
+      true
     end
   end
 
@@ -35,6 +38,18 @@ end
 ```
 
 Now, when any non-`admin` user tries to run the mutation, it won't run. Instead, they'll get an error in the response.
+
+Additionally, `#ready?` may return `false, { ... }` to return {% internal_link "errors as data", "/mutations/mutation_errors" %}:
+
+```ruby
+def ready?
+  if !context[:current_user].allowed?
+    return false, { errors: ["You don't have permission to do this"]}
+  else
+    true
+  end
+end
+```
 
 ## Loading and authorizing objects
 

--- a/guides/mutations/mutation_authorization.md
+++ b/guides/mutations/mutation_authorization.md
@@ -82,13 +82,37 @@ You can add this check by implementing a `#authorized?` method, for example:
 
 ```ruby
 def authorized?(employee:)
+  context[:current_user].manager_of?(employee)
+end
+```
+
+When `#authorized?` returns `false`, the mutation will be halted. If it returns `true` (or something truthy), the mutation will continue.
+
+#### Adding errors
+
+To add errors as data (as described in {% internal_link "Mutation errors", "/mutations/mutation_errors" %}), return a value _along with_ `false`, for example:
+
+```ruby
+def authorized?(employee:)
+  if context[:current_user].manager_of?(employee)
+    true
+  else
+    return false, { errors: ["Can't promote an employee you don't manage"] }
+  end
+end
+```
+
+Alternatively, you can add top-level errors by raising `GraphQL::ExecutionError`, for example:
+
+```ruby
+def authorized?(employee:)
   if !context[:current_user].manager_of?(employee)
     raise GraphQL::ExecutionError, "You can only promote your _own_ employees"
   end
 end
 ```
 
-If this method raises an error, the mutation will be halted.
+In either case (returning `[false, data]` or raising an error), the mutation will be halted.
 
 ## Finally, doing the work
 

--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -31,6 +31,8 @@ module GraphQL
         @context = context
         # Since this hash is constantly rebuilt, cache it for this call
         @arguments_by_keyword = {}
+        # This might be set by {#early_return(val)}
+        @early_return_value = nil
         self.class.arguments.each do |name, arg|
           @arguments_by_keyword[arg.keyword] = arg
         end
@@ -63,7 +65,9 @@ module GraphQL
             authorized_val = authorized?(loaded_args)
             context.schema.after_lazy(authorized_val) do
               # Finally, all the hooks have passed, so resolve it
-              if loaded_args.any?
+              if @early_return_value
+                @early_return_value
+              elsif loaded_args.any?
                 public_send(self.class.resolve_method, **loaded_args)
               else
                 public_send(self.class.resolve_method)
@@ -204,6 +208,23 @@ module GraphQL
 
       def load_application_object_failed(err)
         raise err
+      end
+
+      # Call this during loading or authorization to
+      # skip {#resolve} and return data instead of top-level errors.
+      #
+      # It doesn't halt the flow of the code so be sure to return
+      # after calling it, or combine it with `return return_with(...)`.
+      #
+      #
+      # @param response [Object] The value to respond with
+      # @return [void]
+      def return_with(response)
+        if @early_return_value.nil?
+          @early_return_value = response
+        else
+          raise "Can't return_with again, already returned early with: #{@early_return_value.inspect}"
+        end
       end
 
       class << self

--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -48,37 +48,50 @@ module GraphQL
       # the user-defined `#resolve` method.
       # @api private
       def resolve_with_support(**args)
-        # First call the before_prepare hook which may raise
-        before_prepare_val = if args.any?
-          before_prepare(**args)
+        # First call the ready? hook which may raise
+        ready_val = if args.any?
+          ready?(**args)
         else
-          before_prepare
+          ready?
         end
-        context.schema.after_lazy(before_prepare_val) do
-          # Then call each prepare hook, which may return a different value
-          # for that argument, or may return a lazy object
-          load_arguments_val = load_arguments(args)
-          context.schema.after_lazy(load_arguments_val) do |loaded_args|
-            # Then call `authorized?`, which may raise or may return a lazy object
-            authorized_val = authorized?(loaded_args)
-            context.schema.after_lazy(authorized_val) do |(authorized_result, early_return)|
-              # If the `authorized?` returned two values, `false, early_return`,
-              # then use the early return value instead of continuing
-              if early_return
-                if authorized_result == false
-                  early_return
-                else
-                  raise "Unexpected result from authorized (expected `true`, `false` or `[false, {...}]`): [#{authorized_result.inspect}, #{early_return.inspect}]"
-                end
-              elsif authorized_result
-                # Finally, all the hooks have passed, so resolve it
-                if loaded_args.any?
-                  public_send(self.class.resolve_method, **loaded_args)
-                else
-                  public_send(self.class.resolve_method)
-                end
+        context.schema.after_lazy(ready_val) do |is_ready, ready_early_return|
+          if ready_early_return
+            if is_ready != false
+              raise "Unexpected result from #ready? (expected `true`, `false` or `[false, {...}]`): [#{authorized_result.inspect}, #{ready_early_return.inspect}]"
+            else
+              ready_early_return
+            end
+          elsif is_ready
+            # Then call each prepare hook, which may return a different value
+            # for that argument, or may return a lazy object
+            load_arguments_val = load_arguments(args)
+            context.schema.after_lazy(load_arguments_val) do |loaded_args|
+              # Then call `authorized?`, which may raise or may return a lazy object
+              authorized_val = if loaded_args.any?
+                authorized?(loaded_args)
               else
-                nil
+                authorized?
+              end
+              authorized?(loaded_args)
+              context.schema.after_lazy(authorized_val) do |(authorized_result, early_return)|
+                # If the `authorized?` returned two values, `false, early_return`,
+                # then use the early return value instead of continuing
+                if early_return
+                  if authorized_result == false
+                    early_return
+                  else
+                    raise "Unexpected result from #authorized? (expected `true`, `false` or `[false, {...}]`): [#{authorized_result.inspect}, #{early_return.inspect}]"
+                  end
+                elsif authorized_result
+                  # Finally, all the hooks have passed, so resolve it
+                  if loaded_args.any?
+                    public_send(self.class.resolve_method, **loaded_args)
+                  else
+                    public_send(self.class.resolve_method)
+                  end
+                else
+                  nil
+                end
               end
             end
           end
@@ -100,7 +113,9 @@ module GraphQL
       # @param args [Hash] The input arguments, if there are any
       # @raise [GraphQL::ExecutionError] To add an error to the response
       # @raise [GraphQL::UnauthorizedError] To signal an authorization failure
-      def before_prepare(**args)
+      # @return [Boolean, early_return_data] If `false`, execution will stop (and `early_return_data` will be returned instead, if present.)
+      def ready?(**args)
+        true
       end
 
       # Called after arguments are loaded, but before resolving.
@@ -109,7 +124,7 @@ module GraphQL
       # @param args [Hash] The input arguments
       # @raise [GraphQL::ExecutionError] To add an error to the response
       # @raise [GraphQL::UnauthorizedError] To signal an authorization failure
-      # @return [Boolean] if `false`, execution will stop
+      # @return [Boolean, early_return_data] If `false`, execution will stop (and `early_return_data` will be returned instead, if present.)
       def authorized?(**args)
         true
       end

--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -31,8 +31,6 @@ module GraphQL
         @context = context
         # Since this hash is constantly rebuilt, cache it for this call
         @arguments_by_keyword = {}
-        # This might be set by {#early_return(val)}
-        @early_return_value = nil
         self.class.arguments.each do |name, arg|
           @arguments_by_keyword[arg.keyword] = arg
         end
@@ -220,23 +218,6 @@ module GraphQL
 
       def load_application_object_failed(err)
         raise err
-      end
-
-      # Call this during loading or authorization to
-      # skip {#resolve} and return data instead of top-level errors.
-      #
-      # It doesn't halt the flow of the code so be sure to return
-      # after calling it, or combine it with `return return_with(...)`.
-      #
-      #
-      # @param response [Object] The value to respond with
-      # @return [void]
-      def return_with(response)
-        if @early_return_value.nil?
-          @early_return_value = response
-        else
-          raise "Can't return_with again, already returned early with: #{@early_return_value.inspect}"
-        end
       end
 
       class << self


### PR DESCRIPTION
As pointed out by @cainlevy in #1734 , the new mutation auth doesn't support errors-as-data very well, but it definitely _should_, because errors-as-data is nice. 

How to do it? I can think of a few implementations: 

- Somehow use the return value of `.authorized?` (this is how before-save callbacks used to work, if they returned `false`, then save was prevented. I think this was changed to [`throw(:abort)`](https://blog.bigbinary.com/2016/02/13/rails-5-does-not-halt-callback-chain-when-false-is-returned.html)
- Use `throw :early_return, response`. This has the advantage of being plain Ruby, but it's not a very familiar feature. Also, it halts program flow, which is convenient, since later code will be irrelevant. 
- Use a normal method, as shown here. It's abstract, which is nice, but doesn't halt flow. This is like Rails controller `render` methods.
- Use a method that calls `throw` under the hood (like sinatra's `halt`, I think). It's nice that it halts flow, but maybe too magical? 

Any thoughts? 

TODO: 

- [ ] before_prepare should get the same treatment, be renamed to a `?` method.