### PR TITLE
Enums can only be used for enum type arguments

### DIFF
--- a/lib/graphql/scalar_type.rb
+++ b/lib/graphql/scalar_type.rb
@@ -117,8 +117,6 @@ module GraphQL
         value.to_h
       elsif value.is_a?(Array)
         value.map { |element| raw_coercion_input(element) }
-      elsif value.is_a?(GraphQL::Language::Nodes::Enum)
-        value.name
       else
         value
       end

--- a/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
+++ b/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
@@ -69,7 +69,7 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
 
   describe "enum value" do
     it "can't be used for an ID argument" do
-      schema_sdl = <<~GRAPHQL
+      schema_sdl = <<-GRAPHQL
         type Node {
           id: ID!
         }
@@ -84,7 +84,7 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
       schema = GraphQL::Schema.from_definition(schema_sdl, default_resolve: default_resolve)
 
       result = schema.execute(
-        <<~GRAPHQL
+        <<-GRAPHQL
         {
           node(id: garbage) {
             id
@@ -95,14 +95,14 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
 
       expected_error = {
         "message"=>"Argument 'id' on Field 'node' has an invalid value. Expected type 'ID!'.",
-        "locations"=>[{"line"=>2, "column"=>3}],
+        "locations"=>[{"line"=>2, "column"=>11}],
         "fields"=>["query", "node", "id"],
       }
       assert_includes(result.to_h["errors"], expected_error)
     end
 
     it "can't be used for a String argument" do
-      schema_sdl = <<~GRAPHQL
+      schema_sdl = <<-GRAPHQL
         type Query {
           something(arg: String): String
         }
@@ -113,7 +113,7 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
       schema = GraphQL::Schema.from_definition(schema_sdl, default_resolve: default_resolve)
 
       result = schema.execute(
-        <<~GRAPHQL
+        <<-GRAPHQL
         {
           something(arg: garbage)
         }
@@ -122,7 +122,7 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
 
       expected_error = {
         "message"=>"Argument 'arg' on Field 'something' has an invalid value. Expected type 'String'.",
-        "locations"=>[{"line"=>2, "column"=>3}],
+        "locations"=>[{"line"=>2, "column"=>11}],
         "fields"=>["query", "something", "arg"],
       }
       assert_includes(result.to_h["errors"], expected_error)

--- a/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
+++ b/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
@@ -79,7 +79,7 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
         }
       GRAPHQL
 
-      default_resolve = -> (type, field, obj, args, ctx) { }
+      default_resolve = ->(type, field, obj, args, ctx) { }
 
       schema = GraphQL::Schema.from_definition(schema_sdl, default_resolve: default_resolve)
 
@@ -108,7 +108,7 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
         }
       GRAPHQL
 
-      default_resolve = -> (type, field, obj, args, ctx) { }
+      default_resolve = ->(type, field, obj, args, ctx) { }
 
       schema = GraphQL::Schema.from_definition(schema_sdl, default_resolve: default_resolve)
 


### PR DESCRIPTION
Fixes #1772

As reported in #1772, enum values can currently be used as a value for String-like arguments.

For example, in the following query, the enum value `garbage` was specified for a `id: ID!` argument and ends up getting coerced to `"garbage"`.

```graphql
{
  node(id: garbage) {
    id
  }
}
```

This is disallowed [as per the spec](http://facebook.github.io/graphql/June2018/#sec-Enum-Value):

> Enum values are only used in contexts where the precise enumeration type is known. Therefore it’s not necessary to supply an enumeration type name in the literal.

It appears like this issue was introduced in #1398 when adding support for `JSON` scalar types.

The fix I'm proposing breaks an untested `JSON` scalar case, but I'm not sure it was intended to work in the first place:

```ruby
    it "can be JSON with an enum" do
      query_str = <<-GRAPHQL
      {
        echoJson(input: WOODWIND)
      }
      GRAPHQL

      res = Jazz::Schema.execute(query_str)
      assert_equal("WOODWIND", res["data"]["echoJson"])
    end
```

On a related note, I'm not sure how I feel about this test case:

```ruby
    it "can be JSON with a nested enum" do
      query_str = <<-GRAPHQL
      {
        echoJson(input: [{foo: WOODWIND}])
      }
      GRAPHQL

      res = Jazz::Schema.execute(query_str)
      assert_equal([{"foo" => "WOODWIND"}], res["data"]["echoJson"])
    end
```

I'm all for supporting a `JSON` scalar, but I don't think we should be allowing enum values within them because they are ambiguous and it means adding exceptional code paths that bypass the spec. As far as I can tell, the inspiration for this feature ([`graphql-type-json`](https://github.com/taion/graphql-type-json/blob/5790abc351b3007dc9dc98ccf35e9ea72ed7ba91/src/index.js#L8)) doesn't support enum values either.

cc @jturkel as you may have opinions about this PR.