### PR TITLE
1.9 hash key schema fix

### DIFF
--- a/spec/graphql/schema/field_spec.rb
+++ b/spec/graphql/schema/field_spec.rb
@@ -45,6 +45,12 @@ describe GraphQL::Schema::Field do
       assert_equal 'underscored_arg', arg_defn.name
     end
 
+    it "works with arbitrary hash keys" do
+      result = Jazz::Schema.execute "{ complexHashKey }", root_value: { :'foo bar/fizz-buzz' => "OK!"}
+      hash_val = result["data"]["complexHashKey"]
+      assert_equal "OK!", hash_val, "It looked up the hash key"
+    end
+
     it "exposes the method override" do
       object = Class.new(Jazz::BaseObject) do
         field :t, String, method: :tt, null: true

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -467,6 +467,8 @@ module Jazz
     def default_value_test(arg_with_default:)
       "#{arg_with_default.class.name} -> #{arg_with_default.to_h}"
     end
+
+    field :complex_hash_key, String, null: false, hash_key: :'foo bar/fizz-buzz'
   end
 
   class EnsembleInput < GraphQL::Schema::InputObject


### PR DESCRIPTION
Copies #1979 onto 1.9-dev and shows that it's fixed by #1961 