### PR TITLE
Pusher: use require and module.exports instead of import/export

### DIFF
--- a/javascript_client/subscriptions/PusherLink.js
+++ b/javascript_client/subscriptions/PusherLink.js
@@ -34,7 +34,8 @@
 //     // Do something with `data` and/or `errors`
 //   }})
 //
-import {ApolloLink, Observable} from "apollo-link"
+var ApolloLink = require("apollo-link").ApolloLink
+var Observable = require("apollo-link").Observable
 
 class PusherLink extends ApolloLink {
   constructor(options) {
@@ -88,4 +89,4 @@ class PusherLink extends ApolloLink {
   }
 }
 
-export default PusherLink
+module.exports = PusherLink


### PR DESCRIPTION
Without this, you need to explicitly transpile the node module contents.