### PR TITLE
Ensure enum values respond to graphql_name

### DIFF
--- a/lib/graphql/enum_type.rb
+++ b/lib/graphql/enum_type.rb
@@ -147,6 +147,10 @@ module GraphQL
         GraphQL::NameValidator.validate!(new_name)
         @name = new_name
       end
+
+      def graphql_name
+        name
+      end
     end
 
     class UnresolvedValueError < GraphQL::Error

--- a/spec/graphql/enum_type_spec.rb
+++ b/spec/graphql/enum_type_spec.rb
@@ -130,6 +130,11 @@ describe GraphQL::EnumType do
     assert_equal({ "COW" => cow, "GOAT" => goat }, enum.values)
   end
 
+  it "values respond to graphql_name" do
+    cow = GraphQL::EnumType::EnumValue.define(name: "COW")
+    assert_equal("COW", cow.graphql_name)
+  end
+
   describe "#dup" do
     it "copies the values map without altering the original" do
       enum_2 = enum.dup


### PR DESCRIPTION
Everything else in the schema does, and these should too. They don't
automatically because they don't inherit from BaseType, which they
potentially should, but that's a much larger change.

I couldn't get alias_method to work (something about how `name` is
defined dynamically through method_missing) so I defined the method
manually.

@rmosolgo cc @swalkinshaw there's a weird goose chase behind this one