### PR TITLE
Add an owner-level resolve wrapper method 

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -338,7 +338,7 @@ module GraphQL
         ctx.schema.after_lazy(obj) do |after_obj|
           # First, apply auth ...
           query_ctx = ctx.query.context
-          inner_obj = after_obj && after_obj.object
+          inner_obj = after_obj.object
           if authorized?(inner_obj, query_ctx) && arguments.each_value.all? { |a| a.authorized?(inner_obj, query_ctx) }
             # Then if it passed, resolve the field
             v = if @resolve_proc

--- a/lib/graphql/schema/object.rb
+++ b/lib/graphql/schema/object.rb
@@ -56,6 +56,14 @@ module GraphQL
         @context = context
       end
 
+      # This wraps a call to resolving each field on this object,
+      # finally returning whatever the field would return.
+      # @param field [GraphQL::Schema::Field] The configured field being resolved
+      # @param argument [Hash{Symbol => Object}] Incoming GraphQL arguments
+      def resolve_field(field_instance, arguments, field_ctx)
+        field_instance.resolve_field_on_object(self, arguments, field_ctx)
+      end
+
       class << self
         def implements(*new_interfaces)
           new_interfaces.each do |int|


### PR DESCRIPTION
Sometimes, you need to treat a field differently based on who its _owner_ is. An example is batching: mutation root fields are treated specially, they don't read batched data because they might have just updated it. 

We have something similiar for  `Query.rateLimit`, where other fields may be skipped if `rateLimit(dryRun: true)` is passed. 

I'm not sure this is the right approach though. In `1.9-dev` this is addressed by adding field extensions to root types (eg, the implementation of subscriptions)