### PR TITLE
Document import of PusherLink for Apollo

### DIFF
--- a/guides/javascript_client/apollo_subscriptions.md
+++ b/guides/javascript_client/apollo_subscriptions.md
@@ -37,6 +37,10 @@ import { ApolloLink } from 'apollo-link';
 import { ApolloClient } from 'apollo-client';
 import { HttpLink } from 'apollo-link-http';
 import { InMemoryCache } from 'apollo-cache-inmemory';
+
+// Load PusherLink from graphql-ruby-client
+import PusherLink from 'graphql-ruby-client/subscriptions/PusherLink';
+
 // Load Pusher and create a client
 import Pusher from "pusher-js"
 var pusherClient = new Pusher("your-app-key", { cluster: "us2" })


### PR DESCRIPTION
The current documentation did not indicate where PusherLink comes from (i.e. not clear if it is part of `apollo` or part of `graphql-ruby-client`. This documents that it is part of `graphql-ruby-client` (and the path for import).