### PR TITLE
Remove confusing non-relevant example

### DIFF
--- a/guides/authorization/authorization.md
+++ b/guides/authorization/authorization.md
@@ -45,8 +45,6 @@ By default, GraphQL-Ruby silently replaces unauthorized objects with `nil`, as i
 class MySchema < GraphQL::Schema
   # Override this hook to handle cases when `authorized?` returns false:
   def self.unauthorized_object(error)
-    # Increment a metric somewhere:
-    AppStats.increment("graphql:unauthorized:#{error.type.graphql_name}:#{error.object.class.name}")
     # Add a top-level error to the response instead of returning nil:
     raise GraphQL::ExecutionError, "An object of type #{error.type.graphql_name} was hidden due to permissions"
   end


### PR DESCRIPTION
The usage of non-library code in examples is confusing to beginners and should be avoided.