### PR TITLE
add tip to documentation

### DIFF
--- a/guides/queries/multiplex.md
+++ b/guides/queries/multiplex.md
@@ -80,6 +80,8 @@ def execute
 end
 ```
 
+If Apollo Client has issues recognizing the result of`render json: result`, replace it with `render body: result.to_json, content_type: 'application/json'`.
+
 ## Validation and Error Handling
 
 Each query is validated and {% internal_link "analyzed","/queries/analysis" %} independently. The `results` array may include a mix of successful results and failed results

--- a/guides/queries/multiplex.md
+++ b/guides/queries/multiplex.md
@@ -80,7 +80,7 @@ def execute
 end
 ```
 
-If Apollo Client has issues recognizing the result of`render json: result`, replace it with `render body: result.to_json, content_type: 'application/json'`.
+If Apollo Client has issues recognizing the result of `render json: result`, replace it with `render body: result.to_json, content_type: 'application/json'`.
 
 ## Validation and Error Handling
 


### PR DESCRIPTION
See issue #1948 

Adds a tip to the documentation that could help resolve confusion with query batching and Apollo Client.