### PR TITLE
Fix middleware warning

### DIFF
--- a/lib/graphql/compatibility/execution_specification/specification_schema.rb
+++ b/lib/graphql/compatibility/execution_specification/specification_schema.rb
@@ -49,8 +49,7 @@ module GraphQL
         end
 
         module TestMiddleware
-          # TODO: Once deprecated `next_middleware` argument becomes unsupported, add `&` to the argument
-          def self.call(parent_type, parent_object, field_definition, field_args, query_context, next_middleware)
+          def self.call(parent_type, parent_object, field_definition, field_args, query_context, &next_middleware)
             query_context[:middleware_log] && query_context[:middleware_log] << field_definition.name
             next_middleware.call
           end


### PR DESCRIPTION
Just a quick fix that was marked in the codebase as `TODO:`

`Middleware that takes a next_middleware parameter is deprecated (GraphQL::Compatibility::ExecutionSpecification::SpecificationSchema::TestMiddleware); instead, accept a block and use yield.`