### PR TITLE
Fix infinite resolution bug for Exception (#1803)

### DIFF
--- a/lib/graphql/execution/multiplex.rb
+++ b/lib/graphql/execution/multiplex.rb
@@ -91,7 +91,7 @@ module GraphQL
             # Get the Query::Result, not the Hash
             query.result
           end
-        rescue StandardError
+        rescue Exception
           # Assign values here so that the query's `@executed` becomes true
           queries.map { |q| q.result_values ||= {} }
           raise


### PR DESCRIPTION
If an exception not inheriting from StandardError was thrown in a
GraphQL mutation, then the rescue block added to fix #1072 in 8bf0039
would not have caught that exception. If such an exception was always
thrown, the query would have never been marked as resolved, and so the
schema resolver would have never terminated with certain instrumenting
gems that inspect `query.result`. This could have happened in
development if you made a syntax error inside a mutation, for example.

Rescuing from Exception fixes this. Although it is generally not advised
to rescue from Exception, it is probably okay in this case because we
immediately re-raise it.