### PR TITLE
Let as: overrides loads: argument name

### DIFF
--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -324,8 +324,7 @@ module GraphQL
         # @see {GraphQL::Schema::Argument#initialize} for the signature
         def argument(name, type, *rest, loads: nil, **kwargs, &block)
           if loads
-            arg_keyword = name.to_s.sub(/_id$/, "").to_sym
-            kwargs[:as] = arg_keyword
+            arg_keyword = kwargs[:as] ||= name.to_s.sub(/_id$/, "").to_sym
             own_arguments_loads_as_type[arg_keyword] = loads
           end
           arg_defn = super(name, type, *rest, **kwargs, &block)

--- a/spec/graphql/schema/relay_classic_mutation_spec.rb
+++ b/spec/graphql/schema/relay_classic_mutation_spec.rb
@@ -70,6 +70,12 @@ describe GraphQL::Schema::RelayClassicMutation do
       assert_equal "August Greene", res["data"]["renameEnsemble"]["ensemble"]["name"]
     end
 
+    it "uses the `as:` name when loading" do
+      band_query_str = query_str.sub("renameEnsemble", "renameEnsembleAsBand")
+      res = Jazz::Schema.execute(band_query_str, variables: { id: "Ensemble/Robert Glasper Experiment", newName: "August Greene"})
+      assert_equal "August Greene", res["data"]["renameEnsembleAsBand"]["ensemble"]["name"]
+    end
+
     it "returns an error instead when the ID resolves to nil" do
       res = Jazz::Schema.execute(query_str, variables: {
         id: "Ensemble/Nonexistant Name",

--- a/spec/graphql/schema/resolver_spec.rb
+++ b/spec/graphql/schema/resolver_spec.rb
@@ -194,26 +194,26 @@ describe GraphQL::Schema::Resolver do
 
     class PrepResolver10 < BaseResolver
       argument :int1, Integer, required: true
-      argument :int2, Integer, required: true
+      argument :int2, Integer, required: true, as: :integer_2
       type Integer, null: true
-      def authorized?(int1:, int2:)
-        if int1 + int2 > context[:max_int]
+      def authorized?(int1:, integer_2:)
+        if int1 + integer_2 > context[:max_int]
           raise GraphQL::ExecutionError, "Inputs too big"
-        elsif context[:min_int] && (int1 + int2 < context[:min_int])
+        elsif context[:min_int] && (int1 + integer_2 < context[:min_int])
           false
         else
           true
         end
       end
 
-      def resolve(int1:, int2:)
-        int1 + int2
+      def resolve(int1:, integer_2:)
+        int1 + integer_2
       end
     end
 
     class PrepResolver11 < PrepResolver10
-      def authorized?(int1:, int2:)
-        LazyBlock.new { super(int1: int1 * 2, int2: int2) }
+      def authorized?(int1:, integer_2:)
+        LazyBlock.new { super(int1: int1 * 2, integer_2: integer_2) }
       end
     end
 
@@ -450,6 +450,11 @@ describe GraphQL::Schema::Resolver do
           res = exec_query("{ prepResolver10(int1: 5, int2: 6) }", context: { max_int: 9 })
           assert_equal ["Inputs too big"], res["errors"].map { |e| e["message"] }
 
+          res = exec_query("{ prepResolver10(int1: 5, int2: 6) }", context: { max_int: 90 })
+          assert_equal 11, res["data"]["prepResolver10"]
+        end
+
+        it "uses the argument name provided in `as:`" do
           res = exec_query("{ prepResolver10(int1: 5, int2: 6) }", context: { max_int: 90 })
           assert_equal 11, res["data"]["prepResolver10"]
         end

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -488,6 +488,14 @@ module Jazz
     end
   end
 
+  class RenameEnsembleAsBand < RenameEnsemble
+    argument :ensemble_id, ID, required: true, loads: Ensemble, as: :band
+
+    def resolve(band:, new_name:)
+      super(ensemble: band, new_name: new_name)
+    end
+  end
+
   class Mutation < BaseObject
     field :add_ensemble, Ensemble, null: false do
       argument :input, EnsembleInput, required: true
@@ -496,6 +504,7 @@ module Jazz
     field :add_instrument, mutation: AddInstrument
     field :add_sitar, mutation: AddSitar
     field :rename_ensemble, mutation: RenameEnsemble
+    field :rename_ensemble_as_band, mutation: RenameEnsembleAsBand
 
     def add_ensemble(input:)
       ens = Models::Ensemble.new(input.name)


### PR DESCRIPTION
This is really to support:

```ruby 
argument :id, ID, required: true, loads: Comment, as: :comment
```

Because otherwise, you end up with `id:` being a Comment, which makes no sense.