### PR TITLE
Update how Schema::Field executes definition_block

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -186,7 +186,7 @@ module GraphQL
 
         if definition_block
           if definition_block.arity == 1
-            instance_exec(self, &definition_block)
+            yield self
           else
             instance_eval(&definition_block)
           end


### PR DESCRIPTION
Previously this used `instance_exec` which sets `self` to the field instance.

This changes to `yield` which still executes within the context of the field instance (supporting the same functionality) but doesn't change `self`.

This is probably more relevant to our specific use case. We have resolve procs which call class methods on object type classes. As we're migrating more to use the gem directly, this is a blocker for us.

The irony being that we added this code in the first place 😂 

Note: this is technically a breaking change, but I (highly?) doubt it will affect anyone.

1. it's a fairly new feature
2. the common usage is still supported (since it yields the field instance)
3. no one else would have our use case of class methods on object classes?


cc @RobertWSaunders 