### PR TITLE
Handle multiple top-level errors

### DIFF
--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -42,6 +42,7 @@ end
 # Order matters for these:
 
 require "graphql/execution_error"
+require "graphql/execution_errors_mapper"
 require "graphql/define"
 require "graphql/base_type"
 require "graphql/object_type"

--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -168,6 +168,12 @@ module GraphQL
           query = field_ctx.query
 
           case raw_value
+          when GraphQL::ExecutionErrorsMapper
+            raw_value.errors.each do |error|
+              error.ast_node ||= field_ctx.ast_node
+              error.path = field_ctx.path
+              query.context.errors.push(error)
+            end
           when GraphQL::ExecutionError
             raw_value.ast_node ||= field_ctx.ast_node
             raw_value.path = field_ctx.path
@@ -206,6 +212,12 @@ module GraphQL
               nil
             end
           elsif value.is_a?(GraphQL::ExecutionError)
+            if field_type.kind.non_null?
+              PROPAGATE_NULL
+            else
+              nil
+            end
+          elsif value.is_a?(GraphQL::ExecutionErrorsMapper)
             if field_type.kind.non_null?
               PROPAGATE_NULL
             else

--- a/lib/graphql/execution_errors_mapper.rb
+++ b/lib/graphql/execution_errors_mapper.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module GraphQL
+  # If a field's resolve function returns a {ExecutionError},
+  # the error will be inserted into the response's `"errors"` key
+  # and the field will resolve to `nil`.
+  class ExecutionErrorsMapper
+    attr_accessor :errors
+
+    def initialize(errors = [])
+      @errors = errors
+    end
+
+    def add(error)
+      @errors << error
+    end
+
+    def <<(error)
+      @errors << error
+    end
+  end
+end

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -385,6 +385,8 @@ module GraphQL
           else
             obj.object.public_send(@method_sym)
           end
+        elsif obj.object.is_a?(GraphQL::ExecutionErrorsMapper)
+          obj.object
         else
           raise <<-ERR
         Failed to implement #{@owner.graphql_name}.#{@name}, tried:


### PR DESCRIPTION
Good day!
I'm applying gpraphql in my project and got stuck with validation errors. As described in specification: https://facebook.github.io/graphql/draft/#sec-Data

> If an error was encountered during the execution that prevented a valid response, the data entry in the response should be null.

But the gem suggests us to store validation errors in data entry.
I've discussed it with my frontend developer and he asserts that all errors should be stored in the top-level error entry and all frontend libraries are expected to find it there.
I've added a special class, which can store several errors and then put them in errors entry. It's just a draft because I'm not sure that it would be accepted.
It looks like:
```
GraphQL::ExecutionErrorsMapper.new(
  model_name.errors.full_messages.map { |message| GraphQL::ExecutionError.new(message) }
)
```
```
 "errors": [
    {
      "message": "error1",
      "locations": [
        {
          "line": 4,
          "column": 7
        }
      ],
    },
    {
      "message": "error2",
      "locations": [
        {
          "line": 4,
          "column": 7
        }
      ],
    }
  ]
}
```

Should I continue to work with it?