### PR TITLE
Migrate dummy schema to class-based 

### DIFF
--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -187,7 +187,7 @@ module GraphQL
         resolve_related_type(type_arg.call)
       when String
         # Get a constant by this name
-        Object.const_get(type_arg)
+        resolve_related_type(Object.const_get(type_arg))
       else
         if type_arg.respond_to?(:graphql_definition)
           type_arg.graphql_definition

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -126,7 +126,7 @@ module GraphQL
       # @param complexity [Numeric] When provided, set the complexity for this field
       # @param scope [Boolean] If true, the return type's `.scope_items` method will be called on the return value
       # @param subscription_scope [Symbol, String] A key in `context` which will be used to scope subscription payloads
-      def initialize(type: nil, name: nil, owner: nil, null: nil, field: nil, function: nil, description: nil, deprecation_reason: nil, method: nil, connection: nil, max_page_size: nil, scope: nil, resolve: nil, introspection: false, hash_key: nil, camelize: true, complexity: 1, extras: [], resolver_class: nil, subscription_scope: nil, arguments: {}, &definition_block)
+      def initialize(type: nil, name: nil, owner: nil, null: nil, field: nil, function: nil, description: nil, deprecation_reason: nil, method: nil, connection: nil, max_page_size: nil, scope: nil, resolve: nil, introspection: false, hash_key: nil, camelize: true, trace: nil, complexity: 1, extras: [], resolver_class: nil, subscription_scope: nil, arguments: {}, &definition_block)
 
         if name.nil?
           raise ArgumentError, "missing first `name` argument or keyword `name:`"
@@ -170,6 +170,7 @@ module GraphQL
         @extras = extras
         @resolver_class = resolver_class
         @scope = scope
+        @trace = trace
 
         # Override the default from HasArguments
         @own_arguments = {}
@@ -256,6 +257,10 @@ module GraphQL
             field_defn.mutation = @resolver_class
           end
           field_defn.metadata[:resolver] = @resolver_class
+        end
+
+        if !@trace.nil?
+          field_defn.trace = @trace
         end
 
         field_defn.resolve = self.method(:resolve_field)

--- a/spec/graphql/analysis/analyze_query_spec.rb
+++ b/spec/graphql/analysis/analyze_query_spec.rb
@@ -78,7 +78,7 @@ describe GraphQL::Analysis do
 
     it "calls the defined analyzers" do
       collected_types, node_counts = reduce_result
-      expected_visited_types = [Dummy::DairyAppQueryType, Dummy::CheeseType, GraphQL::INT_TYPE, GraphQL::STRING_TYPE]
+      expected_visited_types = [Dummy::DairyAppQuery.graphql_definition, Dummy::Cheese.graphql_definition, GraphQL::INT_TYPE, GraphQL::STRING_TYPE]
       assert_equal expected_visited_types, collected_types
       expected_node_counts = {
         GraphQL::Language::Nodes::OperationDefinition => 1,

--- a/spec/graphql/base_type_spec.rb
+++ b/spec/graphql/base_type_spec.rb
@@ -11,7 +11,7 @@ describe GraphQL::BaseType do
   end
 
   it "can be compared" do
-    obj_type = Dummy::MilkType
+    obj_type = Dummy::Milk.graphql_definition
     assert_equal(!GraphQL::INT_TYPE, !GraphQL::INT_TYPE)
     refute_equal(!GraphQL::FLOAT_TYPE, GraphQL::FLOAT_TYPE)
     assert_equal(
@@ -25,7 +25,7 @@ describe GraphQL::BaseType do
   end
 
   it "Accepts arbitrary metadata" do
-    assert_equal ["Cheese"], Dummy::CheeseType.metadata[:class_names]
+    assert_equal ["Cheese"], Dummy::Cheese.graphql_definition.metadata[:class_names]
   end
 
   describe "#name" do
@@ -63,7 +63,7 @@ describe GraphQL::BaseType do
   end
 
   describe "forwards-compat with new api" do
-    let(:type_defn) { Dummy::CheeseType }
+    let(:type_defn) { Dummy::Cheese.graphql_definition }
     it "responds to new methods" do
       assert_equal "Cheese", type_defn.graphql_name
       assert_equal type_defn, type_defn.graphql_definition

--- a/spec/graphql/enum_type_spec.rb
+++ b/spec/graphql/enum_type_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 
 describe GraphQL::EnumType do
-  let(:enum) { Dummy::DairyAnimalEnum }
+  let(:enum) { Dummy::DairyAnimal.graphql_definition }
 
   it "coerces names to underlying values" do
     assert_equal("YAK", enum.coerce_isolated_input("YAK"))

--- a/spec/graphql/execution/typecast_spec.rb
+++ b/spec/graphql/execution/typecast_spec.rb
@@ -8,36 +8,36 @@ describe GraphQL::Execution::Typecast do
     end
 
     it "counts the same type as a subtype" do
-      assert subtype?(Dummy::MilkType, Dummy::MilkType)
-      assert !subtype?(Dummy::MilkType, Dummy::CheeseType)
-      assert subtype?(Dummy::MilkType.to_list_type.to_non_null_type, Dummy::MilkType.to_list_type.to_non_null_type)
+      assert subtype?(Dummy::Milk.graphql_definition, Dummy::Milk.graphql_definition)
+      assert !subtype?(Dummy::Milk.graphql_definition, Dummy::Cheese.graphql_definition)
+      assert subtype?(Dummy::Milk.graphql_definition.to_list_type.to_non_null_type, Dummy::Milk.graphql_definition.to_list_type.to_non_null_type)
     end
 
     it "counts member types as subtypes" do
-      assert subtype?(Dummy::EdibleInterface, Dummy::CheeseType)
-      assert subtype?(Dummy::EdibleInterface, Dummy::MilkType)
-      assert subtype?(Dummy::DairyProductUnion, Dummy::MilkType)
-      assert subtype?(Dummy::DairyProductUnion, Dummy::CheeseType)
+      assert subtype?(Dummy::Edible.graphql_definition, Dummy::Cheese.graphql_definition)
+      assert subtype?(Dummy::Edible.graphql_definition, Dummy::Milk.graphql_definition)
+      assert subtype?(Dummy::DairyProduct.graphql_definition, Dummy::Milk.graphql_definition)
+      assert subtype?(Dummy::DairyProduct.graphql_definition, Dummy::Cheese.graphql_definition)
 
-      assert !subtype?(Dummy::DairyAppQueryType, Dummy::DairyProductUnion)
-      assert !subtype?(Dummy::CheeseType, Dummy::DairyProductUnion)
-      assert !subtype?(Dummy::EdibleInterface, Dummy::DairyProductUnion)
-      assert !subtype?(Dummy::EdibleInterface, GraphQL::STRING_TYPE)
-      assert !subtype?(Dummy::EdibleInterface, Dummy::DairyProductInputType)
+      assert !subtype?(Dummy::DairyAppQuery.graphql_definition, Dummy::DairyProduct.graphql_definition)
+      assert !subtype?(Dummy::Cheese.graphql_definition, Dummy::DairyProduct.graphql_definition)
+      assert !subtype?(Dummy::Edible.graphql_definition, Dummy::DairyProduct.graphql_definition)
+      assert !subtype?(Dummy::Edible.graphql_definition, GraphQL::STRING_TYPE)
+      assert !subtype?(Dummy::Edible.graphql_definition, Dummy::DairyProductInput.graphql_definition)
     end
 
     it "counts lists as subtypes if their inner types are subtypes" do
-      assert subtype?(Dummy::EdibleInterface.to_list_type, Dummy::MilkType.to_list_type)
-      assert subtype?(Dummy::DairyProductUnion.to_list_type, Dummy::MilkType.to_list_type)
-      assert !subtype?(Dummy::CheeseType.to_list_type, Dummy::DairyProductUnion.to_list_type)
-      assert !subtype?(Dummy::EdibleInterface.to_list_type, Dummy::DairyProductUnion.to_list_type)
-      assert !subtype?(Dummy::EdibleInterface.to_list_type, GraphQL::STRING_TYPE.to_list_type)
+      assert subtype?(Dummy::Edible.graphql_definition.to_list_type, Dummy::Milk.graphql_definition.to_list_type)
+      assert subtype?(Dummy::DairyProduct.graphql_definition.to_list_type, Dummy::Milk.graphql_definition.to_list_type)
+      assert !subtype?(Dummy::Cheese.graphql_definition.to_list_type, Dummy::DairyProduct.graphql_definition.to_list_type)
+      assert !subtype?(Dummy::Edible.graphql_definition.to_list_type, Dummy::DairyProduct.graphql_definition.to_list_type)
+      assert !subtype?(Dummy::Edible.graphql_definition.to_list_type, GraphQL::STRING_TYPE.to_list_type)
     end
 
     it "counts non-null types as subtypes of nullable parent types" do
-      assert subtype?(Dummy::MilkType, Dummy::MilkType.to_non_null_type)
-      assert subtype?(Dummy::EdibleInterface, Dummy::MilkType.to_non_null_type)
-      assert subtype?(Dummy::EdibleInterface.to_non_null_type, Dummy::MilkType.to_non_null_type)
+      assert subtype?(Dummy::Milk.graphql_definition, Dummy::Milk.graphql_definition.to_non_null_type)
+      assert subtype?(Dummy::Edible.graphql_definition, Dummy::Milk.graphql_definition.to_non_null_type)
+      assert subtype?(Dummy::Edible.graphql_definition.to_non_null_type, Dummy::Milk.graphql_definition.to_non_null_type)
       assert subtype?(
         GraphQL::STRING_TYPE.to_non_null_type.to_list_type,
         GraphQL::STRING_TYPE.to_non_null_type.to_list_type.to_non_null_type,

--- a/spec/graphql/field_spec.rb
+++ b/spec/graphql/field_spec.rb
@@ -116,7 +116,7 @@ describe GraphQL::Field do
 
   describe "#metadata" do
     it "accepts user-defined metadata" do
-      similar_cheese_field = Dummy::CheeseType.get_field("similarCheese")
+      similar_cheese_field = Dummy::Cheese.graphql_definition.get_field("similarCheese")
       assert_equal [:cheeses, :milks], similar_cheese_field.metadata[:joins]
     end
   end

--- a/spec/graphql/interface_type_spec.rb
+++ b/spec/graphql/interface_type_spec.rb
@@ -2,11 +2,11 @@
 require "spec_helper"
 
 describe GraphQL::InterfaceType do
-  let(:interface) { Dummy::EdibleInterface }
+  let(:interface) { Dummy::Edible.graphql_definition }
   let(:dummy_query_context) { OpenStruct.new(schema: Dummy::Schema) }
 
   it "has possible types" do
-    assert_equal([Dummy::CheeseType, Dummy::HoneyType, Dummy::MilkType], Dummy::Schema.possible_types(interface))
+    assert_equal([Dummy::Cheese.graphql_definition, Dummy::Honey.graphql_definition, Dummy::Milk.graphql_definition], Dummy::Schema.possible_types(interface))
   end
 
   describe "query evaluation" do
@@ -96,11 +96,11 @@ describe GraphQL::InterfaceType do
     it "copies orphan types without affecting the original" do
       interface = GraphQL::InterfaceType.define do
         name "AInterface"
-        orphan_types [Dummy::HoneyType]
+        orphan_types [Dummy::Honey]
       end
 
       interface_2 = interface.dup
-      interface_2.orphan_types << Dummy::CheeseType
+      interface_2.orphan_types << Dummy::Cheese
       assert_equal 1, interface.orphan_types.size
       assert_equal 2, interface_2.orphan_types.size
     end

--- a/spec/graphql/introspection/input_value_type_spec.rb
+++ b/spec/graphql/introspection/input_value_type_spec.rb
@@ -40,7 +40,7 @@ describe GraphQL::Introspection::InputValueType do
           ]
         }
       }}
-    assert_equal(expected, result)
+    assert_equal(expected, result.to_h)
   end
 
   let(:cheese_type) {

--- a/spec/graphql/object_type_spec.rb
+++ b/spec/graphql/object_type_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 
 describe GraphQL::ObjectType do
-  let(:type) { Dummy::CheeseType }
+  let(:type) { Dummy::Cheese.graphql_definition }
 
   it "doesn't allow double non-null constraints" do
     assert_raises(GraphQL::DoubleNonNullTypeError) {
@@ -45,10 +45,10 @@ describe GraphQL::ObjectType do
   describe "interfaces" do
     it "may have interfaces" do
       assert_equal([
-        Dummy::EdibleInterface,
-        Dummy::EdibleAsMilkInterface,
-        Dummy::AnimalProductInterface,
-        Dummy::LocalProductInterface
+        Dummy::Edible.graphql_definition,
+        Dummy::EdibleAsMilk.graphql_definition,
+        Dummy::AnimalProduct.graphql_definition,
+        Dummy::LocalProduct.graphql_definition
       ], type.interfaces)
     end
 
@@ -85,7 +85,7 @@ describe GraphQL::ObjectType do
   end
 
   it "accepts fields definition" do
-    last_produced_dairy = GraphQL::Field.define(name: :last_produced_dairy, type: Dummy::DairyProductUnion)
+    last_produced_dairy = GraphQL::Field.define(name: :last_produced_dairy, type: Dummy::DairyProduct)
     cow_type = GraphQL::ObjectType.define(name: "Cow", fields: [last_produced_dairy])
     assert_equal([last_produced_dairy], cow_type.fields)
   end
@@ -94,54 +94,54 @@ describe GraphQL::ObjectType do
     it "adds an interface" do
       type = GraphQL::ObjectType.define do
         name 'Hello'
-        implements Dummy::EdibleInterface
-        implements Dummy::AnimalProductInterface
+        implements Dummy::Edible
+        implements Dummy::AnimalProduct
 
         field :hello, types.String
       end
 
-      assert_equal([Dummy::EdibleInterface, Dummy::AnimalProductInterface], type.interfaces)
+      assert_equal([Dummy::Edible.graphql_definition, Dummy::AnimalProduct.graphql_definition], type.interfaces)
     end
 
     it "adds many interfaces" do
       type = GraphQL::ObjectType.define do
         name 'Hello'
-        implements Dummy::EdibleInterface, Dummy::AnimalProductInterface
+        implements Dummy::Edible, Dummy::AnimalProduct
 
         field :hello, types.String
       end
 
-      assert_equal([Dummy::EdibleInterface, Dummy::AnimalProductInterface], type.interfaces)
+      assert_equal([Dummy::Edible.graphql_definition, Dummy::AnimalProduct.graphql_definition], type.interfaces)
     end
 
     it "preserves existing interfaces and appends a new one" do
       type = GraphQL::ObjectType.define do
         name 'Hello'
-        interfaces [Dummy::EdibleInterface]
-        implements Dummy::AnimalProductInterface
+        interfaces [Dummy::Edible]
+        implements Dummy::AnimalProduct
 
         field :hello, types.String
       end
 
-      assert_equal([Dummy::EdibleInterface, Dummy::AnimalProductInterface], type.interfaces)
+      assert_equal([Dummy::Edible.graphql_definition, Dummy::AnimalProduct.graphql_definition], type.interfaces)
     end
 
     it "can be used to inherit fields from the interface" do
       type_1 = GraphQL::ObjectType.define do
         name 'Hello'
-        implements Dummy::EdibleInterface
-        implements Dummy::AnimalProductInterface
+        implements Dummy::Edible
+        implements Dummy::AnimalProduct
       end
 
       type_2 = GraphQL::ObjectType.define do
         name 'Hello'
-        implements Dummy::EdibleInterface
-        implements Dummy::AnimalProductInterface, inherit: true
+        implements Dummy::Edible
+        implements Dummy::AnimalProduct, inherit: true
       end
 
       type_3 = GraphQL::ObjectType.define do
         name 'Hello'
-        implements Dummy::EdibleInterface, Dummy::AnimalProductInterface, inherit: true
+        implements Dummy::Edible, Dummy::AnimalProduct, inherit: true
       end
 
       assert_equal [], type_1.all_fields.map(&:name)
@@ -158,16 +158,18 @@ describe GraphQL::ObjectType do
     end
 
     it "exposes defined field property" do
-      field_without_prop = Dummy::CheeseType.get_field("flavor")
-      field_with_prop = Dummy::CheeseType.get_field("fatContent")
+      field_without_prop = Dummy::Cheese.graphql_definition.get_field("flavor")
+      field_with_prop = Dummy::Cheese.graphql_definition.get_field("fatContent")
       assert_equal(field_without_prop.property, nil)
-      assert_equal(field_with_prop.property, :fat_content)
+      # This used to lookup `:fat_content`, but not since migrating to class-based
+      assert_equal(field_with_prop.property, nil)
     end
 
     it "looks up from interfaces" do
-      field_from_self = Dummy::CheeseType.get_field("fatContent")
-      field_from_iface = Dummy::MilkType.get_field("fatContent")
-      assert_equal(field_from_self.property, :fat_content)
+      field_from_self = Dummy::Cheese.graphql_definition.get_field("fatContent")
+      field_from_iface = Dummy::Milk.graphql_definition.get_field("fatContent")
+      # This used to lookup `:fat_content`, but not since migrating to class-based
+      assert_equal(field_from_self.property, nil)
       assert_equal(field_from_iface.property, nil)
     end
   end
@@ -175,6 +177,9 @@ describe GraphQL::ObjectType do
   describe "#dup" do
     it "copies fields and interfaces without altering the original" do
       type.interfaces # load the internal cache
+      assert_equal 4, type.interfaces.size
+      assert_equal 9, type.fields.size
+
       type_2 = type.dup
 
       # IRL, use `+=`, not this
@@ -185,8 +190,8 @@ describe GraphQL::ObjectType do
 
       assert_equal 4, type.interfaces.size
       assert_equal 5, type_2.interfaces.size
-      assert_equal 8, type.fields.size
-      assert_equal 9, type_2.fields.size
+      assert_equal 9, type.fields.size
+      assert_equal 10, type_2.fields.size
     end
   end
 end

--- a/spec/graphql/query/executor_spec.rb
+++ b/spec/graphql/query/executor_spec.rb
@@ -110,7 +110,7 @@ describe GraphQL::Query::Executor do
       DummyQueryType = GraphQL::ObjectType.define do
         name "Query"
         field :dairy do
-          type Dummy::DairyType
+          type Dummy::Dairy.graphql_definition
           resolve ->(t, a, c) {
             raise if resolved
             resolved = true
@@ -119,7 +119,7 @@ describe GraphQL::Query::Executor do
         end
       end
 
-      GraphQL::Schema.define(query: DummyQueryType, mutation: Dummy::DairyAppMutationType, resolve_type: ->(a,b,c) { :pass }, id_from_object: :pass)
+      GraphQL::Schema.define(query: DummyQueryType, mutation: Dummy::DairyAppMutation.graphql_definition, resolve_type: ->(a,b,c) { :pass }, id_from_object: :pass)
     }
     let(:variables) { nil }
     let(:query_string) { %|

--- a/spec/graphql/schema/interface_spec.rb
+++ b/spec/graphql/schema/interface_spec.rb
@@ -83,11 +83,11 @@ describe GraphQL::Schema::Interface do
       interface = Module.new do
         include GraphQL::Schema::Interface
         graphql_name "MyInterface"
-        orphan_types Dummy::CheeseType, Dummy::HoneyType
+        orphan_types Dummy::Cheese, Dummy::Honey
       end
 
       interface_type = interface.to_graphql
-      assert_equal [Dummy::CheeseType, Dummy::HoneyType], interface_type.orphan_types
+      assert_equal [Dummy::Cheese, Dummy::Honey], interface_type.orphan_types
     end
   end
 

--- a/spec/graphql/schema/traversal_spec.rb
+++ b/spec/graphql/schema/traversal_spec.rb
@@ -20,24 +20,24 @@ describe GraphQL::Schema::Traversal do
   it "finds types from a single type and its fields" do
     expected = {
       "Boolean" => GraphQL::BOOLEAN_TYPE,
-      "Cheese" => Dummy::CheeseType,
+      "Cheese" => Dummy::Cheese.graphql_definition,
       "Float" => GraphQL::FLOAT_TYPE,
       "String" => GraphQL::STRING_TYPE,
-      "Edible" => Dummy::EdibleInterface,
-      "EdibleAsMilk" => Dummy::EdibleAsMilkInterface,
-      "DairyAnimal" => Dummy::DairyAnimalEnum,
+      "Edible" => Dummy::Edible.graphql_definition,
+      "EdibleAsMilk" => Dummy::EdibleAsMilk.graphql_definition,
+      "DairyAnimal" => Dummy::DairyAnimal.graphql_definition,
       "Int" => GraphQL::INT_TYPE,
-      "AnimalProduct" => Dummy::AnimalProductInterface,
-      "LocalProduct" => Dummy::LocalProductInterface,
+      "AnimalProduct" => Dummy::AnimalProduct.graphql_definition,
+      "LocalProduct" => Dummy::LocalProduct.graphql_definition,
     }
-    result = traversal([Dummy::CheeseType]).type_map
+    result = traversal([Dummy::Cheese.graphql_definition]).type_map
     assert_equal(expected.keys.sort, result.keys.sort)
     assert_equal(expected, result.to_h)
   end
 
   it "finds type from arguments" do
-    result = traversal([Dummy::DairyAppQueryType]).type_map
-    assert_equal(Dummy::DairyProductInputType, result["DairyProductInput"])
+    result = traversal([Dummy::DairyAppQuery.graphql_definition]).type_map
+    assert_equal(Dummy::DairyProductInput.graphql_definition, result["DairyProductInput"])
   end
 
   it "finds types from field instrumentation" do
@@ -126,7 +126,7 @@ describe GraphQL::Schema::Traversal do
 
   describe "when a field is only accessible through an interface" do
     it "is found through Schema.define(types:)" do
-      assert_equal Dummy::HoneyType, Dummy::Schema.types["Honey"]
+      assert_equal Dummy::Honey.graphql_definition, Dummy::Schema.types["Honey"]
     end
   end
 

--- a/spec/graphql/schema/type_expression_spec.rb
+++ b/spec/graphql/schema/type_expression_spec.rb
@@ -13,7 +13,7 @@ describe GraphQL::Schema::TypeExpression do
     describe "simple types" do
       let(:type_name) { "DairyProductInput" }
       it "it gets types from the provided types" do
-        assert_equal(Dummy::DairyProductInputType, type_expression_result)
+        assert_equal(Dummy::DairyProductInput.graphql_definition, type_expression_result)
       end
     end
 
@@ -28,7 +28,7 @@ describe GraphQL::Schema::TypeExpression do
       let(:type_name) { "[DairyAnimal!]!" }
 
       it "makes list types" do
-        expected = Dummy::DairyAnimalEnum
+        expected = Dummy::DairyAnimal.graphql_definition
           .to_non_null_type
           .to_list_type
           .to_non_null_type

--- a/spec/graphql/schema/validation_spec.rb
+++ b/spec/graphql/schema/validation_spec.rb
@@ -315,7 +315,7 @@ describe GraphQL::Schema::Validation do
     let(:null_default_value) {
       GraphQL::Argument.define do
         name "NullDefault"
-        type Dummy::DairyAnimalEnum
+        type Dummy::DairyAnimal
         default_value nil
       end
     }

--- a/spec/graphql/union_type_spec.rb
+++ b/spec/graphql/union_type_spec.rb
@@ -169,7 +169,7 @@ describe GraphQL::UnionType do
     |}
 
     let(:query) { GraphQL::Query.new(Dummy::Schema, query_string) }
-    let(:union) { Dummy::BeverageUnion }
+    let(:union) { Dummy::Beverage.graphql_definition }
 
     it "returns the type definition if the type exists and is a possible type of the union" do
       assert union.get_possible_type("Milk", query.context)
@@ -194,7 +194,7 @@ describe GraphQL::UnionType do
     |}
 
     let(:query) { GraphQL::Query.new(Dummy::Schema, query_string) }
-    let(:union) { Dummy::BeverageUnion }
+    let(:union) { Dummy::Beverage.graphql_definition }
 
     it "returns true if the type exists and is a possible type of the union" do
       assert union.possible_type?("Milk", query.context)

--- a/spec/integration/rails/graphql/input_object_type_spec.rb
+++ b/spec/integration/rails/graphql/input_object_type_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 
 describe GraphQL::InputObjectType do
-  let(:input_object) { Dummy::DairyProductInputType }
+  let(:input_object) { Dummy::DairyProductInput.graphql_definition }
   it "has a description" do
     assert(input_object.description)
   end
@@ -113,7 +113,7 @@ describe GraphQL::InputObjectType do
         end
 
         it "has correct problem explanation" do
-          expected = Dummy::DairyAnimalEnum.validate_isolated_input("KOALA").problems[0]["explanation"]
+          expected = Dummy::DairyAnimal.graphql_definition.validate_isolated_input("KOALA").problems[0]["explanation"]
 
           source_problem = result.problems.detect { |p| p["path"] == ["source"] }
           actual = source_problem["explanation"]
@@ -191,7 +191,7 @@ describe GraphQL::InputObjectType do
       end
 
       describe "list with one invalid element" do
-        let(:list_type) { GraphQL::ListType.new(of_type: Dummy::DairyProductInputType) }
+        let(:list_type) { GraphQL::ListType.new(of_type: Dummy::DairyProductInput.graphql_definition) }
         let(:result) do
           list_type.validate_isolated_input([
             { "source" => "COW", "fatContent" => 0.4 },
@@ -213,7 +213,7 @@ describe GraphQL::InputObjectType do
         end
 
         it "has problem with correct explanation" do
-          expected = Dummy::DairyAnimalEnum.validate_isolated_input("KOALA").problems[0]["explanation"]
+          expected = Dummy::DairyAnimal.graphql_definition.validate_isolated_input("KOALA").problems[0]["explanation"]
           actual = result.problems[0]["explanation"]
           assert_equal(expected, actual)
         end

--- a/spec/integration/rails/graphql/query/variables_spec.rb
+++ b/spec/integration/rails/graphql/query/variables_spec.rb
@@ -69,21 +69,21 @@ describe GraphQL::Query::Variables do
       it "checks for string matches" do
         # These get merged into all the values above
         default_values = {
-          "originDairy"=>"Sugar Hollow Dairy",
-          "organic"=>false,
-          "order_by"=>{"direction"=>"ASC"}
+          origin_dairy: "Sugar Hollow Dairy",
+          organic: false,
+          order_by: { direction: "ASC" },
         }
 
         expected_input_1 = {
-          "source" => 1,
-          "fatContent" => 0.99,
+          source: 1,
+          fat_content: 0.99,
         }.merge(default_values)
 
         assert_equal(expected_input_1, variables["dairy_product_1"].to_h)
 
         expected_input_2 = {
-          "source" => :donkey,
-          "fatContent" => 0.89,
+          source: :donkey,
+          fat_content: 0.89,
         }.merge(default_values)
         assert_equal(expected_input_2, variables["dairy_product_2"].to_h)
       end

--- a/spec/integration/rails/graphql/schema_spec.rb
+++ b/spec/integration/rails/graphql/schema_spec.rb
@@ -47,9 +47,9 @@ describe GraphQL::Schema do
     it "returns a list of the schema's root types" do
       assert_equal(
         [
-          Dummy::DairyAppQueryType,
-          Dummy::DairyAppMutationType.graphql_definition,
-          Dummy::SubscriptionType
+          Dummy::DairyAppQuery.graphql_definition,
+          Dummy::DairyAppMutation.graphql_definition.graphql_definition,
+          Dummy::Subscription.graphql_definition
         ],
         schema.root_types
       )
@@ -58,7 +58,8 @@ describe GraphQL::Schema do
 
   describe "#references_to" do
     it "returns a list of Field and Arguments of that type" do
-      assert_equal [schema.types["Query"].fields["cow"]], schema.references_to("Cow")
+      cow_field = schema.get_field("Query", "cow")
+      assert_equal [cow_field], schema.references_to("Cow")
     end
 
     it "returns an empty list when type is not referenced by any field or argument" do
@@ -450,7 +451,7 @@ type Query {
     it "returns fields by type or type name" do
       field = schema.get_field("Cheese", "id")
       assert_instance_of GraphQL::Field, field
-      field_2 = schema.get_field(Dummy::CheeseType, "id")
+      field_2 = schema.get_field(Dummy::Cheese.graphql_definition, "id")
       assert_equal field, field_2
     end
   end

--- a/spec/support/dummy/data.rb
+++ b/spec/support/dummy/data.rb
@@ -1,27 +1,32 @@
 # frozen_string_literal: true
 require 'ostruct'
 module Dummy
-  Cheese = Struct.new(:id, :flavor, :origin, :fat_content, :source) do
-    def ==(other)
-      # This is buggy on purpose -- it shouldn't be called during execution.
-      other.id == id
+  module Data
+    Cheese = Struct.new(:id, :flavor, :origin, :fat_content, :source) do
+      def ==(other)
+        # This is buggy on purpose -- it shouldn't be called during execution.
+        other.id == id
+      end
+
+      # Alias for when this is treated as milk in EdibleAsMilkInterface
+      def fatContent # rubocop:disable Naming/MethodName
+        fat_content
+      end
     end
 
-    # Alias for when this is treated as milk in EdibleAsMilkInterface
-    def fatContent # rubocop:disable Naming/MethodName
-      fat_content
-    end
+    Milk = Struct.new(:id, :fat_content, :origin, :source, :flavors)
+    Cow = Struct.new(:id, :name, :last_produced_dairy)
+    Goat = Struct.new(:id, :name, :last_produced_dairy)
   end
 
   CHEESES = {
-    1 => Cheese.new(1, "Brie", "France", 0.19, 1),
-    2 => Cheese.new(2, "Gouda", "Netherlands", 0.3, 1),
-    3 => Cheese.new(3, "Manchego", "Spain", 0.065, "SHEEP")
+    1 => Data::Cheese.new(1, "Brie", "France", 0.19, 1),
+    2 => Data::Cheese.new(2, "Gouda", "Netherlands", 0.3, 1),
+    3 => Data::Cheese.new(3, "Manchego", "Spain", 0.065, "SHEEP")
   }
 
-  Milk = Struct.new(:id, :fatContent, :origin, :source, :flavors)
   MILKS = {
-    1 => Milk.new(1, 0.04, "Antiquity", 1, ["Natural", "Chocolate", "Strawberry"]),
+    1 => Data::Milk.new(1, 0.04, "Antiquity", 1, ["Natural", "Chocolate", "Strawberry"]),
   }
 
   DAIRY = OpenStruct.new(
@@ -30,13 +35,11 @@ module Dummy
     milks: [MILKS[1]]
   )
 
-  Cow = Struct.new(:id, :name, :last_produced_dairy)
   COWS = {
-    1 => Cow.new(1, "Billy", MILKS[1])
+    1 => Data::Cow.new(1, "Billy", MILKS[1])
   }
 
-  Goat = Struct.new(:id, :name, :last_produced_dairy)
   GOATS = {
-    1 => Goat.new(1, "Gilly", MILKS[1]),
+    1 => Data::Goat.new(1, "Gilly", MILKS[1]),
   }
 end

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -7,40 +7,58 @@ module Dummy
   GraphQL::Field.accepts_definitions(joins: GraphQL::Define.assign_metadata_key(:joins))
   GraphQL::BaseType.accepts_definitions(class_names: GraphQL::Define.assign_metadata_key(:class_names))
 
-  LocalProductInterface = GraphQL::InterfaceType.define do
-    name "LocalProduct"
+  class BaseField < GraphQL::Schema::Field
+    accepts_definition :joins
+  end
+
+  module BaseInterface
+    include GraphQL::Schema::Interface
+  end
+
+  class BaseObject < GraphQL::Schema::Object
+    field_class BaseField
+    accepts_definition :class_names
+  end
+
+  class BaseUnion < GraphQL::Schema::Union
+  end
+
+  class BaseEnum < GraphQL::Schema::Enum
+  end
+
+  class BaseInputObject < GraphQL::Schema::InputObject
+  end
+
+  class BaseScalar < GraphQL::Schema::Scalar
+  end
+
+  module LocalProduct
+    include BaseInterface
     description "Something that comes from somewhere"
-    field :origin, !types.String, "Place the thing comes from"
+    field :origin, String, null: false,
+      description: "Place the thing comes from"
   end
 
-  EdibleInterface = GraphQL::InterfaceType.define do
-    name "Edible"
+  module Edible
+    include BaseInterface
     description "Something you can eat, yum"
-    field :fatContent, !types.Float, "Percentage which is fat"
-    field :origin, !types.String, "Place the edible comes from"
-    field :selfAsEdible, EdibleInterface, resolve: ->(o, a, c) { o }
+    field :fat_content, Float, null: false, description: "Percentage which is fat"
+    field :origin, String, null: false, description: "Place the edible comes from"
+    field :self_as_edible, Edible, null: true
+    def self_as_edible
+      object
+    end
   end
 
-  EdibleAsMilkInterface = EdibleInterface.redefine do
-    name "EdibleAsMilk"
+  module EdibleAsMilk
+    include Edible
     description "Milk :+1:"
-    resolve_type ->(obj, ctx) { MilkType }
+    def self.resolve_type(obj, ctx)
+      Milk
+    end
   end
 
-  AnimalProductInterface = GraphQL::InterfaceType.define do
-    name "AnimalProduct"
-    description "Comes from an animal, no joke"
-    field :source, !DairyAnimalEnum, "Animal which produced this product"
-  end
-
-  BeverageUnion = GraphQL::UnionType.define do
-    name "Beverage"
-    description "Something you can drink"
-    possible_types [MilkType]
-  end
-
-  DairyAnimalEnum = GraphQL::EnumType.define do
-    name "DairyAnimal"
+  class DairyAnimal < BaseEnum
     description "An animal which can yield milk"
     value("COW",      "Animal with black and white spots", value: 1)
     value("DONKEY",   "Animal with fur", value: :donkey)
@@ -50,217 +68,206 @@ module Dummy
     value("YAK",      "Animal with long hair", deprecation_reason: "Out of fashion")
   end
 
-  CheeseType = GraphQL::ObjectType.define do
-    name "Cheese"
+  module AnimalProduct
+    include BaseInterface
+    description "Comes from an animal, no joke"
+    field :source, DairyAnimal, "Animal which produced this product", null: false
+  end
+
+  class Cheese < BaseObject
     class_names ["Cheese"]
     description "Cultured dairy product"
-    interfaces [EdibleInterface, EdibleAsMilkInterface, AnimalProductInterface, LocalProductInterface]
+    implements Edible
+    implements EdibleAsMilk
+    implements AnimalProduct
+    implements LocalProduct
 
-    # Can have (name, type, desc)
-    field :id, !types.Int, "Unique identifier"
-    field :flavor, !types.String, "Kind of Cheese"
-    field :origin, !types.String, "Place the cheese comes from"
+    field :id, Int, "Unique identifier", null: false
+    field :flavor, String, "Kind of Cheese", null: false
+    field :origin, String, "Place the cheese comes from", null: false
 
-    field :source, !DairyAnimalEnum,
-      "Animal which produced the milk for this cheese"
+    field :source, DairyAnimal,
+      "Animal which produced the milk for this cheese",
+      null: false
 
-    # Or can define by block, `resolve ->` should override `property:`
-    field :similarCheese, CheeseType, "Cheeses like this one", property: :this_should_be_overriden  do
+    field :similar_cheese, Cheese, "Cheeses like this one", null: true  do
       # metadata test
       joins [:cheeses, :milks]
-      argument :source, !types[!DairyAnimalEnum]
-      argument :nullableSource, types[!DairyAnimalEnum], default_value: [1]
-      resolve ->(t, a, c) {
-        # get the strings out:
-        sources = a["source"]
-        if sources.include?("YAK")
-          raise NoSuchDairyError.new("No cheeses are made from Yak milk!")
-        else
-          CHEESES.values.find { |cheese| sources.include?(cheese.source) }
-        end
-      }
+      argument :source, [DairyAnimal], required: true
+      argument :nullableSource, [DairyAnimal], required: false, default_value: [1]
     end
 
-    field :nullableCheese, CheeseType, "Cheeses like this one" do
-      argument :source, types[!DairyAnimalEnum]
-      resolve ->(t, a, c) { raise("NotImplemented") }
+    def similar_cheese(source:, nullable_source:)
+      # get the strings out:
+      sources = source
+      if sources.include?("YAK")
+        raise NoSuchDairyError.new("No cheeses are made from Yak milk!")
+      else
+        CHEESES.values.find { |cheese| sources.include?(cheese.source) }
+      end
     end
 
-    field :deeplyNullableCheese, CheeseType, "Cheeses like this one" do
-      argument :source, types[types[DairyAnimalEnum]]
-      resolve ->(t, a, c) { raise("NotImplemented") }
+    field :nullable_cheese, Cheese, "Cheeses like this one", null: true do
+      argument :source, [DairyAnimal], required: false
     end
+    def nullable_cheese; raise("NotImplemented"); end
+
+    field :deeply_nullable_cheese, Cheese, "Cheeses like this one", null: true do
+      argument :source, [[DairyAnimal, null: true], null: true], required: false
+    end
+    def deeply_nullable_cheese; raise("NotImplemented"); end
 
     # Keywords can be used for definition methods
-    field :fatContent,
-      property: :fat_content,
-      type: !GraphQL::FLOAT_TYPE,
+    field :fat_content,
+      type: GraphQL::FLOAT_TYPE,
+      null: false,
       description: "Percentage which is milkfat",
       deprecation_reason: "Diet fashion has changed"
   end
 
-  MilkType = GraphQL::ObjectType.define do
-    name "Milk"
+  class Milk < BaseObject
     description "Dairy beverage"
-    interfaces [EdibleInterface, EdibleAsMilkInterface, AnimalProductInterface, LocalProductInterface]
-    field :id, !types.ID
-    field :source, !DairyAnimalEnum, "Animal which produced this milk", hash_key: :source
-    field :origin, !types.String, "Place the milk comes from"
-    field :flavors, types[types.String], "Chocolate, Strawberry, etc" do
-      argument :limit, types.Int
-      resolve ->(milk, args, ctx) {
-        args[:limit] ? milk.flavors.first(args.limit) : milk.flavors
-      }
-    end
-    field :executionError do
-      type GraphQL::STRING_TYPE
-      resolve ->(t, a, c) { raise(GraphQL::ExecutionError, "There was an execution error") }
+    implements Edible
+    implements EdibleAsMilk
+    implements AnimalProduct
+    implements LocalProduct
+
+    field :id, ID, null: false
+    field :source, DairyAnimal, null: false, description: "Animal which produced this milk"
+    field :origin, String, null: false, description: "Place the milk comes from"
+    field :flavors, [String, null: true], null: true, description: "Chocolate, Strawberry, etc" do
+      argument :limit, Int, required: false
     end
 
-    field :allDairy, -> { types[DairyProductUnion] } do
-      resolve ->(obj, args, ctx) { CHEESES.values + MILKS.values }
+    def flavors(limit: nil)
+      limit ? object.flavors.first(limit) : object.flavors
     end
+
+    field :execution_error, String, null: true
+    def execution_error; raise(GraphQL::ExecutionError, "There was an execution error"); end
+
+    field :all_dairy, ["Dummy::DairyProduct", null: true], null: true
+    def all_dairy; CHEESES.values + MILKS.values; end
   end
 
-  SweetenerInterface = GraphQL::InterfaceType.define do
-    name "Sweetener"
-    field :sweetness, types.Int
+  class Beverage < BaseUnion
+    description "Something you can drink"
+    possible_types Milk
+  end
+
+  module Sweetener
+    include BaseInterface
+    field :sweetness, Integer, null: true
   end
 
   # No actual data; This type is an "orphan", only accessible through Interfaces
-  HoneyType = GraphQL::ObjectType.define do
-    name "Honey"
+  class Honey < BaseObject
     description "Sweet, dehydrated bee barf"
-    field :flowerType, types.String, "What flower this honey came from"
-    interfaces [EdibleInterface, AnimalProductInterface, SweetenerInterface]
+    field :flower_type, String, "What flower this honey came from", null: true
+    implements Edible
+    implements AnimalProduct
+    implements Sweetener
   end
 
-  DairyType = GraphQL::ObjectType.define do
-    name "Dairy"
+  class Dairy < BaseObject
     description "A farm where milk is harvested and cheese is produced"
-    field :id, !types.ID
-    field :cheese, CheeseType
-    field :milks, types[MilkType]
+    field :id, ID, null: false
+    field :cheese, Cheese, null: true
+    field :milks, [Milk, null: true], null: true
   end
 
-  MaybeNullType = GraphQL::ObjectType.define do
-    name "MaybeNull"
+  class MaybeNull < BaseObject
     description "An object whose fields return nil"
-    field :cheese, CheeseType
+    field :cheese, Cheese, null: true
   end
 
-  TracingScalarType = GraphQL::ObjectType.define do
-    name "TracingScalar"
+  class TracingScalar < BaseObject
     description "An object which has traced scalars"
 
-    field :traceNil, types.Int
-    field :traceFalse, types.Int, trace: false
-    field :traceTrue, types.Int, trace: true
+    field :trace_nil, Integer, null: true
+    field :trace_false, Integer, null: true, trace: false
+    field :trace_true, Integer, null: true, trace: true
   end
 
-  DairyProductUnion = GraphQL::UnionType.define do
-    name "DairyProduct"
+  class DairyProduct < BaseUnion
     description "Kinds of food made from milk"
     # Test that these forms of declaration still work:
-    possible_types ["Dummy::MilkType", -> { CheeseType }]
+    possible_types "Dummy::Milk", Cheese
   end
 
-  CowType = GraphQL::ObjectType.define do
-    name "Cow"
+  class Cow < BaseObject
     description "A bovine animal that produces milk"
-    field :id, !types.ID
-    field :name, types.String
-    field :last_produced_dairy, DairyProductUnion
+    field :id, ID, null: false
+    field :name, String, null: true
+    field :last_produced_dairy, DairyProduct, null: true
 
-    field :cantBeNullButIs do
-      type !GraphQL::STRING_TYPE
-      resolve ->(t, a, c) { nil }
-    end
+    field :cant_be_null_but_is, String, null: false
+    def cant_be_null_but_is; nil; end
 
-    field :cantBeNullButRaisesExecutionError do
-      type !GraphQL::STRING_TYPE
-      resolve ->(t, a, c) { raise GraphQL::ExecutionError, "BOOM" }
-    end
+    field :cant_be_null_but_raises_execution_error, String, null: false
+    def cant_be_null_but_raises_execution_error; raise(GraphQL::ExecutionError, "BOOM"); end
   end
 
-  GoatType = GraphQL::ObjectType.define do
-    name "Goat"
+  class Goat < BaseObject
     description "An caprinae animal that produces milk"
-    field :id, !types.ID
-    field :name, types.String
-    field :last_produced_dairy, DairyProductUnion
+    field :id, ID, null: false
+    field :name, String, null: true
+    field :last_produced_dairy, DairyProduct, null: true
   end
 
-  AnimalUnion = GraphQL::UnionType.define do
-    name "Animal"
+  class Animal < BaseUnion
     description "Species of living things"
-    possible_types [CowType, GoatType]
+    possible_types Cow, Goat
   end
 
-  AnimalAsCowUnion = GraphQL::UnionType.define do
-    name "AnimalAsCow"
+  class AnimalAsCow < BaseUnion
     description "All animals go mooooo!"
-    possible_types [CowType]
-    resolve_type ->(obj, ctx) {
-      CowType
-    }
+    possible_types Cow
+    def self.resolve_type(obj, ctx)
+      Cow
+    end
   end
 
-  ResourceOrderType = GraphQL::InputObjectType.define {
-    name "ResourceOrderType"
+  class ResourceOrder < BaseInputObject
+    graphql_name "ResourceOrderType"
     description "Properties used to determine ordering"
 
-    argument :direction, !types.String do
-      description "ASC or DESC"
-    end
-  }
-
-  DairyProductInputType = GraphQL::InputObjectType.define {
-    name "DairyProductInput"
-    description "Properties for finding a dairy product"
-    input_field :source, !DairyAnimalEnum do
-      # ensure we can define description in block
-      description "Where it came from"
-    end
-
-    input_field :originDairy, types.String, "Dairy which produced it", default_value: "Sugar Hollow Dairy"
-
-    input_field :fatContent, types.Float, "How much fat it has" do
-      # ensure we can define default in block
-      default_value 0.3
-    end
-
-    # ensure default can be false
-    input_field :organic, types.Boolean, default_value: false
-
-    input_field :order_by, -> { ResourceOrderType }, default_value: { direction: 'ASC' }
-  }
-
-  DeepNonNullType = GraphQL::ObjectType.define do
-    name "DeepNonNull"
-    field :nonNullInt, !types.Int do
-      argument :returning, types.Int
-      resolve ->(obj, args, ctx) { args.returning }
-    end
-
-    field :deepNonNull, DeepNonNullType.to_non_null_type do
-      resolve ->(obj, args, ctx) { :deepNonNull }
-    end
+    argument :direction, String, required: true, description: "ASC or DESC"
   end
 
-  TimeType = GraphQL::ScalarType.define do
-    name "Time"
-    description "Time since epoch in seconds"
+  class DairyProductInput < BaseInputObject
+    description "Properties for finding a dairy product"
+    argument :source, DairyAnimal, required: true, description: "Where it came from"
+    argument :origin_dairy, String, required: false, description: "Dairy which produced it", default_value: "Sugar Hollow Dairy"
+    argument :fat_content, Float, required: false, description: "How much fat it has", default_value: 0.3
+    argument :organic, Boolean, required: false, default_value: false
+    argument :order_by, ResourceOrder, required: false, default_value: { direction: "ASC" }, camelize: false
+  end
 
-    coerce_input ->(value, ctx) do
-      begin
-        Time.at(Float(value))
-      rescue ArgumentError
-        raise GraphQL::CoercionError, 'cannot coerce to Float'
-      end
+  class DeepNonNull < BaseObject
+    field :non_null_int, Integer, null: false do
+      argument :returning, Integer, required: false
+    end
+    def non_null_int(returning: nil)
+      returning
     end
 
-    coerce_result ->(value, ctx) { value.to_f }
+    field :deep_non_null, DeepNonNull, null: false
+    def deep_non_null; :deep_non_null; end
+  end
+
+  class Time < BaseScalar
+    description "Time since epoch in seconds"
+
+    def self.coerce_input(value, ctx)
+      Time.at(Float(value))
+    rescue ArgumentError
+      raise GraphQL::CoercionError, 'cannot coerce to Float'
+    end
+
+    def self.coerce_result(value, ctx)
+      value.to_f
+    end
   end
 
   class FetchItem < GraphQL::Function
@@ -294,162 +301,146 @@ module Dummy
     end
   end
 
-  SourceFieldDefn = Proc.new {
-    type GraphQL::ListType.new(of_type: CheeseType)
-    description "Cheese from source"
-    argument :source, DairyAnimalEnum, default_value: 1
-    resolve ->(target, arguments, context) {
-      CHEESES.values.select{ |c| c.source == arguments["source"] }
-    }
-  }
-
   FavoriteFieldDefn = GraphQL::Field.define do
     name "favoriteEdible"
     description "My favorite food"
-    type EdibleInterface
+    type Edible
     resolve ->(t, a, c) { MILKS[1] }
   end
 
-  DairyAppQueryType = GraphQL::ObjectType.define do
-    name "Query"
+  class DairyAppQuery < BaseObject
+    graphql_name "Query"
     description "Query root of the system"
-    field :root, types.String do
-      resolve ->(root_value, args, c) { root_value }
+    # Returns `root_value:`
+    field :root, String, null: true
+    def root
+      object
     end
-    field :cheese, function: FetchItem.new(type: CheeseType, data: CHEESES)
-    field :milk, function: FetchItem.new(type: MilkType, data: MILKS, id_type: !types.ID)
-    field :dairy, function: GetSingleton.new(type: DairyType, data: DAIRY)
-    field :fromSource, &SourceFieldDefn
-    field :favoriteEdible, FavoriteFieldDefn
-    field :cow, function: GetSingleton.new(type: CowType, data: COWS[1])
-    field :searchDairy do
+    field :cheese, function: FetchItem.new(type: Cheese, data: CHEESES)
+    field :milk, function: FetchItem.new(type: Milk, data: MILKS, id_type: GraphQL::Types::ID.to_non_null_type)
+    field :dairy, function: GetSingleton.new(type: Dairy, data: DAIRY)
+    field :from_source, [Cheese, null: true], null: true, description: "Cheese from source" do
+      argument :source, DairyAnimal, required: false, default_value: 1
+    end
+    def from_source(source:)
+      CHEESES.values.select { |c| c.source == source }
+    end
+
+    field :favorite_edible, field: FavoriteFieldDefn
+    field :cow, function: GetSingleton.new(type: Cow, data: COWS[1])
+    field :search_dairy, DairyProduct, null: false do
       description "Find dairy products matching a description"
-      type !DairyProductUnion
       # This is a list just for testing 😬
-      argument :product, types[DairyProductInputType], default_value: [{"source" => "SHEEP"}]
-      argument :expiresAfter, TimeType
-      resolve ->(t, args, c) {
-        source = args["product"][0][:source] # String or Sym is ok
-        products = CHEESES.values + MILKS.values
-        if !source.nil?
-          products = products.select { |pr| pr.source == source }
-        end
-        products.first
-      }
+      argument :product, [DairyProductInput, null: true], required: false, default_value: [{"source" => "SHEEP"}]
+      argument :expires_after, Time, required: false
     end
 
-    field :allAnimal, !types[AnimalUnion] do
-      resolve ->(obj, args, ctx) { COWS.values + GOATS.values }
+    def search_dairy(product:, expires_after: nil)
+      source = product[0][:source]
+      products = CHEESES.values + MILKS.values
+      if !source.nil?
+        products = products.select { |pr| pr.source == source }
+      end
+      products.first
     end
 
-    field :allAnimalAsCow, !types[AnimalAsCowUnion] do
-      resolve ->(obj, args, ctx) { COWS.values + GOATS.values }
+    field :all_animal, [Animal, null: true], null: false
+    def all_animal
+      COWS.values + GOATS.values
     end
 
-    field :allDairy, types[DairyProductUnion] do
-      argument :executionErrorAtIndex, types.Int
-      resolve ->(obj, args, ctx) {
-        result = CHEESES.values + MILKS.values
-        result[args.executionErrorAtIndex] = GraphQL::ExecutionError.new("missing dairy") if args.executionErrorAtIndex
-        result
-      }
+    field :all_animal_as_cow, [AnimalAsCow, null: true], null: false, method: :all_animal
+
+    field :all_dairy, [DairyProduct, null: true], null: true do
+      argument :execution_error_at_index, Integer, required: false
+    end
+    def all_dairy(execution_error_at_index: nil)
+      result = CHEESES.values + MILKS.values
+      if execution_error_at_index
+        result[execution_error_at_index] = GraphQL::ExecutionError.new("missing dairy")
+      end
+      result
     end
 
-    field :allEdible, types[EdibleInterface] do
-      resolve ->(obj, args, ctx) { CHEESES.values + MILKS.values }
+    field :all_edible, [Edible, null: true], null: true
+    def all_edible
+      CHEESES.values + MILKS.values
     end
 
-    field :allEdibleAsMilk, types[EdibleAsMilkInterface] do
-      resolve ->(obj, args, ctx) { CHEESES.values + MILKS.values }
+    field :all_edible_as_milk, [EdibleAsMilk, null: true], null: true, method: :all_edible
+
+    field :error, String, null: true, description: "Raise an error"
+    def error
+      raise("This error was raised on purpose")
     end
 
-    field :error do
-      description "Raise an error"
-      type GraphQL::STRING_TYPE
-      resolve ->(t, a, c) { raise("This error was raised on purpose") }
+    field :execution_error, String, null: true
+    def execution_error
+      raise(GraphQL::ExecutionError, "There was an execution error")
     end
 
-    field :executionError do
-      type GraphQL::STRING_TYPE
-      resolve ->(t, a, c) { raise(GraphQL::ExecutionError, "There was an execution error") }
+    field :value_with_execution_error, Integer, null: false, extras: [:execution_errors]
+    def value_with_execution_error(execution_errors:)
+      execution_errors.add("Could not fetch latest value")
+      0
     end
 
-    field :valueWithExecutionError do
-      type !GraphQL::INT_TYPE
-      resolve ->(t, a, c) {
-        c.add_error(GraphQL::ExecutionError.new("Could not fetch latest value"))
-        return 0
-      }
+    field :multiple_errors_on_non_nullable_field, String, null: false
+    def multiple_errors_on_non_nullable_field
+      [
+        GraphQL::ExecutionError.new("This is an error message for some error."),
+        GraphQL::ExecutionError.new("This is another error message for a different error.")
+      ]
     end
 
-    field :multipleErrorsOnNonNullableField do
-      type !GraphQL::STRING_TYPE
-      resolve ->(t, a, c) {
-        [GraphQL::ExecutionError.new("This is an error message for some error."),
-         GraphQL::ExecutionError.new("This is another error message for a different error.")]
-      }
+    field :execution_error_with_options, Integer, null: true
+    def execution_error_with_options
+      GraphQL::ExecutionError.new("Permission Denied!", options: { "code" => "permission_denied" })
     end
 
-    field :executionErrorWithOptions do
-      type GraphQL::INT_TYPE
-      resolve ->(t, a, c) {
-        GraphQL::ExecutionError.new("Permission Denied!", options: { "code" => "permission_denied" })
-      }
-    end
-
-    field :executionErrorWithExtensions do
-      type GraphQL::INT_TYPE
-      resolve ->(t, a, c) {
-        GraphQL::ExecutionError.new("Permission Denied!", extensions: { "code" => "permission_denied" })
-      }
+    field :execution_error_with_extensions, Integer, null: true
+    def execution_error_with_extensions
+      GraphQL::ExecutionError.new("Permission Denied!", extensions: { "code" => "permission_denied" })
     end
 
     # To test possibly-null fields
-    field :maybeNull, MaybeNullType do
-      resolve ->(t, a, c) { OpenStruct.new(cheese: nil) }
+    field :maybe_null, MaybeNull, null: true
+    def maybe_null
+      OpenStruct.new(cheese: nil)
     end
 
-    field :tracingScalar, TracingScalarType do
-      resolve ->(o, a, c) do
-        OpenStruct.new(
-          traceNil: 2,
-          traceFalse: 3,
-          tracetrue: 5,
-        )
-      end
+    field :tracing_scalar, TracingScalar, null: true
+    def tracing_scalar
+      OpenStruct.new(
+        trace_nil: 2,
+        trace_false: 3,
+        trace_true: 5,
+      )
     end
 
-    field :deepNonNull, !DeepNonNullType do
-      resolve ->(o, a, c) { :deepNonNull }
-    end
+    field :deep_non_null, DeepNonNull, null: false
+    def deep_non_null; :deep_non_null; end
   end
 
   GLOBAL_VALUES = []
 
-  ReplaceValuesInputType = GraphQL::InputObjectType.define do
-    name "ReplaceValuesInput"
-    input_field :values, !types[!types.Int]
+  class ReplaceValuesInput < BaseInputObject
+    argument :values, [Integer], required: true
   end
 
-  PushValueField = GraphQL::Field.define do
-    name :pushValue
-    type !types[!types.Int]
-    description("Push a value onto a global array :D")
-    argument :value, !types.Int, as: :val
-    resolve ->(o, args, ctx) {
-      GLOBAL_VALUES << args.val
-      GLOBAL_VALUES
-    }
-  end
-
-  class DairyAppMutationType < GraphQL::Schema::Object
+  class DairyAppMutation < BaseObject
     graphql_name "Mutation"
     description "The root for mutations in this schema"
-    # Test the `field:` compatibility option
-    field :pushValue, field: PushValueField
+    field :push_value, [Integer], null: false, description: "Push a value onto a global array :D" do
+      argument :value, Integer, required: true, as: :val
+    end
+    def push_value(val:)
+      GLOBAL_VALUES << val
+      GLOBAL_VALUES
+    end
 
     field :replaceValues, [Integer], "Replace the global array with new values", null: false do
-      argument :input, ReplaceValuesInputType, required: true
+      argument :input, ReplaceValuesInput, required: true
     end
 
     def replace_values(input:)
@@ -459,19 +450,18 @@ module Dummy
     end
   end
 
-  SubscriptionType = GraphQL::ObjectType.define do
-    name "Subscription"
-    field :test, types.String do
-      resolve ->(o, a, c) { "Test" }
-    end
+  class Subscription < BaseObject
+    field :test, String, null: true
+    def test; "Test"; end
   end
 
   class Schema < GraphQL::Schema
-    query DairyAppQueryType
-    mutation DairyAppMutationType
-    subscription SubscriptionType
+    query DairyAppQuery
+    mutation DairyAppMutation
+    subscription Subscription
     max_depth 5
-    orphan_types [HoneyType, BeverageUnion]
+    # TODO why is `.graphql_definition` required here?
+    orphan_types Honey, Beverage.graphql_definition
 
     rescue_from(NoSuchDairyError) { |err| err.message  }
 


### PR DESCRIPTION
This is a tradeoff in gem maintenance: 

- CON: we greatly _reduce_ our test coverage for `.define`-based schemas 
- PRO: we greatly _improve_ our test coverage for class-based schemas 

I want to use this schema to test the new interpreter, since this schema is used for testing _lots_ of runtime features. Before I can run the new interpreter on it, it has to be class-based."

Lots of the test changes involve adding `.graphql_definition` everywhere. I hope to drop lots of those tests in graphql-ruby 2.0, when `.define` will be gone altogther.