### PR TITLE
Clarify argument prepare documentation

### DIFF
--- a/guides/fields/arguments.md
+++ b/guides/fields/arguments.md
@@ -81,8 +81,9 @@ Provide a `prepare` function to modify or validate the value of an argument befo
 ```ruby
 field :posts, [PostType], null: false do
   argument :start_date, String, required: true, prepare: ->(startDate, ctx) {
-    # return the prepared argument or GraphQL::ExecutionError.new("msg")
-    # to halt the execution of the field and add "msg" to the `errors` key.
+    # return the prepared argument.
+    # raise a GraphQL::ExecutionError to halt the execution of the field and
+    # add the exception's message to the `errors` key.
   }
 end
 


### PR DESCRIPTION
The current documentation suggests that returning a
GraphQL::ExecutionError from an argument's prepare function is valid,
but you must actually raise the GraphQL::ExecutionError to achieve the
desired behavior.