### PR TITLE
Add m gem for easier test running

### DIFF
--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -46,4 +46,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "yard"
   s.add_development_dependency "jekyll-algolia" if RUBY_VERSION >= '2.3.0'
   s.add_development_dependency "jekyll-redirect-from" if RUBY_VERSION >= '2.3.0'
+  s.add_development_dependency "m", "~> 1.5.0"
 end

--- a/guides/development.md
+++ b/guides/development.md
@@ -47,6 +47,13 @@ bundle exec rake test TEST=spec/graphql/query_spec.rb
 # run tests in `query_spec.rb` only
 ```
 
+Alternatively, you can run a __specific file__ with the [m](https://github.com/qrush/m) gem:
+
+```
+m spec/graphql/query_spec.rb
+# run tests in `query_spec.rb` only
+```
+
 You can focus on a __specific example__ with `focus`:
 
 ```ruby

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rubygems'
+require 'bundler'
 Bundler.require
 
 # Print full backtrace for failiures:
@@ -10,6 +11,7 @@ require "codeclimate-test-reporter"
 CodeClimate::TestReporter.start
 
 require "graphql"
+require "rake"
 require "graphql/rake_task"
 require "benchmark"
 require "pry"


### PR DESCRIPTION
Having had some RSI issues in the past, I like to try to keep my typing as minimial as possible while developing, and the current way to run specs is a bit verbose for my liking. Would it be OK to add the m gem to make this process easier?