### PR TITLE
Work better with identified Ably client

### DIFF
--- a/javascript_client/subscriptions/createAblyHandler.js
+++ b/javascript_client/subscriptions/createAblyHandler.js
@@ -12,7 +12,11 @@ function createAblyHandler(options) {
       channelName = response.headers.get("X-Subscription-ID")
       channel = ably.channels.get(channelName)
       // Register presence, so that we can detect empty channels and clean them up server-side
-      channel.presence.enterClient("graphql-subscriber", "subscribed")
+      if (ably.auth.clientId) {
+        channel.presence.enter("subscribed")
+      } else {
+        channel.presence.enterClient("graphql-subscriber", "subscribed")
+      }
       // When you get an update from ably, give it to Relay
       channel.subscribe("update", function(message) {
         // TODO Extract this code


### PR DESCRIPTION
This avoids warnings when using an Ably "Realtime" client instance
that uses "identified" authentication.