### PR TITLE
[Documentation] Use parenthesis for consistency

### DIFF
--- a/guides/queries/tracing.md
+++ b/guides/queries/tracing.md
@@ -89,7 +89,7 @@ To add [New Relic](https://newrelic.com/) instrumentation:
 class MySchema < GraphQL::Schema
   use(GraphQL::Tracing::NewRelicTracing)
   # Optional, use the operation name to set the new relic transaction name:
-  # use GraphQL::Tracing::NewRelicTracing, set_transaction_name: true
+  # use(GraphQL::Tracing::NewRelicTracing, set_transaction_name: true)
 end
 ```
 


### PR DESCRIPTION
Consistent with the other examples in the `tracing` documentation.