### PR TITLE
Regression in `extras: [:path]`

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -8,6 +8,8 @@ module GraphQL
       include GraphQL::Schema::Member::HasArguments
       include GraphQL::Schema::Member::HasPath
 
+      CONTEXT_EXTRAS = [:path]
+
       # @return [String] the GraphQL name for this field, camelized unless `camelize: false` is provided
       attr_reader :name
       alias :graphql_name :name
@@ -407,7 +409,6 @@ module GraphQL
       end
 
       # @param ctx [GraphQL::Query::Context::FieldResolutionContext]
-      CONTEXT_EXTRAS = [:path]
       def fetch_extra(extra_name, ctx)
         if !CONTEXT_EXTRAS.include?(extra_name) && respond_to?(extra_name)
           self.public_send(extra_name)

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -407,8 +407,9 @@ module GraphQL
       end
 
       # @param ctx [GraphQL::Query::Context::FieldResolutionContext]
+      CONTEXT_EXTRAS = [:path]
       def fetch_extra(extra_name, ctx)
-        if respond_to?(extra_name)
+        if !CONTEXT_EXTRAS.include?(extra_name) && respond_to?(extra_name)
           self.public_send(extra_name)
         elsif ctx.respond_to?(extra_name)
           ctx.public_send(extra_name)

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -8,8 +8,6 @@ module GraphQL
       include GraphQL::Schema::Member::HasArguments
       include GraphQL::Schema::Member::HasPath
 
-      CONTEXT_EXTRAS = [:path]
-
       # @return [String] the GraphQL name for this field, camelized unless `camelize: false` is provided
       attr_reader :name
       alias :graphql_name :name
@@ -407,6 +405,8 @@ module GraphQL
           value
         end
       end
+
+      CONTEXT_EXTRAS = [:path]
 
       # @param ctx [GraphQL::Query::Context::FieldResolutionContext]
       def fetch_extra(extra_name, ctx)

--- a/spec/graphql/schema/resolver_spec.rb
+++ b/spec/graphql/schema/resolver_spec.rb
@@ -56,6 +56,15 @@ describe GraphQL::Schema::Resolver do
       end
     end
 
+    class ResolverWithPath < BaseResolver
+      type String, null: false
+
+      extras [:path]
+      def resolve(path:)
+        path.inspect
+      end
+    end
+
     class Resolver5 < Resolver4
     end
 
@@ -323,6 +332,7 @@ describe GraphQL::Schema::Resolver do
       field :resolver_6, resolver: Resolver6
       field :resolver_7, resolver: Resolver7
       field :resolver_8, resolver: Resolver8
+      field :resolver_with_path, resolver: ResolverWithPath
 
       field :prep_resolver_1, resolver: PrepResolver1
       field :prep_resolver_2, resolver: PrepResolver2
@@ -404,6 +414,11 @@ describe GraphQL::Schema::Resolver do
     it "gets extras" do
       res = exec_query " { resolver4 } ", root_value: OpenStruct.new(value: 0)
       assert_equal 9, res["data"]["resolver4"]
+    end
+
+    it "gets path from extras" do
+      res = exec_query " { resolverWithPath } ", root_value: OpenStruct.new(value: 0)
+      assert_equal '["resolverWithPath"]', res["data"]["resolverWithPath"]
     end
   end
 


### PR DESCRIPTION
It appears like a regression was introduced in #1808.

Given the following code:

```ruby
require 'graphql'

class Query < GraphQL::Schema::Object
  field :hello, String, null: true,
    extras: [:execution_errors, :path]

  def hello(execution_errors:, path:)
    p path
  end
end

class Schema < GraphQL::Schema
  query Query
end

Schema.execute('{ alias: hello }')
```

Previously, `path` would return `["alias"]`.

As of v1.8.9, it returns `"Query.hello"`.

It seems like the issue is that `path` is obtaining its value from the field's `path` instead of `context.path`. I'm not sure if this is the most elegant way of fixing this so please let me know if you think there is a better way.