### PR TITLE
Passthrough `null` values for arguments using `loads`

### DIFF
--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -139,10 +139,14 @@ module GraphQL
         args.each do |key, value|
           arg_defn = @arguments_by_keyword[key]
           if arg_defn
-            prepped_value = prepared_args[key] = load_argument(key, value)
-            if context.schema.lazy?(prepped_value)
-              prepare_lazies << context.schema.after_lazy(prepped_value) do |finished_prepped_value|
-                prepared_args[key] = finished_prepped_value
+            if value.nil?
+              prepared_args[key] = value
+            else
+              prepped_value = prepared_args[key] = load_argument(key, value)
+              if context.schema.lazy?(prepped_value)
+                prepare_lazies << context.schema.after_lazy(prepped_value) do |finished_prepped_value|
+                  prepared_args[key] = finished_prepped_value
+                end
               end
             end
           else

--- a/spec/graphql/schema/resolver_spec.rb
+++ b/spec/graphql/schema/resolver_spec.rb
@@ -271,6 +271,36 @@ describe GraphQL::Schema::Resolver do
       end
     end
 
+    class MutationWithNullableLoadsArgument < GraphQL::Schema::Mutation
+      argument :label_id, ID, required: false, loads: HasValue
+      argument :label_ids, [ID], required: false, loads: HasValue
+
+      field :inputs, String, null: false
+
+      def resolve(**inputs)
+        {
+          inputs: JSON.dump(inputs)
+        }
+      end
+    end
+
+    class MutationWithRequiredLoadsArgument < GraphQL::Schema::Mutation
+      argument :label_id, ID, required: true, loads: HasValue
+
+      field :inputs, String, null: false
+
+      def resolve(**inputs)
+        {
+          inputs: JSON.dump(inputs)
+        }
+      end
+    end
+
+    class Mutation < GraphQL::Schema::Object
+      field :mutation_with_nullable_loads_argument, mutation: MutationWithNullableLoadsArgument
+      field :mutation_with_required_loads_argument, mutation: MutationWithRequiredLoadsArgument
+    end
+
     class Query < GraphQL::Schema::Object
       class CustomField < GraphQL::Schema::Field
         def resolve_field(*args)
@@ -312,8 +342,17 @@ describe GraphQL::Schema::Resolver do
 
     class Schema < GraphQL::Schema
       query(Query)
+      mutation(Mutation)
       lazy_resolve LazyBlock, :value
       orphan_types IntegerWrapper
+
+      def object_from_id(id, ctx)
+        if id == "invalid"
+          nil
+        else
+          1
+        end
+      end
     end
   end
 
@@ -534,6 +573,41 @@ describe GraphQL::Schema::Resolver do
         # (10 + 8) * 3
         # (100 + 8) * 3
         assert_equal [27, 54, 324], res["data"]["prepResolver9Array"].map { |v| v["value"] }
+      end
+
+      it "preserves `nil` when nullable argument is provided `null`" do
+        res = exec_query("mutation { mutationWithNullableLoadsArgument(labelId: null) { inputs } }")
+
+        assert_equal nil, res["errors"]
+        assert_equal '{"label":null}', res["data"]["mutationWithNullableLoadsArgument"]["inputs"]
+      end
+
+      it "preserves `nil` when nullable list argument is provided `null`" do
+        res = exec_query("mutation { mutationWithNullableLoadsArgument(labelIds: null) { inputs } }")
+
+        assert_equal nil, res["errors"]
+        assert_equal '{"labels":null}', res["data"]["mutationWithNullableLoadsArgument"]["inputs"]
+      end
+
+      it "omits omitted nullable argument" do
+        res = exec_query("mutation { mutationWithNullableLoadsArgument { inputs } }")
+
+        assert_equal nil, res["errors"]
+        assert_equal "{}", res["data"]["mutationWithNullableLoadsArgument"]["inputs"]
+      end
+
+      it "returns an error when nullable argument is provided an invalid value" do
+        res = exec_query('mutation { mutationWithNullableLoadsArgument(labelId: "invalid") { inputs } }')
+
+        assert res["errors"]
+        assert_equal 'No object found for `labelId: "invalid"`', res["errors"][0]["message"]
+      end
+
+      it "returns an error when a non-nullable argument is provided an invalid value" do
+        res = exec_query('mutation { mutationWithRequiredLoadsArgument(labelId: "invalid") { inputs } }')
+
+        assert res["errors"]
+        assert_equal 'No object found for `labelId: "invalid"`', res["errors"][0]["message"]
       end
     end
   end


### PR DESCRIPTION
Fixes #1840 

If a nullable argument using `loads: ...` is provided a `null` value, we should passthrough the `nil` value to the resolver instead of trying to resolve it to an object.