### PR TITLE
Remove duplicate method definitions

### DIFF
--- a/lib/graphql/argument.rb
+++ b/lib/graphql/argument.rb
@@ -36,7 +36,8 @@ module GraphQL
   class Argument
     include GraphQL::Define::InstanceDefinable
     accepts_definitions :name, :type, :description, :default_value, :as, :prepare
-    attr_accessor :type, :description, :default_value, :name, :as
+    attr_reader :default_value
+    attr_accessor :description, :name, :as
     attr_accessor :ast_node
     alias :graphql_name :name
 

--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -35,7 +35,7 @@ module GraphQL
     end
 
     # @return [String] the name of this type, must be unique within a Schema
-    attr_accessor :name
+    attr_reader :name
     # Future-compatible alias
     # @see {GraphQL::SchemaMember}
     alias :graphql_name :name

--- a/lib/graphql/define/instance_definable.rb
+++ b/lib/graphql/define/instance_definable.rb
@@ -177,6 +177,7 @@ module GraphQL
         pending_methods = @pending_methods
         self.singleton_class.class_eval {
           pending_methods.each do |method|
+            undef_method(method.name) if method_defined?(method.name)
             define_method(method.name, method)
           end
         }
@@ -200,6 +201,7 @@ module GraphQL
         @pending_methods = method_names.map { |n| self.class.instance_method(n) }
         self.singleton_class.class_eval do
           method_names.each do |method_name|
+            undef_method(method_name) if method_defined?(method_name)
             define_method(method_name) { |*args, &block|
               ensure_defined
               self.send(method_name, *args, &block)

--- a/lib/graphql/enum_type.rb
+++ b/lib/graphql/enum_type.rb
@@ -141,6 +141,7 @@ module GraphQL
       attr_accessor :ast_node
       ensure_defined(*ATTRIBUTES)
 
+      undef name=
       def name=(new_name)
         # Validate that the name is correct
         GraphQL::NameValidator.validate!(new_name)

--- a/lib/graphql/field.rb
+++ b/lib/graphql/field.rb
@@ -156,7 +156,7 @@ module GraphQL
     attr_reader :lazy_resolve_proc
 
     # @return [String] The name of this field on its {GraphQL::ObjectType} (or {GraphQL::InterfaceType})
-    attr_accessor :name
+    attr_reader :name
     alias :graphql_name :name
 
     # @return [String, nil] The client-facing description of this field
@@ -175,10 +175,10 @@ module GraphQL
     attr_accessor :complexity
 
     # @return [Symbol, nil] The method to call on `obj` to return this field (overrides {#name} if present)
-    attr_accessor :property
+    attr_reader :property
 
     # @return [Object, nil] The key to access with `obj.[]` to resolve this field (overrides {#name} if present)
-    attr_accessor :hash_key
+    attr_reader :hash_key
 
     # @return [Object, GraphQL::Function] The function used to derive this field
     attr_accessor :function

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -29,7 +29,7 @@ module GraphQL
       end
     end
 
-    attr_reader :schema, :context, :warden, :provided_variables
+    attr_reader :schema, :context, :provided_variables
 
     # The value for root types
     attr_accessor :root_value
@@ -59,9 +59,6 @@ module GraphQL
 
     # @return [String, nil] the triggered event, if this query is a subscription update
     attr_reader :subscription_topic
-
-    # @return [String, nil]
-    attr_reader :operation_name
 
     attr_reader :tracers
 
@@ -218,11 +215,6 @@ module GraphQL
     # @return [GraphQL::Query::Arguments] Arguments for this node, merging default values, literal values and query variables
     def arguments_for(irep_or_ast_node, definition)
       @arguments_cache[irep_or_ast_node][definition]
-    end
-
-    # @return [GraphQL::Language::Nodes::OperationDefinition, nil]
-    def selected_operation
-      with_prepared_ast { @selected_operation }
     end
 
     def validation_pipeline

--- a/lib/graphql/relay/mutation.rb
+++ b/lib/graphql/relay/mutation.rb
@@ -101,7 +101,8 @@ module GraphQL
         return_field: GraphQL::Define::AssignObjectField,
         function: GraphQL::Define::AssignMutationFunction,
       )
-      attr_accessor :name, :description, :fields, :arguments, :return_type, :return_interfaces
+      attr_accessor :name, :description, :fields, :arguments
+      attr_writer :return_type, :return_interfaces
 
       ensure_defined(
         :input_fields, :return_fields, :name, :description,

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -123,7 +123,7 @@ module GraphQL
     attr_accessor :context_class
 
     class << self
-      attr_accessor :default_execution_strategy
+      attr_writer :default_execution_strategy
     end
 
     def default_filter
@@ -655,7 +655,7 @@ module GraphQL
         # Execution
         :execute, :multiplex,
         :static_validator, :introspection_system,
-        :query_analyzers, :middleware, :tracers, :instrumenters,
+        :query_analyzers, :tracers, :instrumenters,
         :query_execution_strategy, :mutation_execution_strategy, :subscription_execution_strategy,
         :validate, :multiplex_analyzers, :lazy?, :lazy_method_name, :after_lazy,
         # Configuration
@@ -664,7 +664,7 @@ module GraphQL
         :default_mask,
         :default_filter, :redefine,
         :id_from_object_proc, :object_from_id_proc,
-        :id_from_object=, :object_from_id=, :type_error,
+        :id_from_object=, :object_from_id=,
         :remove_handler,
         # Members
         :types, :get_fields, :find,
@@ -672,7 +672,7 @@ module GraphQL
         :subscriptions,
         :union_memberships,
         :get_field, :root_types, :references_to, :type_from_ast,
-        :possible_types, :get_field
+        :possible_types
 
       def graphql_definition
         @graphql_definition ||= to_graphql

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -11,8 +11,7 @@ module GraphQL
       attr_reader :name
       alias :graphql_name :name
 
-      # @return [String]
-      attr_accessor :description
+      attr_writer :description
 
       # @return [String, nil] If present, the field is marked as deprecated with this documentation
       attr_accessor :deprecation_reason
@@ -193,6 +192,8 @@ module GraphQL
         end
       end
 
+      # @param text [String]
+      # @return [String]
       def description(text = nil)
         if text
           @description = text

--- a/lib/graphql/static_validation/validation_context.rb
+++ b/lib/graphql/static_validation/validation_context.rb
@@ -14,9 +14,7 @@ module GraphQL
     class ValidationContext
       extend Forwardable
 
-      attr_reader :query, :schema,
-        :document, :errors, :visitor,
-        :warden, :dependencies, :each_irep_node_handlers
+      attr_reader :query, :errors, :visitor, :dependencies, :each_irep_node_handlers
 
       def_delegators :@query, :schema, :document, :fragments, :operations, :warden
 

--- a/lib/graphql/types/relay/base_connection.rb
+++ b/lib/graphql/types/relay/base_connection.rb
@@ -35,9 +35,6 @@ module GraphQL
           # @return [Class]
           attr_reader :node_type
 
-          # @return [Class]
-          attr_reader :edge_type
-
           # Configure this connection to return `edges` and `nodes` based on `edge_type_class`.
           #
           # This method will use the inputs to create:

--- a/spec/graphql/language/generation_spec.rb
+++ b/spec/graphql/language/generation_spec.rb
@@ -7,11 +7,13 @@ describe GraphQL::Language::Generation do
       GraphQL.parse('type Query { a: String! }')
     }
 
-    class CustomPrinter < GraphQL::Language::Printer
-      def print_field_definition(print_field_definition)
-        "<Field Hidden>"
-      end
-    end
+    let(:custom_printer_class) {
+      Class.new(GraphQL::Language::Printer) {
+        def print_field_definition(print_field_definition)
+          "<Field Hidden>"
+        end
+      }
+    }
 
     it "accepts a custom printer" do
       expected = <<-SCHEMA
@@ -30,7 +32,7 @@ type Query {
 }
       SCHEMA
 
-      assert_equal expected.chomp, GraphQL::Language::Generation.generate(document, printer: CustomPrinter.new)
+      assert_equal expected.chomp, GraphQL::Language::Generation.generate(document, printer: custom_printer_class.new)
     end
   end
 end

--- a/spec/graphql/language/nodes_spec.rb
+++ b/spec/graphql/language/nodes_spec.rb
@@ -27,11 +27,13 @@ describe GraphQL::Language::Nodes::AbstractNode do
       GraphQL.parse('type Query { a: String! }')
     }
 
-    class CustomPrinter < GraphQL::Language::Printer
-      def print_field_definition(print_field_definition)
-        "<Field Hidden>"
-      end
-    end
+    let(:custom_printer_class) {
+      Class.new(GraphQL::Language::Printer) {
+        def print_field_definition(print_field_definition)
+          "<Field Hidden>"
+        end
+      }
+    }
 
     it "accepts a custom printer" do
       expected = <<-SCHEMA
@@ -39,7 +41,7 @@ type Query {
   <Field Hidden>
 }
       SCHEMA
-      assert_equal expected.chomp, document.to_query_string(printer: CustomPrinter.new)
+      assert_equal expected.chomp, document.to_query_string(printer: custom_printer_class.new)
     end
   end
 end

--- a/spec/graphql/schema/resolver_spec.rb
+++ b/spec/graphql/schema/resolver_spec.rb
@@ -77,6 +77,7 @@ describe GraphQL::Schema::Resolver do
     class PrepResolver1 < BaseResolver
       argument :int, Integer, required: true
 
+      undef_method :load_int
       def load_int(i)
         i * 10
       end

--- a/spec/graphql/subscriptions/serialize_spec.rb
+++ b/spec/graphql/subscriptions/serialize_spec.rb
@@ -1,28 +1,6 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-if defined?(GlobalID)
-  GlobalID.app = "graphql-ruby-test"
-
-  class GlobalIDUser
-    include GlobalID::Identification
-
-    attr_reader :id
-
-    def initialize(id)
-      @id = id
-    end
-
-    def self.find(id)
-      GlobalIDUser.new(id)
-    end
-
-    def ==(that)
-      self.id == that.id
-    end
-  end
-end
-
 describe GraphQL::Subscriptions::Serialize do
   def serialize_dump(v)
     GraphQL::Subscriptions::Serialize.dump(v)

--- a/spec/support/global_id.rb
+++ b/spec/support/global_id.rb
@@ -1,0 +1,21 @@
+if defined?(GlobalID)
+  GlobalID.app = "graphql-ruby-test"
+
+  class GlobalIDUser
+    include GlobalID::Identification
+
+    attr_reader :id
+
+    def initialize(id)
+      @id = id
+    end
+
+    def self.find(id)
+      GlobalIDUser.new(id)
+    end
+
+    def ==(that)
+      self.id == that.id
+    end
+  end
+end

--- a/spec/support/global_id.rb
+++ b/spec/support/global_id.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if defined?(GlobalID)
   GlobalID.app = "graphql-ruby-test"
 

--- a/spec/support/lazy_helpers.rb
+++ b/spec/support/lazy_helpers.rb
@@ -20,7 +20,7 @@ module LazyHelpers
 
   class SumAll
     attr_reader :own_value
-    attr_accessor :value
+    attr_writer :value
 
     def initialize(ctx, own_value)
       @own_value = own_value


### PR DESCRIPTION
According to ruby's warning messages (run with `RUBYOPT=-w`), some method definitions were duplicate. I have removed them without changing existing behavior.

* removed some attribute names from `attr_*` or `def_delegators` since each of them has another definition
* added `undef` and `undef_method` to avoid warnings from ruby (related to #1256)
* removed `CustomPrinter` from toplevel
* moved multiple `GlobalIDUser` class definitions into one place