### PR TITLE
1.8.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@
 
 ### Bug fixes
 
+## 1.8.8 (27 Aug 2018)
+
+### Bug fixes
+
+- When using `RelayClassicMutation`, `client_mutation_id` will no longer be passed to `authorized?` method #1771
+- Fix issue in schema upgrader script which would cause `.to_non_null_type` calls in type definition to be ignored #1783
+- Ensure enum values respond to `graphql_name` #1792
+- Fix infinite resolution bug that could occur when an exception not inheriting from `StandardError` is thrown #1804
+
+### New features
+
+- Add `#path` method to schema members #1766
+- Add `as:` argument to allow overriding the name of the argument when using `loads:` #1773
+- Add support for list of IDs when using `loads:` in an argument definition #1797
+
 ## 1.8.7 (9 Aug 2018)
 
 ### Breaking changes

--- a/lib/graphql/version.rb
+++ b/lib/graphql/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module GraphQL
-  VERSION = "1.8.7"
+  VERSION = "1.8.8"
 end


### PR DESCRIPTION
:wave: @rmosolgo, I went through the commits since 1.8.7 and the 1.8.8 milestone to write up this addition to the `CHANGELOG`. Hats off to you for tracking the merged changes in the milestone, it made this a lot easier to do. 😄 

I'm currently writing up some docs for the `loads:` argument which I will commit to this branch, but thought you could :eyes: the `CHANGELOG` in the meantime.