### PR TITLE
Low hanging fruit in interpreter 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -92,6 +92,12 @@ namespace :bench do
     prepare_benchmark
     GraphQLBenchmark.profile
   end
+
+  desc "Run benchmarks on a very large result"
+  task :profile_large_result do
+    prepare_benchmark
+    GraphQLBenchmark.profile_large_result
+  end
 end
 
 namespace :test do

--- a/benchmark/run.rb
+++ b/benchmark/run.rb
@@ -63,12 +63,18 @@ module GraphQLBenchmark
     end
 
     result = RubyProf.profile do
-      schema.execute( document: document)
+      schema.execute(document: document)
     end
     printer = RubyProf::FlatPrinter.new(result)
     # printer = RubyProf::GraphHtmlPrinter.new(result)
     # printer = RubyProf::FlatPrinterWithLineNumbers.new(result)
     printer.print(STDOUT, {})
+
+    report = MemoryProfiler.report do
+      schema.execute(document: document)
+    end
+
+    report.pretty_print
   end
 
   module ProfileLargeResult

--- a/benchmark/run.rb
+++ b/benchmark/run.rb
@@ -51,4 +51,86 @@ module GraphQLBenchmark
 
     printer.print(STDOUT, {})
   end
+
+  # Adapted from https://github.com/rmosolgo/graphql-ruby/issues/861
+  def self.profile_large_result
+    schema = ProfileLargeResult::Schema
+    document = ProfileLargeResult::ALL_FIELDS
+    Benchmark.ips do |x|
+      x.report("Querying for #{ProfileLargeResult::DATA.size} objects") {
+        schema.execute(document: document)
+      }
+    end
+
+    result = RubyProf.profile do
+      schema.execute( document: document)
+    end
+    printer = RubyProf::FlatPrinter.new(result)
+    # printer = RubyProf::GraphHtmlPrinter.new(result)
+    # printer = RubyProf::FlatPrinterWithLineNumbers.new(result)
+    printer.print(STDOUT, {})
+  end
+
+  module ProfileLargeResult
+    DATA = 1000.times.map {
+      {
+        id:             SecureRandom.uuid,
+        int1:           SecureRandom.random_number(100000),
+        int2:           SecureRandom.random_number(100000),
+        string1:        SecureRandom.base64,
+        string2:        SecureRandom.base64,
+        boolean1:       SecureRandom.random_number(1) == 0,
+        boolean2:       SecureRandom.random_number(1) == 0,
+        int_array:      10.times.map { SecureRandom.random_number(100000) },
+        string_array:   10.times.map { SecureRandom.base64 },
+        boolean_array:  10.times.map { SecureRandom.random_number(1) == 0 },
+      }
+    }
+
+
+    class FooType < GraphQL::Schema::Object
+      field :id, ID, null: false
+      field :int1, Integer, null: false
+      field :int2, Integer, null: false
+      field :string1, String, null: false
+      field :string2, String, null: false
+      field :boolean1, Boolean, null: false
+      field :boolean2, Boolean, null: false
+      field :string_array, [String], null: false
+      field :int_array, [Integer], null: false
+      field :boolean_array, [Boolean], null: false
+    end
+
+    class QueryType < GraphQL::Schema::Object
+      description "Query root of the system"
+      field :foos, [FooType], null: false, description: "Return a list of Foo objects"
+      def foos
+        DATA
+      end
+    end
+
+    class Schema < GraphQL::Schema
+      query QueryType
+      if TESTING_INTERPRETER
+        use GraphQL::Execution::Interpreter
+      end
+    end
+
+    ALL_FIELDS = GraphQL.parse <<-GRAPHQL
+      {
+        foos {
+          id
+          int1
+          int2
+          string1
+          string2
+          boolean1
+          boolean2
+          stringArray
+          intArray
+          booleanArray
+        }
+      }
+    GRAPHQL
+  end
 end

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -311,8 +311,9 @@ module GraphQL
 
         def arguments(graphql_object, arg_owner, ast_node)
           kwarg_arguments = {}
+          arg_defns = arg_owner.arguments
           ast_node.arguments.each do |arg|
-            arg_defn = arg_owner.arguments[arg.name]
+            arg_defn = arg_defns[arg.name]
             # Need to distinguish between client-provided `nil`
             # and nothing-at-all
             is_present, value = arg_to_value(graphql_object, arg_defn.type, arg.value)
@@ -325,7 +326,7 @@ module GraphQL
               kwarg_arguments[arg_defn.keyword] = value
             end
           end
-          arg_owner.arguments.each do |name, arg_defn|
+          arg_defns.each do |name, arg_defn|
             if arg_defn.default_value? && !kwarg_arguments.key?(arg_defn.keyword)
               kwarg_arguments[arg_defn.keyword] = arg_defn.default_value
             end

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -195,11 +195,11 @@ module GraphQL
         def continue_field(path, value, field, type, ast_node, next_selections)
           type = resolve_if_late_bound_type(type)
 
-          case type.kind
-          when TypeKinds::SCALAR, TypeKinds::ENUM
+          case type.kind.name
+          when "SCALAR", "ENUM"
             r = type.coerce_result(value, context)
             write_in_response(path, r)
-          when TypeKinds::UNION, TypeKinds::INTERFACE
+          when "UNION", "INTERFACE"
             resolved_type = query.resolve_type(type, value)
             possible_types = query.possible_types(type)
 
@@ -212,7 +212,7 @@ module GraphQL
               resolved_type = resolved_type.metadata[:type_class]
               continue_field(path, value, field, resolved_type, ast_node, next_selections)
             end
-          when TypeKinds::OBJECT
+          when "OBJECT"
             object_proxy = begin
               type.authorized_new(value, context)
             rescue GraphQL::ExecutionError => err
@@ -225,10 +225,10 @@ module GraphQL
                 evaluate_selections(path, continue_value, type, next_selections)
               end
             end
-          when TypeKinds::LIST
+          when "LIST"
             write_in_response(path, [])
             inner_type = type.of_type
-            value.each_with_index.each do |inner_value, idx|
+            value.each_with_index do |inner_value, idx|
               next_path = [*path, idx].freeze
               set_type_at_path(next_path, inner_type)
               after_lazy(inner_value, path: next_path, field: field) do |inner_inner_value|
@@ -238,7 +238,7 @@ module GraphQL
                 end
               end
             end
-          when TypeKinds::NON_NULL
+          when "NON_NULL"
             inner_type = type.of_type
             # Don't `set_type_at_path` because we want the static type,
             # we're going to use that to determine whether a `nil` should be propagated or not.

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -94,7 +94,7 @@ module GraphQL
           selections_by_name.each do |result_name, fields|
             ast_node = fields.first
             field_name = ast_node.name
-            field_defn = owner_type.fields[field_name]
+            field_defn = owner_type.get_field(field_name)
             is_introspection = false
             if field_defn.nil?
               field_defn = if owner_type == schema.query.metadata[:type_class] && (entry_point_field = schema.introspection_system.entry_point(name: field_name))

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -90,7 +90,6 @@ module GraphQL
 
         def evaluate_selections(path, owner_object, owner_type, selections, root_operation_type: nil)
           selections_by_name = {}
-          owner_type = resolve_if_late_bound_type(owner_type)
           gather_selections(owner_type, selections, selections_by_name)
           selections_by_name.each do |result_name, fields|
             ast_node = fields.first

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -110,7 +110,10 @@ module GraphQL
 
             return_type = resolve_if_late_bound_type(field_defn.type)
 
-            next_path = [*path, result_name].freeze
+            next_path = path.dup
+            next_path << result_name
+            next_path.freeze
+
             # This seems janky, but we need to know
             # the field's return type at this path in order
             # to propagate `null`
@@ -227,7 +230,9 @@ module GraphQL
             inner_type = type.of_type
             idx = 0
             value.each do |inner_value|
-              next_path = [*path, idx].freeze
+              next_path = path.dup
+              next_path << idx
+              next_path.freeze
               set_type_at_path(next_path, inner_type)
               after_lazy(inner_value, path: next_path, field: field) do |inner_inner_value|
                 should_continue, continue_value = continue_value(next_path, inner_inner_value, field, inner_type, ast_node)

--- a/lib/graphql/schema/member/has_arguments.rb
+++ b/lib/graphql/schema/member/has_arguments.rb
@@ -29,9 +29,13 @@ module GraphQL
 
         # @return [Hash<String => GraphQL::Schema::Argument] Arguments defined on this thing, keyed by name. Includes inherited definitions
         def arguments
-          inherited_arguments = ((self.is_a?(Class) && superclass.respond_to?(:arguments)) ? superclass.arguments : {})
+          inherited_arguments = ((self.is_a?(Class) && superclass.respond_to?(:arguments)) ? superclass.arguments : nil)
           # Local definitions override inherited ones
-          inherited_arguments.merge(own_arguments)
+          if inherited_arguments
+            inherited_arguments.merge(own_arguments)
+          else
+            own_arguments
+          end
         end
 
         # @param new_arg_class [Class] A class to use for building argument definitions

--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -66,6 +66,15 @@ module GraphQL
           all_fields
         end
 
+        def get_field(field_name)
+          for ancestor in ancestors
+            if ancestor.respond_to?(:own_fields) && f = ancestor.own_fields[field_name]
+              return f
+            end
+          end
+          nil
+        end
+
         # Register this field with the class, overriding a previous one if needed.
         # Also, add a parent method for resolving this field.
         # @param field_defn [GraphQL::Schema::Field]
@@ -123,7 +132,7 @@ ERR
           end
           default_resolve_module.module_eval <<-RUBY, __FILE__, __LINE__ + 1
             def #{method_name}(**args)
-              field_inst = self.class.fields[#{field_key}] || raise(%|Failed to find field #{field_key} for \#{self.class} among \#{self.class.fields.keys}|)
+              field_inst = self.class.get_field(#{field_key}) || raise(%|Failed to find field #{field_key} for \#{self.class} among \#{self.class.fields.keys}|)
               field_inst.resolve_field_method(self, args, context)
             end
           RUBY


### PR DESCRIPTION
I don't want to fuss over this too much, because the application benchmarks might be different from isolated ones, but I thought I'd look for low-hanging fruit now. 

I added a benchmark based on #861, here's the initial result: 


```
Warming up --------------------------------------
Querying for 1000 objects
                         1.000  i/100ms
Calculating -------------------------------------
Querying for 1000 objects
                          1.704  (± 0.0%) i/s -      9.000  in   5.286738s
```

<details>
<summary>Method calls</summary>
<pre>
Measure Mode: wall_time
Thread ID: 70366903138220
Fiber ID: 70366933287300
Total: 2.387865
Sort by: self_time

 %self      total      self      wait     child     calls  name
  4.53      0.108     0.108     0.000     0.000   528057   Kernel#is_a?
    called from:
      GraphQL::Query#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=76)
      GraphQL::BaseType#== (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/base_type.rb&line=75)
      GraphQL::Language::Visitor#on_node_with_modifications (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb&line=144)
      GraphQL::Query#arguments_for (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=216)
      GraphQL::Execution::Interpreter::Runtime#resolve_if_late_bound_type (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=266)
      GraphQL::Schema::Member::HasArguments#arguments (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb&line=31)
      GraphQL::Execution::Interpreter::Runtime#continue_value (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=157)
      GraphQL::Execution::Interpreter::Runtime#write_in_response (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=389)
      GraphQL::Schema::Field#resolve_field_method (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb&line=476)
      <Class::GraphQL::Types::ID>#coerce_result (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/types/id.rb&line=8)

  3.87      0.197     0.092     0.000     0.105    20001   Array#reverse_each
    called from:
      GraphQL::Schema::Member::HasFields#fields (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=58)

  3.78      0.134     0.090     0.000     0.043   347013   Kernel#===
    called from:
      GraphQL::Execution::Interpreter::Runtime#continue_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=196)

  3.23      0.500     0.077     0.000     0.423    41001   GraphQL::Execution::Interpreter::Runtime#write_in_response
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=389
    called from:
      GraphQL::Execution::Interpreter::Runtime#continue_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=196)
      GraphQL::Execution::Interpreter::Runtime#after_lazy (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=279)

  3.06      0.112     0.073     0.000     0.039    42001   GraphQL::Execution::Interpreter::Runtime#continue_value
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=157
    called from:
      GraphQL::Execution::Interpreter::Runtime#after_lazy (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=279)

  2.48      0.082     0.059     0.000     0.022    93004   GraphQL::Execution::Interpreter::Runtime#resolve_if_late_bound_type
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=266
    called from:
      GraphQL::Execution::Interpreter::Runtime#evaluate_selections (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=91)
      GraphQL::Execution::Interpreter::Runtime#continue_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=196)

  2.15      0.051     0.051     0.000     0.000    40002   Hash#merge!

  1.96      0.055     0.047     0.000     0.008   117015   Hash#fetch
    called from:
      GraphQL::Schema#references_to (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=291)
      Concurrent::Collection::NonConcurrentMapBackend#compute_if_absent (txmt://open?url=file:///Users/rmosolgo/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/concurrent-ruby-1.0.5/lib/concurrent/collection/map/non_concurrent_map_backend.rb&line=27)

  1.81      0.043     0.043     0.000     0.000   265011   BasicObject#==

  1.79      0.052     0.043     0.000     0.009    46003   Concurrent::Collection::NonConcurrentMapBackend#[]
    defined at:
      txmt://open?url=file:///Users/rmosolgo/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/concurrent-ruby-1.0.5/lib/concurrent/collection/map/non_concurrent_map_backend.rb&line=19
    called from:
      Concurrent::Collection::MriMapBackend#compute_if_absent (txmt://open?url=file:///Users/rmosolgo/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/concurrent-ruby-1.0.5/lib/concurrent/collection/map/mri_map_backend.rb&line=21)

  1.67      0.310     0.040     0.000     0.270    41001   GraphQL::Execution::Interpreter::HashResponse#write
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/hash_response.rb&line=23
    called from:
      GraphQL::Execution::Interpreter::Runtime#write_in_response (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=389)

  1.60      0.038     0.038     0.000     0.000   203142   Kernel#respond_to?
    called from:
      GraphQL::Query#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=76)
      <Class::GraphQL::Schema>#call_on_type_class (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=971)
      GraphQL::Analysis::ReducerState#initialize_reducer (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/reducer_state.rb&line=39)
      Set#do_with_enum (txmt://open?url=file:///Users/rmosolgo/.rbenv/versions/2.4.2/lib/ruby/2.4.0/set.rb&line=112)
      GraphQL::Analysis::ReducerState#finalize_reducer (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/reducer_state.rb&line=24)
      GraphQL::Schema::Field::ScopeExtension#after_resolve (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field/scope_extension.rb&line=7)

  1.57      0.105     0.037     0.000     0.068    46003   Thread::Mutex#synchronize
    called from:
      Concurrent::Collection::MriMapBackend#compute_if_absent (txmt://open?url=file:///Users/rmosolgo/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/concurrent-ruby-1.0.5/lib/concurrent/collection/map/mri_map_backend.rb&line=21)

  1.56      0.195     0.037     0.000     0.157    46003   Concurrent::Collection::MriMapBackend#compute_if_absent
    defined at:
      txmt://open?url=file:///Users/rmosolgo/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/concurrent-ruby-1.0.5/lib/concurrent/collection/map/mri_map_backend.rb&line=21
    called from:
      GraphQL::Execution::Lazy::LazyMethodMap#get (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/lazy/lazy_method_map.rb&line=35)

  1.54      0.037     0.037     0.000     0.000   204062   Kernel#nil?
    called from:
      GraphQL::Query#prepare_ast (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=287)
      GraphQL::StaticValidation::FieldsWillMerge#conflicts_within_selection_set (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb&line=34)
      GraphQL::StaticValidation::FieldsHaveAppropriateSelections#validate_field_selections (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb&line=25)
      GraphQL::StaticValidation::BaseVisitor::ContextMethods#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb&line=78)
      GraphQL::InternalRepresentation::Rewrite#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=120)
      GraphQL::StaticValidation::FieldsAreDefinedOnType#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb&line=5)
      <Class::GraphQL::Execution::Multiplex>#begin_query (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=104)
      GraphQL::Execution::Interpreter::Runtime#continue_value (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=157)
      GraphQL::Execution::Interpreter::Runtime#write_in_response (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=389)

  1.36      0.237     0.033     0.000     0.205    46003   GraphQL::Execution::Lazy::LazyMethodMap#get
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/lazy/lazy_method_map.rb&line=35
    called from:
      GraphQL::Schema#lazy_method_name (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=609)

  1.33      0.158     0.032     0.000     0.126    41001   GraphQL::Execution::Interpreter::Runtime#set_type_at_path
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=429

  1.29      0.068     0.031     0.000     0.037    46003   Concurrent::Collection::NonConcurrentMapBackend#compute_if_absent
    defined at:
      txmt://open?url=file:///Users/rmosolgo/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/concurrent-ruby-1.0.5/lib/concurrent/collection/map/non_concurrent_map_backend.rb&line=27

  1.23      0.080     0.029     0.000     0.050    41001   GraphQL::Execution::Interpreter::Runtime#dead_path?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=455
    called from:
      GraphQL::Execution::Interpreter::Runtime#write_in_response (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=389)

  1.20      0.047     0.029     0.000     0.019    51056   Enumerable#none?
    called from:
      <Class::GraphQL::StaticValidation::BaseVisitor>#including_rules (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb&line=31)
      GraphQL::Language::Visitor#on_abstract_node (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb&line=80)
      GraphQL::StaticValidation::FieldsHaveAppropriateSelections#validate_field_selections (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb&line=25)
      GraphQL::InternalRepresentation::Rewrite#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=120)
      GraphQL::Query::ValidationPipeline#ensure_has_validated (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb&line=58)
      GraphQL::Query#valid? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=227)
      GraphQL::Query#arguments_for (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=216)
      GraphQL::Schema::Field#with_extensions (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb&line=557)
      GraphQL::Execution::Interpreter::HashResponse#write (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/hash_response.rb&line=23)

  1.06      0.080     0.025     0.000     0.054    40002  *<Class::GraphQL::Schema::Object>#interfaces
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb&line=90
    called from:
      <Class::GraphQL::Schema::Object>#fields (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb&line=99)
      <Class::GraphQL::Schema::Object>#interfaces (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb&line=90)

  1.01      0.285     0.024     0.000     0.261    46003   GraphQL::Schema#lazy?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=614
    called from:
      GraphQL::Schema#after_lazy (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=1010)
      GraphQL::Execution::Interpreter::Runtime#after_lazy (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=279)

  1.01      0.261     0.024     0.000     0.237    46003   GraphQL::Schema#lazy_method_name
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=609
    called from:
      GraphQL::Schema#lazy? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=614)

  1.01      0.341     0.024     0.000     0.317    20001   <Class::GraphQL::Schema::Object>#fields
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb&line=99
    called from:
      #<Module:0x00007fff25dff3a0>#id (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#int1 (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#int2 (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#string1 (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#string2 (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#boolean1 (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#boolean2 (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#string_array (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#int_array (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#boolean_array (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)

  0.86      0.301     0.020     0.000     0.281    10001   GraphQL::Schema::Field#with_extensions
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb&line=557
    called from:
      GraphQL::Schema::Field#resolve (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb&line=430)

  0.85      0.062     0.020     0.000     0.041    20002   GraphQL::Schema::Member::HasArguments#arguments
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb&line=31
    called from:
      GraphQL::Execution::Interpreter::Runtime#arguments (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=306)
      GraphQL::Schema::Field#authorized? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb&line=392)

  0.83      0.233     0.020     0.000     0.213    20001   GraphQL::Schema::Member::HasFields#fields
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=58
    called from:
      <Class::GraphQL::Schema::Object>#fields (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb&line=99)

  0.74      0.029     0.018     0.000     0.012    20002   Hash#merge
    called from:
      GraphQL::Schema::Member::HasArguments#arguments (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb&line=31)

  0.74      0.018     0.018     0.000     0.000    92178   Kernel#hash
    called from:
      GraphQL::StaticValidation::VariablesAreUsedAndDefined#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb&line=33)
      GraphQL::StaticValidation::DefinitionDependencies#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=44)
      GraphQL::Schema::Warden#get_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=66)
      GraphQL::Schema::Warden#visible? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=176)
      Set#include? (txmt://open?url=file:///Users/rmosolgo/.rbenv/versions/2.4.2/lib/ruby/2.4.0/set.rb&line=232)
      GraphQL::StaticValidation::VariablesAreUsedAndDefined#follow_spreads (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb&line=94)
      GraphQL::Schema::Warden#possible_types (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=83)
      Set#add (txmt://open?url=file:///Users/rmosolgo/.rbenv/versions/2.4.2/lib/ruby/2.4.0/set.rb&line=330)
      GraphQL::Query#arguments_for (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=216)
      Concurrent::Collection::NonConcurrentMapBackend#[] (txmt://open?url=file:///Users/rmosolgo/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/concurrent-ruby-1.0.5/lib/concurrent/collection/map/non_concurrent_map_backend.rb&line=19)

  0.67      0.016     0.016     0.000     0.000    40002   GraphQL::Schema::Member::HasFields#own_fields
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=105

  0.67      0.016     0.016     0.000     0.000    20001   Module#ancestors
    called from:
      GraphQL::Schema::Member::HasFields#fields (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=58)

  0.64      0.015     0.015     0.000     0.000    82011   NilClass#nil?
    called from:
      GraphQL::Query#find_operation (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=277)
      GraphQL::Query#prepare_ast (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=287)
      Set#initialize (txmt://open?url=file:///Users/rmosolgo/.rbenv/versions/2.4.2/lib/ruby/2.4.0/set.rb&line=83)
      GraphQL::Execution::Interpreter#sync_lazies (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb&line=73)

  0.63      0.015     0.015     0.000     0.000    40002   <Class::GraphQL::Schema::Object>#own_interfaces
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb&line=94
    called from:
      <Class::GraphQL::Schema::Object>#interfaces (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb&line=90)

  0.61      0.374     0.015     0.000     0.359    10001   GraphQL::Schema::Field#resolve
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb&line=430
    called from:
      GraphQL::Tracing::Traceable#call_tracers (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing.rb&line=74)

  0.59      0.052     0.014     0.000     0.038    10001   GraphQL::Execution::Interpreter::Runtime#arguments
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=306

  0.53      0.018     0.013     0.000     0.006    10000   GraphQL::Schema::Field#resolve_field_method
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb&line=476
    called from:
      #<Module:0x00007fff25dff3a0>#id (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#int1 (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#int2 (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#string1 (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#string2 (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#boolean1 (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#boolean2 (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#string_array (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#int_array (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#boolean_array (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)

  0.51      0.012     0.012     0.000     0.000    37000   <Class::GraphQL::Schema::Scalar>#kind
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/scalar.rb&line=30
    called from:
      GraphQL::Execution::Interpreter::Runtime#continue_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=196)

  0.51      0.012     0.012     0.000     0.000    41001   GraphQL::Schema::NonNull#kind
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/non_null.rb&line=14
    called from:
      GraphQL::Execution::Interpreter::Runtime#continue_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=196)

  0.50      0.012     0.012     0.000     0.000    56050   Kernel#class
    called from:
      GraphQL::Filter#merge (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb&line=16)
      Set#merge (txmt://open?url=file:///Users/rmosolgo/.rbenv/versions/2.4.2/lib/ruby/2.4.0/set.rb&line=405)
      Set#& (txmt://open?url=file:///Users/rmosolgo/.rbenv/versions/2.4.2/lib/ruby/2.4.0/set.rb&line=439)
      <Module::GraphQL::Authorization::Analyzer>#call (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/authorization.rb&line=33)
      GraphQL::Execution::Lazy::LazyMethodMap#get (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/lazy/lazy_method_map.rb&line=35)
      #<Module:0x00007fff25dff3a0>#id (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#int1 (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#int2 (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#string1 (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#string2 (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#boolean1 (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#boolean2 (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#string_array (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#int_array (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)
      #<Module:0x00007fff25dff3a0>#boolean_array (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125)

  0.48      0.026     0.011     0.000     0.015    12000   <Class::GraphQL::Types::String>#coerce_result
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb&line=8
    called from:
      GraphQL::Execution::Interpreter::Runtime#continue_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=196)

  0.47      0.011     0.011     0.000     0.000    60003   Class#superclass
    called from:
      <Class::GraphQL::Schema::Object>#interfaces (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb&line=90)

  0.46      0.058     0.011     0.000     0.047    10001   GraphQL::Schema::Field#authorized?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb&line=392
    called from:
      GraphQL::Schema::Field#resolve (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb&line=430)

  0.42      0.010     0.010     0.000     0.000    41001   Kernel#freeze

  0.41      0.215     0.010     0.000     0.205    10053  *Kernel#public_send
    called from:
      GraphQL::Language::Visitor#visit_node (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb&line=135)
      <Class::GraphQL::Schema>#call_on_type_class (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=971)
      GraphQL::Schema::Field#with_extensions (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb&line=557)

  0.38      0.009     0.009     0.000     0.000    12000   String#encode
    called from:
      <Class::GraphQL::Types::String>#coerce_result (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb&line=8)

  0.38      0.009     0.009     0.000     0.000    20002   Hash#each_value
    called from:
      GraphQL::Schema::Field#authorized? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb&line=392)

  0.36      0.009     0.009     0.000     0.000    40000   Array#fetch

  0.36      0.009     0.009     0.000     0.000    40002   Module#<=
    called from:
      <Class::GraphQL::Schema::Object>#interfaces (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb&line=90)

  0.31      0.012     0.007     0.000     0.004    20048  *Kernel#initialize_dup

  0.30      0.007     0.007     0.000     0.000    20002   GraphQL::Schema::Member::HasArguments#own_arguments
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb&line=52
    called from:
      GraphQL::Schema::Member::HasArguments#arguments (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb&line=31)

  0.30      0.017     0.007     0.000     0.010    13002   Enumerable#all?
    called from:
      GraphQL::Schema::Field#authorized? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb&line=392)
      GraphQL::Execution::Interpreter::Runtime#continue_value (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=157)

  0.28      0.061     0.007     0.000     0.055     4002   GraphQL::Schema#after_lazy
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=1010
    called from:
      <Class::GraphQL::Schema::Object>#authorized_new (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb&line=37)
      GraphQL::Schema::Field#with_extensions (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb&line=557)

  0.26      0.006     0.006     0.000     0.000    13002   GraphQL::Schema::Field#type
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb&line=370
    called from:
      GraphQL::Schema::Field::ScopeExtension#after_resolve (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field/scope_extension.rb&line=7)

  0.26      0.016     0.006     0.000     0.010    10002   Enumerable#inject
    called from:
      GraphQL::StaticValidation::OperationNamesAreValid#on_document (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/operation_names_are_valid.rb&line=15)

  0.25      0.008     0.006     0.000     0.002    10001   GraphQL::Execution::Interpreter::Runtime#passes_skip_and_include?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=252

  0.25      0.008     0.006     0.000     0.002    12000   <Class::GraphQL::Types::Int>#coerce_result
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/types/int.rb&line=12
    called from:
      GraphQL::Execution::Interpreter::Runtime#continue_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=196)

  0.23      0.017     0.005     0.000     0.011     3001   GraphQL::Schema::Field::ScopeExtension#after_resolve
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field/scope_extension.rb&line=7

  0.18      0.004     0.004     0.000     0.000    12000   <Class::GraphQL::Types::Boolean>#coerce_result
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/types/boolean.rb&line=11
    called from:
      GraphQL::Execution::Interpreter::Runtime#continue_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=196)

  0.18      0.004     0.004     0.000     0.000    20014   Hash#initialize_copy

  0.14      0.003     0.003     0.000     0.000    12000   String#encoding
    called from:
      <Class::GraphQL::Types::String>#coerce_result (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb&line=8)

  0.13      0.003     0.003     0.000     0.000    10000   Hash#key?
    called from:
      GraphQL::Schema::Field#resolve_field_method (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb&line=476)

  0.13      0.003     0.003     0.000     0.000     3001   GraphQL::Schema::FieldExtension#before_resolve
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field_extension.rb&line=44

  0.12      0.003     0.003     0.000     0.000    10006   Array#concat
    called from:
      GraphQL::Filter#merge (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb&line=16)
      GraphQL::StaticValidation::DefinitionDependencies#resolve_dependencies (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=114)
      GraphQL::Query::ValidationPipeline#ensure_has_validated (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb&line=58)

  0.10      0.002     0.002     0.000     0.000    12000   String#to_s
    called from:
      <Class::GraphQL::Types::String>#coerce_result (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb&line=8)

  0.10      0.002     0.002     0.000     0.000    10027   Hash#any?
    called from:
      GraphQL::Query#prepare_ast (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=287)
      GraphQL::Language::Visitor#on_abstract_node (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb&line=80)
      GraphQL::InternalRepresentation::Node#typed_children (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/node.rb&line=24)
      GraphQL::Schema::Field#with_extensions (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb&line=557)

  0.10      0.002     0.002     0.000     0.000    12000   Integer#to_i
    called from:
      <Class::GraphQL::Types::Int>#coerce_result (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/types/int.rb&line=12)

  0.09      0.002     0.002     0.000     0.000    10026   Array#first
    called from:
      <Class::GraphQL::Execution::Multiplex>#supports_multiplexing? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=162)
      GraphQL::Query#find_operation (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=277)
      GraphQL::InternalRepresentation::Node#definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/node.rb&line=113)
      GraphQL::InternalRepresentation::Node#ast_node (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/node.rb&line=120)

  0.09      0.007     0.002     0.000     0.005     9003  *GraphQL::Schema::Wrapper#unwrap
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/wrapper.rb&line=20
    called from:
      GraphQL::Schema::Field::ScopeExtension#after_resolve (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field/scope_extension.rb&line=7)
      GraphQL::Schema::Wrapper#unwrap (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/wrapper.rb&line=20)

  0.09      0.002     0.002     0.000     0.000    10081   Module#===
    called from:
      GraphQL::InternalRepresentation::Scope#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/scope.rb&line=20)
      GraphQL::Schema#with_definition_error_check (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=1082)
      <Class::GraphQL::Argument>#deep_stringify (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/argument.rb&line=138)
      GraphQL::Schema::PossibleTypes#possible_types (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/possible_types.rb&line=23)

  0.07      2.387     0.002     0.000     2.385   247132  *Array#each
    called from:
      <Module::GraphQL::Execution::Instrumentation>#call_hooks (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/instrumentation.rb&line=54)
      GraphQL::Query#prepare_ast (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=287)
      GraphQL::Tracing::Traceable#call_tracers (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing.rb&line=74)
      GraphQL::StaticValidation::DefinitionDependencies#on_document (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=32)
      GraphQL::Language::Visitor#on_abstract_node (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb&line=80)
      GraphQL::StaticValidation::FieldsWillMerge#find_fields_and_fragments (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb&line=290)
      GraphQL::StaticValidation::VariablesAreUsedAndDefined#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb&line=33)
      GraphQL::InternalRepresentation::Scope#each (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/scope.rb&line=69)
      GraphQL::StaticValidation::VariablesAreUsedAndDefined#follow_spreads (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb&line=94)
      GraphQL::StaticValidation::FragmentSpreadsArePossible#on_document (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb&line=25)
      GraphQL::StaticValidation::FragmentsAreUsed#on_document (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragments_are_used.rb&line=5)
      GraphQL::StaticValidation::FragmentsAreFinite#on_document (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragments_are_finite.rb&line=5)
      <Module::GraphQL::Analysis>#visit_analyzers (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/analyze_query.rb&line=79)
      GraphQL::Execution::Interpreter::Runtime#gather_selections (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=52)
      GraphQL::Execution::Interpreter::Runtime#passes_skip_and_include? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=252)
      <Class::GraphQL::Schema::Object>#fields (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb&line=99)
      GraphQL::Execution::Interpreter::Runtime#set_type_at_path (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=429)
      GraphQL::Execution::Interpreter::Runtime#arguments (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=306)
      GraphQL::Schema::Field#with_extensions (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb&line=557)
      GraphQL::Execution::Interpreter::Runtime#dead_path? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=455)
      <Module::GraphQL::Execution::Instrumentation>#call_after_hooks (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/instrumentation.rb&line=77)

  0.06      0.021     0.002     0.000     0.019     1000   #<Module:0x00007fff25dff3a0>#id
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125

  0.06      0.021     0.002     0.000     0.019     1000   #<Module:0x00007fff25dff3a0>#int_array
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125

  0.06      0.021     0.001     0.000     0.019     1000   #<Module:0x00007fff25dff3a0>#boolean_array
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125

  0.06      0.020     0.001     0.000     0.018     1000   #<Module:0x00007fff25dff3a0>#string2
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125

  0.06      0.020     0.001     0.000     0.019     1000   #<Module:0x00007fff25dff3a0>#boolean1
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125

  0.06      0.020     0.001     0.000     0.019     1000   #<Module:0x00007fff25dff3a0>#boolean2
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125

  0.06      0.020     0.001     0.000     0.019     1000   #<Module:0x00007fff25dff3a0>#string_array
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125

  0.06      0.020     0.001     0.000     0.018     1000   #<Module:0x00007fff25dff3a0>#int2
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125

  0.06      0.020     0.001     0.000     0.018     1000   #<Module:0x00007fff25dff3a0>#string1
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125

  0.06      0.020     0.001     0.000     0.019     1000   #<Module:0x00007fff25dff3a0>#int1
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb&line=125

  0.05      0.012     0.001     0.000     0.011     1001   <Class::GraphQL::Schema::Object>#authorized_new
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb&line=37
    called from:
      GraphQL::Execution::Interpreter::Runtime#run_eager (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=39)
      GraphQL::Execution::Interpreter::Runtime#continue_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=196)

  0.05      0.001     0.001     0.000     0.000     3001   GraphQL::Schema::Member::Scoped#scope_items
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/scoped.rb&line=15
    called from:
      GraphQL::Schema::Field::ScopeExtension#after_resolve (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field/scope_extension.rb&line=7)

  0.05      0.001     0.001     0.000     0.000     3001   GraphQL::Schema::List#kind
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/list.rb&line=14
    called from:
      GraphQL::Execution::Interpreter::Runtime#continue_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=196)

  0.04      0.001     0.001     0.000     0.000     3075   Array#any?
    called from:
      GraphQL::StaticValidation::UniqueDirectivesPerLocation#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/unique_directives_per_location.rb&line=23)
      GraphQL::StaticValidation::VariableNamesAreUnique#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variable_names_are_unique.rb&line=5)
      GraphQL::InternalRepresentation::Rewrite#skip? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=178)
      GraphQL::StaticValidation::UniqueDirectivesPerLocation#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/unique_directives_per_location.rb&line=23)
      GraphQL::Schema::Warden#referenced? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=156)
      GraphQL::StaticValidation::RequiredArgumentsArePresent#assert_required_args (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb&line=18)
      GraphQL::StaticValidation::ArgumentNamesAreUnique#validate_arguments (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/argument_names_are_unique.rb&line=17)
      GraphQL::StaticValidation::FieldsHaveAppropriateSelections#validate_field_selections (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb&line=25)
      GraphQL::StaticValidation::NoDefinitionsArePresent#on_document (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/no_definitions_are_present.rb&line=33)
      GraphQL::Tracing::Traceable#call_tracers (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing.rb&line=74)
      GraphQL::Analysis::ReducerState#finalize_reducer (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/reducer_state.rb&line=24)
      <Module::GraphQL::Authorization::Analyzer>#final_value (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/authorization.rb&line=64)
      GraphQL::Execution::Interpreter::Runtime#write_in_response (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=389)
      <Class::GraphQL::Execution::Multiplex>#finish_query (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=122)

  0.04      0.002     0.001     0.000     0.001     1099  *Class#new
    called from:
      GraphQL::Schema#default_filter (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=130)
      GraphQL::Filter#merge (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb&line=16)
      GraphQL::Query#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=76)
      GraphQL::Query::Context#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query/context.rb&line=140)
      <Module::GraphQL::Query::ArgumentsCache>#build (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query/arguments_cache.rb&line=7)
      <Class::GraphQL::Execution::Multiplex>#run_queries (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=56)
      GraphQL::Query#prepare_ast (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=287)
      GraphQL::Schema::Warden#read_through (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=180)
      GraphQL::Tracing::Traceable#call_tracers (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing.rb&line=74)
      GraphQL::StaticValidation::ValidationContext#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/validation_context.rb&line=22)
      GraphQL::StaticValidation::DefinitionDependencies#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=10)
      GraphQL::StaticValidation::VariablesAreUsedAndDefined#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb&line=26)
      GraphQL::StaticValidation::FragmentNamesAreUnique#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_names_are_unique.rb&line=6)
      GraphQL::StaticValidation::OperationNamesAreValid#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/operation_names_are_valid.rb&line=5)
      GraphQL::InternalRepresentation::Rewrite#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=24)
      Set#initialize (txmt://open?url=file:///Users/rmosolgo/.rbenv/versions/2.4.2/lib/ruby/2.4.0/set.rb&line=83)
      GraphQL::InternalRepresentation::Rewrite#push_root_node (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=75)
      GraphQL::InternalRepresentation::Node#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/node.rb&line=65)
      GraphQL::StaticValidation::VariablesAreUsedAndDefined#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb&line=33)
      GraphQL::StaticValidation::DefinitionDependencies#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=44)
      GraphQL::InternalRepresentation::Rewrite#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=120)
      GraphQL::StaticValidation::DefinitionDependencies#resolve_dependencies (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=114)
      GraphQL::StaticValidation::DefinitionDependencies::DependencyMap#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=85)
      GraphQL::Query#with_prepared_ast (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=353)
      GraphQL::InternalRepresentation::Node#typed_children (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/node.rb&line=24)
      Set#& (txmt://open?url=file:///Users/rmosolgo/.rbenv/versions/2.4.2/lib/ruby/2.4.0/set.rb&line=439)
      GraphQL::Query#arguments_for (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=216)
      <Class::GraphQL::Execution::Interpreter>#begin_multiplex (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb&line=27)
      GraphQL::Execution::Interpreter#evaluate (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb&line=54)
      GraphQL::Schema#after_lazy (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=1010)
      GraphQL::Query#result (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=165)

  0.04      0.001     0.001     0.000     0.000     4002   Kernel#block_given?
    called from:
      GraphQL::Schema#after_lazy (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=1010)

  0.03      0.001     0.001     0.000     0.000     1001   GraphQL::Schema::Object#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb&line=68

  0.03      0.001     0.001     0.000     0.000     1001   GraphQL::Schema::Member::BaseDSLMethods#authorized?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/base_dsl_methods.rb&line=107
    called from:
      <Class::GraphQL::Schema::Object>#authorized_new (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb&line=37)

  0.03      0.001     0.001     0.000     0.000     3001   Kernel#itself
    called from:
      GraphQL::Schema::Wrapper#unwrap (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/wrapper.rb&line=20)

  0.03      0.001     0.001     0.000     0.000     1000   <Class::GraphQL::Types::ID>#coerce_result
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/types/id.rb&line=8
    called from:
      GraphQL::Execution::Interpreter::Runtime#continue_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=196)

  0.02      0.026     0.001     0.000     0.026     1001   GraphQL::Execution::Interpreter::Runtime#gather_selections
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=52
    called from:
      GraphQL::Execution::Interpreter::Runtime#evaluate_selections (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=91)

  0.02      0.000     0.000     0.000     0.000     1000   <Class::GraphQL::Schema::Object>#kind
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb&line=131
    called from:
      GraphQL::Execution::Interpreter::Runtime#continue_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=196)

  0.00      0.000     0.000     0.000     0.000       41   <Class::GraphQL::Schema>#call_on_type_class
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=971
    called from:
      <Class::GraphQL::Schema>#visible? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=856)
      <Class::GraphQL::Schema>#accessible? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=860)

  0.00      0.000     0.000     0.000     0.000       36   GraphQL::Schema::Warden#visible?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=176
    called from:
      GraphQL::Schema::Warden#visible_field? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=134)
      GraphQL::Schema::Warden#visible_type? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=138)

  0.00      0.000     0.000     0.000     0.000       24   <Module::GraphQL::Authorization::Analyzer>#call
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/authorization.rb&line=33
    called from:
      GraphQL::Analysis::ReducerState#call (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/reducer_state.rb&line=14)

  0.00      0.001     0.000     0.000     0.001       22   GraphQL::Schema::Warden#get_field
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=66
    called from:
      GraphQL::StaticValidation::FieldsAreDefinedOnType#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb&line=5)
      GraphQL::InternalRepresentation::Node#definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/node.rb&line=113)

  0.00      0.000     0.000     0.000     0.000       48   Hash#initialize

  0.00      0.000     0.000     0.000     0.000       11   GraphQL::Query#arguments_for
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=216
    called from:
      GraphQL::InternalRepresentation::Node#arguments (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/node.rb&line=109)

  0.00      0.000     0.000     0.000     0.000       69   GraphQL::BaseType#unwrap
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/base_type.rb&line=81
    called from:
      GraphQL::BaseType::ModifiesAnotherType#unwrap (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/base_type.rb&line=96)
      GraphQL::Schema::Warden#referenced? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=156)
      GraphQL::InternalRepresentation::Node#typed_children (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/node.rb&line=24)

  0.00      0.000     0.000     0.000     0.000       98  *GraphQL::BaseType::ModifiesAnotherType#unwrap
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/base_type.rb&line=96
    called from:
      GraphQL::StaticValidation::BaseVisitor::ContextMethods#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb&line=78)
      GraphQL::BaseType::ModifiesAnotherType#unwrap (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/base_type.rb&line=96)
      GraphQL::InternalRepresentation::Rewrite#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=120)
      GraphQL::Schema::Warden#visible_field? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=134)
      GraphQL::StaticValidation::FieldsHaveAppropriateSelections#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb&line=9)
      <Module::GraphQL::Authorization::Analyzer>#call (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/authorization.rb&line=33)
      GraphQL::InternalRepresentation::Node#typed_children (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/node.rb&line=24)

  0.00      2.385     0.000     0.000     2.385    11076  *Hash#each
    called from:
      GraphQL::StaticValidation::FieldsWillMerge#find_conflicts_within (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb&line=171)
      GraphQL::StaticValidation::DefinitionDependencies#resolve_dependencies (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=114)
      GraphQL::StaticValidation::VariablesAreUsedAndDefined#on_document (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb&line=78)
      GraphQL::StaticValidation::VariablesAreUsedAndDefined#create_errors (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb&line=124)
      GraphQL::StaticValidation::FragmentsAreUsed#on_document (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragments_are_used.rb&line=5)
      GraphQL::StaticValidation::FragmentNamesAreUnique#on_document (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_names_are_unique.rb&line=16)
      GraphQL::StaticValidation::OperationNamesAreValid#on_document (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/operation_names_are_valid.rb&line=15)
      <Class::GraphQL::Argument>#deep_stringify (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/argument.rb&line=138)
      GraphQL::Tracing::Traceable#call_tracers (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing.rb&line=74)
      GraphQL::InternalRepresentation::Node#get_typed_children (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/node.rb&line=185)
      <Module::GraphQL::Analysis>#reduce_node (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/analyze_query.rb&line=67)
      <Module::GraphQL::Authorization::Analyzer>#call (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/authorization.rb&line=33)
      GraphQL::Execution::Interpreter::Runtime#evaluate_selections (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=91)
      GraphQL::Execution::Interpreter::Runtime#arguments (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=306)

  0.00      0.000     0.000     0.000     0.000       79   GraphQL::Define::InstanceDefinable#metadata
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/define/instance_definable.rb&line=106
    called from:
      <Class::GraphQL::Schema>#call_on_type_class (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=971)
      GraphQL::Execution::Interpreter::Runtime#run_eager (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=39)

  0.00      2.388     0.000     0.000     2.388       30  *Array#map
    called from:
      <Class::GraphQL::Execution::Multiplex>#run_all (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=46)
      GraphQL::Tracing::Traceable#call_tracers (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing.rb&line=74)
      GraphQL::StaticValidation::RequiredArgumentsArePresent#assert_required_args (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb&line=18)
      GraphQL::StaticValidation::DefinitionDependencies#resolve_dependencies (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=114)
      <Class::GraphQL::Execution::Multiplex>#run_as_multiplex (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=77)

  0.00      0.000     0.000     0.000     0.000       12   GraphQL::InternalRepresentation::Node#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/node.rb&line=65

  0.00      0.000     0.000     0.000     0.000       19   Method#call
    called from:
      GraphQL::Filter::MergedOnly#call (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb&line=31)

  0.00      0.000     0.000     0.000     0.000       12   GraphQL::StaticValidation::FieldsHaveAppropriateSelections#validate_field_selections
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb&line=25
    called from:
      GraphQL::StaticValidation::FieldsHaveAppropriateSelections#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb&line=16)
      GraphQL::StaticValidation::FieldsHaveAppropriateSelections#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb&line=9)

  0.00      0.000     0.000     0.000     0.000       13   GraphQL::Schema::Warden#visible_type?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=138
    called from:
      GraphQL::Schema::Warden#visible_field? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=134)

  0.00      2.388     0.000     0.000     2.388        1   <Module::GraphQLBenchmark>#profile_large_result
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/benchmark/run.rb&line=66

  0.00      0.000     0.000     0.000     0.000       35   GraphQL::Query#with_prepared_ast
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=353
    called from:
      GraphQL::Query#validation_pipeline (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=220)
      GraphQL::Query#warden (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=231)
      GraphQL::Query#document (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=46)
      GraphQL::Query#variables (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=191)
      GraphQL::Query#selected_operation (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=181)

  0.00      0.000     0.000     0.000     0.000       91   Array#last
    called from:
      GraphQL::StaticValidation::BaseVisitor::ContextMethods#type_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb&line=132)
      GraphQL::StaticValidation::BaseVisitor::ContextMethods#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb&line=78)
      GraphQL::InternalRepresentation::Rewrite#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=120)
      GraphQL::StaticValidation::BaseVisitor::ContextMethods#field_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb&line=142)

  0.00      0.000     0.000     0.000     0.000       11   GraphQL::InternalRepresentation::Node#initialize_copy
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/node.rb&line=81

  0.00      0.000     0.000     0.000     0.000       55   GraphQL::Field#type
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/field.rb&line=264
    called from:
      GraphQL::StaticValidation::BaseVisitor::ContextMethods#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb&line=78)
      GraphQL::InternalRepresentation::Rewrite#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=120)
      GraphQL::Schema::Warden#visible_field? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=134)
      GraphQL::StaticValidation::FieldsHaveAppropriateSelections#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb&line=9)
      <Module::GraphQL::Authorization::Analyzer>#call (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/authorization.rb&line=33)

  0.00      0.000     0.000     0.000     0.000       11   GraphQL::StaticValidation::RequiredArgumentsArePresent#assert_required_args
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb&line=18
    called from:
      GraphQL::StaticValidation::RequiredArgumentsArePresent#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb&line=5)

  0.00      0.000     0.000     0.000     0.000       33   GraphQL::Schema#get_field
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=368
    called from:
      GraphQL::StaticValidation::BaseVisitor::ContextMethods#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb&line=78)
      GraphQL::Schema::Warden#get_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=66)

  0.00      0.000     0.000     0.000     0.000       12   GraphQL::StaticValidation::FieldsWillMerge#conflicts_within_selection_set
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb&line=34
    called from:
      GraphQL::StaticValidation::FieldsWillMerge#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb&line=22)
      GraphQL::StaticValidation::FieldsWillMerge#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb&line=27)

  0.00      0.000     0.000     0.000     0.000       23   GraphQL::InternalRepresentation::Node#definition
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/node.rb&line=113
    called from:
      <Module::GraphQL::Authorization::Analyzer>#call (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/authorization.rb&line=33)
      GraphQL::InternalRepresentation::Node#arguments (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/node.rb&line=109)

  0.00      0.000     0.000     0.000     0.000       27   GraphQL::Query#warden
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=231
    called from:
      GraphQL::Query::Context#warden (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query/context.rb&line=178)
      GraphQL::StaticValidation::FieldsAreDefinedOnType#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb&line=5)
      GraphQL::InternalRepresentation::Node#typed_children (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/node.rb&line=24)
      GraphQL::InternalRepresentation::Node#definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/node.rb&line=113)

  0.00      0.000     0.000     0.000     0.000       19   GraphQL::Filter::MergedOnly#call
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb&line=31
    called from:
      GraphQL::Filter#call (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb&line=11)

  0.00      0.000     0.000     0.000     0.000       12   GraphQL::StaticValidation::FieldsWillMerge#fields_and_fragments_from_selection
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb&line=284
    called from:
      GraphQL::StaticValidation::FieldsWillMerge#conflicts_within_selection_set (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb&line=34)

  0.00      0.000     0.000     0.000     0.000       12   GraphQL::InternalRepresentation::Node#typed_children
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/node.rb&line=24
    called from:
      <Module::GraphQL::Analysis>#reduce_node (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/analyze_query.rb&line=67)

  0.00      0.000     0.000     0.000     0.000       24   Set#each
    defined at:
      txmt://open?url=file:///Users/rmosolgo/.rbenv/versions/2.4.2/lib/ruby/2.4.0/set.rb&line=322
    called from:
      GraphQL::InternalRepresentation::Node#typed_children (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/node.rb&line=24)

  0.00      0.000     0.000     0.000     0.000       11   GraphQL::Schema::Warden#visible_field?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=134
    called from:
      GraphQL::Schema::Warden#get_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=66)

  0.00      0.000     0.000     0.000     0.000       12   GraphQL::InternalRepresentation::Scope#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/scope.rb&line=20

  0.00      0.000     0.000     0.000     0.000       19   <Class::GraphQL::Schema>#visible?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=856

  0.00      0.000     0.000     0.000     0.000       61   Array#pop
    called from:
      GraphQL::InternalRepresentation::Rewrite#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=120)
      GraphQL::StaticValidation::BaseVisitor::ContextMethods#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb&line=78)
      GraphQL::StaticValidation::VariablesAreUsedAndDefined#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb&line=33)
      GraphQL::InternalRepresentation::Rewrite#push_root_node (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=75)
      GraphQL::StaticValidation::BaseVisitor::ContextMethods#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb&line=55)
      GraphQL::StaticValidation::DefinitionDependencies#resolve_dependencies (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=114)

  0.00      0.000     0.000     0.000     0.000       13   Set#include?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/.rbenv/versions/2.4.2/lib/ruby/2.4.0/set.rb&line=232
    called from:
      GraphQL::InternalRepresentation::Rewrite#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=120)

  0.00      0.000     0.000     0.000     0.000       33   GraphQL::StaticValidation::BaseVisitor::ContextMethods#field_definition
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb&line=142
    called from:
      GraphQL::InternalRepresentation::Rewrite#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=120)
      GraphQL::StaticValidation::FieldsHaveAppropriateSelections#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb&line=9)
      GraphQL::StaticValidation::RequiredArgumentsArePresent#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb&line=5)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=76

  0.00      0.000     0.000     0.000     0.000       26   Hash#each_key
    called from:
      Set#each (txmt://open?url=file:///Users/rmosolgo/.rbenv/versions/2.4.2/lib/ruby/2.4.0/set.rb&line=322)
      GraphQL::InternalRepresentation::Node#typed_children (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/node.rb&line=24)

  0.00      0.000     0.000     0.000     0.000       57  *GraphQL::Filter#call
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb&line=11
    called from:
      GraphQL::Schema::Warden#visible? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=176)
      GraphQL::Filter::MergedOnly#call (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb&line=31)
      GraphQL::Filter#call (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb&line=11)

  0.00      0.000     0.000     0.000     0.000       14   Array#include?
    called from:
      <Class::GraphQL::Execution::Multiplex>#supports_multiplexing? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=162)
      GraphQL::Schema::Warden#root_type? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=152)

  0.00      0.000     0.000     0.000     0.000       24   GraphQL::Analysis::ReducerState#call
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/reducer_state.rb&line=14

  0.00      0.000     0.000     0.000     0.000       11   GraphQL::InternalRepresentation::Scope#each
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/scope.rb&line=69
    called from:
      GraphQL::InternalRepresentation::Rewrite#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=120)

  0.00      0.000     0.000     0.000     0.000       60   Array#push
    called from:
      GraphQL::StaticValidation::BaseVisitor::ContextMethods#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb&line=55)
      GraphQL::InternalRepresentation::Rewrite#push_root_node (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=75)
      GraphQL::StaticValidation::VariablesAreUsedAndDefined#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb&line=33)
      GraphQL::StaticValidation::BaseVisitor::ContextMethods#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb&line=78)
      GraphQL::InternalRepresentation::Rewrite#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=120)

  0.00      0.000     0.000     0.000     0.000        4   GraphQL::Schema::Warden#possible_types
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=83
    called from:
      GraphQL::InternalRepresentation::Node#typed_children (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/node.rb&line=24)

  0.00      2.384     0.000     0.000     2.384    50019  *Enumerable#each_with_index
    called from:
      GraphQL::StaticValidation::FieldsWillMerge#conflicts_within_selection_set (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb&line=34)
      GraphQL::Tracing::Traceable#call_tracers (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing.rb&line=74)
      GraphQL::Schema#after_lazy (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=1010)
      GraphQL::Execution::Interpreter::HashResponse#write (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/hash_response.rb&line=23)
      GraphQL::Execution::Interpreter::Runtime#continue_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=196)
      <Class::GraphQL::Execution::Multiplex>#run_as_multiplex (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=77)

  0.00      0.000     0.000     0.000     0.000       46  *Kernel#dup
    called from:
      GraphQL::Schema#with_definition_error_check (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=1082)
      GraphQL::StaticValidation::BaseVisitor#path (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb&line=23)
      GraphQL::InternalRepresentation::Node#initialize_copy (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/node.rb&line=81)

  0.00      0.000     0.000     0.000     0.000       14   GraphQL::BaseType#==
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/base_type.rb&line=75
    called from:
      <Module::GraphQL::Execution::Typecast>#subtype? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/typecast.rb&line=7)

  0.00      0.000     0.000     0.000     0.000       13   GraphQL::Schema::Warden#root_type?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=152
    called from:
      GraphQL::Schema::Warden#visible_type? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=138)

  0.00      0.000     0.000     0.000     0.000       12   GraphQL::TypeKinds::TypeKind#union?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/type_kinds.rb&line=45
    called from:
      GraphQL::Schema::Warden#visible_type? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=138)

  0.00      0.000     0.000     0.000     0.000       12   GraphQL::Schema#references_to
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=291
    called from:
      GraphQL::Schema::Warden#referenced? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=156)

  0.00      0.000     0.000     0.000     0.000       24   <Module::GraphQL::Analysis>#visit_analyzers
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/analyze_query.rb&line=79
    called from:
      <Module::GraphQL::Analysis>#reduce_node (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/analyze_query.rb&line=67)

  0.00      0.000     0.000     0.000     0.000       11   GraphQL::InternalRepresentation::Node#arguments
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/node.rb&line=109
    called from:
      <Module::GraphQL::Authorization::Analyzer>#call (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/authorization.rb&line=33)

  0.00      0.000     0.000     0.000     0.000       12   GraphQL::Schema::Warden#referenced?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=156
    called from:
      GraphQL::Schema::Warden#visible_type? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=138)

  0.00      0.000     0.000     0.000     0.000       22   <Class::GraphQL::Schema>#accessible?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=860
    called from:
      <Module::GraphQL::Authorization::Analyzer>#call (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/authorization.rb&line=33)

  0.00      0.002     0.000     0.000     0.002        4   GraphQL::Query::ValidationPipeline#ensure_has_validated
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb&line=58
    called from:
      GraphQL::Query::ValidationPipeline#valid? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb&line=32)
      GraphQL::Query::ValidationPipeline#analyzers (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb&line=49)
      GraphQL::Query::ValidationPipeline#internal_representation (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb&line=44)

  0.00      0.000     0.000     0.000     0.000        2   GraphQL::Filter#merge
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb&line=16
    called from:
      GraphQL::Query#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=76)
      GraphQL::Query#merge_filters (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=262)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query#prepare_ast
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=287
    called from:
      GraphQL::Query#with_prepared_ast (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=353)

  0.00      0.000     0.000     0.000     0.000       12   GraphQL::TypeKinds::TypeKind#interface?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/type_kinds.rb&line=41
    called from:
      GraphQL::Schema::Warden#visible_type? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=138)

  0.00      0.002     0.000     0.000     0.002        1   GraphQL::InternalRepresentation::Rewrite#push_root_node
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=75
    called from:
      GraphQL::InternalRepresentation::Rewrite#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=67)

  0.00      0.000     0.000     0.000     0.000        8   Integer#===
    called from:
      <Class::GraphQL::Filter::MergedOnly>#build (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb&line=35)

  0.00      0.000     0.000     0.000     0.000       23   Array#initialize_copy

  0.00      0.000     0.000     0.000     0.000       11   <Class::GraphQL::StaticValidation::FieldsWillMerge::Field>#new

  0.00      0.000     0.000     0.000     0.000       11   GraphQL::InternalRepresentation::Node#ast_node
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/node.rb&line=120
    called from:
      GraphQL::Query#arguments_for (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=216)

  0.00      0.000     0.000     0.000     0.000       19   <Module::GraphQL::Schema::NullMask>#call
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/null_mask.rb&line=6
    called from:
      GraphQL::Filter#call (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb&line=11)

  0.00      0.000     0.000     0.000     0.000       16   Array#select
    called from:
      GraphQL::StaticValidation::RequiredArgumentsArePresent#assert_required_args (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb&line=18)
      GraphQL::Tracing::Traceable#call_tracers (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing.rb&line=74)
      GraphQL::Schema::Warden#possible_types (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=83)
      <Module::GraphQL::Analysis>#analysis_errors (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/analyze_query.rb&line=87)

  0.00      0.000     0.000     0.000     0.000       11   GraphQL::InternalRepresentation::Rewrite#skip?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=178
    called from:
      GraphQL::InternalRepresentation::Rewrite#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=120)

  0.00      0.000     0.000     0.000     0.000       40   GraphQL::ScalarType#kind
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/scalar_type.rb&line=101
    called from:
      GraphQL::Schema::Warden#visible_type? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=138)
      GraphQL::StaticValidation::FieldsHaveAppropriateSelections#validate_field_selections (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb&line=25)

  0.00      0.000     0.000     0.000     0.000       14   GraphQL::StaticValidation::BaseVisitor::ContextMethods#type_definition
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb&line=132
    called from:
      GraphQL::InternalRepresentation::Rewrite#push_root_node (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=75)
      GraphQL::StaticValidation::FieldsWillMerge#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb&line=22)
      GraphQL::StaticValidation::FieldsHaveAppropriateSelections#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb&line=16)
      GraphQL::StaticValidation::FieldsWillMerge#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb&line=27)

  0.00      0.002     0.000     0.000     0.002        1   GraphQL::StaticValidation::DefinitionDependencies#on_operation_definition
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=44
    called from:
      GraphQL::StaticValidation::SubscriptionRootExists#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/subscription_root_exists.rb&line=5)

  0.00      0.000     0.000     0.000     0.000       13   GraphQL::Schema#root_types
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=264
    called from:
      GraphQL::Schema::Warden#root_type? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=152)

  0.00      0.000     0.000     0.000     0.000       26   Module#method_defined?

  0.00      0.002     0.000     0.000     0.002       11  *GraphQL::InternalRepresentation::Rewrite#on_field
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=120
    called from:
      GraphQL::StaticValidation::BaseVisitor::ContextMethods#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb&line=78)

  0.00      2.388     0.000     0.000     2.388        1   <Class::GraphQL::Execution::Multiplex>#run_all
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=46
    called from:
      GraphQL::Schema#with_definition_error_check (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=1082)

  0.00      0.000     0.000     0.000     0.000       11   GraphQL::Language::Nodes::Field#visit_method
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/(eval)&line=1
    called from:
      GraphQL::Language::Visitor#visit_node (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb&line=135)

  0.00      0.002     0.000     0.000     0.002        1   GraphQL::StaticValidation::VariablesAreUsedAndDefined#on_operation_definition
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb&line=33
    called from:
      GraphQL::StaticValidation::VariableNamesAreUnique#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variable_names_are_unique.rb&line=5)

  0.00      0.000     0.000     0.000     0.000        5   GraphQL::Schema::Warden#read_through
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=180
    called from:
      GraphQL::Schema::Warden#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=41)
      GraphQL::Schema::Warden#get_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=66)
      GraphQL::Schema::Warden#possible_types (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=83)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::InternalRepresentation::Rewrite#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=24

  0.00      0.000     0.000     0.000     0.000       12   GraphQL::BaseType#introspection?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/base_type.rb&line=55
    called from:
      GraphQL::Schema::Warden#visible_type? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=138)

  0.00      0.000     0.000     0.000     0.000       14   Hash#values
    called from:
      GraphQL::Query#find_operation (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=277)
      GraphQL::StaticValidation::RequiredArgumentsArePresent#assert_required_args (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb&line=18)
      GraphQL::StaticValidation::DefinitionDependencies#resolve_dependencies (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=114)
      GraphQL::StaticValidation::OperationNamesAreValid#on_document (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/operation_names_are_valid.rb&line=15)

  0.00      0.000     0.000     0.000     0.000       11   GraphQL::Language::Nodes::Field#children
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/language/nodes.rb&line=169
    called from:
      GraphQL::Language::Visitor#on_abstract_node (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb&line=80)

  0.00      0.002     0.000     0.000     0.002        2   GraphQL::Query#valid?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=227
    called from:
      <Class::GraphQL::Execution::Multiplex>#begin_query (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=104)

  0.00      0.000     0.000     0.000     0.000       11   GraphQL::StaticValidation::ArgumentNamesAreUnique#validate_arguments
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/argument_names_are_unique.rb&line=17
    called from:
      GraphQL::StaticValidation::ArgumentNamesAreUnique#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/argument_names_are_unique.rb&line=7)

  0.00      0.000     0.000     0.000     0.000       11   GraphQL::Schema::Field#accessible?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb&line=384

  0.00      0.000     0.000     0.000     0.000        5   Set#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/.rbenv/versions/2.4.2/lib/ruby/2.4.0/set.rb&line=83

  0.00      0.000     0.000     0.000     0.000       12   GraphQL::StaticValidation::FieldsWillMerge#find_fields_and_fragments
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb&line=290
    called from:
      GraphQL::StaticValidation::FieldsWillMerge#fields_and_fragments_from_selection (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb&line=284)

  0.00      0.000     0.000     0.000     0.000       11   GraphQL::Schema::Member::BaseDSLMethods#accessible?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/base_dsl_methods.rb&line=99

  0.00      0.000     0.000     0.000     0.000       12   GraphQL::TypeKinds::TypeKind#scalar?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/type_kinds.rb&line=33
    called from:
      GraphQL::StaticValidation::FieldsHaveAppropriateSelections#validate_field_selections (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb&line=25)

  0.00      0.000     0.000     0.000     0.000        6   GraphQL::Schema::Member::BaseDSLMethods#visible?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/base_dsl_methods.rb&line=91

  0.00      0.000     0.000     0.000     0.000        8   GraphQL::ObjectType#kind
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/object_type.rb&line=72
    called from:
      GraphQL::StaticValidation::FieldsHaveAppropriateSelections#validate_field_selections (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb&line=25)
      GraphQL::Schema::Warden#visible_type? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=138)

  0.00      0.000     0.000     0.000     0.000        4   Set#add
    defined at:
      txmt://open?url=file:///Users/rmosolgo/.rbenv/versions/2.4.2/lib/ruby/2.4.0/set.rb&line=330

  0.00      0.000     0.000     0.000     0.000        4   Set#do_with_enum
    defined at:
      txmt://open?url=file:///Users/rmosolgo/.rbenv/versions/2.4.2/lib/ruby/2.4.0/set.rb&line=112
    called from:
      Set#merge (txmt://open?url=file:///Users/rmosolgo/.rbenv/versions/2.4.2/lib/ruby/2.4.0/set.rb&line=405)
      Set#& (txmt://open?url=file:///Users/rmosolgo/.rbenv/versions/2.4.2/lib/ruby/2.4.0/set.rb&line=439)

  0.00      0.000     0.000     0.000     0.000       12   GraphQL::StaticValidation::FieldsWillMerge#find_conflicts_within
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb&line=171
    called from:
      GraphQL::StaticValidation::FieldsWillMerge#conflicts_within_selection_set (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb&line=34)

  0.00      0.002     0.000     0.000     0.002       11  *GraphQL::StaticValidation::BaseVisitor::ContextMethods#on_field
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb&line=78

  0.00      0.002     0.000     0.000     0.002        1   GraphQL::StaticValidation::BaseVisitor::ContextMethods#on_operation_definition
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb&line=55

  0.00      0.002     0.000     0.000     0.002        1   GraphQL::StaticValidation::FieldsWillMerge#on_operation_definition
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb&line=22
    called from:
      GraphQL::StaticValidation::OperationNamesAreValid#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/operation_names_are_valid.rb&line=10)

  0.00      0.000     0.000     0.000     0.000        2   Set#merge
    defined at:
      txmt://open?url=file:///Users/rmosolgo/.rbenv/versions/2.4.2/lib/ruby/2.4.0/set.rb&line=405

  0.00      0.000     0.000     0.000     0.000        2   Set#&
    defined at:
      txmt://open?url=file:///Users/rmosolgo/.rbenv/versions/2.4.2/lib/ruby/2.4.0/set.rb&line=439
    called from:
      GraphQL::InternalRepresentation::Node#typed_children (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/node.rb&line=24)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query::Context#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query/context.rb&line=140

  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Execution::Interpreter>#finish_multiplex
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb&line=43
    called from:
      <Class::GraphQL::Execution::Multiplex>#run_as_multiplex (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=77)

  0.00      0.000     0.000     0.000     0.000        4   Kernel#Array
    called from:
      GraphQL::Filter#merge (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb&line=16)

  0.00      0.000     0.000     0.000     0.000        4   GraphQL::Query#validation_pipeline
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=220
    called from:
      GraphQL::Query#valid? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=227)
      GraphQL::Tracing::Traceable#call_tracers (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing.rb&line=74)

  0.00      2.388     0.000     0.000     2.388        2  *<Module::GraphQL::Execution::Instrumentation>#call_hooks
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/instrumentation.rb&line=54
    called from:
      <Module::GraphQL::Execution::Instrumentation>#apply_instrumenters (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/instrumentation.rb&line=19)
      <Module::GraphQL::Execution::Instrumentation>#each_query_call_hooks (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/instrumentation.rb&line=39)

  0.00      0.002     0.000     0.000     0.002        1   GraphQL::StaticValidation::FragmentsAreFinite#on_document
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragments_are_finite.rb&line=5
    called from:
      GraphQL::StaticValidation::FragmentNamesAreUnique#on_document (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_names_are_unique.rb&line=16)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::BaseVisitor#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb&line=5
    called from:
      GraphQL::StaticValidation::DefinitionDependencies#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=10)

  0.00      0.000     0.000     0.000     0.000       22   GraphQL::StaticValidation::FieldsWillMerge::Field#node

  0.00      2.388     0.000     0.000     2.388       34  *GraphQL::Schema#with_definition_error_check
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=1082
    called from:
      GraphQL::Schema#multiplex (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=343)
      GraphQL::Schema#get_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=368)

  0.00      0.002     0.000     0.000     0.002        1   GraphQL::StaticValidation::UniqueDirectivesPerLocation#on_operation_definition
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/unique_directives_per_location.rb&line=23
    called from:
      GraphQL::InternalRepresentation::Rewrite#push_root_node (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=75)

  0.00      0.000     0.000     0.000     0.000        4   <Class::GraphQL::Filter::MergedOnly>#build
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb&line=35
    called from:
      GraphQL::Filter#merge (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb&line=16)

  0.00      0.000     0.000     0.000     0.000       13   Array#-
    called from:
      GraphQL::StaticValidation::RequiredArgumentsArePresent#assert_required_args (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb&line=18)
      GraphQL::StaticValidation::DefinitionDependencies#resolve_dependencies (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=114)
      GraphQL::StaticValidation::VariablesAreUsedAndDefined#follow_spreads (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb&line=94)

  0.00      0.000     0.000     0.000     0.000       12   Enumerable#group_by
    called from:
      GraphQL::StaticValidation::FieldsWillMerge#fields_and_fragments_from_selection (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb&line=284)

  0.00      0.000     0.000     0.000     0.000       12   GraphQL::TypeKinds::TypeKind#fields?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/type_kinds.rb&line=24
    called from:
      GraphQL::StaticValidation::FieldsHaveAppropriateSelections#validate_field_selections (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb&line=25)

  0.00      2.388     0.000     0.000     2.388    10007  *GraphQL::Tracing::Traceable#call_tracers
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing.rb&line=74
    called from:
      GraphQL::Tracing::Traceable#trace (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing.rb&line=61)

  0.00      0.000     0.000     0.000     0.000        3   GraphQL::Query::Context#namespace
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query/context.rb&line=185
    called from:
      <Class::GraphQL::Execution::Interpreter>#begin_query (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb&line=33)
      GraphQL::Execution::Interpreter#evaluate (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb&line=54)
      <Class::GraphQL::Execution::Interpreter>#finish_query (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb&line=48)

  0.00      0.000     0.000     0.000     0.000        4   Hash#select
    called from:
      GraphQL::StaticValidation::VariablesAreUsedAndDefined#on_document (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb&line=78)
      GraphQL::StaticValidation::VariablesAreUsedAndDefined#create_errors (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb&line=124)

  0.00      2.388     0.000     0.000     2.388        1   GraphQL::Schema#execute
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=307
    called from:
      <Module::GraphQLBenchmark>#profile_large_result (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/benchmark/run.rb&line=66)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::DirectivesAreDefined#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/directives_are_defined.rb&line=5
    called from:
      GraphQL::StaticValidation::NoDefinitionsArePresent#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/no_definitions_are_present.rb&line=7)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::DefinitionDependencies#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=10
    called from:
      GraphQL::StaticValidation::VariableUsagesAreAllowed#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb&line=5)

  0.00      0.002     0.000     0.000     0.002        1   GraphQL::StaticValidation::FragmentsAreUsed#on_document
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragments_are_used.rb&line=5
    called from:
      GraphQL::StaticValidation::FragmentsAreFinite#on_document (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragments_are_finite.rb&line=5)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::DefinitionDependencies#resolve_dependencies
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=114
    called from:
      GraphQL::StaticValidation::DefinitionDependencies#dependency_map (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=68)

  0.00      0.000     0.000     0.000     0.000        2   <Module::GraphQL::Execution::Instrumentation>#call_after_hooks
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/instrumentation.rb&line=77
    called from:
      <Module::GraphQL::Execution::Instrumentation>#call_hooks (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/instrumentation.rb&line=54)

  0.00      2.385     0.000     0.000     2.385        1   GraphQL::Execution::Interpreter::Runtime#run_eager
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=39
    called from:
      GraphQL::Tracing::Traceable#call_tracers (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing.rb&line=74)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::ValidationContext#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/validation_context.rb&line=22

  0.00      0.000     0.000     0.000     0.000        3   GraphQL::Filter#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb&line=5

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::FragmentNamesAreUnique#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_names_are_unique.rb&line=6
    called from:
      GraphQL::StaticValidation::OperationNamesAreValid#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/operation_names_are_valid.rb&line=5)

  0.00      0.002     0.000     0.000     0.002        1   GraphQL::StaticValidation::DefinitionDependencies#on_document
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=32
    called from:
      GraphQL::StaticValidation::VariablesAreUsedAndDefined#on_document (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb&line=78)

  0.00      2.385     0.000     0.000     2.385        1   GraphQL::Execution::Interpreter#evaluate
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb&line=54
    called from:
      <Class::GraphQL::Execution::Interpreter>#begin_query (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb&line=33)

  0.00      2.385     0.000     0.000     2.385        1   <Class::GraphQL::Execution::Interpreter>#begin_query
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb&line=33
    called from:
      <Class::GraphQL::Execution::Multiplex>#begin_query (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=104)

  0.00      0.000     0.000     0.000     0.000        2   GraphQL::Schema#root_type_for_operation
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=412
    called from:
      GraphQL::StaticValidation::BaseVisitor::ContextMethods#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb&line=55)
      GraphQL::Execution::Interpreter::Runtime#run_eager (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=39)

  0.00      0.000     0.000     0.000     0.000        9   Array#==
    called from:
      <Class::GraphQL::StaticValidation::BaseVisitor>#including_rules (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb&line=31)

  0.00      0.002     0.000     0.000     0.002        1   GraphQL::StaticValidation::FragmentSpreadsArePossible#on_document
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb&line=25
    called from:
      GraphQL::StaticValidation::FragmentsAreUsed#on_document (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragments_are_used.rb&line=5)

  0.00      2.384     0.000     0.000     2.384    82002  *GraphQL::Execution::Interpreter::Runtime#continue_field
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=196
    called from:
      GraphQL::Execution::Interpreter::Runtime#after_lazy (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=279)
      GraphQL::Execution::Interpreter::Runtime#continue_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=196)

  0.00      0.002     0.000     0.000     0.002       11  *GraphQL::StaticValidation::FieldsAreDefinedOnType#on_field
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb&line=5
    called from:
      GraphQL::StaticValidation::UniqueDirectivesPerLocation#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/unique_directives_per_location.rb&line=23)

  0.00      2.384     0.000     0.000     2.384    42001  *GraphQL::Execution::Interpreter::Runtime#after_lazy
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=279
    called from:
      GraphQL::Execution::Interpreter::Runtime#continue_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=196)

  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Argument>#deep_stringify
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/argument.rb&line=138
    called from:
      GraphQL::Query::Variables#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query/variables.rb&line=13)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query::Variables#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query/variables.rb&line=13

  0.00      0.000     0.000     0.000     0.000       12   String#==
    called from:
      GraphQL::Language::Visitor#on_node_with_modifications (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb&line=144)

  0.00      0.001     0.000     0.000     0.001       11  *GraphQL::StaticValidation::FieldsHaveAppropriateSelections#on_field
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb&line=9
    called from:
      GraphQL::StaticValidation::FieldsWillMerge#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb&line=27)

  0.00      0.000     0.000     0.000     0.000       11   GraphQL::Schema::Field#visible?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb&line=376

  0.00      0.000     0.000     0.000     0.000        2   GraphQL::Schema::PossibleTypes#possible_types
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/possible_types.rb&line=23
    called from:
      GraphQL::Schema#possible_types (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=405)

  0.00      0.000     0.000     0.000     0.000        4   Enumerable#each_entry
    called from:
      Set#do_with_enum (txmt://open?url=file:///Users/rmosolgo/.rbenv/versions/2.4.2/lib/ruby/2.4.0/set.rb&line=112)

  0.00      0.002     0.000     0.000     0.002        1   GraphQL::StaticValidation::VariableUsagesAreAllowed#on_operation_definition
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb&line=11
    called from:
      GraphQL::StaticValidation::VariablesAreUsedAndDefined#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb&line=33)

  0.00      0.002     0.000     0.000     0.002        1   GraphQL::StaticValidation::VariableNamesAreUnique#on_operation_definition
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variable_names_are_unique.rb&line=5
    called from:
      GraphQL::StaticValidation::FieldsHaveAppropriateSelections#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb&line=16)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Analysis::ReducerState#finalize_reducer
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/reducer_state.rb&line=24

  0.00      0.000     0.000     0.000     0.000        2   Array#flatten
    called from:
      <Module::GraphQL::Analysis>#analysis_errors (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/analyze_query.rb&line=87)

  0.00      0.002     0.000     0.000     0.002        1   GraphQL::StaticValidation::OperationNamesAreValid#on_operation_definition
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/operation_names_are_valid.rb&line=10
    called from:
      GraphQL::StaticValidation::UniqueDirectivesPerLocation#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/unique_directives_per_location.rb&line=23)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query::ValidationPipeline#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb&line=17

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Execution::Interpreter::Runtime#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=18

  0.00      2.384     0.000     0.000     2.384    13003  *Enumerator#each
    called from:
      GraphQL::Execution::Interpreter::Runtime#continue_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=196)

  0.00      0.000     0.000     0.000     0.000        1   Array#uniq!
    called from:
      <Class::GraphQL::Execution::Multiplex>#supports_multiplexing? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=162)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Filter::MergedOnly#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb&line=26

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query#merge_filters
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=262
    called from:
      GraphQL::Query#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=76)

  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Execution::Multiplex>#finish_query
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=122

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Schema#default_filter
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=130
    called from:
      GraphQL::Query#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=76)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query#result
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=165

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::FieldsWillMerge#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb&line=16
    called from:
      GraphQL::StaticValidation::FragmentSpreadsArePossible#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb&line=5)

  0.00      0.002     0.000     0.000     0.002       11  *GraphQL::StaticValidation::UniqueDirectivesPerLocation#on_field
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/unique_directives_per_location.rb&line=23
    called from:
      GraphQL::InternalRepresentation::Rewrite#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=120)

  0.00      2.385     0.000     0.000     2.385        1   <Class::GraphQL::Execution::Multiplex>#run_as_multiplex
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=77
    called from:
      <Module::GraphQL::Execution::Instrumentation>#each_query_call_hooks (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/instrumentation.rb&line=39)

  0.00      0.001     0.000     0.000     0.001       11  *GraphQL::StaticValidation::FieldsWillMerge#on_field
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb&line=27
    called from:
      GraphQL::StaticValidation::FieldsAreDefinedOnType#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb&line=5)

  0.00      0.000     0.000     0.000     0.000        4   Enumerable#reduce
    called from:
      <Class::GraphQL::Filter::MergedOnly>#build (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb&line=35)

  0.00      0.000     0.000     0.000     0.000        2   <Module::GraphQL::Execution::Typecast>#subtype?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/typecast.rb&line=7

  0.00      0.000     0.000     0.000     0.000       11   Kernel#initialize_copy
    called from:
      GraphQL::InternalRepresentation::Node#initialize_copy (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/node.rb&line=81)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::VariablesAreUsedAndDefined#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb&line=26
    called from:
      GraphQL::StaticValidation::FieldsWillMerge#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb&line=16)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Execution::Multiplex#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=33

  0.00      0.002     0.000     0.000     0.002        1   GraphQL::StaticValidation::Validator#validate
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/validator.rb&line=24
    called from:
      GraphQL::Query::ValidationPipeline#ensure_has_validated (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb&line=58)

  0.00      0.000     0.000     0.000     0.000        2   GraphQL::Schema#possible_types
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=405
    called from:
      GraphQL::Schema::Warden#possible_types (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=83)

  0.00      0.000     0.000     0.000     0.000        2   <Module::GraphQL::Tracing>#tracers
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing.rb&line=101
    called from:
      GraphQL::Query#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=76)
      GraphQL::Execution::Multiplex#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=33)

  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Execution::Multiplex>#supports_multiplexing?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=162
    called from:
      GraphQL::Tracing::Traceable#call_tracers (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing.rb&line=74)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Analysis::ReducerState#initialize_reducer
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/reducer_state.rb&line=39
    called from:
      GraphQL::Analysis::ReducerState#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/reducer_state.rb&line=8)

  0.00      0.001     0.000     0.000     0.001       11  *GraphQL::StaticValidation::RequiredArgumentsArePresent#on_field
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb&line=5
    called from:
      GraphQL::StaticValidation::FieldsHaveAppropriateSelections#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb&line=9)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Language::Visitor#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb&line=45
    called from:
      GraphQL::StaticValidation::BaseVisitor#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb&line=5)

  0.00      0.000     0.000     0.000     0.000        2   <Object::GraphQL::Argument>#metadata
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/define/instance_definable.rb&line=106
    called from:
      <Class::GraphQL::Schema>#call_on_type_class (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=971)

  0.00      0.002     0.000     0.000     0.002        1   GraphQL::StaticValidation::MutationRootExists#on_operation_definition
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/mutation_root_exists.rb&line=5
    called from:
      GraphQL::StaticValidation::VariableUsagesAreAllowed#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb&line=11)

  0.00      0.002     0.000     0.000     0.002        1   GraphQL::StaticValidation::OperationNamesAreValid#on_document
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/operation_names_are_valid.rb&line=15
    called from:
      GraphQL::StaticValidation::NoDefinitionsArePresent#on_document (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/no_definitions_are_present.rb&line=33)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::FragmentSpreadsArePossible#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb&line=5
    called from:
      GraphQL::StaticValidation::FragmentNamesAreUnique#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_names_are_unique.rb&line=6)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::OperationNamesAreValid#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/operation_names_are_valid.rb&line=5
    called from:
      GraphQL::StaticValidation::DirectivesAreDefined#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/directives_are_defined.rb&line=5)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::LiteralValidator#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/literal_validator.rb&line=6

  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Schema>#graphql_definition
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=681
    called from:
      <Module::GraphQLBenchmark>#profile_large_result (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/benchmark/run.rb&line=66)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::VariablesAreUsedAndDefined#follow_spreads
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb&line=94

  0.00      0.000     0.000     0.000     0.000        2   GraphQL::InternalRepresentation::Node#get_typed_children
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/node.rb&line=185

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query#find_operation
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=277
    called from:
      GraphQL::Query#prepare_ast (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=287)

  0.00      0.002     0.000     0.000     0.002       13  *GraphQL::Language::Visitor#on_node_with_modifications
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb&line=144
    called from:
      GraphQL::Language::Visitor#visit (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb&line=67)

  0.00      0.001     0.000     0.000     0.001       11  *GraphQL::StaticValidation::ArgumentNamesAreUnique#on_field
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/argument_names_are_unique.rb&line=7
    called from:
      GraphQL::StaticValidation::RequiredArgumentsArePresent#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb&line=5)

  0.00      0.002     0.000     0.000     0.002        1   GraphQL::StaticValidation::VariablesAreUsedAndDefined#on_document
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb&line=78
    called from:
      GraphQL::StaticValidation::FragmentSpreadsArePossible#on_document (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb&line=25)

  0.00      0.000     0.000     0.000     0.000       11   Struct#initialize

  0.00      0.002     0.000     0.000     0.002        1   GraphQL::StaticValidation::FragmentNamesAreUnique#on_document
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_names_are_unique.rb&line=16
    called from:
      GraphQL::StaticValidation::OperationNamesAreValid#on_document (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/operation_names_are_valid.rb&line=15)

  0.00      0.002     0.000     0.000     0.002       13  *GraphQL::Language::Visitor#visit_node
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb&line=135
    called from:
      GraphQL::Language::Visitor#on_node_with_modifications (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb&line=144)

  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::StaticValidation::BaseVisitor>#including_rules
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb&line=31
    called from:
      GraphQL::Tracing::Traceable#call_tracers (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing.rb&line=74)

  0.00      0.000     0.000     0.000     0.000        2   <Object::GraphQL::Argument>#metadata
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/define/instance_definable.rb&line=106
    called from:
      <Class::GraphQL::Schema>#call_on_type_class (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=971)

  0.00      0.002     0.000     0.000     0.002        1   GraphQL::StaticValidation::FieldsHaveAppropriateSelections#on_operation_definition
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb&line=16
    called from:
      GraphQL::StaticValidation::FieldsWillMerge#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb&line=22)

  0.00      0.002     0.000     0.000     0.002       13  *GraphQL::Language::Visitor#on_abstract_node
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb&line=80
    called from:
      GraphQL::StaticValidation::DefinitionDependencies#on_document (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=32)
      GraphQL::StaticValidation::DefinitionDependencies#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=44)
      GraphQL::StaticValidation::ArgumentNamesAreUnique#on_field (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/argument_names_are_unique.rb&line=7)

  0.00      0.002     0.000     0.000     0.002        1   GraphQL::StaticValidation::SubscriptionRootExists#on_operation_definition
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/subscription_root_exists.rb&line=5
    called from:
      GraphQL::StaticValidation::MutationRootExists#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/mutation_root_exists.rb&line=5)

  0.00      2.388     0.000     0.000     2.388        1   <Class::GraphQL::Execution::Multiplex>#run_queries
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=56
    called from:
      <Class::GraphQL::Execution::Multiplex>#run_all (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=46)

  0.00      0.000     0.000     0.000     0.000        3   NilClass#to_a

  0.00      0.002     0.000     0.000     0.002        1   GraphQL::StaticValidation::NoDefinitionsArePresent#on_document
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/no_definitions_are_present.rb&line=33

  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Execution::Interpreter>#finish_query
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb&line=48
    called from:
      <Class::GraphQL::Execution::Multiplex>#finish_query (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=122)

  0.00      2.388     0.000     0.000     2.388        1   <Module::GraphQL::Execution::Instrumentation>#apply_instrumenters
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/instrumentation.rb&line=19
    called from:
      <Class::GraphQL::Execution::Multiplex>#instrument_and_analyze (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=171)

  0.00      0.000     0.000     0.000     0.000        2   GraphQL::Query#selected_operation
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=181
    called from:
      <Class::GraphQL::Execution::Multiplex>#begin_query (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=104)
      GraphQL::Execution::Interpreter::Runtime#run_eager (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=39)

  0.00      0.002     0.000     0.000     0.002        1   GraphQL::Language::Visitor#visit
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb&line=67
    called from:
      GraphQL::Tracing::Traceable#call_tracers (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing.rb&line=74)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query::ValidationPipeline#build_analyzers
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb&line=95
    called from:
      GraphQL::Query::ValidationPipeline#ensure_has_validated (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb&line=58)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::NoDefinitionsArePresent#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/no_definitions_are_present.rb&line=7
    called from:
      GraphQL::InternalRepresentation::Rewrite#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=24)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query#document
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=46
    called from:
      GraphQL::StaticValidation::ValidationContext#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/validation_context.rb&line=22)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Language::Nodes::OperationDefinition#children
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/language/nodes.rb&line=169
    called from:
      GraphQL::Language::Visitor#on_abstract_node (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb&line=80)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Execution::Interpreter::HashResponse#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/hash_response.rb&line=9

  0.00      2.384     0.000     0.000     2.384     1001  *GraphQL::Execution::Interpreter::Runtime#evaluate_selections
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=91
    called from:
      GraphQL::Execution::Interpreter::Runtime#run_eager (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=39)
      GraphQL::Execution::Interpreter::Runtime#after_lazy (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=279)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query::Result#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query/result.rb&line=11

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Schema::Warden#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb&line=41

  0.00      0.000     0.000     0.000     0.000        1   GraphQLBenchmark::ProfileLargeResult::QueryType#foos
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/benchmark/run.rb&line=107

  0.00      0.001     0.000     0.000     0.001       12  *<Module::GraphQL::Analysis>#reduce_node
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/analyze_query.rb&line=67

  0.00      2.388     0.000     0.000     2.388        2  *<Module::GraphQL::Execution::Instrumentation>#each_query_call_hooks
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/instrumentation.rb&line=39
    called from:
      <Module::GraphQL::Execution::Instrumentation>#call_hooks (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/instrumentation.rb&line=54)

  0.00      2.388     0.000     0.000     2.388        1   <Class::GraphQL::Execution::Multiplex>#instrument_and_analyze
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=171
    called from:
      GraphQL::Tracing::Traceable#call_tracers (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing.rb&line=74)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query::ValidationPipeline#analyzers
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb&line=49

  0.00      0.002     0.000     0.000     0.002        1   GraphQL::InternalRepresentation::Rewrite#on_operation_definition
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=67
    called from:
      GraphQL::StaticValidation::BaseVisitor::ContextMethods#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb&line=55)

  0.00      2.385     0.000     0.000     2.385        1   <Class::GraphQL::Execution::Multiplex>#begin_query
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=104

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::InternalRepresentation::Document#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/document.rb&line=11

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query#variables
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=191
    called from:
      GraphQL::Query::ValidationPipeline#ensure_has_validated (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb&line=58)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query#result_values=
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=143
    called from:
      <Class::GraphQL::Execution::Multiplex>#finish_query (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=122)

  0.00      0.002     0.000     0.000     0.002        2   GraphQL::Query::ValidationPipeline#valid?
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb&line=32
    called from:
      GraphQL::Query#valid? (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=227)

  0.00      0.000     0.000     0.000     0.000        2   Array#reverse
    called from:
      <Module::GraphQL::Execution::Instrumentation>#call_after_hooks (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/instrumentation.rb&line=77)

  0.00      0.003     0.000     0.000     0.003        1   <Module::GraphQL::Analysis>#analyze_multiplex
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/analyze_query.rb&line=7
    called from:
      <Module::GraphQL::Execution::Instrumentation>#each_query_call_hooks (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/instrumentation.rb&line=39)

  0.00      0.000     0.000     0.000     0.000        1   Kernel#method
    called from:
      GraphQL::Query#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=76)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Execution::Interpreter#sync_lazies
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb&line=73
    called from:
      <Class::GraphQL::Execution::Interpreter>#finish_multiplex (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb&line=43)

  0.00      0.000     0.000     0.000     0.000        1   <Module::GraphQL::Query::ArgumentsCache>#build
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query/arguments_cache.rb&line=7
    called from:
      GraphQL::Query#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb&line=76)

  0.00      0.000     0.000     0.000     0.000        1   Enumerable#map
    called from:
      <Class::GraphQL::Execution::Multiplex>#run_as_multiplex (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=77)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query::Context#warden
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query/context.rb&line=178
    called from:
      GraphQL::StaticValidation::LiteralValidator#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/literal_validator.rb&line=6)

  0.00      2.388     0.000     0.000     2.388        1   GraphQL::Schema#multiplex
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=343
    called from:
      GraphQL::Schema#execute (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb&line=307)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Analysis::ReducerState#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/reducer_state.rb&line=8

  0.00      0.000     0.000     0.000     0.000        1   <Module::GraphQL::Authorization::Analyzer>#initial_value
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/authorization.rb&line=25
    called from:
      GraphQL::Analysis::ReducerState#initialize_reducer (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/reducer_state.rb&line=39)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::ValidationContext#on_dependency_resolve
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/validation_context.rb&line=34
    called from:
      GraphQL::InternalRepresentation::Rewrite#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/internal_representation/rewrite.rb&line=24)

  0.00      0.000     0.000     0.000     0.000        1   <Module::GraphQL::Authorization::Analyzer>#final_value
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/authorization.rb&line=64
    called from:
      GraphQL::Analysis::ReducerState#finalize_reducer (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/reducer_state.rb&line=24)

  0.00      0.001     0.000     0.000     0.001        1   <Module::GraphQL::Analysis>#analyze_query
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/analyze_query.rb&line=40

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::VariableUsagesAreAllowed#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb&line=5
    called from:
      GraphQL::StaticValidation::VariablesAreUsedAndDefined#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb&line=26)

  0.00      0.000     0.000     0.000     0.000        2   Enumerable#each_with_object
    called from:
      GraphQL::StaticValidation::VariableUsagesAreAllowed#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb&line=11)
      GraphQL::Query::Variables#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query/variables.rb&line=13)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Execution::Interpreter::Runtime#final_value
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb&line=28
    called from:
      <Class::GraphQL::Execution::Interpreter>#finish_query (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb&line=48)

  0.00      0.000     0.000     0.000     0.000        3   Hash#keys
    called from:
      GraphQL::StaticValidation::DirectivesAreDefined#initialize (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/directives_are_defined.rb&line=5)
      GraphQL::StaticValidation::DefinitionDependencies#resolve_dependencies (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=114)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::DefinitionDependencies#dependency_map
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=68
    called from:
      GraphQL::StaticValidation::DefinitionDependencies#on_document (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=32)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::DefinitionDependencies::DependencyMap#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=85

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Language::Nodes::OperationDefinition#visit_method
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/(eval)&line=1
    called from:
      GraphQL::Language::Visitor#visit_node (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb&line=135)

  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Execution::Interpreter>#begin_multiplex
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb&line=27
    called from:
      <Class::GraphQL::Execution::Multiplex>#run_as_multiplex (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=77)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Language::Nodes::Document#visit_method
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/(eval)&line=1
    called from:
      GraphQL::Language::Visitor#visit_node (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb&line=135)

  0.00      0.000     0.000     0.000     0.000        1   BasicObject#equal?
    called from:
      <Class::GraphQL::Execution::Multiplex>#finish_query (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb&line=122)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query::ValidationPipeline#internal_representation
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb&line=44
    called from:
      GraphQL::Tracing::Traceable#call_tracers (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing.rb&line=74)

  0.00      0.000     0.000     0.000     0.000        2   <Module::GraphQL::Analysis>#analysis_errors
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/analyze_query.rb&line=87
    called from:
      GraphQL::Tracing::Traceable#call_tracers (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing.rb&line=74)

  0.00      0.000     0.000     0.000     0.000        1   Array#compact!
    called from:
      GraphQL::StaticValidation::DefinitionDependencies#resolve_dependencies (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=114)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::BaseVisitor#path
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb&line=23
    called from:
      GraphQL::StaticValidation::DefinitionDependencies#on_operation_definition (txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=44)

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::DefinitionDependencies::NodeWithPath#initialize
    defined at:
      txmt://open?url=file:///Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb&line=101

  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Execution::Interpreter#initialize
</pre>
</details>