### PR TITLE
Fix scalar tracing in NewRelic and Skylight instrumentation

### DIFF
--- a/lib/graphql/tracing/new_relic_tracing.rb
+++ b/lib/graphql/tracing/new_relic_tracing.rb
@@ -17,8 +17,8 @@ module GraphQL
       # @param set_transaction_name [Boolean] If true, the GraphQL operation name will be used as the transaction name.
       #   This is not advised if you run more than one query per HTTP request, for example, with `graphql-client` or multiplexing.
       #   It can also be specified per-query with `context[:set_new_relic_transaction_name]`.
-      def initialize(set_transaction_name: false)
-        @set_transaction_name = set_transaction_name
+      def initialize(options = {})
+        @set_transaction_name = options.fetch(:set_transaction_name, false)
         super
       end
 

--- a/lib/graphql/tracing/skylight_tracing.rb
+++ b/lib/graphql/tracing/skylight_tracing.rb
@@ -17,8 +17,8 @@ module GraphQL
       # @param set_endpoint_name [Boolean] If true, the GraphQL operation name will be used as the endpoint name.
       #   This is not advised if you run more than one query per HTTP request, for example, with `graphql-client` or multiplexing.
       #   It can also be specified per-query with `context[:set_skylight_endpoint_name]`.
-      def initialize(set_endpoint_name: false)
-        @set_endpoint_name = set_endpoint_name
+      def initialize(options = {})
+        @set_endpoint_name = options.fetch(:set_endpoint_name, false)
         super
       end
 

--- a/spec/graphql/tracing/new_relic_tracing_spec.rb
+++ b/spec/graphql/tracing/new_relic_tracing_spec.rb
@@ -20,6 +20,11 @@ describe GraphQL::Tracing::NewRelicTracing do
       query(Query)
       use(GraphQL::Tracing::NewRelicTracing, set_transaction_name: true)
     end
+
+    class SchemaWithScalarTrace < GraphQL::Schema
+      query(Query)
+      use(GraphQL::Tracing::NewRelicTracing, trace_scalars: true)
+    end
   end
 
   before do
@@ -43,5 +48,10 @@ describe GraphQL::Tracing::NewRelicTracing do
     # Override with `true`
     NewRelicTest::SchemaWithoutTransactionName.execute "{ int }", context: { set_new_relic_transaction_name: true }
     assert_equal ["GraphQL/query.anonymous"], NewRelic::TRANSACTION_NAMES
+  end
+
+  it "traces scalars when trace_scalars is true" do
+    NewRelicTest::SchemaWithScalarTrace.execute "query X { int }"
+    assert_includes NewRelic::EXECUTION_SCOPES, "GraphQL/Query/int"
   end
 end

--- a/spec/graphql/tracing/skylight_tracing_spec.rb
+++ b/spec/graphql/tracing/skylight_tracing_spec.rb
@@ -20,6 +20,11 @@ describe GraphQL::Tracing::SkylightTracing do
       query(Query)
       use(GraphQL::Tracing::SkylightTracing, set_endpoint_name: true)
     end
+
+    class SchemaWithScalarTrace < GraphQL::Schema
+      query(Query)
+      use(GraphQL::Tracing::SkylightTracing, trace_scalars: true)
+    end
   end
 
   before do
@@ -43,5 +48,10 @@ describe GraphQL::Tracing::SkylightTracing do
     # Override with `true`
     SkylightTest::SchemaWithoutTransactionName.execute "{ int }", context: { set_skylight_endpoint_name: true }
     assert_equal ["GraphQL/query.<anonymous>"], Skylight::ENDPOINT_NAMES
+  end
+
+  it "traces scalars when trace_scalars is true" do
+    SkylightTest::SchemaWithScalarTrace.execute "query X { int }"
+    assert_includes Skylight::TITLE_NAMES, "graphql.Query.int"
   end
 end

--- a/spec/support/new_relic.rb
+++ b/spec/support/new_relic.rb
@@ -6,9 +6,11 @@ end
 
 module NewRelic
   TRANSACTION_NAMES = []
+  EXECUTION_SCOPES = []
   # Reset state between tests
   def self.clear_all
     TRANSACTION_NAMES.clear
+    EXECUTION_SCOPES.clear
   end
   module Agent
     def self.set_transaction_name(name)
@@ -17,6 +19,7 @@ module NewRelic
 
     module MethodTracerHelpers
       def self.trace_execution_scoped(trace_name)
+        EXECUTION_SCOPES << trace_name
         yield
       end
     end

--- a/spec/support/skylight.rb
+++ b/spec/support/skylight.rb
@@ -9,9 +9,11 @@ end
 
 module Skylight
   ENDPOINT_NAMES = []
+  TITLE_NAMES = []
   # Reset state between tests
   def self.clear_all
     ENDPOINT_NAMES.clear
+    TITLE_NAMES.clear
   end
 
   def self.instrumenter
@@ -19,6 +21,7 @@ module Skylight
   end
 
   def self.instrument(category:, title:)
+    TITLE_NAMES << title
     yield
   end
 


### PR DESCRIPTION
The New Relic and Skylight subclasses of `GraphQL::Tracing::PlatformTracing` weren't plumbing through superclass options.