### PR TITLE
Make error_bubbling=false the schema default

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -184,7 +184,7 @@ module GraphQL
       @introspection_namespace = nil
       @introspection_system = nil
       @interpeter = false
-      @error_bubbling = true
+      @error_bubbling = false
     end
 
     # @return [Boolean] True if using the new {GraphQL::Execution::Interpreter}


### PR DESCRIPTION
This makes the new behavior from #2013 the default. It will require `error_bubbling true` to unset it. Thanks again @modosc for your work on this!