### PR TITLE
member upgrader: .to_non_null_type handling

### DIFF
--- a/lib/graphql/upgrader/member.rb
+++ b/lib/graphql/upgrader/member.rb
@@ -19,6 +19,7 @@ module GraphQL
       # Recursively transform a `.define`-DSL-based type expression into a class-ready expression, for example:
       #
       # - `types[X]` -> `[X, null: true]`
+      # - `types[X.to_non_null_type]` -> `[X]`
       # - `Int` -> `Integer`
       # - `X!` -> `X`
       #
@@ -37,6 +38,9 @@ module GraphQL
           if inner_type.start_with?("!")
             nullable = false
             inner_type = inner_type[1..-1]
+          elsif inner_type.end_with?(".to_non_null_type")
+            nullable = false
+            inner_type = inner_type[0...-17]
           else
             nullable = true
           end
@@ -647,6 +651,7 @@ module GraphQL
 
             if return_type
               non_nullable = return_type.sub! /(^|[^\[])!/, '\1'
+              non_nullable ||= return_type.sub! /([^\[])\.to_non_null_type([^\]]|$)/, '\1'
               nullable = !non_nullable
               return_type = normalize_type_expression(return_type)
             else

--- a/spec/graphql/upgrader/member_spec.rb
+++ b/spec/graphql/upgrader/member_spec.rb
@@ -292,11 +292,19 @@ RUBY
       new = %{field :name, String, null: false}
       assert_equal new, upgrade(old)
 
+      old = %{field :name, types.String.to_non_null_type}
+      new = %{field :name, String, null: false}
+      assert_equal new, upgrade(old)
+
       old = %{field :name, !types.String, "description", method: :name_full}
       new = %{field :name, String, "description", method: :name_full, null: false}
       assert_equal new, upgrade(old)
 
       old = %{field :name, -> { !types.String }}
+      new = %{field :name, String, null: false}
+      assert_equal new, upgrade(old)
+
+      old = %{field :name, -> { types.String.to_non_null_type }}
       new = %{field :name, String, null: false}
       assert_equal new, upgrade(old)
 
@@ -308,7 +316,15 @@ RUBY
       new = %{field :name, Name.connection_type, "names", null: false, connection: true}
       assert_equal new, upgrade(old)
 
+      old = %{connection :name, Name.connection_type.to_non_null_type, "names"}
+      new = %{field :name, Name.connection_type, "names", null: false, connection: true}
+      assert_equal new, upgrade(old)
+
       old = %{field :names, types[!types.String]}
+      new = %{field :names, [String], null: true}
+      assert_equal new, upgrade(old)
+
+      old = %{field :names, types[types.String.to_non_null_type]}
       new = %{field :names, [String], null: true}
       assert_equal new, upgrade(old)
 
@@ -342,7 +358,32 @@ RUBY
       assert_equal new, upgrade(old)
 
       old = %{
+        field :name, types.String.to_non_null_type do
+          description "abc"
+        end
+
+        field :name2, types.Int.to_non_null_type do
+          description "def"
+        end
+      }
+      new = %{
+        field :name, String, description: "abc", null: false
+
+        field :name2, Integer, description: "def", null: false
+      }
+      assert_equal new, upgrade(old)
+
+      old = %{
         field :name, -> { !types.String } do
+        end
+      }
+      new = %{
+        field :name, String, null: false
+      }
+      assert_equal new, upgrade(old)
+
+      old = %{
+        field :name, -> { types.String.to_non_null_type } do
         end
       }
       new = %{
@@ -377,6 +418,22 @@ RUBY
       assert_equal new, upgrade(old)
 
       old = %{
+        field :name do
+          type String.to_non_null_type
+        end
+
+        field :name2 do
+          type String.to_non_null_type
+        end
+      }
+      new = %{
+        field :name, String, null: false
+
+        field :name2, String, null: false
+      }
+      assert_equal new, upgrade(old)
+
+      old = %{
         field :name, -> { types.String },
           "newline description" do
         end
@@ -388,6 +445,16 @@ RUBY
 
       old = %{
         field :name, -> { !types.String },
+          "newline description" do
+        end
+      }
+      new = %{
+        field :name, String, "newline description", null: false
+      }
+      assert_equal new, upgrade(old)
+
+      old = %{
+        field :name, -> { types.String.to_non_null_type },
           "newline description" do
         end
       }


### PR DESCRIPTION
Currently member upgrader ignores .to_non_null_type, which is a bit annoying to handle manually. Current patch removes ".to_non_null_type" from fileds and marks them as non-nullable.