### PR TITLE
Allow multiple errors as args to Schema.rescue_from.

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -855,9 +855,11 @@ module GraphQL
         end
       end
 
-      def rescue_from(err_class, &handler_block)
+      def rescue_from(*err_classes, &handler_block)
         @rescues ||= {}
-        @rescues[err_class] = handler_block
+        err_classes.each do |err_class|
+          @rescues[err_class] = handler_block
+        end
       end
 
       def resolve_type(type, obj, ctx)

--- a/spec/integration/rails/graphql/schema_spec.rb
+++ b/spec/integration/rails/graphql/schema_spec.rb
@@ -18,8 +18,8 @@ describe GraphQL::Schema do
       rescue_middleware = schema_defn.middleware.first
       assert_equal(1, rescue_middleware.rescue_table.length)
       # normally, you'd use a real class, not a symbol:
-      schema_defn.rescue_from(:error_class) { "my custom message" }
-      assert_equal(2, rescue_middleware.rescue_table.length)
+      schema_defn.rescue_from(:error_class, :another_err_class) { "my custom message" }
+      assert_equal(3, rescue_middleware.rescue_table.length)
     end
   end
 


### PR DESCRIPTION
This allows you to pass multiple error types into `rescue_from`'s in your schema, instead of just one:

``` ruby 
class Schema < GraphQL::Schema
  rescue_from(ActiveRecord::RecordInvalid, ActiveModel::ValidationError) { |e| "Validation failed." }
end
```

### Because:

* the underlying `RescueMiddleware#rescue_from` already accepts multiple error classes
* would be nice to follow the same signature as Rails `rescue_from`, which accepts multiple errors

