### PR TITLE
[WIP] Proposal: add inaccessible_field feature

### DIFF
--- a/lib/graphql/authorization.rb
+++ b/lib/graphql/authorization.rb
@@ -71,7 +71,13 @@ module GraphQL
           end
           context = memo[:context]
           err = InaccessibleFieldsError.new(fields: fields, irep_nodes: nodes, context: context)
-          context.schema.inaccessible_fields(err)
+
+          # TODO: fix
+          if context.schema.respond_to?(:inaccessible_field)
+            context[:inaccessible_nodes] = memo[:inaccessible_nodes]
+          else
+            context.schema.inaccessible_fields(err)
+          end
         else
           nil
         end

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -310,6 +310,10 @@ module GraphQL
       #
       # Eventually, we might hook up field instances to execution in another way. TBD.
       def resolve_field(obj, args, ctx)
+        if ctx[:inaccessible_nodes] && ctx[:inaccessible_nodes].include?(ctx.irep_node)
+          ctx.schema.inaccessible_field(self)
+        end
+
         ctx.schema.after_lazy(obj) do |after_obj|
           # First, apply auth ...
           query_ctx = ctx.query.context

--- a/spec/graphql/authorization_spec.rb
+++ b/spec/graphql/authorization_spec.rb
@@ -588,6 +588,30 @@ describe GraphQL::Authorization do
     end
   end
 
+  # TODO: fix
+  describe "applying the accessible? method when inaccessible_field is defined on schema" do
+    class AuthTest::Schema
+      def self.inaccessible_field(field)
+        raise GraphQL::ExecutionError.new("#{field.owner.graphql_name}.#{field.graphql_name} is not accessible")
+      end
+    end
+
+    it "works with fields and arguments" do
+      queries = {
+        "{ inaccessible }" => ["Query.inaccessible is not accessible"],
+        "{ int2(inaccessible: 1) }" => ["Query.int2 is not accessible"],
+      }
+
+      queries.each do |query_str, errors|
+        res = auth_execute(query_str, context: { hide: true })
+        assert_equal errors, res.fetch("errors").map { |e| e["message"] }
+
+        res = auth_execute(query_str, context: { hide: false })
+        refute res.key?("errors")
+      end
+    end
+  end
+
   describe "applying the authorized? method" do
     it "halts on unauthorized objects" do
       query = "{ unauthorizedObject { __typename } }"


### PR DESCRIPTION
Right now accessibility is done at query analysis time. The only provided hook is `inaccessible_fields` where you can either allow the query to continue or raise an error.

If you raise an error, query execution does not occur. This prevents any partial responses from happening.

If `nil` is returned and the query continues, all information from `GraphQL::Authorization::Analyzer` is lost.

The idea behind this is to provide a 2nd option where the authorization enforcement is done during field execution (but before actually resolving) to allow for partial responses.

Ideally this would be opt-in at the schema level by providing a `inaccessible_field` (note the difference, no `s` at the end, name TBD) method which would be called for *each* field which is not accessible. An `ExecutionError` could be raised to prevent the field was being resolved.

Things to figure out:

1. how to opt-in to this behaviour. The optional schema method doesn't actually work due to the legacy schema and delegation.
2. this only works for class-based fields. Does this need to be supported for the legacy ones as well? Is there even a way to do this nicely?
3. is checking the `irep_node` a stable enough way to do this?