### PR TITLE
support a Promise as an ably client

### DIFF
--- a/javascript_client/subscriptions/createAblyHandler.js
+++ b/javascript_client/subscriptions/createAblyHandler.js
@@ -7,8 +7,14 @@ function createAblyHandler(options) {
   var fetchOperation = options.fetchOperation
   return function (operation, variables, cacheConfig, observer) {
     var channelName, channel
-    // POST the subscription like a normal query
-    fetchOperation(operation, variables, cacheConfig).then(function(response) {
+    Promise.all([
+       // POST the subscription like a normal query
+      fetchOperation(operation, variables, cacheConfig),
+      // and try to resolve ably in case it's a Promise
+      Promise.resolve(ably)
+    ]).then(function(results) {
+      var response = results[0]
+      ably = results[1]
       channelName = response.headers.get("X-Subscription-ID")
       channel = ably.channels.get(channelName)
       // Register presence, so that we can detect empty channels and clean them up server-side

--- a/javascript_client/subscriptions/createHandler.js
+++ b/javascript_client/subscriptions/createHandler.js
@@ -11,7 +11,7 @@ var createAblyHandler = require("./createAblyHandler")
  *   var network = Network.create(fetchQuery, subscriptionHandler)
  * @param {ActionCable.Consumer} options.cable - A consumer from `.createConsumer`
  * @param {Pusher} options.pusher - A Pusher client
- * @param {Ably.Realtime} options.ably - An Ably client
+ * @param {Ably.Realtime} options.ably - An Ably client or a Promise that resolves to an Ably client
  * @param {OperationStoreClient} options.operations - A generated `OperationStoreClient` for graphql-pro's OperationStore
  * @return {Function} A handler for a Relay Modern network
 */


### PR DESCRIPTION
we got things working with ably + `authUrl` but in react-native we need to do an async read in order to get the token to use for that request. this pr allows the `ably` option to be either a client or a `Promise` that resolves to a client.