### PR TITLE
Fix non-null abstract fields that return nil

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -256,9 +256,9 @@ module GraphQL
               idx += 1
               set_type_at_path(next_path, inner_type)
               after_lazy(inner_value, path: next_path, field: field) do |inner_inner_value|
-                continue_value = continue_value(next_path, inner_inner_value, field, is_non_null, ast_node)
+                # reset `is_non_null` here and below, because the inner type will have its own nullability constraint
+                continue_value = continue_value(next_path, inner_inner_value, field, false, ast_node)
                 if HALT != continue_value
-                  # reset `is_non_null` here, because the inner type will have its own nullability constraint
                   continue_field(next_path, continue_value, field, inner_type, ast_node, next_selections, false)
                 end
               end

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -258,7 +258,8 @@ module GraphQL
               after_lazy(inner_value, path: next_path, field: field) do |inner_inner_value|
                 continue_value = continue_value(next_path, inner_inner_value, field, is_non_null, ast_node)
                 if HALT != continue_value
-                  continue_field(next_path, continue_value, field, inner_type, ast_node, next_selections, is_non_null)
+                  # reset `is_non_null` here, because the inner type will have its own nullability constraint
+                  continue_field(next_path, continue_value, field, inner_type, ast_node, next_selections, false)
                 end
               end
             end

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -132,7 +132,7 @@ describe GraphQL::Execution::Interpreter do
       end
 
       def find_many(ids:)
-        find(id: ids)
+        find(id: ids).map { |e| Box.new(value: e) }
       end
 
       field :field_counter, FieldCounter, null: false
@@ -286,7 +286,7 @@ describe GraphQL::Execution::Interpreter do
     it "works with lists of unions" do
       res = InterpreterTest::Schema.execute <<-GRAPHQL
       {
-        findMany(ids: ["RAV", "NOPE"]) {
+        findMany(ids: ["RAV", "NOPE", "BOGUS"]) {
           ... on Expansion {
             sym
           }
@@ -294,9 +294,10 @@ describe GraphQL::Execution::Interpreter do
       }
       GRAPHQL
 
-      assert_equal 2, res["data"]["findMany"].size
+      assert_equal 3, res["data"]["findMany"].size
       assert_equal "RAV", res["data"]["findMany"][0]["sym"]
       assert_equal nil, res["data"]["findMany"][1]
+      assert_equal nil, res["data"]["findMany"][2]
       assert_equal false, res.key?("errors")
     end
   end


### PR DESCRIPTION
The problem was that `.non_null?` information was left behind when unwrapping them in `continue_field`. So we should retain that value when resolving the field, that's why I added a new argument which can be set to `true` when unwrapping a non-null type.