### PR TITLE
Handle visitor when no operation is selected

### DIFF
--- a/lib/graphql/analysis/ast/visitor.rb
+++ b/lib/graphql/analysis/ast/visitor.rb
@@ -32,6 +32,11 @@ module GraphQL
         # @return [Array<GraphQL::ObjectType>] Types whose scope we've entered
         attr_reader :object_types
 
+        def visit
+          return unless @document
+          super
+        end
+
         # Visit Helpers
 
         # @return [GraphQL::Query::Arguments] Arguments for this node, merging default values, literal values and query variables

--- a/spec/graphql/analysis/ast_spec.rb
+++ b/spec/graphql/analysis/ast_spec.rb
@@ -137,6 +137,18 @@ describe GraphQL::Analysis::AST do
       }
     |}
 
+    describe "without a selected operation" do
+      let(:query_string) {%|
+        # A comment
+        # And nothing else
+        # Should not break
+      |}
+
+      it "bails early when there is no selected operation to be executed" do
+        assert_equal 2, reduce_result.size
+      end
+    end
+
     describe "conditional analysis" do
       let(:analyzers) { [AstTypeCollector, AstConditionalAnalyzer] }
 


### PR DESCRIPTION
The AST visitor is a special case visitor that only visits the selected operation of a query (what will actually be ran), which emulates was the Internal Representation used to do. The irep also took care of queries with no selected operations, which was missing here.

This PR returns early when no @document is present for the visitor (when there was no selected operation on the query)