### PR TITLE
allow using false as enum values :value argument

### DIFF
--- a/lib/graphql/schema/enum_value.rb
+++ b/lib/graphql/schema/enum_value.rb
@@ -40,7 +40,7 @@ module GraphQL
       def initialize(graphql_name, desc = nil, owner:, description: nil, value: nil, deprecation_reason: nil, &block)
         @graphql_name = graphql_name.to_s
         @description = desc || description
-        @value = value || @graphql_name
+        @value = value.nil? ? @graphql_name : value
         @deprecation_reason = deprecation_reason
         @owner = owner
 
@@ -57,7 +57,7 @@ module GraphQL
       end
 
       def value(new_val = nil)
-        if new_val
+        unless new_val.nil?
           @value = new_val
         end
         @value

--- a/spec/graphql/schema/enum_spec.rb
+++ b/spec/graphql/schema/enum_spec.rb
@@ -14,7 +14,7 @@ describe GraphQL::Schema::Enum do
     it "tells about the definition" do
       assert_equal "Family", enum.graphql_name
       assert_equal 29, enum.description.length
-      assert_equal 6, enum.values.size
+      assert_equal 7, enum.values.size
     end
 
     it "inherits values and description" do
@@ -26,8 +26,8 @@ describe GraphQL::Schema::Enum do
       # Description was inherited
       assert_equal 29, new_enum.description.length
       # values were inherited without modifying the parent
-      assert_equal 6, enum.values.size
-      assert_equal 7, new_enum.values.size
+      assert_equal 7, enum.values.size
+      assert_equal 8, new_enum.values.size
       perc_value = new_enum.values["PERCUSSION"]
       assert_equal "new description", perc_value.description
     end
@@ -56,8 +56,10 @@ describe GraphQL::Schema::Enum do
 
       string_val = enum_type.values["STRING"]
       didg_val = enum_type.values["DIDGERIDOO"]
+      silence_val = enum_type.values["SILENCE"]
       assert_equal "STRING", string_val.name
       assert_equal :str, string_val.value
+      assert_equal false, silence_val.value
       assert_equal "DIDGERIDOO", didg_val.name
       assert_equal "Merged into BRASS", didg_val.deprecation_reason
     end

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -219,6 +219,7 @@ module Jazz
     value "KEYS" do
       description "Neither here nor there, really"
     end
+    value "SILENCE", "Makes no sound", value: false
   end
 
   # Lives side-by-side with an old-style definition


### PR DESCRIPTION
Hi there,

I don't know if it's a feature or a bug, but `false` used to be an accepted `:value` argument in enum values, and didn't work when I switched to the latest 1.9.0.pre1 build and the class based schema.

This PR just allows `false` as an enum custom ruby value :

```ruby
class Family < BaseEnum
  description "Groups of musical instruments"
  # support string and symbol
  # ...
  value "SILENCE", "Makes no sound", value: false
end
```

I added an assertion in the test that seemed right to me.
I'm available to update the PR code if needed !

Thanks