### PR TITLE
Remove Forwardable from GraphQL::Schema::Wrapper

### DIFF
--- a/lib/graphql/schema/wrapper.rb
+++ b/lib/graphql/schema/wrapper.rb
@@ -5,9 +5,8 @@ module GraphQL
     class Wrapper
       include GraphQL::Schema::Member::CachedGraphQLDefinition
       include GraphQL::Schema::Member::TypeSystemHelpers
-      extend Forwardable
 
-      # @return [Class, Module] The inner type of this list, the type of which one or more objects may be present.
+      # @return [Class, Module] The inner type of this wrapping type, the type of which one or more objects may be present.
       attr_reader :of_type
 
       def initialize(of_type)


### PR DESCRIPTION
## Proposal

Seems like I missed removing `extend Forwardable` in #1724.

Circling back here to remove it for good, sorry about that. 😃 

## Why

I included Forwardable in #1724 because I wanted to delegate some of the methods to base classes however after the discussion in that PR it made sense to not delegate and instead just reimplement the methods. Now that it's not being used it makes sense to get rid of it. 

## How

Remove `extend Forwardable` from `GraphQL::Schema::Wrapper`.