### PR TITLE
Clarify that `loads:` supports abstract types

### DIFF
--- a/guides/mutations/mutation_classes.md
+++ b/guides/mutations/mutation_classes.md
@@ -153,3 +153,5 @@ class Mutations::AddStar < Mutations::BaseMutation
   end
 end
 ```
+
+In the above examples, `loads:` is provided a concrete type, but it also supports abstract types (i.e. interfaces and unions).

--- a/spec/graphql/schema/relay_classic_mutation_spec.rb
+++ b/spec/graphql/schema/relay_classic_mutation_spec.rb
@@ -135,6 +135,42 @@ describe GraphQL::Schema::RelayClassicMutation do
       assert_equal "August Greene", res["data"]["renameEnsemble"]["ensemble"]["name"]
     end
 
+    it "loads arguments as objects when provided an interface type" do
+      query = <<-GRAPHQL
+        mutation($id: ID!, $newName: String!) {
+          renameNamedEntity(input: {namedEntityId: $id, newName: $newName}) {
+            namedEntity {
+              __typename
+              name
+            }
+          }
+        }
+      GRAPHQL
+
+      res = Jazz::Schema.execute(query, variables: { id: "Ensemble/Robert Glasper Experiment", newName: "August Greene"})
+      assert_equal "August Greene", res["data"]["renameNamedEntity"]["namedEntity"]["name"]
+      assert_equal "Ensemble", res["data"]["renameNamedEntity"]["namedEntity"]["__typename"]
+    end
+
+    it "loads arguments as objects when provided an union type" do
+      query = <<-GRAPHQL
+        mutation($id: ID!, $newName: String!) {
+          renamePerformingAct(input: {performingActId: $id, newName: $newName}) {
+            performingAct {
+              __typename
+              ... on Ensemble {
+                name
+              }
+            }
+          }
+        }
+      GRAPHQL
+
+      res = Jazz::Schema.execute(query, variables: { id: "Ensemble/Robert Glasper Experiment", newName: "August Greene"})
+      assert_equal "August Greene", res["data"]["renamePerformingAct"]["performingAct"]["name"]
+      assert_equal "Ensemble", res["data"]["renamePerformingAct"]["performingAct"]["__typename"]
+    end
+
     it "uses the `as:` name when loading" do
       band_query_str = query_str.sub("renameEnsemble", "renameEnsembleAsBand")
       res = Jazz::Schema.execute(band_query_str, variables: { id: "Ensemble/Robert Glasper Experiment", newName: "August Greene"})

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -472,6 +472,40 @@ module Jazz
     end
   end
 
+  class RenameNamedEntity < GraphQL::Schema::RelayClassicMutation
+    argument :named_entity_id, ID, required: true, loads: NamedEntity
+    argument :new_name, String, required: true
+
+    field :named_entity, NamedEntity, null: false
+
+    def resolve(named_entity:, new_name:)
+      # doesn't actually update the "database"
+      dup_named_entity = named_entity.dup
+      dup_named_entity.name = new_name
+
+      {
+        named_entity: dup_named_entity
+      }
+    end
+  end
+
+  class RenamePerformingAct < GraphQL::Schema::RelayClassicMutation
+    argument :performing_act_id, ID, required: true, loads: PerformingAct
+    argument :new_name, String, required: true
+
+    field :performing_act, PerformingAct, null: false
+
+    def resolve(performing_act:, new_name:)
+      # doesn't actually update the "database"
+      dup_performing_act = performing_act.dup
+      dup_performing_act.name = new_name
+
+      {
+        performing_act: dup_performing_act
+      }
+    end
+  end
+
   class RenameEnsemble < GraphQL::Schema::RelayClassicMutation
     argument :ensemble_id, ID, required: true, loads: Ensemble
     argument :new_name, String, required: true
@@ -540,6 +574,8 @@ module Jazz
     field :add_instrument, mutation: AddInstrument
     field :add_sitar, mutation: AddSitar
     field :rename_ensemble, mutation: RenameEnsemble
+    field :rename_named_entity, mutation: RenameNamedEntity
+    field :rename_performing_act, mutation: RenamePerformingAct
     field :upvote_ensembles, mutation: UpvoteEnsembles
     field :upvote_ensembles_as_bands, mutation: UpvoteEnsemblesAsBands
     field :upvote_ensembles_ids, mutation: UpvoteEnsemblesIds


### PR DESCRIPTION
When writing the docs for `loads:` in #1797, I overlooked the fact that `loads:` also works with abstract types.

This clarifies that and I added a few tests just for good measure.

Let me know if you think this is overkill.