### PR TITLE
Fix typo in GraphQL::Schema

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -184,7 +184,7 @@ module GraphQL
       @context_class = GraphQL::Query::Context
       @introspection_namespace = nil
       @introspection_system = nil
-      @interpeter = false
+      @interpreter = false
       @error_bubbling = false
     end
 


### PR DESCRIPTION
I just fixed a typo. By this change, the method `interpreter?` returns `false` instead of `nil`. I believe it's not a breaking change but please have a look. Thanks!