### PR TITLE
Add GraphQL::Execution::Lookahead#selections

### DIFF
--- a/lib/graphql/execution/lookahead.rb
+++ b/lib/graphql/execution/lookahead.rb
@@ -94,6 +94,29 @@ module GraphQL
         end
       end
 
+      # Like {#selection}, but for all nodes.
+      # It returns a list of Lookaheads for all Selections
+      #
+      # If `arguments:` is provided, each provided key/value will be matched
+      # against the arguments in each selection. This method will filter the selections
+      # if any of the given `arguments:` do not match the given selection.
+      # @param arguments [Hash] Arguments which must match in the selection
+      # @return [Array<GraphQL::Execution::Lookahead>]
+      def selections(arguments: nil)
+        @ast_nodes
+          .flat_map(&:selections)
+          .map(&:name)
+          .map { |name| selection(name, arguments: arguments) }
+          .select(&:selected?)
+      end
+
+      # The name of the field.
+      # It returns the same of the Lookahead's field.
+      # @return [Symbol]
+      def name
+        @field&.method_sym
+      end
+
       # This is returned for {Lookahead#selection} when a non-existent field is passed
       class NullLookahead < Lookahead
         # No inputs required here.

--- a/lib/graphql/execution/lookahead.rb
+++ b/lib/graphql/execution/lookahead.rb
@@ -110,11 +110,15 @@ module GraphQL
       # @param arguments [Hash] Arguments which must match in the selection
       # @return [Array<GraphQL::Execution::Lookahead>]
       def selections(arguments: nil)
-        @ast_nodes
-          .flat_map(&:selections)
-          .map(&:name)
-          .map { |name| selection(name, arguments: arguments) }
-          .select(&:selected?)
+        subselections_by_name = {}
+        @ast_nodes.each do |node|
+          node.selections.each do |subselection|
+            subselections_by_name[subselection.name] ||= selection(subselection.name, arguments: arguments)
+          end
+        end
+
+        # Items may be filtered out if `arguments` doesn't match
+        subselections_by_name.values.select(&:selected?)
       end
 
       # The method name of the field.

--- a/lib/graphql/execution/lookahead.rb
+++ b/lib/graphql/execution/lookahead.rb
@@ -154,6 +154,10 @@ module GraphQL
         def selection(*)
           NULL_LOOKAHEAD
         end
+
+        def selections(*)
+          []
+        end
       end
 
       # A singleton, so that misses don't come with overhead.

--- a/lib/graphql/execution/lookahead.rb
+++ b/lib/graphql/execution/lookahead.rb
@@ -100,6 +100,13 @@ module GraphQL
       # If `arguments:` is provided, each provided key/value will be matched
       # against the arguments in each selection. This method will filter the selections
       # if any of the given `arguments:` do not match the given selection.
+      #
+      # @example getting the name of a selection
+      #   def articles(lookahead:)
+      #     next_lookaheads = lookahead.selections # => [#<GraphQL::Execution::Lookahead ...>, ...]
+      #     next_lookaheads.map(&:name) #=> [:full_content, :title]
+      #   end
+      #
       # @param arguments [Hash] Arguments which must match in the selection
       # @return [Array<GraphQL::Execution::Lookahead>]
       def selections(arguments: nil)
@@ -110,8 +117,15 @@ module GraphQL
           .select(&:selected?)
       end
 
-      # The name of the field.
-      # It returns the same of the Lookahead's field.
+      # The method name of the field.
+      # It returns the method_sym of the Lookahead's field.
+      #
+      # @example getting the name of a selection
+      #   def articles(lookahead:)
+      #     article.selection(:full_content).name # => :full_content
+      #     # ...
+      #   end
+      #
       # @return [Symbol]
       def name
         @field&.method_sym

--- a/lib/graphql/execution/lookahead.rb
+++ b/lib/graphql/execution/lookahead.rb
@@ -128,7 +128,9 @@ module GraphQL
       #
       # @return [Symbol]
       def name
-        @field&.method_sym
+        return unless @field.respond_to?(:original_name)
+
+        @field.original_name
       end
 
       # This is returned for {Lookahead#selection} when a non-existent field is passed

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -26,6 +26,9 @@ module GraphQL
       # @return [Class] The type that this field belongs to
       attr_reader :owner
 
+      # @return [Symobol] the orignal name of the field, passed in by the user
+      attr_reader :original_name
+
 
       # @return [Class, nil] The {Schema::Resolver} this field was derived from, if there is one
       def resolver
@@ -142,6 +145,7 @@ module GraphQL
         if (field || function || resolve) && extras.any?
           raise ArgumentError, "keyword `extras:` may only be used with method-based resolve and class-based field such as mutation class, please remove `field:`, `function:` or `resolve:`"
         end
+        @original_name = name
         @name = camelize ? Member::BuildType.camelize(name.to_s) : name.to_s
         @description = description
         if field.is_a?(GraphQL::Schema::Field)

--- a/spec/graphql/execution/lookahead_spec.rb
+++ b/spec/graphql/execution/lookahead_spec.rb
@@ -278,5 +278,15 @@ describe GraphQL::Execution::Lookahead do
       assert_equal [:find_bird_species], lookahead.selections.map(&:name), "Selections are merged"
       assert_equal [:name, :similar_species], lookahead.selections.first.selections.map(&:name), "Subselections are merged"
     end
+
+    it "works for missing selections" do
+      ast_node = document.definitions.first.selections.first
+      field = LookaheadTest::Query.fields["findBirdSpecies"]
+      lookahead = GraphQL::Execution::Lookahead.new(query: query, ast_nodes: [ast_node], field: field)
+      null_lookahead = lookahead.selection(:genus)
+      # This is an implementation detail, but I want to make sure the test is set up right
+      assert_instance_of GraphQL::Execution::Lookahead::NullLookahead, null_lookahead
+      assert_equal [], null_lookahead.selections
+    end
   end
 end

--- a/spec/graphql/execution/lookahead_spec.rb
+++ b/spec/graphql/execution/lookahead_spec.rb
@@ -265,7 +265,6 @@ describe GraphQL::Execution::Lookahead do
           }
 
           findBirdSpecies(byName: "Laughing Gull") {
-            name
             similarSpecies {
               likesWater: isWaterfowl
             }
@@ -276,7 +275,8 @@ describe GraphQL::Execution::Lookahead do
       ast_node = doc.definitions.first
       lookahead = GraphQL::Execution::Lookahead.new(query: query(doc), ast_nodes: [ast_node], root_type: LookaheadTest::Query)
 
-      assert_equal lookahead.selections.map(&:name), [:find_bird_species, :find_bird_species]
+      assert_equal [:find_bird_species], lookahead.selections.map(&:name), "Selections are merged"
+      assert_equal [:name, :similar_species], lookahead.selections.first.selections.map(&:name), "Subselections are merged"
     end
   end
 end

--- a/spec/graphql/schema/field_spec.rb
+++ b/spec/graphql/schema/field_spec.rb
@@ -281,4 +281,17 @@ describe GraphQL::Schema::Field do
       assert_equal "Broken!!", field.deprecation_reason
     end
   end
+
+  describe "#original_name" do
+    it "is exactly the same as the passed in name" do
+      field = GraphQL::Schema::Field.from_options(
+        :my_field,
+        String,
+        null: false,
+        camelize: true
+      )
+
+      assert_equal :my_field, field.original_name
+    end
+  end
 end


### PR DESCRIPTION
This PR adds the ability to get all of the selections from a Lookahead. I decided to keep the implementation simple by just re-using the `selection` method instead of refactoring, let me know if that's alright :smile:

Continuation of https://github.com/rmosolgo/graphql-ruby/pull/1894