### PR TITLE
Fix RelayClassicMutation extras on interpreter

### DIFF
--- a/lib/graphql/schema/relay_classic_mutation.rb
+++ b/lib/graphql/schema/relay_classic_mutation.rb
@@ -32,7 +32,12 @@ module GraphQL
         # Without the interpreter, the inputs are unwrapped by an instrumenter.
         # But when using the interpreter, no instrumenters are applied.
         if context.interpreter?
-          input = inputs[:input]
+          input = inputs[:input].to_h
+          # Transfer these from the top-level hash to the
+          # shortcutted `input:` object
+          self.class.extras.each do |ext|
+            input[ext] = inputs[ext]
+          end
         else
           input = inputs
         end

--- a/spec/graphql/schema/relay_classic_mutation_spec.rb
+++ b/spec/graphql/schema/relay_classic_mutation_spec.rb
@@ -50,6 +50,32 @@ describe GraphQL::Schema::RelayClassicMutation do
 
       assert_equal "Sitar", res["data"]["addSitar"]["instrument"]["name"]
     end
+
+    it "supports extras" do
+      res = Jazz::Schema.execute <<-GRAPHQL
+      mutation {
+        hasExtras(input: {}) {
+          nodeClass
+          int
+        }
+      }
+      GRAPHQL
+
+      assert_equal "GraphQL::Language::Nodes::Field", res["data"]["hasExtras"]["nodeClass"]
+      assert_nil res["data"]["hasExtras"]["int"]
+
+      # Also test with given args
+      res = Jazz::Schema.execute <<-GRAPHQL
+      mutation {
+        hasExtras(input: {int: 5}) {
+          nodeClass
+          int
+        }
+      }
+      GRAPHQL
+      assert_equal "GraphQL::Language::Nodes::Field", res["data"]["hasExtras"]["nodeClass"]
+      assert_equal 5, res["data"]["hasExtras"]["int"]
+    end
   end
 
   describe "loading multiple application objects" do

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -495,6 +495,24 @@ module Jazz
     end
   end
 
+  class HasExtras < GraphQL::Schema::RelayClassicMutation
+    null true
+    description "Test extras in RelayClassicMutation"
+
+    argument :int, Integer, required: false
+    extras [:ast_node]
+
+    field :node_class, String, null: false
+    field :int, Integer, null: true
+
+    def resolve(int: nil, ast_node:)
+      {
+        int: int,
+        node_class: ast_node.class.name,
+      }
+    end
+  end
+
   class RenameNamedEntity < GraphQL::Schema::RelayClassicMutation
     argument :named_entity_id, ID, required: true, loads: NamedEntity
     argument :new_name, String, required: true
@@ -603,6 +621,7 @@ module Jazz
     field :upvote_ensembles_as_bands, mutation: UpvoteEnsemblesAsBands
     field :upvote_ensembles_ids, mutation: UpvoteEnsemblesIds
     field :rename_ensemble_as_band, mutation: RenameEnsembleAsBand
+    field :has_extras, mutation: HasExtras
 
     def add_ensemble(input:)
       ens = Models::Ensemble.new(input.name)


### PR DESCRIPTION
Oops, `extras [...]` didn't work on relay classic mutations.