### PR TITLE
Allow code to be accessed outside of the errors

### DIFF
--- a/lib/graphql/static_validation/rules/argument_literals_are_compatible_error.rb
+++ b/lib/graphql/static_validation/rules/argument_literals_are_compatible_error.rb
@@ -23,7 +23,6 @@ module GraphQL
         })
       end
 
-      private
       def code
         "argumentLiteralsIncompatible"
       end

--- a/lib/graphql/static_validation/rules/argument_names_are_unique_error.rb
+++ b/lib/graphql/static_validation/rules/argument_names_are_unique_error.rb
@@ -21,7 +21,6 @@ module GraphQL
         })
       end
 
-      private
       def code
         "argumentNotUnique"
       end

--- a/lib/graphql/static_validation/rules/arguments_are_defined_error.rb
+++ b/lib/graphql/static_validation/rules/arguments_are_defined_error.rb
@@ -27,7 +27,6 @@ module GraphQL
         })
       end
 
-      private
       def code
         "argumentNotAccepted"
       end

--- a/lib/graphql/static_validation/rules/directives_are_defined_error.rb
+++ b/lib/graphql/static_validation/rules/directives_are_defined_error.rb
@@ -21,7 +21,6 @@ module GraphQL
         })
       end
 
-      private
       def code
         "undefinedDirective"
       end

--- a/lib/graphql/static_validation/rules/directives_are_in_valid_locations_error.rb
+++ b/lib/graphql/static_validation/rules/directives_are_in_valid_locations_error.rb
@@ -23,7 +23,6 @@ module GraphQL
         })
       end
 
-      private
       def code
         "directiveCannotBeApplied"
       end

--- a/lib/graphql/static_validation/rules/fields_are_defined_on_type_error.rb
+++ b/lib/graphql/static_validation/rules/fields_are_defined_on_type_error.rb
@@ -24,7 +24,6 @@ module GraphQL
         })
       end
 
-      private
       def code
         "undefinedField"
       end

--- a/lib/graphql/static_validation/rules/fields_have_appropriate_selections_error.rb
+++ b/lib/graphql/static_validation/rules/fields_have_appropriate_selections_error.rb
@@ -23,7 +23,6 @@ module GraphQL
         })
       end
 
-      private
       def code
         "selectionMismatch"
       end

--- a/lib/graphql/static_validation/rules/fields_will_merge_error.rb
+++ b/lib/graphql/static_validation/rules/fields_will_merge_error.rb
@@ -24,7 +24,6 @@ module GraphQL
         })
       end
 
-      private
       def code
         "fieldConflict"
       end

--- a/lib/graphql/static_validation/rules/fragment_names_are_unique_error.rb
+++ b/lib/graphql/static_validation/rules/fragment_names_are_unique_error.rb
@@ -21,7 +21,6 @@ module GraphQL
         })
       end
 
-      private
       def code
         "fragmentNotUnique"
       end

--- a/lib/graphql/static_validation/rules/fragment_spreads_are_possible_error.rb
+++ b/lib/graphql/static_validation/rules/fragment_spreads_are_possible_error.rb
@@ -27,7 +27,6 @@ module GraphQL
         })
       end
 
-      private
       def code
         "cannotSpreadFragment"
       end

--- a/lib/graphql/static_validation/rules/fragment_types_exist_error.rb
+++ b/lib/graphql/static_validation/rules/fragment_types_exist_error.rb
@@ -21,7 +21,6 @@ module GraphQL
         })
       end
 
-      private
       def code
         "undefinedType"
       end

--- a/lib/graphql/static_validation/rules/fragments_are_finite_error.rb
+++ b/lib/graphql/static_validation/rules/fragments_are_finite_error.rb
@@ -21,7 +21,6 @@ module GraphQL
         })
       end
 
-      private
       def code
         "infiniteLoop"
       end

--- a/lib/graphql/static_validation/rules/fragments_are_named_error.rb
+++ b/lib/graphql/static_validation/rules/fragments_are_named_error.rb
@@ -18,7 +18,6 @@ module GraphQL
         })
       end
 
-      private
       def code
         "anonymousFragment"
       end

--- a/lib/graphql/static_validation/rules/fragments_are_on_composite_types_error.rb
+++ b/lib/graphql/static_validation/rules/fragments_are_on_composite_types_error.rb
@@ -22,7 +22,6 @@ module GraphQL
         })
       end
 
-      private
       def code
         "fragmentOnNonCompositeType"
       end

--- a/lib/graphql/static_validation/rules/fragments_are_used_error.rb
+++ b/lib/graphql/static_validation/rules/fragments_are_used_error.rb
@@ -21,7 +21,6 @@ module GraphQL
         })
       end
 
-      private
       def code
         "useAndDefineFragment"
       end

--- a/lib/graphql/static_validation/rules/mutation_root_exists_error.rb
+++ b/lib/graphql/static_validation/rules/mutation_root_exists_error.rb
@@ -18,7 +18,6 @@ module GraphQL
         })
       end
 
-      private
       def code
         "missingMutationConfiguration"
       end

--- a/lib/graphql/static_validation/rules/no_definitions_are_present_error.rb
+++ b/lib/graphql/static_validation/rules/no_definitions_are_present_error.rb
@@ -17,7 +17,6 @@ module GraphQL
         })
       end
 
-      private
       def code
         "queryContainsSchemaDefinitions"
       end

--- a/lib/graphql/static_validation/rules/operation_names_are_valid_error.rb
+++ b/lib/graphql/static_validation/rules/operation_names_are_valid_error.rb
@@ -20,7 +20,6 @@ module GraphQL
         })
       end
 
-      private
       def code
         "uniquelyNamedOperations"
       end

--- a/lib/graphql/static_validation/rules/required_arguments_are_present_error.rb
+++ b/lib/graphql/static_validation/rules/required_arguments_are_present_error.rb
@@ -27,7 +27,6 @@ module GraphQL
         })
       end
 
-      private
       def code
         "missingRequiredArguments"
       end

--- a/lib/graphql/static_validation/rules/subscription_root_exists_error.rb
+++ b/lib/graphql/static_validation/rules/subscription_root_exists_error.rb
@@ -18,7 +18,6 @@ module GraphQL
         })
       end
 
-      private
       def code
         "missingSubscriptionConfiguration"
       end

--- a/lib/graphql/static_validation/rules/unique_directives_per_location_error.rb
+++ b/lib/graphql/static_validation/rules/unique_directives_per_location_error.rb
@@ -21,7 +21,6 @@ module GraphQL
         })
       end
 
-      private
       def code
         "directiveNotUniqueForLocation"
       end

--- a/lib/graphql/static_validation/rules/variable_default_values_are_correctly_typed_error.rb
+++ b/lib/graphql/static_validation/rules/variable_default_values_are_correctly_typed_error.rb
@@ -31,7 +31,6 @@ module GraphQL
         })
       end
 
-      private
       def code
         @violation
       end

--- a/lib/graphql/static_validation/rules/variable_names_are_unique_error.rb
+++ b/lib/graphql/static_validation/rules/variable_names_are_unique_error.rb
@@ -21,7 +21,6 @@ module GraphQL
         })
       end
 
-      private
       def code
         "variableNotUnique"
       end

--- a/lib/graphql/static_validation/rules/variable_usages_are_allowed_error.rb
+++ b/lib/graphql/static_validation/rules/variable_usages_are_allowed_error.rb
@@ -30,7 +30,6 @@ module GraphQL
         })
       end
 
-      private
       def code
         "variableMismatch"
       end

--- a/lib/graphql/static_validation/rules/variables_are_input_types_error.rb
+++ b/lib/graphql/static_validation/rules/variables_are_input_types_error.rb
@@ -24,7 +24,6 @@ module GraphQL
         })
       end
 
-      private
       def code
         "variableRequiresValidType"
       end

--- a/lib/graphql/static_validation/rules/variables_are_used_and_defined_error.rb
+++ b/lib/graphql/static_validation/rules/variables_are_used_and_defined_error.rb
@@ -29,7 +29,6 @@ module GraphQL
         })
       end
 
-      private
       def code
         @violation
       end


### PR DESCRIPTION
This allows better reporting of codes without the need to use `to_h`. It's also better for subclasses as they can modify if they need to. Which for fine grained reporting they would want to.

I'm sure I had good reasons to make this private originally, but use cases now show this would be a much better solution.