### PR TITLE
Suggest splitting off a 2.0

### DIFF
--- a/guides/schema/class_based_api.md
+++ b/guides/schema/class_based_api.md
@@ -276,6 +276,7 @@ Here is a working plan for rolling out this feature:
   - ☐ Update all GraphQL-Ruby docs to reflect this new API
 - graphql 1.10:
   - ☐ Begin sunsetting `.define`: isolate it in its own module
+- graphql 2.0:
   - ☐ Remove `.define`
 
 ## Common Type Configurations


### PR DESCRIPTION
Hey @rmosolgo, I was looking through the upgrade guide for the class-based API and was very surprised to see  a suggestion that the `.define` API would be outright removed in 1.x. I'd strongly suggest keeping a major removal/API change like that to a major version bump instead. I think as a downstream consumer of this gem I'd be quite surprised to see that happen in a minor version and the major version gives you a chance to celebrate the new change.

I've started you off here on the roadmap. 🙏 