### PR TITLE
read context values using dig

### DIFF
--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -154,7 +154,7 @@ module GraphQL
       # @api private
       attr_writer :value
 
-      def_delegators :@provided_values, :[], :[]=, :to_h, :key?, :fetch
+      def_delegators :@provided_values, :[], :[]=, :to_h, :key?, :fetch, :dig
       def_delegators :@query, :trace
 
       # @!method [](key)
@@ -220,7 +220,7 @@ module GraphQL
         end
 
         def_delegators :@context,
-          :[], :[]=, :key?, :fetch, :to_h, :namespace,
+          :[], :[]=, :key?, :fetch, :to_h, :namespace, :dig,
           :spawn, :warden, :errors,
           :execution_strategy, :strategy
 

--- a/spec/graphql/query/context_spec.rb
+++ b/spec/graphql/query/context_spec.rb
@@ -217,6 +217,24 @@ TABLE
     end
   end
 
+  describe "read values" do
+    let(:context) { GraphQL::Query::Context.new(query: OpenStruct.new(schema: schema), values: {a: {b: 1}}, object: nil) }
+
+    it "allows you to read values of contexts using []" do
+      assert_equal({b: 1}, context[:a])
+    end
+
+    it "allows you to read values of contexts using dig" do
+      if RUBY_VERSION >= '2.3.0'
+        assert_equal(1, context.dig(:a, :b))
+      else
+        assert_raises NoMethodError do
+          context.dig(:a, :b)
+        end
+      end
+    end
+  end
+
   describe "accessing context after the fact" do
     let(:query_string) { %|
       { pushContext }


### PR DESCRIPTION
# Why
It's sometimes useful to use `dig` to fetch deeply nested context values 

https://ruby-doc.org/core-2.3.0_preview1/Hash.html#method-i-dig

# What 

delegate `dig` to `@provided_values`