### PR TITLE
Fix cache busting when duping nodes

### DIFF
--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -45,6 +45,12 @@ module GraphQL
           []
         end
 
+        # This might be unnecessary, but its easiest to add it here.
+        def initialize_copy(other)
+          @children = nil
+          @scalars = nil
+        end
+
         # @return [Symbol] the method to call on {Language::Visitor} for this node
         def visit_method
           raise NotImplementedError, "#{self.class.name}#visit_method shold return a symbol"

--- a/spec/graphql/language/nodes_spec.rb
+++ b/spec/graphql/language/nodes_spec.rb
@@ -44,4 +44,24 @@ type Query {
       assert_equal expected.chomp, document.to_query_string(printer: custom_printer_class.new)
     end
   end
+
+  describe "#dup" do
+    it "works with adding selections" do
+      f = GraphQL::Language::Nodes::Field.new(name: "f")
+      # Calling `.children` may populate an internal cache
+      assert_equal "f", f.to_query_string, "the original is unchanged"
+      assert_equal 0, f.children.size
+      assert_equal 0, f.selections.size
+
+      f2 = f.merge(selections: [GraphQL::Language::Nodes::Field.new(name: "__typename")])
+
+      assert_equal "f", f.to_query_string, "the original is unchanged"
+      assert_equal 0, f.children.size
+      assert_equal 0, f.selections.size
+
+      assert_equal "f {\n  __typename\n}", f2.to_query_string, "the duplicate is updated"
+      assert_equal 1, f2.children.size
+      assert_equal 1, f2.selections.size
+    end
+  end
 end


### PR DESCRIPTION
Found while updating graphql-client