### PR TITLE
Support field hash_key: values that are not valid ruby method names

### DIFF
--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -127,7 +127,10 @@ Check `inherited` on #{self}'s superclasses.
 ERR
           end
           default_resolve_module.module_eval <<-RUBY, __FILE__, __LINE__ + 1
-            def #{method_name}(**args)
+            # method_name can be a hash_key (see lib/graphql/schema/field.rb)
+            # so we need to make a raw define_method :sym call to avoid crashing
+            # on hash keys like :'some key with/weird-chars'
+            define_method #{method_name.inspect} do |**args|
               field_inst = self.class.fields[#{field_key}] || raise(%|Failed to find field #{field_key} for \#{self.class} among \#{self.class.fields.keys}|)
               field_inst.resolve_field_method(self, args, context)
             end

--- a/spec/graphql/schema/member/has_fields_spec.rb
+++ b/spec/graphql/schema/member/has_fields_spec.rb
@@ -75,6 +75,7 @@ describe GraphQL::Schema::Member::HasFields do
       field :string3, SubSubObjectWithStringField, null: false, method: :object
       field :float1, ObjectWithFloatField, null: false, method: :object
       field :float2, ObjectWithSubFloatField, null: false, method: :object
+      field :hash_key1, String, null: false, hash_key: :'foo bar/fizz-buzz'
     end
 
     class Schema < GraphQL::Schema


### PR DESCRIPTION
ruby-2.5.1 / graphql-1.8.9

The schema default_resolver crashes if a field uses a non-standard hash_key, like so:

```
field :foo, String, hash_key: :"foo/bar"
field :bar, String, hash_key: "2nd test case"
```

```
SyntaxError (/usr/local/rvm/gems/ruby-2.5.1/gems/graphql-1.8.9/lib/graphql/schema/member/has_fields.rb:121: syntax error, unexpected '/', expecting ';' or '\n'
            def foo/bar(**args)
                   ^
/usr/local/rvm/gems/ruby-2.5.1/gems/graphql-1.8.9/lib/graphql/schema/member/has_fields.rb:124: syntax error, unexpected keyword_end, expecting end-of-input
            end
            ^~~):
```
Putting aside the wisdom of such hash_keys, this PR is intended to allow the user to use any valid string or symbol as a hash_key. I've updated the spec tests to cover at least one such hash_key.