### PR TITLE
Loader support for argument default values that are lists of input objects

### DIFF
--- a/spec/graphql/schema/loader_spec.rb
+++ b/spec/graphql/schema/loader_spec.rb
@@ -103,6 +103,7 @@ describe GraphQL::Schema::Loader do
         argument :id, !types.ID
         argument :varied, variant_input_type, default_value: { id: "123", int: 234, float: 2.3, enum: :foo, sub: [{ string: "str" }] }
         argument :variedWithNull, variant_input_type_with_nulls, default_value: { id: nil, int: nil, float: nil, enum: nil, sub: nil, bigint: nil, bool: nil }
+        argument :variedArray, types[variant_input_type], default_value: [{ id: "123", int: 234, float: 2.3, enum: :foo, sub: [{ string: "str" }] }]
         argument :enum, choice_type, default_value: :foo
         argument :array, types[!types.String], default_value: ["foo", "bar"]
       end
@@ -228,6 +229,10 @@ describe GraphQL::Schema::Loader do
       varied = field.arguments['varied']
       assert_equal varied.default_value, { 'id' => "123", 'int' => 234, 'float' => 2.3, 'enum' => "FOO", 'sub' => [{ 'string' => "str" }] }
       assert !varied.default_value.key?('bool'), 'Omits default value for unspecified arguments'
+
+      variedArray = field.arguments['variedArray']
+      assert_equal variedArray.default_value, [{ 'id' => "123", 'int' => 234, 'float' => 2.3, 'enum' => "FOO", 'sub' => [{ 'string' => "str" }] }]
+      assert !variedArray.default_value.first.key?('bool'), 'Omits default value for unspecified arguments'
 
       array = field.arguments['array']
       assert_equal array.default_value, ["foo", "bar"]


### PR DESCRIPTION
Attempts to load schemas with argument default values that are lists of input objects failed with following exception:

```
/Users/jturkel/.rvm/gems/ruby-2.4.3/gems/graphql-1.8.10/lib/graphql/schema/traversal.rb:219:in `validate_type': Query is invalid: field "inventory" argument "ordering" default value [#<GraphQL::Language::Nodes::InputObject:0x00007fa3510db460 @line=1, @col=34, @filename=nil, @arguments=[#<GraphQL::Language::Nodes::Argument:0x00007fa3510dbc80 @line=1, @col=35, @filename=nil, @name="asc", @value="supplierPartNumber">]>] is not valid for type [orderingInput] (undefined method `reduce' for #<GraphQL::Language::Nodes::InputObject:0x00007fa3510db460>) (GraphQL::Schema::InvalidTypeError)
	from /Users/jturkel/.rvm/gems/ruby-2.4.3/gems/graphql-1.8.10/lib/graphql/schema/traversal.rb:138:in `visit'
	from /Users/jturkel/.rvm/gems/ruby-2.4.3/gems/graphql-1.8.10/lib/graphql/schema/traversal.rb:124:in `block in visit'
	from /Users/jturkel/.rvm/gems/ruby-2.4.3/gems/graphql-1.8.10/lib/graphql/schema/traversal.rb:124:in `each'
	from /Users/jturkel/.rvm/gems/ruby-2.4.3/gems/graphql-1.8.10/lib/graphql/schema/traversal.rb:124:in `visit'
	from /Users/jturkel/.rvm/gems/ruby-2.4.3/gems/graphql-1.8.10/lib/graphql/schema/traversal.rb:43:in `initialize'
	from /Users/jturkel/.rvm/gems/ruby-2.4.3/gems/graphql-1.8.10/lib/graphql/schema.rb:1059:in `new'
	from /Users/jturkel/.rvm/gems/ruby-2.4.3/gems/graphql-1.8.10/lib/graphql/schema.rb:1059:in `rebuild_artifacts'
	from /Users/jturkel/.rvm/gems/ruby-2.4.3/gems/graphql-1.8.10/lib/graphql/schema.rb:272:in `types'
	from /Users/jturkel/.rvm/gems/ruby-2.4.3/gems/graphql-1.8.10/lib/graphql/schema/validation.rb:134:in `block in <module:Rules>'
	from /Users/jturkel/.rvm/gems/ruby-2.4.3/gems/graphql-1.8.10/lib/graphql/schema/validation.rb:19:in `block in validate'
	from /Users/jturkel/.rvm/gems/ruby-2.4.3/gems/graphql-1.8.10/lib/graphql/schema/validation.rb:19:in `each'
	from /Users/jturkel/.rvm/gems/ruby-2.4.3/gems/graphql-1.8.10/lib/graphql/schema/validation.rb:19:in `reduce'
	from /Users/jturkel/.rvm/gems/ruby-2.4.3/gems/graphql-1.8.10/lib/graphql/schema/validation.rb:19:in `validate'
	from /Users/jturkel/.rvm/gems/ruby-2.4.3/gems/graphql-1.8.10/lib/graphql/schema.rb:233:in `define'
	from /Users/jturkel/.rvm/gems/ruby-2.4.3/gems/graphql-1.8.10/lib/graphql/define/instance_definable.rb:228:in `define'
	from /Users/jturkel/.rvm/gems/ruby-2.4.3/gems/graphql-1.8.10/lib/graphql/schema/loader.rb:33:in `load'
	from /Users/jturkel/.rvm/gems/ruby-2.4.3/gems/graphql-client-0.13.0/lib/graphql/client.rb:52:in `load_schema'
	from /Users/jturkel/.rvm/gems/ruby-2.4.3/gems/graphql-client-0.13.0/lib/graphql/client.rb:61:in `load_schema'
```
The problem was the loader set the default values to AST nodes rather than the extracted literal values.