### PR TITLE
fix doc: s/default/default_value/ for argument definitions

### DIFF
--- a/guides/type_definitions/objects.md
+++ b/guides/type_definitions/objects.md
@@ -250,7 +250,7 @@ Arguments can also accept a description and a `default_value:`, for example:
 field :transactions, [Types::Transaction], null: false do
   # Description is added after the type name or the `description:` keyword argument
   # By default, `isCompleted: true` will be used
-  argument :is_completed, Boolean, "Filter by completed/incompleted status", required: false, default: true
+  argument :is_completed, Boolean, "Filter by completed/incompleted status", required: false, default_value: true
 end
 ```
 


### PR DESCRIPTION
Just fixed a token in docs.