### PR TITLE
Fall back to input_field_defn default value if coerce_input returns nil

### DIFF
--- a/lib/graphql/enum_type.rb
+++ b/lib/graphql/enum_type.rb
@@ -169,6 +169,10 @@ module GraphQL
     def coerce_non_null_input(value_name, ctx)
       if @values_by_name.key?(value_name)
         @values_by_name.fetch(value_name).value
+      elsif match_by_value = @values_by_name.find { |k, v| v.value == value_name }
+        # this is for matching default values, which are "inputs", but they're
+        # the Ruby value, not the GraphQL string.
+        match_by_value[1].value
       else
         nil
       end

--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -93,7 +93,7 @@ module GraphQL
           coerced_value = input_field_defn.type.coerce_input(field_value, ctx)
           input_values[input_key] = input_field_defn.prepare(coerced_value, ctx)
         elsif input_field_defn.default_value?
-          coerced_value = input_field_defn.type.coerce_input(input_field_defn.default_value, ctx)
+          coerced_value = input_field_defn.type.coerce_input(input_field_defn.default_value, ctx) || input_field_defn.default_value
           input_values[input_key] = coerced_value
           defaults_used << input_key
         end

--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -93,7 +93,7 @@ module GraphQL
           coerced_value = input_field_defn.type.coerce_input(field_value, ctx)
           input_values[input_key] = input_field_defn.prepare(coerced_value, ctx)
         elsif input_field_defn.default_value?
-          coerced_value = input_field_defn.type.coerce_input(input_field_defn.default_value, ctx) || input_field_defn.default_value
+          coerced_value = input_field_defn.type.coerce_input(input_field_defn.default_value, ctx)
           input_values[input_key] = coerced_value
           defaults_used << input_key
         end

--- a/spec/graphql/input_object_type_spec.rb
+++ b/spec/graphql/input_object_type_spec.rb
@@ -16,9 +16,9 @@ describe GraphQL::InputObjectType do
           argument :foo, TestEnum, 'TestEnum', required: false, default_value: 'a'
         end
 
-        test = TestInput.to_graphql
-
-        assert_equal test.coerce_input({})[:foo], 'a'
+        test_input_type = TestInput.to_graphql
+        default_test_input_value = test_input_type.coerce_isolated_input({})
+        assert_equal default_test_input_value[:foo], 'a'
       end
     end
   end

--- a/spec/graphql/input_object_type_spec.rb
+++ b/spec/graphql/input_object_type_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe GraphQL::InputObjectType do
+  describe 'default values' do
+    describe 'when the type is an enum with underlying ruby values' do
+      it 'provides the default value' do
+        TestEnum = GraphQL::EnumType.define do
+          name 'Test'
+
+          value 'A', 'Represents an authorized agent in our system.', value: 'a'
+          value 'B', 'Agent is disabled, web app access is denied.', value: 'b'
+        end
+
+        class TestInput < GraphQL::Schema::InputObject
+          argument :foo, TestEnum, 'TestEnum', required: false, default_value: 'a'
+        end
+
+        test = TestInput.to_graphql
+
+        assert_equal test.coerce_input({})[:foo], 'a'
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a simple PR to solve: https://github.com/rmosolgo/graphql-ruby/issues/1826.  Basically it just falls back to the pre-existing behavior in case the lookup of default value in nested inputs fails as it does in the case of enum types.