### PR TITLE
Skip rewrite when interpreter is enabled

### DIFF
--- a/lib/graphql/execution/interpreter.rb
+++ b/lib/graphql/execution/interpreter.rb
@@ -17,6 +17,7 @@ module GraphQL
       end
 
       def self.use(schema_defn)
+        schema_defn.target.interpreter = true
         # Reach through the legacy objects for the actual class defn
         schema_class = schema_defn.target.class
         # This is not good, since both of these are holding state now,
@@ -58,7 +59,6 @@ module GraphQL
       # Run the eager part of `query`
       # @return {Interpreter::Runtime}
       def evaluate(query)
-        query.context.interpreter = true
         # Although queries in a multiplex _share_ an Interpreter instance,
         # they also have another item of state, which is private to that query
         # in particular, assign it here:

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -135,6 +135,8 @@ module GraphQL
       end
     end
 
+    def_delegators :@schema, :interpreter?
+
     def subscription_update?
       @subscription_topic && subscription?
     end

--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -155,13 +155,6 @@ module GraphQL
         @path = []
         @value = nil
         @context = self # for SharedMethods
-        # The interpreter will set this
-        @interpreter = nil
-      end
-
-      # @return [Boolean] True if using the new {GraphQL::Execution::Interpreter}
-      def interpreter?
-        @interpreter
       end
 
       # @api private
@@ -171,7 +164,7 @@ module GraphQL
       attr_writer :value
 
       def_delegators :@provided_values, :[], :[]=, :to_h, :key?, :fetch, :dig
-      def_delegators :@query, :trace
+      def_delegators :@query, :trace, :interpreter?
 
       # @!method [](key)
       #   Lookup `key` from the hash passed to {Schema#execute} as `context:`

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -174,7 +174,16 @@ module GraphQL
       @context_class = GraphQL::Query::Context
       @introspection_namespace = nil
       @introspection_system = nil
+      @interpeter = false
     end
+
+    # @return [Boolean] True if using the new {GraphQL::Execution::Interpreter}
+    def interpreter?
+      @interpreter
+    end
+
+    # @api private
+    attr_writer :interpreter
 
     def inspect
       "#<#{self.class.name} ...>"
@@ -673,7 +682,7 @@ module GraphQL
         :execution_strategy_for_operation,
         :validate, :multiplex_analyzers, :lazy?, :lazy_method_name, :after_lazy, :sync_lazy,
         # Configuration
-        :analysis_engine, :analysis_engine=, :using_ast_analysis?,
+        :analysis_engine, :analysis_engine=, :using_ast_analysis?, :interpreter?,
         :max_complexity=, :max_depth=,
         :metadata,
         :default_mask,

--- a/lib/graphql/static_validation.rb
+++ b/lib/graphql/static_validation.rb
@@ -15,3 +15,4 @@ end
 
 require "graphql/static_validation/all_rules"
 require "graphql/static_validation/default_visitor"
+require "graphql/static_validation/interpreter_visitor"

--- a/lib/graphql/static_validation/base_visitor.rb
+++ b/lib/graphql/static_validation/base_visitor.rb
@@ -27,12 +27,17 @@ module GraphQL
       # Build a class to visit the AST and perform validation,
       # or use a pre-built class if rules is `ALL_RULES` or empty.
       # @param rules [Array<Module, Class>]
+      # @param rewrite [Boolean] if `false`, don't include rewrite
       # @return [Class] A class for validating `rules` during visitation
-      def self.including_rules(rules)
+      def self.including_rules(rules, rewrite: true)
         if rules.none?
           NoValidateVisitor
         elsif rules == ALL_RULES
-          DefaultVisitor
+          if rewrite
+            DefaultVisitor
+          else
+            InterpreterVisitor
+          end
         else
           visitor_class = Class.new(self) do
             include(GraphQL::StaticValidation::DefinitionDependencies)

--- a/lib/graphql/static_validation/interpreter_visitor.rb
+++ b/lib/graphql/static_validation/interpreter_visitor.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+module GraphQL
+  module StaticValidation
+    class InterpreterVisitor < BaseVisitor
+      include(GraphQL::StaticValidation::DefinitionDependencies)
+
+      StaticValidation::ALL_RULES.reverse_each do |r|
+        include(r)
+      end
+
+      include(ContextMethods)
+    end
+  end
+end

--- a/spec/graphql/analysis/ast_spec.rb
+++ b/spec/graphql/analysis/ast_spec.rb
@@ -77,6 +77,7 @@ describe GraphQL::Analysis::AST do
         query query_type
         use GraphQL::Analysis::AST
         query_analyzer AstErrorAnalyzer
+        use GraphQL::Execution::Interpreter
       end
     end
 
@@ -89,7 +90,16 @@ describe GraphQL::Analysis::AST do
     let(:query) { GraphQL::Query.new(schema, query_string, variables: {}) }
 
     it "runs the AST analyzers correctly" do
+      res = query.result
+      refute res.key?("data")
+      assert_equal ["An Error!"], res["errors"].map { |e| e["message"] }
+    end
+
+    it "skips rewrite" do
+      # Try running the query:
       query.result
+      # But the validation step doesn't build an irep_node tree
+      assert_nil query.irep_selection
     end
   end
 

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -171,6 +171,7 @@ describe GraphQL::Execution::Interpreter do
 
     class Schema < GraphQL::Schema
       use GraphQL::Execution::Interpreter
+      use GraphQL::Analysis::AST
       query(Query)
       lazy_resolve(Box, :value)
     end

--- a/spec/graphql/schema/warden_spec.rb
+++ b/spec/graphql/schema/warden_spec.rb
@@ -185,6 +185,7 @@ module MaskHelpers
     instrument :query, FilterInstrumentation
     if TESTING_INTERPRETER
       use GraphQL::Execution::Interpreter
+      use GraphQL::Analysis::AST
     end
   end
 

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -736,6 +736,7 @@ module Jazz
     end
     if TESTING_INTERPRETER
       use GraphQL::Execution::Interpreter
+      use GraphQL::Analysis::AST
     end
   end
 end

--- a/spec/support/lazy_helpers.rb
+++ b/spec/support/lazy_helpers.rb
@@ -173,6 +173,7 @@ module LazyHelpers
 
     if TESTING_INTERPRETER
       use GraphQL::Execution::Interpreter
+      use GraphQL::Analysis::AST
     end
 
     def self.sync_lazy(lazy)


### PR DESCRIPTION
We have this alternative path that doesn't require `irep_node`s, so let's see if we can skip building them altogether (which is the goal). 

This is a bit different take than #1918 , because you have to explicitly opt into _both_ (but this is kind of good, since you can adopt them separately).