### PR TITLE
FieldsWillMerge: keep owner_type separate from static scoping; support unbalanced static scopes 

### DIFF
--- a/spec/graphql/static_validation/rules/fields_will_merge_spec.rb
+++ b/spec/graphql/static_validation/rules/fields_will_merge_spec.rb
@@ -548,6 +548,27 @@ describe GraphQL::StaticValidation::FieldsWillMerge do
         assert_equal [], errors
       end
     end
+
+    describe "allows different args where no conflict is possible with uneven abstract scoping" do
+      let(:query_string) {%|
+        {
+          pet {
+            ... on Pet {
+              ... on Dog {
+                name
+              }
+            }
+            ... on Cat {
+              name(surname: true)
+            }
+          }
+        }
+      |}
+
+      it "passes rule" do
+        assert_equal [], errors
+      end
+    end
   end
 
   describe "allows different args where no conflict is possible deep" do


### PR DESCRIPTION
Previously, it was assumed that to maybe-conflicting nodes would have equally-deep `parents` arrays. But this is sometimes not true, for example, in: 

```graphql 
{
  ... on Pet { 
    ... on Dog {
      x 
    }
  }
  ... on Cat {
    x: y 
  }
}
```

Those are _not_ conflicting, but because their `parents` arrays were mismatched lengths, the method returned `false` (in the fallback case). 

When I changed the method to support any depth of either array (via a double-nested `#each`), there was the problem that those arrays also included the _owner_ type of the field. The presence of the owner type would wrongly cause the method to return `true`. So I refactored the code to pass `owner_type:` separately. 

Now, `parents` is usually an array with one entry, but in the case of multiply-scoped fields like the one above, it has more than one entry.

