### PR TITLE
Minor: Argument renaming.

### DIFF
--- a/lib/graphql/schema/base_64_encoder.rb
+++ b/lib/graphql/schema/base_64_encoder.rb
@@ -6,13 +6,13 @@ module GraphQL
   class Schema
     # @api private
     module Base64Encoder
-      def self.encode(plaintext, nonce: false)
-        Base64.strict_encode64(plaintext)
+      def self.encode(unencoded_text, nonce: false)
+        Base64.strict_encode64(unencoded_text)
       end
 
-      def self.decode(ciphertext, nonce: false)
+      def self.decode(encoded_text, nonce: false)
         # urlsafe_decode64 is for forward compatibility
-        Base64Bp.urlsafe_decode64(ciphertext)
+        Base64Bp.urlsafe_decode64(encoded_text)
       end
     end
   end

--- a/spec/integration/rails/graphql/relay/range_add_spec.rb
+++ b/spec/integration/rails/graphql/relay/range_add_spec.rb
@@ -4,12 +4,12 @@ require "spec_helper"
 describe GraphQL::Relay::RangeAdd do
   # Make sure that the encoder is found through `ctx.schema`:
   module PassThroughEncoder
-    def self.encode(plaintext, nonce: false)
-      "__#{plaintext}"
+    def self.encode(unencoded_text, nonce: false)
+      "__#{unencoded_text}"
     end
 
-    def self.decode(ciphertext, nonce: false)
-      ciphertext[2..-1]
+    def self.decode(encoded_text, nonce: false)
+      encoded_text[2..-1]
     end
   end
 


### PR DESCRIPTION
This just renames some arguments to clarify that they're encoded, and not encrypted. Not intended to be pedantic, just wanted to help avoid downstream misconceptions. 😆 