### PR TITLE
Don't pass resolver objects to field extensions

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -388,9 +388,6 @@ MSG
             if @resolve_proc
               # Might be nil, still want to call the func in that case
               @resolve_proc.call(inner_obj, args, ctx)
-            elsif @resolver_class
-              singleton_inst = @resolver_class.new(object: inner_obj, context: query_ctx)
-              public_send_field(singleton_inst, args, ctx)
             else
               public_send_field(after_obj, args, ctx)
             end
@@ -463,6 +460,13 @@ MSG
 
         query_ctx = field_ctx.query.context
         with_extensions(obj, ruby_kwargs, query_ctx) do |extended_obj, extended_args|
+          if @resolver_class
+            if extended_obj.is_a?(GraphQL::Schema::Object)
+              extended_obj = extended_obj.object
+            end
+            extended_obj = @resolver_class.new(object: extended_obj, context: query_ctx)
+          end
+
           if extended_args.any?
             extended_obj.public_send(@method_sym, **extended_args)
           else

--- a/lib/graphql/schema/field/connection_extension.rb
+++ b/lib/graphql/schema/field/connection_extension.rb
@@ -29,6 +29,9 @@ module GraphQL
           elsif value.nil?
             nil
           else
+            if object.is_a?(GraphQL::Schema::Object)
+              object = object.object
+            end
             connection_class = GraphQL::Relay::BaseConnection.connection_for_nodes(value)
             connection_class.new(
               value,

--- a/lib/graphql/schema/field/connection_extension.rb
+++ b/lib/graphql/schema/field/connection_extension.rb
@@ -29,9 +29,6 @@ module GraphQL
           elsif value.nil?
             nil
           else
-            if object.is_a?(GraphQL::Schema::Object)
-              object = object.object
-            end
             connection_class = GraphQL::Relay::BaseConnection.connection_for_nodes(value)
             connection_class.new(
               value,

--- a/spec/integration/rails/graphql/relay/connection_resolve_spec.rb
+++ b/spec/integration/rails/graphql/relay/connection_resolve_spec.rb
@@ -53,6 +53,22 @@ describe GraphQL::Relay::ConnectionResolve do
     end
   end
 
+  describe "when a resolver is used" do
+    it "returns the items with the correct parent" do
+      resolver_query_str = <<-GRAPHQL
+        {
+          rebels {
+            shipsByResolver {
+              parentClassName
+            }
+          }
+        }
+        GRAPHQL
+      result = star_wars_query(resolver_query_str)
+      assert_equal "StarWars::FactionRecord", result["data"]["rebels"]["shipsByResolver"]["parentClassName"]
+    end
+  end
+
   describe "when nil is returned" do
     it "becomes null" do
       result = star_wars_query(query_string, { "name" => "null" })

--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -108,6 +108,14 @@ module StarWars
     end
   end
 
+  class ShipsByResolver < GraphQL::Schema::Resolver
+    type ShipConnectionWithParentType, null: false
+
+    def resolve
+      object.ships.map { |ship_id| StarWars::DATA["Ship"][ship_id] }
+    end
+  end
+
   class Faction < GraphQL::Schema::Object
     implements GraphQL::Relay::Node.interface
 
@@ -116,6 +124,8 @@ module StarWars
     field :ships, ShipConnectionWithParentType, connection: true, max_page_size: 1000, null: true do
       argument :name_includes, String, required: false
     end
+
+    field :shipsByResolver, resolver: ShipsByResolver, connection: true
 
     def ships(name_includes: nil)
       all_ships = object.ships.map {|ship_id| StarWars::DATA["Ship"][ship_id] }


### PR DESCRIPTION
Oops, a bug in #1758  which showed up when I tried GitHub on the latest master