### PR TITLE
Put runtime info in mutable context, too

### DIFF
--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -4,10 +4,17 @@ require "spec_helper"
 describe GraphQL::Execution::Interpreter do
   module InterpreterTest
     class Box
-      attr_reader :value
-
-      def initialize(value:)
+      def initialize(value: nil, &block)
         @value = value
+        @block = block
+      end
+
+      def value
+        if @block
+          @value = @block.call
+          @block = nil
+        end
+        @value
       end
     end
 
@@ -59,6 +66,7 @@ describe GraphQL::Execution::Interpreter do
       field :calls, Integer, null: false do
         argument :expected, Integer, required: true
       end
+
       def calls(expected:)
         c = context[:calls] += 1
         if c != expected
@@ -66,6 +74,18 @@ describe GraphQL::Execution::Interpreter do
         else
           c
         end
+      end
+
+      field :runtime_info, String, null: false
+      def runtime_info
+        "#{context.namespace(:interpreter)[:current_path]} -> #{context.namespace(:interpreter)[:current_field].path}"
+      end
+
+      field :lazy_runtime_info, String, null: false
+      def lazy_runtime_info
+        Box.new {
+          "#{context.namespace(:interpreter)[:current_path]} -> #{context.namespace(:interpreter)[:current_field].path}"
+        }
       end
     end
 
@@ -203,6 +223,26 @@ describe GraphQL::Execution::Interpreter do
       # This can be removed later, just a sanity check during migration
       res = InterpreterTest::Schema.execute("{ __typename }")
       assert_equal true, res.context.interpreter?
+    end
+  end
+
+  describe "runtime info in context" do
+    it "is available" do
+      res = InterpreterTest::Schema.execute <<-GRAPHQL
+      {
+        fieldCounter {
+          runtimeInfo
+          fieldCounter {
+            runtimeInfo
+            lazyRuntimeInfo
+          }
+        }
+      }
+      GRAPHQL
+
+      assert_equal '["fieldCounter", "runtimeInfo"] -> FieldCounter.runtimeInfo', res["data"]["fieldCounter"]["runtimeInfo"]
+      assert_equal '["fieldCounter", "fieldCounter", "runtimeInfo"] -> FieldCounter.runtimeInfo', res["data"]["fieldCounter"]["fieldCounter"]["runtimeInfo"]
+      assert_equal '["fieldCounter", "fieldCounter", "lazyRuntimeInfo"] -> FieldCounter.lazyRuntimeInfo', res["data"]["fieldCounter"]["fieldCounter"]["lazyRuntimeInfo"]
     end
   end
 


### PR DESCRIPTION
You can get this information injected into field methods which is definitely the best way to get it. But sometimes you need it in places that _aren't_ field methods. So, I'll write them into this little bit of context so they can be read elsewhere. 