### PR TITLE
Use .all over .to_a to enable Sequel eager loading

### DIFF
--- a/lib/graphql/relay/relation_connection.rb
+++ b/lib/graphql/relay/relation_connection.rb
@@ -98,7 +98,7 @@ module GraphQL
         # Store this here so we can convert the relation to an Array
         # (this avoids an extra DB call on Sequel)
         @paged_nodes_offset = relation_offset(items)
-        @paged_nodes = items.to_a
+        @paged_nodes = items.all
       end
 
       def paged_nodes_offset


### PR DESCRIPTION
I know the contribution guidelines says I should open an issue but I hope this works equally well.

I'd like to propose this change (bear in mind I haven't run the specs) to enable eager loading for Sequel models. As described [in the docs for associations](https://sequel.jeremyevans.net/rdoc/classes/Sequel/Model/Associations/DatasetMethods.html#method-i-eager) one must use `.all` on datasets for eager loading to work.

I've tested this by doing the same change to my locally installed gem, and it does indeed remove the N+1 query I was chasing.

The use case here is that I'm calling `model_a.can_do_something?` which in turn needs to fetch an associated model, which results in an N+1 query. A RecordLoader or so isn't appropriate in this case.

While writing this PR I just had the epiphany that I'm checking for nil in a column that is no longer nullable (😁) but I would still open up this change for discussion.

I'm expecting CI to (hopefully) tell me if this breaks for AR (and arrays?)