### PR TITLE
Require opting in to Authorization::Analyzer

### DIFF
--- a/guides/authorization/accessibility.md
+++ b/guides/authorization/accessibility.md
@@ -7,9 +7,22 @@ desc: Reject queries from unauthorized users if they access certain parts of the
 index: 2
 ---
 
+__NOTE:__ This kind of authorization is deprecated and isn't supported by the {% internal_link "forthcoming GraphQL runtime", "/queries/interpreter" %} because it's too slow.
+
 With GraphQL-Ruby, you can inspect an incoming query, and return a custom error if that query accesses some unauthorized parts of the schema.
 
 This is different from {% internal_link "visibility", "/authorization/visibility" %}, where unauthorized parts of the schema are treated as non-existent. It's also different from {% internal_link "authorization", "/authorization/authorization" %}, which makes checks _while running_, instead of _before running_.
+
+## Opt-In
+
+To use this kind of authorization, you must add a query analyzer:
+
+```ruby
+class MySchema < GraphQL::Schema
+  # Set up ahead-of-time `accessible?` authorization
+  query_analyzer GraphQL::Authorization::Analyzer
+end
+```
 
 ## Preventing Access
 

--- a/lib/graphql/query/validation_pipeline.rb
+++ b/lib/graphql/query/validation_pipeline.rb
@@ -100,10 +100,8 @@ module GraphQL
         # Filter out the built in authorization analyzer.
         # It is deprecated and does not have an AST analyzer alternative.
         qa = qa.select do |analyzer|
-          if analyzer == GraphQL::Authorization::Analyzer
-            warn("The Authorization query analyzer is deprecated. Authorizing at query runtime is generally a better idea.")
-            # Only use the authorization analyzer if we're using the old analysis engine
-            !schema.using_ast_analysis?
+          if analyzer == GraphQL::Authorization::Analyzer && schema.using_ast_analysis?
+            raise "The Authorization analyzer is not supported with AST Analyzers"
           else
             true
           end

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -90,7 +90,12 @@ module GraphQL
         end
         schema.instrumenters[type] << instrumenter
       },
-      query_analyzer: ->(schema, analyzer) { schema.query_analyzers << analyzer },
+      query_analyzer: ->(schema, analyzer) {
+        if analyzer == GraphQL::Authorization::Analyzer
+          warn("The Authorization query analyzer is deprecated. Authorizing at query runtime is generally a better idea.")
+        end
+        schema.query_analyzers << analyzer
+      },
       multiplex_analyzer: ->(schema, analyzer) { schema.multiplex_analyzers << analyzer },
       middleware: ->(schema, middleware) { schema.middleware << middleware },
       lazy_resolve: ->(schema, lazy_class, lazy_value_method) { schema.lazy_methods.set(lazy_class, lazy_value_method) },
@@ -717,7 +722,6 @@ module GraphQL
         schema_defn.cursor_encoder = cursor_encoder
         schema_defn.tracers.concat(defined_tracers)
         schema_defn.query_analyzers.concat(defined_query_analyzers)
-        schema_defn.query_analyzers << GraphQL::Authorization::Analyzer
 
         schema_defn.middleware.concat(defined_middleware)
         schema_defn.multiplex_analyzers.concat(defined_multiplex_analyzers)
@@ -930,6 +934,9 @@ module GraphQL
       end
 
       def query_analyzer(new_analyzer)
+        if new_analyzer == GraphQL::Authorization::Analyzer
+          warn("The Authorization query analyzer is deprecated. Authorizing at query runtime is generally a better idea.")
+        end
         defined_query_analyzers << new_analyzer
       end
 

--- a/spec/graphql/authorization_spec.rb
+++ b/spec/graphql/authorization_spec.rb
@@ -375,6 +375,9 @@ describe GraphQL::Authorization do
       query(Query)
       mutation(Mutation)
 
+      # Opt in to accessible? checks
+      query_analyzer GraphQL::Authorization::Analyzer
+
       lazy_resolve(Box, :value)
 
       def self.unauthorized_object(err)


### PR DESCRIPTION
This is a breaking change, since you have to opt in to the old analyzer which was previously default