### PR TITLE
add jekyll-redirect-from to Gemfile for fixing 'bundle exec rake site:serve'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,5 @@ gem 'pry-byebug'
 # Required for running `jekyll algolia ...` (via `rake site:update_search_index`)
 group :jekyll_plugins do
   gem 'jekyll-algolia', '~> 1.0'
+  gem 'jekyll-redirect-from'
 end


### PR DESCRIPTION
I got below error message.
```
Configuration file: /Users/technuma/gems/graphql-ruby/guides/_config.yml                                                                                                                                Dependency Error: Yikes! It looks like you don't have jekyll-redirect-from or one of its dependencies installed. In order to use Jekyll as currently configured, you'll need to install this gem. The full
 error message from Ruby is: 'cannot load such file -- jekyll-redirect-from' If you run into trouble, you can find helpful resources at https://jekyllrb.com/help/! 
rake aborted! 
```