### PR TITLE
Guard against recursive calls for cached methods

### DIFF
--- a/lib/graphql/relay/type_extensions.rb
+++ b/lib/graphql/relay/type_extensions.rb
@@ -6,7 +6,9 @@ module GraphQL
     module TypeExtensions
       # @return [GraphQL::ObjectType] The default connection type for this object type
       def connection_type
-        @connection_type ||= define_connection
+        RecursionGuard.guard(self, :connection_type) do
+          @connection_type ||= define_connection
+        end
       end
 
       # Define a custom connection type for this object type
@@ -17,7 +19,9 @@ module GraphQL
 
       # @return [GraphQL::ObjectType] The default edge type for this object type
       def edge_type
-        @edge_type ||= define_edge
+        RecursionGuard.guard(self, :edge_type) do
+          @edge_type ||= define_edge
+        end
       end
 
       # Define a custom edge type for this object type

--- a/lib/graphql/schema/member/cached_graphql_definition.rb
+++ b/lib/graphql/schema/member/cached_graphql_definition.rb
@@ -12,7 +12,9 @@ module GraphQL
         # It's cached here so that user-overridden {.to_graphql} implementations
         # are also cached
         def graphql_definition
-          @graphql_definition ||= to_graphql
+          RecursionGuard.guard(self, :graphql_definition) do
+            @graphql_definition ||= to_graphql
+          end
         end
 
         # Wipe out the cached graphql_definition so that `.to_graphql` will be called again.


### PR DESCRIPTION
This PR raises an exception when it detects a recursive invocation of a cached method, like `graphql_definition` or `connection_type`. This helps you avoid the dreaded, "Duplicate type definition found for SomeType" error message, by attempting to detect the scenario early.

The solution usually involves wrapping the type definition in a proc inside of the legacy-style type (eg, `-> { SomeType.graphql_definition }`).