### PR TITLE
Improve field type string-to-constant resolution

### DIFF
--- a/lib/graphql/schema/member/build_type.rb
+++ b/lib/graphql/schema/member/build_type.rb
@@ -33,7 +33,7 @@ module GraphQL
               null = false
               parse_type(type_expr[0..-2], null: true)
             else
-              maybe_type = Object.const_get(type_expr)
+              maybe_type = constantize(type_expr)
               case maybe_type
               when GraphQL::BaseType
                 maybe_type
@@ -123,6 +123,38 @@ module GraphQL
             camelized = "#{match_data[0]}#{camelized}"
           end
           camelized
+        end
+
+        # Resolves constant from string (based on Rails `ActiveSupport::Inflector.constantize`)
+        def constantize(string)
+          names = string.split('::')
+
+          # Trigger a built-in NameError exception including the ill-formed constant in the message.
+          Object.const_get(string) if names.empty?
+
+          # Remove the first blank element in case of '::ClassName' notation.
+          names.shift if names.size > 1 && names.first.empty?
+
+          names.inject(Object) do |constant, name|
+            if constant == Object
+              constant.const_get(name)
+            else
+              candidate = constant.const_get(name)
+              next candidate if constant.const_defined?(name, false)
+              next candidate unless Object.const_defined?(name)
+
+              # Go down the ancestors to check if it is owned directly. The check
+              # stops when we reach Object or the end of ancestors tree.
+              constant = constant.ancestors.inject do |const, ancestor|
+                break const    if ancestor == Object
+                break ancestor if ancestor.const_defined?(name, false)
+                const
+              end
+
+              # Owner is in Object, so raise.
+              constant.const_get(name, false)
+            end
+          end
         end
 
         def underscore(string)

--- a/spec/graphql/schema/member/build_type_spec.rb
+++ b/spec/graphql/schema/member/build_type_spec.rb
@@ -2,6 +2,52 @@
 require "spec_helper"
 
 describe GraphQL::Schema::Member::BuildType do
+  describe ".parse_type" do
+    it "resolves a string type from a string" do
+      assert_equal GraphQL::Types::String, GraphQL::Schema::Member::BuildType.parse_type("String", null: true)
+    end
+
+    it "resolves an integer type from a string" do
+      assert_equal GraphQL::Types::Int, GraphQL::Schema::Member::BuildType.parse_type("Integer", null: true)
+    end
+
+    it "resolves a float type from a string" do
+      assert_equal GraphQL::Types::Float, GraphQL::Schema::Member::BuildType.parse_type("Float", null: true)
+    end
+
+    it "resolves a boolean type from a string" do
+      assert_equal GraphQL::Types::Boolean, GraphQL::Schema::Member::BuildType.parse_type("Boolean", null: true)
+    end
+
+    it "resolves an interface type from a string" do
+      assert_equal Jazz::BaseInterface, GraphQL::Schema::Member::BuildType.parse_type("Jazz::BaseInterface", null: true)
+    end
+
+    it "resolves an object type from a class" do
+      assert_equal Jazz::BaseObject, GraphQL::Schema::Member::BuildType.parse_type(Jazz::BaseObject, null: true)
+    end
+
+    it "resolves an object type from a string" do
+      assert_equal Jazz::BaseObject, GraphQL::Schema::Member::BuildType.parse_type("Jazz::BaseObject", null: true)
+    end
+
+    it "resolves a nested object type from a string" do
+      assert_equal Jazz::Introspection::NestedType, GraphQL::Schema::Member::BuildType.parse_type("Jazz::Introspection::NestedType", null: true)
+    end
+
+    it "resolves a deeply nested object type from a string" do
+      assert_equal Jazz::Introspection::NestedType::DeeplyNestedType, GraphQL::Schema::Member::BuildType.parse_type("Jazz::Introspection::NestedType::DeeplyNestedType", null: true)
+    end
+
+    it "resolves a list type from an array of classes" do
+      assert_instance_of GraphQL::Schema::List, GraphQL::Schema::Member::BuildType.parse_type([Jazz::BaseObject], null: true)
+    end
+
+    it "resolves a list type from an array of strings" do
+      assert_instance_of GraphQL::Schema::List, GraphQL::Schema::Member::BuildType.parse_type(["Jazz::BaseObject"], null: true)
+    end
+  end
+
   describe ".to_type_name" do
     it "works with lists and non-nulls" do
       t = Class.new(GraphQL::Schema::Object) do

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -637,6 +637,18 @@ module Jazz
       end
     end
 
+    class NestedType < GraphQL::Introspection::TypeType
+      def name
+        object.name.upcase
+      end
+
+      class DeeplyNestedType < GraphQL::Introspection::TypeType
+        def name
+          object.name.upcase
+        end
+      end
+    end
+
     class SchemaType < GraphQL::Introspection::SchemaType
       graphql_name "__Schema"
 


### PR DESCRIPTION
Currently string arguments passed to a type definition (such as `field :user, "Types::UserType", null: true`) are resolved using a basic `Object.const_get` call. This is prone to autoloading issues, particularly in development with classes down several module levels (e.g., `Types::User::Foo::BarType` where `Foo` is also a type).

Rails' `ActiveSupport::Inflector.constantize` has a few workarounds built-in, which this PR grifts in `BuildType#parse_type` for more robust string-to-constant resolution, without assuming the project has `String.constantize` available.

A more complex solution could be allowing a custom string-to-constant resolver as an option on the schema, but that seemed like overkill. On the other hand a simpler solution could be checking that the type string `respond_to?(:constantize)` with a fallback to `Object.get_const`, though that assumes the constantize extension would always behave as expected.