### PR TITLE
add GraphQL::Types::ISO8601DateTime.time_precision to customize time pricisions

### DIFF
--- a/lib/graphql/types/iso_8601_date_time.rb
+++ b/lib/graphql/types/iso_8601_date_time.rb
@@ -15,10 +15,24 @@ module GraphQL
     class ISO8601DateTime < GraphQL::Schema::Scalar
       description "An ISO 8601-encoded datetime"
 
+      # It's not compatible with Rails' default,
+      # i.e. ActiveSupport::JSON::Encoder.time_precision (3 by default)
+      DEFAULT_TIME_PRECISION = 0
+
+      # @return [Integer]
+      def self.time_precision
+        @time_precision || DEFAULT_TIME_PRECISION
+      end
+
+      # @param [Integer] value
+      def self.time_precision=(value)
+        @time_precision = value
+      end
+
       # @param value [DateTime]
       # @return [String]
       def self.coerce_result(value, _ctx)
-        value.iso8601
+        value.iso8601(time_precision)
       end
 
       # @param str_value [String]

--- a/spec/graphql/types/iso_8601_date_time_spec.rb
+++ b/spec/graphql/types/iso_8601_date_time_spec.rb
@@ -90,6 +90,31 @@ describe GraphQL::Types::ISO8601DateTime do
       full_res = DateTimeTest::Schema.execute(query_str, variables: { date: date_str })
       assert_equal date_str, full_res["data"]["parseDate"]["iso8601"]
     end
+
+    describe "with time_precision = 3 (i.e. 'with milliseconds')" do
+      before do
+        @tp = GraphQL::Types::ISO8601DateTime.time_precision
+        GraphQL::Types::ISO8601DateTime.time_precision = 3
+      end
+
+      after do
+        GraphQL::Types::ISO8601DateTime.time_precision = @tp
+      end
+
+      it "returns a string" do
+        query_str = <<-GRAPHQL
+        query($date: ISO8601DateTime!){
+          parseDate(date: $date) {
+            iso8601
+          }
+        }
+        GRAPHQL
+
+        date_str = "2010-02-02T22:30:30.123-06:00"
+        full_res = DateTimeTest::Schema.execute(query_str, variables: { date: date_str })
+        assert_equal date_str, full_res["data"]["parseDate"]["iso8601"]
+      end
+    end
   end
 
   describe "structure" do


### PR DESCRIPTION
The result of `Time.zone.now.to_json` (Rails' datetime format)  differs from `GraphQL::Types::ISO8601`'s serialized one:

* Rails': `"2010-02-02T22:30:30.124-06:00"` (ISO8601 *with* miliseconds)
* GraphQL-Ruby's: `"2010-02-02T22:30:30-06:00"` (ISO8601 *without* milliseconds)

This incompatibility causes problems in my project :sob:, so I have monkey-patched to `GraphQL::Types::ISO8601` for now.

This PR provides a way to customize the precision of the serialized format just like [ActiveSupport::JSON::Encoding.time_precision](https://www.rubydoc.info/github/rails/rails/ActiveSupport/JSON/Encoding.time_precision).

Usage:

```ruby
# in a file, e.g. my_schema.rb
GraphQL::Types::ISO8601.time_precision = ActiveSupport::JSON::Encoding.time_precision
```

No breaking change is introduced by the PR.