### PR TITLE
Raise execution error when trying to decode an invalid cursor

### DIFF
--- a/lib/graphql/relay/base_connection.rb
+++ b/lib/graphql/relay/base_connection.rb
@@ -70,6 +70,8 @@ module GraphQL
 
       def decode(data)
         @encoder.decode(data, nonce: true)
+      rescue ArgumentError
+        raise GraphQL::ExecutionError, "Invalid cursor '#{data}'"
       end
 
       # The value passed as `first:`, if there was one. Negative numbers become `0`.

--- a/lib/graphql/relay/base_connection.rb
+++ b/lib/graphql/relay/base_connection.rb
@@ -71,7 +71,7 @@ module GraphQL
       def decode(data)
         @encoder.decode(data, nonce: true)
       rescue ArgumentError
-        raise GraphQL::ExecutionError, "Invalid cursor '#{data}'"
+        raise GraphQL::ExecutionError, "Invalid cursor: #{data.inspect}"
       end
 
       # The value passed as `first:`, if there was one. Negative numbers become `0`.

--- a/spec/integration/rails/graphql/relay/array_connection_spec.rb
+++ b/spec/integration/rails/graphql/relay/array_connection_spec.rb
@@ -286,5 +286,20 @@ describe GraphQL::Relay::ArrayConnection do
         assert_equal(first_second_and_third_names, get_names(result))
       end
     end
+
+    it "raises an execution error when an invalid 'after' cursor is given" do
+      res = star_wars_query(query_string, "after" => "0")
+      errors = res["errors"]
+      assert_equal 3, errors.size, "should have some query errors"
+      assert_equal ["Invalid cursor '0'"], errors.map { |error| error["message"] }.uniq
+    end
+
+    it "raises an execution error when an invalid 'before' cursor is given" do
+      res = star_wars_query(query_string, "before" => "something something")
+      errors = res["errors"]
+      assert_equal 3, errors.size, "should have some query errors"
+      assert_equal ["Invalid cursor 'something something'"],
+        errors.map { |error| error["message"] }.uniq
+    end
   end
 end

--- a/spec/integration/rails/graphql/relay/array_connection_spec.rb
+++ b/spec/integration/rails/graphql/relay/array_connection_spec.rb
@@ -286,20 +286,5 @@ describe GraphQL::Relay::ArrayConnection do
         assert_equal(first_second_and_third_names, get_names(result))
       end
     end
-
-    it "raises an execution error when an invalid 'after' cursor is given" do
-      res = star_wars_query(query_string, "after" => "0")
-      errors = res["errors"]
-      assert_equal 3, errors.size, "should have some query errors"
-      assert_equal ["Invalid cursor '0'"], errors.map { |error| error["message"] }.uniq
-    end
-
-    it "raises an execution error when an invalid 'before' cursor is given" do
-      res = star_wars_query(query_string, "before" => "something something")
-      errors = res["errors"]
-      assert_equal 3, errors.size, "should have some query errors"
-      assert_equal ["Invalid cursor 'something something'"],
-        errors.map { |error| error["message"] }.uniq
-    end
   end
 end

--- a/spec/integration/rails/graphql/relay/base_connection_spec.rb
+++ b/spec/integration/rails/graphql/relay/base_connection_spec.rb
@@ -89,5 +89,13 @@ describe GraphQL::Relay::BaseConnection do
 
       assert_equal "Person/1", conn.decode("UGVyc29uLzE")
     end
+
+    it "raises an execution error when an invalid cursor is given" do
+      conn = GraphQL::Relay::BaseConnection.new([], {}, context: nil)
+
+      assert_raises(GraphQL::ExecutionError) do
+        conn.decode("0")
+      end
+    end
   end
 end


### PR DESCRIPTION
A problem I hit recently is that I could run a query with an invalid cursor and instead of getting an error response back, I'd get an exception. This branch rescues that exception ("ArgumentError: invalid base64") and raises an ExecutionError, which results in a normal error response from GraphQL explaining that the caller provided a bad cursor.