### PR TITLE
Manipulate AST with visitor

### DIFF
--- a/guides/guides.html
+++ b/guides/guides.html
@@ -14,6 +14,7 @@ sections:
   - name: GraphQL Pro
   - name: GraphQL Pro - OperationStore
   - name: JavaScript Client
+  - name: Language Tools
   - name: Other
 ---
 

--- a/guides/language_tools/visitor.md
+++ b/guides/language_tools/visitor.md
@@ -1,0 +1,143 @@
+---
+layout: guide
+doc_stub: false
+search: true
+section: Language Tools
+title: AST Visitor
+desc: Analyze and modify parsed GraphQL code
+index: 0
+---
+
+GraphQL code is usually contained in a string, for example:
+
+```ruby
+query_string = "query { user(id: \"1\") { userName } }"
+```
+
+You can perform programmatic analysis and modifications to GraphQL code using a three-step process:
+
+- __Parse__ the code into an abstract syntax tree
+- __Analyze/Modify__ the code with a visitor
+- __Print__ the code back to a string
+
+## Parse
+
+{{ "GraphQL.parse" | api_doc }} turns a string into a GraphQL document:
+
+```ruby
+parsed_doc = GraphQL.parse("{ user(id: \"1\") { userName } }")
+# => #<GraphQL::Language::Nodes::Document ...>
+```
+
+Also, {{ "GraphQL.parse_file" | api_doc }} parses the contents of the named file and includes a `filename` in the parsed document.
+
+#### AST Nodes
+
+The parsed document is a tree of nodes, called an _abstract syntax tree_ (AST). This tree is _immutable_: once a document has been parsed, those Ruby objects can't be changed. Modifications are performed by _copying_ existing nodes, applying changes to the copy, then making a new tree to hold the copied node. Where possible, unmodified nodes are retained in the new tree (it's _persistent_).
+
+The copy-and-modify workflow is supported by a few methods on the AST nodes:
+
+- `.merge(new_attrs)` returns a copy of the node with `new_attrs` applied. This new copy can replace the original node.
+- `.add_{child}(new_child_attrs)` makes a new node with `new_child_attrs`, adds it to the array specified by `{child}`, and returns a copy whose `{children}` array contains the newly created node.
+
+For example, to rename a field and add an argument to it, you could:
+
+```ruby
+modified_node = field_node
+  # Apply a new name
+  .merge(name: "newName")
+  # Add an argument to this field's arguments
+  .add_argument(name: "newArgument", value: "newValue")
+```
+
+Above, `field_node` is unmodified, but `modified_node` reflects the new name and new argument.
+
+## Analyze/Modify
+
+To inspect or modify a parsed document, extend {{ "GraphQL::Language::Visitor" | api_doc }} and implement its various hooks. It's an implementation of the [visitor pattern](https://en.wikipedia.org/wiki/Visitor_pattern). In short, each node of the tree will be "visited" by calling a method, and those methods can gather information and perform modifications.
+
+In the visitor, each node class has a hook, for example:
+
+- {{ "GraphQL::Language::Nodes::Field" | api_doc }}s are routed to `#on_field`
+- {{ "GraphQL::Language::Nodes::Argument" | api_doc }}s are routed to `#on_argument`
+
+See the {{ "GraphQL::Language::Visitor" | api_doc }} API docs for a full list of methods.
+
+Each method is called with `(node, parent)`, where:
+
+- `node` is the AST node currently visited
+- `parent` is the AST node above this node in the tree
+
+The method has a few options for analyzing or modifying the AST:
+
+#### Continue/Halt
+
+To continue visiting, the hook should call `super`. This allows the visit to continue to `node`'s children in the tree, for example:
+
+```ruby
+def on_field(_node, _parent)
+  # Do nothing, this is the default behavior:
+  super
+end
+```
+
+To _halt_ the visit, a method may skip the call to `super`. For example, if the visitor encountered an error, it might want to return early instead of continuing to visit.
+
+#### Modify a Node
+
+Visitor hooks are expected to return the `(node, parent)` they are called with. If they return a different node, then that node will replace the original `node`. When you call `super(node, parent)`, the `node` is returned. So, to modify a node and continue visiting:
+
+- Make a modified copy of `node`
+- Pass the modified copy to `super(new_node, parent)`
+
+For example, to rename an argument:
+
+```ruby
+def on_argument(node, parent)
+  # make a copy of `node` with a new name
+  modified_node = node.merge(name: "renamed")
+  # continue visiting with the modified node and parent
+  super(modified_node, parent)
+end
+```
+
+#### Delete a Node
+
+To delete the currently-visited `node`, don't pass `node` to `super(...)`. Instead, pass a magic constant, `DELETE_NODE`, in place of `node`.
+
+For example, to delete a directive:
+
+```ruby
+def on_directive(node, parent)
+  # Don't pass `node` to `super`,
+  # instead, pass `DELETE_NODE`
+  super(DELETE_NODE, parent)
+end
+```
+
+#### Insert a Node
+
+Inserting nodes is similar to modifying nodes. To insert a new child into `node`, call one of its `.add_` helpers. This returns a copied node with a new child added. For example, to add a selection to a field's selection set:
+
+```ruby
+def on_field(node, parent)
+  node_with_selection = node.add_selection(name: "emailAddress")
+  super(node_with_selection, parent)
+end
+```
+
+This will add `emailAddress` the fields selection on `node`.
+
+
+(These `.add_*` helpers are wrappers around {{ "GraphQL::Language::Nodes::AbstractNode#merge" | api_doc }}.)
+
+## Print
+
+The easiest way to turn an AST back into a string of GraphQL is {{ "GraphQL::Language::Nodes::AbstractNode#to_query_string" | api_doc }}, for example:
+
+```ruby
+parsed_doc.to_query_string
+# => '{ user(id: "1") { userName } }'
+```
+
+You can also create a subclass of {{ "GraphQL::Language::Printer" | api_doc }} to customize how nodes are printed.

--- a/lib/graphql/compatibility/schema_parser_specification.rb
+++ b/lib/graphql/compatibility/schema_parser_specification.rb
@@ -595,31 +595,27 @@ module GraphQL
 
             assert_equal 6, document.definitions.size
 
-            schema_definition = document.definitions.shift
+            schema_definition, directive_definition, enum_type_definition, object_type_definition, input_object_type_definition, interface_type_definition = document.definitions
+
             assert_equal GraphQL::Language::Nodes::SchemaDefinition, schema_definition.class
 
-            directive_definition = document.definitions.shift
             assert_equal GraphQL::Language::Nodes::DirectiveDefinition, directive_definition.class
             assert_equal 'This is a directive', directive_definition.description
 
-            enum_type_definition = document.definitions.shift
             assert_equal GraphQL::Language::Nodes::EnumTypeDefinition, enum_type_definition.class
             assert_equal "Multiline comment\n\nWith an enum", enum_type_definition.description
 
             assert_nil enum_type_definition.values[0].description
             assert_equal 'Not a creative color', enum_type_definition.values[1].description
 
-            object_type_definition = document.definitions.shift
             assert_equal GraphQL::Language::Nodes::ObjectTypeDefinition, object_type_definition.class
             assert_equal 'Comment without preceding space', object_type_definition.description
             assert_equal 'And a field to boot', object_type_definition.fields[0].description
 
-            input_object_type_definition = document.definitions.shift
             assert_equal GraphQL::Language::Nodes::InputObjectTypeDefinition, input_object_type_definition.class
             assert_equal 'Comment for input object types', input_object_type_definition.description
             assert_equal 'Color of the car', input_object_type_definition.fields[0].description
 
-            interface_type_definition = document.definitions.shift
             assert_equal GraphQL::Language::Nodes::InterfaceTypeDefinition, interface_type_definition.class
             assert_equal 'Comment for interface definitions', interface_type_definition.description
             assert_equal 'Amount of wheels', interface_type_definition.fields[0].description

--- a/lib/graphql/language/document_from_schema_definition.rb
+++ b/lib/graphql/language/document_from_schema_definition.rb
@@ -65,7 +65,7 @@ module GraphQL
         )
 
         if field.deprecation_reason
-          field_node.directives << GraphQL::Language::Nodes::Directive.new(
+          field_node = field_node.merge_directive(
             name: GraphQL::Directive::DeprecatedDirective.name,
             arguments: [GraphQL::Language::Nodes::Argument.new(name: "reason", value: field.deprecation_reason)]
           )
@@ -107,7 +107,7 @@ module GraphQL
         )
 
         if enum_value.deprecation_reason
-          enum_value_node.directives << GraphQL::Language::Nodes::Directive.new(
+          enum_value_node = enum_value_node.merge_directive(
             name: GraphQL::Directive::DeprecatedDirective.name,
             arguments: [GraphQL::Language::Nodes::Argument.new(name: "reason", value: enum_value.deprecation_reason)]
           )

--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -197,6 +197,11 @@ module GraphQL
         def children_method_name
           :directives
         end
+
+        # TODO generate these
+        def merge_argument(node_opts)
+          self.merge(arguments: arguments + [GraphQL::Language::Nodes::Argument.new(node_opts)])
+        end
       end
 
       class DirectiveDefinition < AbstractNode
@@ -286,6 +291,18 @@ module GraphQL
         def initialize_node(name: nil, arguments: [], directives: [], selections: [], **kwargs)
           # oops, alias is a keyword:
           set_attributes(name: name, arguments: arguments, directives: directives, selections: selections, alias: kwargs.fetch(:alias, nil))
+        end
+
+        def merge_selection(node_opts)
+          self.merge(selections: selections + [GraphQL::Language::Nodes::Field.new(node_opts)])
+        end
+
+        def merge_argument(node_opts)
+          self.merge(arguments: arguments + [GraphQL::Language::Nodes::Argument.new(node_opts)])
+        end
+
+        def merge_directive(node_opts)
+          self.merge(directives: directives + [GraphQL::Language::Nodes::Directive.new(node_opts)])
         end
 
         def scalars

--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -79,11 +79,31 @@ module GraphQL
         def replace_child(previous_child, new_child)
           # Figure out which list `previous_child` may be found in
           method_name = previous_child.children_method_name
-          # Copy that list, and replace `previous_child` with `new_child`
-          # in the list.
+          # Get the value from this (original) node
+          prev_children = public_send(method_name)
+          if prev_children.is_a?(Array)
+            # Copy that list, and replace `previous_child` with `new_child`
+            # in the list.
+            new_children = public_send(method_name).dup
+            prev_idx = new_children.index(previous_child)
+            new_children[prev_idx] = new_child
+          else
+            # Use the new value for the given attribute
+            new_children = new_child
+          end
+          # Copy this node, but with the new child value
+          copy_of_self = merge(method_name => new_children)
+          # Return the copy:
+          copy_of_self
+        end
+
+        # TODO DRY with `replace_child`
+        def delete_child(previous_child)
+          # Figure out which list `previous_child` may be found in
+          method_name = previous_child.children_method_name
+          # Copy that list, and delete previous_child
           new_children = public_send(method_name).dup
-          prev_idx = new_children.index(previous_child)
-          new_children[prev_idx] = new_child
+          new_children.delete(previous_child)
           # Copy this node, but with the new list of children:
           copy_of_self = merge(method_name => new_children)
           # Return the copy:
@@ -387,6 +407,11 @@ module GraphQL
         def visit_method
           :on_input_object
         end
+
+        def children_method_name
+          :value
+        end
+
         private
 
         def serialize_value_for_hash(value)

--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -168,7 +168,7 @@ module GraphQL
               else
                 module_eval <<-RUBY, __FILE__, __LINE__
                   def children
-                    @children ||= #{children_of_type.keys.map { |k| "@#{k}" }.join(" + ")}
+                    @children ||= (#{children_of_type.keys.map { |k| "@#{k}" }.join(" + ")}).freeze
                   end
                 RUBY
               end
@@ -200,7 +200,7 @@ module GraphQL
                 attr_reader #{method_names.map { |m| ":#{m}"}.join(", ")}
 
                 def scalars
-                  @scalars ||= [#{method_names.map { |k| "@#{k}" }.join(", ")}]
+                  @scalars ||= [#{method_names.map { |k| "@#{k}" }.join(", ")}].freeze
                 end
               RUBY
             end
@@ -224,7 +224,9 @@ module GraphQL
               arguments = scalar_method_names.map { |m| "#{m}: nil"} +
                 @children_methods.keys.map { |m| "#{m}: []" }
 
-              assignments = all_method_names.map { |m| "@#{m} = #{m}"}
+              assignments = scalar_method_names.map { |m| "@#{m} = #{m}"} +
+                @children_methods.keys.map { |m| "@#{m} = #{m}.freeze" }
+
               module_eval <<-RUBY, __FILE__, __LINE__
                 def initialize_node #{arguments.join(", ")}
                   #{assignments.join("\n")}

--- a/lib/graphql/language/visitor.rb
+++ b/lib/graphql/language/visitor.rb
@@ -147,7 +147,6 @@ module GraphQL
           new_parent = new_parent && new_parent.delete_child(node)
           return nil, new_parent
         else
-          # TODO: be less lax here
           # The user-provided hook didn't make any modifications.
           # In fact, the hook might have returned who-knows-what, so
           # ignore the return value and use the original values.

--- a/lib/graphql/language/visitor.rb
+++ b/lib/graphql/language/visitor.rb
@@ -36,6 +36,11 @@ module GraphQL
       # @deprecated Use `super` to continue the visit; or don't call it to halt.
       SKIP = :_skip
 
+      class DeleteNode; end
+      # When this is returned from a visitor method,
+      # Then the `node` passed into the method is removed from `parent`'s children.
+      DELETE_NODE = DeleteNode.new
+
       def initialize(document)
         @document = document
         @visitors = {}
@@ -72,16 +77,22 @@ module GraphQL
       # @param parent [GraphQL::Language::Nodes::AbstractNode, nil] the previously-visited node, or `nil` if this is the root node.
       # @return [void]
       def on_abstract_node(node, parent)
-        # Run hooks if there are any
-        begin_hooks_ok = @visitors.none? || begin_visit(node, parent)
-        if begin_hooks_ok
-          node.children.each do |child_node|
-            # Reassign `node` in case the child hook makes a modification
-            _new_child_node, node = on_node_with_modifications(child_node, node)
+        if node == DELETE_NODE
+          # This might be passed to `super(DELETE_NODE, ...)`
+          # by a user hook, don't want to keep visiting in that case.
+          return node, parent
+        else
+          # Run hooks if there are any
+          begin_hooks_ok = @visitors.none? || begin_visit(node, parent)
+          if begin_hooks_ok
+            node.children.each do |child_node|
+              # Reassign `node` in case the child hook makes a modification
+              _new_child_node, node = on_node_with_modifications(child_node, node)
+            end
           end
+          @visitors.any? && end_visit(node, parent)
+          return node, parent
         end
-        @visitors.any? && end_visit(node, parent)
-        return node, parent
       end
 
       alias :on_argument :on_abstract_node
@@ -131,7 +142,12 @@ module GraphQL
           # The user-provided hook returned a new node.
           new_parent = new_parent && new_parent.replace_child(node, new_node)
           return new_node, new_parent
+        elsif new_node == DELETE_NODE
+          # The user-provided hook requested to remove this node
+          new_parent = new_parent && new_parent.delete_child(node)
+          return nil, new_parent
         else
+          # TODO: be less lax here
           # The user-provided hook didn't make any modifications.
           # In fact, the hook might have returned who-knows-what, so
           # ignore the return value and use the original values.

--- a/lib/graphql/static_validation/rules/no_definitions_are_present.rb
+++ b/lib/graphql/static_validation/rules/no_definitions_are_present.rb
@@ -11,6 +11,7 @@ module GraphQL
 
       def on_invalid_node(node, parent)
         @schema_definition_nodes << node
+        nil
       end
 
       alias :on_directive_definition :on_invalid_node

--- a/spec/graphql/language/nodes_spec.rb
+++ b/spec/graphql/language/nodes_spec.rb
@@ -42,28 +42,4 @@ type Query {
       assert_equal expected.chomp, document.to_query_string(printer: CustomPrinter.new)
     end
   end
-
-  describe "required methods" do
-    node_classes = (GraphQL::Language::Nodes.constants - [:WrapperType, :NameOnlyNode])
-      .map { |name| GraphQL::Language::Nodes.const_get(name) }
-      .select { |const| const.is_a?(Class) && const < GraphQL::Language::Nodes::AbstractNode }
-
-    it "all classes have #visit_method (and Visitor has a hook)" do
-      node_classes.each do |node_class|
-        concrete_method = node_class.instance_method(:visit_method)
-        refute_nil concrete_method.super_method, "#{node_class} overrides #visit_method"
-        visit_method_name = "on_" + node_class.name
-          .split("::").last
-          .gsub(/([a-z\d])([A-Z])/,'\1_\2')     # someThing -> some_Thing
-          .downcase
-        assert GraphQL::Language::Visitor.method_defined?(visit_method_name), "Language::Visitor has a method for #{node_class} (##{visit_method_name})"
-      end
-    end
-
-    it "has #children_method_name" do
-      node_classes.each do |node_class|
-        assert node_class.method_defined?(:children_method_name), "#{node_class} has a children_method_name"
-      end
-    end
-  end
 end


### PR DESCRIPTION
It would be nice to have a way to programmaticaly modify GraphQL ASTs, but we don't have one yet. I propose a way to do it using the class-based visitor on the `1.9-dev` branch. 

Goals: 

- Efficient
- Easy-to-use 
- Respects immutability of nodes 

So, this implementation will treat the AST as a persistent immutable data structure: 

- By default, the tree is only traversed; no modification or duplication 
- When a hook returns a new node, then: 
  - the node's parent is shallow-copied; the copy is modified to include the new child 
  - the copied parent is returned so that its parent may also be modified 

__TODO:__

- Lots of nodes need reorganization to support persistent copying, for example: 
  - Implementing `.children_method_name` (I sure hope that each node type has only one possible name!) 
  - Refactor `initialize_node` to call `set_attributes`? 
  - But, instance_variable_set is slow, consider another metaprogramming approach? 
  - Maybe generate classes from configuration? There's a lot of duplication and I'm about to add a lot more.
- Implement more modifications: 
  - [x] modify node & replace child 
  - [x] delete node & remove child 
  - [x] create node & insert child 
  - others?
- [x] Add a guide


Fixes #455 