### PR TITLE
Add support for array of IDs to `loads:` argument

### DIFF
--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -324,9 +324,23 @@ module GraphQL
         # @see {GraphQL::Schema::Argument#initialize} for the signature
         def argument(name, type, *rest, loads: nil, **kwargs, &block)
           if loads
-            arg_keyword = kwargs[:as] ||= name.to_s.sub(/_id$/, "").to_sym
-            own_arguments_loads_as_type[arg_keyword] = loads
+            name_as_string = name.to_s
+
+            inferred_arg_name = case name_as_string
+            when /_id$/
+              name_as_string.sub(/_id$/, "").to_sym
+            when /_ids$/
+              name_as_string.sub(/_ids$/, "")
+                .sub(/([^s])$/, "\\1s")
+                .to_sym
+            else
+              name
+            end
+
+            kwargs[:as] ||= inferred_arg_name
+            own_arguments_loads_as_type[kwargs[:as]] = loads
           end
+
           arg_defn = super(name, type, *rest, **kwargs, &block)
 
           if loads && arg_defn.type.list?

--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -329,7 +329,13 @@ module GraphQL
           end
           arg_defn = super(name, type, *rest, **kwargs, &block)
 
-          if loads
+          if loads && arg_defn.type.list?
+            class_eval <<-RUBY, __FILE__, __LINE__ + 1
+            def load_#{arg_defn.keyword}(values)
+              GraphQL::Execution::Lazy.all(values.map { |value| load_application_object(:#{arg_defn.keyword}, value) })
+            end
+            RUBY
+          elsif loads
             class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def load_#{arg_defn.keyword}(value)
               load_application_object(:#{arg_defn.keyword}, value)

--- a/spec/graphql/schema/relay_classic_mutation_spec.rb
+++ b/spec/graphql/schema/relay_classic_mutation_spec.rb
@@ -52,6 +52,50 @@ describe GraphQL::Schema::RelayClassicMutation do
     end
   end
 
+  describe "loading multiple application objects" do
+    let(:query_str) {
+      <<-GRAPHQL
+        mutation($ids: [ID!]!) {
+          upvoteEnsembles(input: {ensembleIds: $ids}) {
+            ensembles {
+              id
+            }
+          }
+        }
+      GRAPHQL
+    }
+
+    it "loads arguments as objects of the given type" do
+      res = Jazz::Schema.execute(query_str, variables: { ids: ["Ensemble/Robert Glasper Experiment", "Ensemble/Bela Fleck and the Flecktones"]})
+      assert_equal ["Ensemble/Robert Glasper Experiment", "Ensemble/Bela Fleck and the Flecktones"], res["data"]["upvoteEnsembles"]["ensembles"].map { |e| e["id"] }
+    end
+
+    it "returns an error instead when the ID resolves to nil" do
+      res = Jazz::Schema.execute(query_str, variables: {
+        ids: ["Ensemble/Nonexistant Name"],
+      })
+      assert_nil res["data"].fetch("upvoteEnsembles")
+      assert_equal ['No object found for `ensembleIds: "Ensemble/Nonexistant Name"`'], res["errors"].map { |e| e["message"] }
+    end
+
+    it "returns an error instead when the ID resolves to an object of the wrong type" do
+      res = Jazz::Schema.execute(query_str, variables: {
+        ids: ["Instrument/Organ"],
+      })
+      assert_nil res["data"].fetch("upvoteEnsembles")
+      assert_equal ["No object found for `ensembleIds: \"Instrument/Organ\"`"], res["errors"].map { |e| e["message"] }
+    end
+
+    it "raises an authorization error when the type's auth fails" do
+      res = Jazz::Schema.execute(query_str, variables: {
+        ids: ["Ensemble/Spinal Tap"],
+      })
+      assert_nil res["data"].fetch("upvoteEnsembles")
+      # Failed silently
+      refute res.key?("errors")
+    end
+  end
+
   describe "loading application objects" do
     let(:query_str) {
       <<-GRAPHQL

--- a/spec/graphql/schema/resolver_spec.rb
+++ b/spec/graphql/schema/resolver_spec.rb
@@ -192,6 +192,23 @@ describe GraphQL::Schema::Resolver do
       end
     end
 
+    class PrepResolver9Array < BaseResolver
+      argument :int_ids, [ID], required: true, loads: HasValue, as: :ints
+      # Make sure the lazy object is resolved properly:
+      type [HasValue], null: false
+      def object_from_id(type, id, ctx)
+        # Make sure a lazy object is handled appropriately
+        LazyBlock.new {
+          # Make sure that the right type ends up here
+          id.to_i + type.graphql_name.length
+        }
+      end
+
+      def resolve(ints:)
+        ints.map { |int| int * 3}
+      end
+    end
+
     class PrepResolver10 < BaseResolver
       argument :int1, Integer, required: true
       argument :int2, Integer, required: true, as: :integer_2
@@ -285,6 +302,7 @@ describe GraphQL::Schema::Resolver do
       field :prep_resolver_6, resolver: PrepResolver6
       field :prep_resolver_7, resolver: PrepResolver7
       field :prep_resolver_9, resolver: PrepResolver9
+      field :prep_resolver_9_array, resolver: PrepResolver9Array
       field :prep_resolver_10, resolver: PrepResolver10
       field :prep_resolver_11, resolver: PrepResolver11
       field :prep_resolver_12, resolver: PrepResolver12
@@ -508,6 +526,14 @@ describe GraphQL::Schema::Resolver do
         res = exec_query('{ prepResolver9(intId: "5") { value } }')
         # (5 + 8) * 3
         assert_equal 39, res["data"]["prepResolver9"]["value"]
+      end
+
+      it "supports loading array of ids" do
+        res = exec_query('{ prepResolver9Array(intIds: ["1", "10", "100"]) { value } }')
+        # (1 + 8) * 3
+        # (10 + 8) * 3
+        # (100 + 8) * 3
+        assert_equal [27, 54, 324], res["data"]["prepResolver9Array"].map { |v| v["value"] }
       end
     end
   end

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -489,7 +489,31 @@ module Jazz
   end
 
   class UpvoteEnsembles < GraphQL::Schema::RelayClassicMutation
-    argument :ensemble_ids, [ID], required: true, loads: Ensemble, as: :ensembles
+    argument :ensemble_ids, [ID], required: true, loads: Ensemble
+
+    field :ensembles, [Ensemble], null: false
+
+    def resolve(ensembles:)
+      {
+        ensembles: ensembles
+      }
+    end
+  end
+
+  class UpvoteEnsemblesAsBands < GraphQL::Schema::RelayClassicMutation
+    argument :ensemble_ids, [ID], required: true, loads: Ensemble, as: :bands
+
+    field :ensembles, [Ensemble], null: false
+
+    def resolve(bands:)
+      {
+        ensembles: bands
+      }
+    end
+  end
+
+  class UpvoteEnsemblesIds < GraphQL::Schema::RelayClassicMutation
+    argument :ensembles_ids, [ID], required: true, loads: Ensemble
 
     field :ensembles, [Ensemble], null: false
 
@@ -517,6 +541,8 @@ module Jazz
     field :add_sitar, mutation: AddSitar
     field :rename_ensemble, mutation: RenameEnsemble
     field :upvote_ensembles, mutation: UpvoteEnsembles
+    field :upvote_ensembles_as_bands, mutation: UpvoteEnsemblesAsBands
+    field :upvote_ensembles_ids, mutation: UpvoteEnsemblesIds
     field :rename_ensemble_as_band, mutation: RenameEnsembleAsBand
 
     def add_ensemble(input:)

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -488,6 +488,18 @@ module Jazz
     end
   end
 
+  class UpvoteEnsembles < GraphQL::Schema::RelayClassicMutation
+    argument :ensemble_ids, [ID], required: true, loads: Ensemble, as: :ensembles
+
+    field :ensembles, [Ensemble], null: false
+
+    def resolve(ensembles:)
+      {
+        ensembles: ensembles
+      }
+    end
+  end
+
   class RenameEnsembleAsBand < RenameEnsemble
     argument :ensemble_id, ID, required: true, loads: Ensemble, as: :band
 
@@ -504,6 +516,7 @@ module Jazz
     field :add_instrument, mutation: AddInstrument
     field :add_sitar, mutation: AddSitar
     field :rename_ensemble, mutation: RenameEnsemble
+    field :upvote_ensembles, mutation: UpvoteEnsembles
     field :rename_ensemble_as_band, mutation: RenameEnsembleAsBand
 
     def add_ensemble(input:)


### PR DESCRIPTION
Currently it is possible to have GraphQL Ruby automatically load objects for `ID` arguments, for example:

```ruby
argument :label_id, ID, required: true, loads: Label
```

In some cases, the argument will be a list of `ID`. It would be great if the `loads:` option worked in this case too, for example:

```ruby
argument :label_ids, [ID], required: true, loads: Label, as: :labels
```

I managed to do this by re-using the existing logic for `loads:`. I _think_ this is fine, but I'd love an extra pair of :eyes: in case I didn't think of something.

Another note, in the singular case, the `as:` is inferred by stripping `_id` off the original argument name. In the list case, this is a bit trickier as we'd have to pluralize the remainder, which would mean having to leverage something like [`ActiveSupport::Inflector#pluralize`](https://github.com/rails/rails/blob/c03dde6117ed995d1ada57736b5b0d44dfe31ed5/activesupport/lib/active_support/inflector/methods.rb#L19-L33). I think this might be overkill, so I didn't bother trying to fix this.

**Edit:** If you're happy with this, I'll add some documentation to https://github.com/rmosolgo/graphql-ruby/blob/b1c376f2bccbf0f3148155474237dcdd616b74dd/guides/mutations/mutation_classes.md.