### PR TITLE
Add GraphQL::Query::Context#to_hash to allow splatting

### DIFF
--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -160,7 +160,7 @@ module GraphQL
       # @api private
       attr_writer :value
 
-      def_delegators :@provided_values, :[], :[]=, :to_h, :key?, :fetch, :dig
+      def_delegators :@provided_values, :[], :[]=, :to_h, :to_hash, :key?, :fetch, :dig
       def_delegators :@query, :trace
 
       # @!method [](key)

--- a/spec/graphql/query/context_spec.rb
+++ b/spec/graphql/query/context_spec.rb
@@ -235,6 +235,16 @@ TABLE
     end
   end
 
+  describe "splatting" do
+    let(:context) { GraphQL::Query::Context.new(query: OpenStruct.new(schema: schema), values: {a: {b: 1}}, object: nil) }
+
+    let(:splat) { ->(**context) { context } }
+
+    it "runs successfully" do
+      assert_equal({a: { b: 1 }}, splat.call(context))
+    end
+  end
+
   describe "accessing context after the fact" do
     let(:query_string) { %|
       { pushContext }


### PR DESCRIPTION
Right now extending of fields via something like

```ruby
module ExtendedField
  def initialize(*args, custom_key:, **kwargs, &block)
    …
    super(*args, **kwargs, &block)
  end
end
```

because sometimes context is passed as the second argument and it
ends up in args instead of kwargs.

Fixes #1821