### PR TITLE
Rescue GraphQL::ExecutionErrors raised during before_query hooks

### DIFF
--- a/lib/graphql/execution/instrumentation.rb
+++ b/lib/graphql/execution/instrumentation.rb
@@ -62,6 +62,8 @@ module GraphQL
             # if any before hooks raise an exception, quit calling before hooks,
             # but call the after hooks on anything that succeeded but also
             # raise the exception that came from the before hook.
+          rescue GraphQL::ExecutionError => err
+            object.context.errors << err
           rescue => e
             raise call_after_hooks(successful, object, after_hook_name, e)
           end

--- a/lib/graphql/query/result.rb
+++ b/lib/graphql/query/result.rb
@@ -37,7 +37,7 @@ module GraphQL
       end
 
       def inspect
-        "#<GraphQL::Query::Result @query=... @to_h=#{@to_h} >"
+        "#<GraphQL::Query::Result @query=... @to_h=#{@to_h}>"
       end
 
       # A result is equal to another object when:

--- a/spec/graphql/execution/instrumentation_spec.rb
+++ b/spec/graphql/execution/instrumentation_spec.rb
@@ -57,6 +57,7 @@ describe GraphQL::Schema do
           raise GraphQL::ExecutionError, "Raised from instrumenter before_query"
         end
       end
+
       def after_query(query)
       end
     end

--- a/spec/graphql/execution/instrumentation_spec.rb
+++ b/spec/graphql/execution/instrumentation_spec.rb
@@ -51,6 +51,16 @@ describe GraphQL::Schema do
     class FirstInstrumenter < LogInstrumenter; end
     class SecondInstrumenter < LogInstrumenter; end
 
+    class ExecutionErrorInstrumenter
+      def before_query(query)
+        if query.context[:raise_execution_error]
+          raise GraphQL::ExecutionError, "Raised from instrumenter before_query"
+        end
+      end
+      def after_query(query)
+      end
+    end
+
     let(:query_type) {
       GraphQL::ObjectType.define do
         name "Query"
@@ -67,6 +77,7 @@ describe GraphQL::Schema do
         query(spec.query_type)
         instrument(:query, FirstInstrumenter.new)
         instrument(:query, SecondInstrumenter.new)
+        instrument(:query, ExecutionErrorInstrumenter.new)
       end
     }
 
@@ -94,6 +105,13 @@ describe GraphQL::Schema do
         assert context[:first_instrumenter_did_end]
         assert context[:second_instrumenter_did_begin]
         assert context[:second_instrumenter_did_end]
+      end
+
+      it "rescues execution errors from before_query" do
+        context = {raise_execution_error: true}
+        res = schema.execute(" { int(value: 2) } ", context: context)
+        assert_equal "Raised from instrumenter before_query", res["errors"].first["message"]
+        refute res.key?("data"), "The query doesn't run"
       end
     end
 


### PR DESCRIPTION
This allows you to halt a query with errors by raising GraphQL::ExecutionError in before_query