### PR TITLE
Fix type printing in Schema printer

### DIFF
--- a/lib/graphql/schema/printer.rb
+++ b/lib/graphql/schema/printer.rb
@@ -89,7 +89,7 @@ module GraphQL
       end
 
       def print_type(type)
-        node = @document_from_schema.build_object_type_node(type)
+        node = @document_from_schema.build_type_definition_node(type)
         print(node)
       end
 

--- a/spec/graphql/schema/printer_spec.rb
+++ b/spec/graphql/schema/printer_spec.rb
@@ -630,6 +630,20 @@ SCHEMA
       assert_equal expected.chomp, GraphQL::Schema::Printer.new(schema).print_type(schema.types['Post'])
     end
 
+    it "can print non-object types" do
+      expected = <<SCHEMA
+# Test
+input Sub {
+  # Something
+  int: Int
+
+  # Something
+  string: String
+}
+SCHEMA
+      assert_equal expected.chomp, GraphQL::Schema::Printer.new(schema).print_type(schema.types['Sub'])
+    end
+
     it "can print arguments that use non-standard Ruby objects as default values" do
       backing_object = Struct.new(:value)
 


### PR DESCRIPTION
Fixes a very old regression in `print_type`. Right now it only handles
object types and breaks on anything else.

This updates it to use `build_type_definition_node` which detects the
type kind and works as expected with every kind.