### PR TITLE
Support lookahead in interpreter

### DIFF
--- a/spec/graphql/execution/lookahead_spec.rb
+++ b/spec/graphql/execution/lookahead_spec.rb
@@ -60,6 +60,9 @@ describe GraphQL::Execution::Lookahead do
     class Schema < GraphQL::Schema
       query(Query)
       instrument :query, LookaheadInstrumenter
+      if TESTING_INTERPRETER
+        use GraphQL::Execution::Interpreter
+      end
     end
   end
 


### PR DESCRIPTION
`extras: [:lookahead]` wasn't working quite right, because it was being delegated to `Query::Context#lookahead` instead of being injected by the runtime.