### PR TITLE
Allow fields to pass additional parameters

### DIFF
--- a/guides/type_definitions/objects.md
+++ b/guides/type_definitions/objects.md
@@ -294,19 +294,21 @@ end
 
 At runtime, the requested runtime object will be passed to the field.
 
-### Field Parameter Default Values 
+__Custom extras__ are also possible. Any method on your field class can be passed to `extras: [...]`, and the value will be injected into the method. For example, `extras: [:owner]` will inject the object type who owns the field. Any new methods on your custom field class may be used, too.
 
-The field method requires you to pass `null:` keyword argument to determine whether the field is nullable or not. Another field you may want to overrid is `camelize`, which is `true` by default. You can override this behavior by adding a custom field. 
+### Field Parameter Default Values
+
+The field method requires you to pass `null:` keyword argument to determine whether the field is nullable or not. Another field you may want to overrid is `camelize`, which is `true` by default. You can override this behavior by adding a custom field.
 
 ```ruby
 class CustomField < GraphQL::Schema::Field
-  # Add `null: false` and `camelize: false` which provide default values 
-  # in case the caller doesn't pass anything for those arguments. 
-  # **kwargs is a catch-all that will get everything else 
+  # Add `null: false` and `camelize: false` which provide default values
+  # in case the caller doesn't pass anything for those arguments.
+  # **kwargs is a catch-all that will get everything else
   def initialize(*args, null: false, camelize: false, **kwargs, &block)
-    # Then, call super _without_ any args, where Ruby will take 
+    # Then, call super _without_ any args, where Ruby will take
     # _all_ the args originally passed to this method and pass it to the super method.
-    super 
+    super
   end
 end
 ```

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -425,7 +425,11 @@ module GraphQL
 
           @extras.each do |extra_arg|
             # TODO: provide proper tests for `:ast_node`, `:irep_node`, `:parent`, others?
-            ruby_kwargs[extra_arg] = field_ctx.public_send(extra_arg)
+            if respond_to? extra_arg
+              ruby_kwargs[extra_arg] = send(extra_arg) 
+            else
+              ruby_kwargs[extra_arg] = field_ctx.public_send(extra_arg)
+            end
           end
         else
           ruby_kwargs = NO_ARGS

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -401,6 +401,17 @@ module GraphQL
         end
       end
 
+      # @param ctx [GraphQL::Query::Context::FieldResolutionContext]
+      def fetch_extra(extra_name, ctx)
+        if respond_to?(extra_name)
+          self.public_send(extra_name)
+        elsif ctx.respond_to?(extra_name)
+          ctx.public_send(extra_name)
+        else
+          raise NotImplementedError, "Unknown field extra for #{self.path}: #{extra_name.inspect}"
+        end
+      end
+
       NO_ARGS = {}.freeze
 
       def public_send_field(obj, graphql_args, field_ctx)
@@ -424,12 +435,7 @@ module GraphQL
           end
 
           @extras.each do |extra_arg|
-            # TODO: provide proper tests for `:ast_node`, `:irep_node`, `:parent`, others?
-            if respond_to? extra_arg
-              ruby_kwargs[extra_arg] = send(extra_arg) 
-            else
-              ruby_kwargs[extra_arg] = field_ctx.public_send(extra_arg)
-            end
+            ruby_kwargs[extra_arg] = fetch_extra(extra_arg, field_ctx)
           end
         else
           ruby_kwargs = NO_ARGS

--- a/spec/graphql/schema/field_spec.rb
+++ b/spec/graphql/schema/field_spec.rb
@@ -107,6 +107,22 @@ describe GraphQL::Schema::Field do
         assert_equal ["find", "addError"], err["path"]
         assert_equal [{"line"=>4, "column"=>15}], err["locations"]
       end
+
+      it "can get methods from the field instance" do
+        query_str = <<-GRAPHQL
+        {
+          upcaseCheck1
+          upcaseCheck2
+          upcaseCheck3
+          upcaseCheck4
+        }
+        GRAPHQL
+        res = Jazz::Schema.execute(query_str)
+        assert_equal "nil", res["data"].fetch("upcaseCheck1")
+        assert_equal "false", res["data"]["upcaseCheck2"]
+        assert_equal "TRUE", res["data"]["upcaseCheck3"]
+        assert_equal "\"WHY NOT?\"", res["data"]["upcaseCheck4"]
+      end
     end
 
     it "is the #owner of its arguments" do

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -61,6 +61,7 @@ module Jazz
   # A custom field class that supports the `upcase:` option
   class BaseField < GraphQL::Schema::Field
     argument_class BaseArgument
+    attr_reader :upcase
     def initialize(*args, **options, &block)
       @upcase = options.delete(:upcase)
       super(*args, **options, &block)
@@ -348,6 +349,14 @@ module Jazz
 
     field :echo_first_json, RawJson, null: false do
       argument :input, [RawJson], required: true
+    end
+
+    field :upcase_check_1, String, null: true, method: :upcase_check, extras: [:upcase]
+    field :upcase_check_2, String, null: false, upcase: false, method: :upcase_check, extras: [:upcase]
+    field :upcase_check_3, String, null: false, upcase: true, method: :upcase_check, extras: [:upcase]
+    field :upcase_check_4, String, null: false, upcase: "why not?", method: :upcase_check, extras: [:upcase]
+    def upcase_check(upcase:)
+      upcase.inspect
     end
 
     def ensembles


### PR DESCRIPTION
Before the 1.8 update you could use closures to pass information from a field to it's type. Now it's much more difficult (using `:method`).

Example from our codebase:

```ruby
class SomeType < GraphQL::Schema::Object
...
  # a dynamically generated field
  field generated_name, type, method: :resolver, extras: [:ast_node]

...
  def resolver(:ast_node)
    generated_name = parse_name(ast_node.name)
    # do stuff based on the name

```

This pulled request would allow this:

```ruby
# a dynamically generated field
field generated_name, type, method: :resolver, extras: [:name]
...
def resolver(name:)
  # do stuff based on the name
```

or even this:
```ruby
class SpecialField < GraphQL::Schema::Field
  attr_reader :klass, :attribute

  def initialize(*args, klass:, attribute:, **kwargs, &block)
    @klass = klass
    @attribute = attribute
...
end


...
class SomeType < GraphQL::Schema::Object
  field_class SpecialField

  field generated_name, type, klass: klass, attribute: attribute, method: :resolver, extras: [:klass, :attribute]
...

  def resolver(klass:, attribute:)
    # resolve based on a class and attribute

```