### PR TITLE
Alias to_type_signature to graphql_name in wrapping types

### DIFF
--- a/lib/graphql/schema/list.rb
+++ b/lib/graphql/schema/list.rb
@@ -20,9 +20,11 @@ module GraphQL
         true
       end
 
-      def to_type_signature
-        "[#{@of_type.to_type_signature}]"
+      def graphql_name
+        "[#{@of_type.graphql_name}]"
       end
+
+      alias_method :to_type_signature, :graphql_name
     end
   end
 end

--- a/lib/graphql/schema/member/type_system_helpers.rb
+++ b/lib/graphql/schema/member/type_system_helpers.rb
@@ -24,10 +24,6 @@ module GraphQL
           false
         end
 
-        def to_type_signature
-          graphql_name
-        end
-
         # @return [GraphQL::TypeKinds::TypeKind]
         def kind
           raise NotImplementedError

--- a/lib/graphql/schema/non_null.rb
+++ b/lib/graphql/schema/non_null.rb
@@ -25,9 +25,11 @@ module GraphQL
         @of_type.list?
       end
       
-      def to_type_signature
-        "#{@of_type.to_type_signature}!"
+      def graphql_name
+        "#{@of_type.graphql_name}!"
       end
+
+      alias_method :to_type_signature, :graphql_name
     end
   end
 end

--- a/lib/graphql/schema/wrapper.rb
+++ b/lib/graphql/schema/wrapper.rb
@@ -13,6 +13,14 @@ module GraphQL
         @of_type = of_type
       end
 
+      def description
+        nil
+      end
+
+      def graphql_name
+        raise NotImplementedError
+      end
+
       def to_graphql
         raise NotImplementedError
       end

--- a/spec/graphql/schema/list_spec.rb
+++ b/spec/graphql/schema/list_spec.rb
@@ -18,8 +18,12 @@ describe GraphQL::Schema::List do
     assert_equal GraphQL::TypeKinds::LIST, list_type.kind
   end
 
-  it "returns correct type signature" do
+  it "returns correct type graphql_name and to_type_signature is aliased" do
     assert_equal "[Musician]", list_type.to_type_signature
+  end
+
+  it "returns correct type graphql_name" do
+    assert_equal "[Musician]", list_type.graphql_name
   end
 
   describe "comparison operator" do

--- a/spec/graphql/schema/non_null_spec.rb
+++ b/spec/graphql/schema/non_null_spec.rb
@@ -18,8 +18,12 @@ describe GraphQL::Schema::NonNull do
     assert_equal GraphQL::TypeKinds::NON_NULL, non_null_type.kind
   end
 
-  it "returns correct type signature" do
+  it "returns correct type graphql_name and to_type_signature is aliased" do
     assert_equal "Musician!", non_null_type.to_type_signature
+  end
+
+  it "returns correct type graphql_name" do
+    assert_equal "Musician!", non_null_type.graphql_name
   end
 
   describe "comparison operator" do


### PR DESCRIPTION
## Proposal

Closes: #1711

Most types respond to #graphql_name and #description, but not the new list and non-null wrappers. It is in spec that wrapping types do have a name and a description so our wrapping types should implement them. This is a good opportunity as well to consolidate naming, as mentioned in the attached issue it would be nice to alias `to_type_signature` to `graphql_name`.

## Why

Adhere to spec and reduce the number of names to remember.

## How

Remove `to_type_signature` and alias it to `graphql_name`, also implement `description` in wrapping types.
