### PR TITLE
Don't pass client_mutation_id: to .authorized?

### DIFF
--- a/lib/graphql/schema/relay_classic_mutation.rb
+++ b/lib/graphql/schema/relay_classic_mutation.rb
@@ -25,19 +25,13 @@ module GraphQL
       # Relay classic default:
       null(true)
 
-      # Override {GraphQL::Schema::Mutation#resolve_mutation} to
+      # Override {GraphQL::Schema::Resolver#resolve_with_support} to
       # delete `client_mutation_id` from the kwargs.
-      def resolve_mutation(**kwargs)
+      def resolve_with_support(**kwargs)
         # This is handled by Relay::Mutation::Resolve, a bit hacky, but here we are.
         kwargs.delete(:client_mutation_id)
-        if kwargs.any?
-          resolve(**kwargs)
-        else
-          resolve
-        end
+        super
       end
-
-      resolve_method(:resolve_mutation)
 
       class << self
         # The base class for generated input object types

--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -74,7 +74,6 @@ module GraphQL
               else
                 authorized?
               end
-              authorized?(loaded_args)
               context.schema.after_lazy(authorized_val) do |(authorized_result, early_return)|
                 # If the `authorized?` returned two values, `false, early_return`,
                 # then use the early return value instead of continuing

--- a/spec/graphql/schema/resolver_spec.rb
+++ b/spec/graphql/schema/resolver_spec.rb
@@ -242,6 +242,17 @@ describe GraphQL::Schema::Resolver do
       end
     end
 
+    class PrepResolver14 < GraphQL::Schema::RelayClassicMutation
+      field :number, Integer, null: false
+
+      def authorized?
+        true
+      end
+
+      def resolve
+        { number: 1 }
+      end
+    end
 
     class Query < GraphQL::Schema::Object
       class CustomField < GraphQL::Schema::Field
@@ -278,6 +289,7 @@ describe GraphQL::Schema::Resolver do
       field :prep_resolver_11, resolver: PrepResolver11
       field :prep_resolver_12, resolver: PrepResolver12
       field :prep_resolver_13, resolver: PrepResolver13
+      field :prep_resolver_14, resolver: PrepResolver14
     end
 
     class Schema < GraphQL::Schema
@@ -477,6 +489,11 @@ describe GraphQL::Schema::Resolver do
           GRAPHQL
           res = exec_query(str, context: { max_int: 100, min_int: 20 })
           assert_equal({ "prepResolver10" => nil, "prepResolver11" => nil }, res["data"])
+        end
+
+        it "works with no arguments for RelayClassicMutation" do
+          res = exec_query("{ prepResolver14(input: {}) { number } }")
+          assert_equal 1, res["data"]["prepResolver14"]["number"]
         end
       end
     end


### PR DESCRIPTION
Oops, it was passing `client_mutation_id:` to authorized, which we want to hide from mutation code.