### PR TITLE
Move NotImplementedError out to default_graphql_name

### DIFF
--- a/lib/graphql/schema/member/base_dsl_methods.rb
+++ b/lib/graphql/schema/member/base_dsl_methods.rb
@@ -20,8 +20,6 @@ module GraphQL
           when overridden = overridden_graphql_name
             overridden
           else
-            raise NotImplementedError, 'Anonymous class should declare a `graphql_name`' if name.nil?
-
             default_graphql_name
           end
         end
@@ -81,6 +79,8 @@ module GraphQL
         # The default name is the Ruby constant name,
         # without any namespaces and with any `-Type` suffix removed
         def default_graphql_name
+          raise NotImplementedError, 'Anonymous class should declare a `graphql_name`' if name.nil?
+
           name.split("::").last.sub(/Type\Z/, "")
         end
 


### PR DESCRIPTION
## Proposal

Small tweak to move the `NotImplementedError` into `default_graphql_name` based on @eapache suggestion, missed this in #1729.

## Why

Raise the error where it should be raised!