### PR TITLE
Fix relay root-level node declaration syntax (in docs)

### DIFF
--- a/guides/relay/object_identification.md
+++ b/guides/relay/object_identification.md
@@ -107,7 +107,7 @@ You should also provide a root-level `node` field so that Relay can refetch obje
 ```ruby
 class Types::QueryType < GraphQL::Schema::Object
   # Used by Relay to lookup objects by UUID:
-  field :node, GraphQL::Relay::Node.field
+  field :node, field: GraphQL::Relay::Node.field
   # ...
 end
 ```
@@ -119,7 +119,7 @@ You can also provide a root-level `nodes` field so that Relay can refetch object
 ```ruby
 class QueryType < GraphQL::Schema::Object
   # Fetches a list of objects given a list of IDs
-  field :nodes, GraphQL::Relay::Node.plural_field
+  field :nodes, field: GraphQL::Relay::Node.plural_field
   # ...
 end
 ```


### PR DESCRIPTION
While following [this guide](http://graphql-ruby.org/relay/object_identification.html#node-field-find-by-uuid) verbatim, I ran into the following error:

```
 GraphQL::Field was passed as the second argument, use the `field:` keyword for this instead.
/Users/Patrick/.gem/ruby/2.5.1/gems/graphql-1.8.6/lib/graphql/schema/field.rb:61:in `from_options'
/Users/Patrick/.gem/ruby/2.5.1/gems/graphql-1.8.6/lib/graphql/schema/member/has_fields.rb:52:in `field'
/Users/Patrick/Code/parsnip/app/graphql/types/query_type.rb:6:in `<class:QueryType>'
/Users/Patrick/Code/parsnip/app/graphql/types/query_type.rb:4:in `<module:Types>'
/Users/Patrick/Code/parsnip/app/graphql/types/query_type.rb:3:in `<main>'
...
```

I don't know when the docs got out of date, but it turns out that a `field: ` keyword is required before the argument, as of at latest 1.8.6.

gem version: 1.8.6
ruby version: 2.5.1
Rails version: 5.2.0