### PR TITLE
Better node field compat with interpreter

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -4,7 +4,7 @@ appraise 'rails_3.2' do
   gem 'activerecord', '~> 3.2.21'
   gem 'actionpack', '~> 3.2.21'
   gem 'test-unit'
-  gem 'sqlite3', platform: :ruby
+  gem 'sqlite3', "~> 1.3.6", platform: :ruby
   gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby
   gem 'sequel'
 end
@@ -12,7 +12,7 @@ end
 appraise 'rails_4.1' do
   gem 'rails', '~> 4.1.10', require: 'rails/all'
   gem 'test-unit'
-  gem 'sqlite3', platform: :ruby
+  gem 'sqlite3', "~> 1.3.6", platform: :ruby
   gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby
   gem 'sequel'
 end
@@ -22,7 +22,7 @@ appraise 'rails_4.2' do
   gem 'activerecord', '~> 4.2.4'
   gem 'actionpack', '~> 4.2.4'
   gem 'concurrent-ruby', '1.0.0'
-  gem 'sqlite3', platform: :ruby
+  gem 'sqlite3', "~> 1.3.6", platform: :ruby
   gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby
   gem 'sequel'
 end
@@ -31,7 +31,7 @@ appraise 'rails_5.0' do
   gem 'rails', '~> 5.0', require: 'rails/all'
   gem 'activerecord', '~> 5.0.0'
   gem 'actionpack', '~> 5.0.0'
-  gem 'sqlite3', platform: :ruby
+  gem 'sqlite3', "~> 1.3.6", platform: :ruby
   gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby
   gem 'sequel'
 end
@@ -43,14 +43,14 @@ appraise 'rails_5.1' do
   # Required for system tests
   gem 'capybara', '~> 2.13'
   gem 'selenium-webdriver'
-  gem 'sqlite3', platform: :ruby
+  gem 'sqlite3', "~> 1.3.6", platform: :ruby
   gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby
   gem 'sequel'
 end
 
 appraise 'rails_5.2' do
   gem 'rails', '~> 5.2.0', require: 'rails/all'
-  gem 'sqlite3', platform: :ruby
+  gem 'sqlite3', "~> 1.3.6", platform: :ruby
   gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby
   gem 'sequel'
 end

--- a/gemfiles/rails_3.2.gemfile
+++ b/gemfiles/rails_3.2.gemfile
@@ -10,7 +10,7 @@ gem "rails", "3.2.22.5", require: "rails/all"
 gem "activerecord", "~> 3.2.21"
 gem "actionpack", "~> 3.2.21"
 gem "test-unit"
-gem "sqlite3", platform: :ruby
+gem "sqlite3", "~> 1.3.6", platform: :ruby
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sequel"
 

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -8,7 +8,7 @@ gem "pry"
 gem "pry-stack_explorer", platform: :ruby
 gem "rails", "~> 4.1.10", require: "rails/all"
 gem "test-unit"
-gem "sqlite3", platform: :ruby
+gem "sqlite3", "~> 1.3.6", platform: :ruby
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sequel"
 

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -10,7 +10,7 @@ gem "rails", "~> 4.2", require: "rails/all"
 gem "activerecord", "~> 4.2.4"
 gem "actionpack", "~> 4.2.4"
 gem "concurrent-ruby", "1.0.0"
-gem "sqlite3", platform: :ruby
+gem "sqlite3", "~> 1.3.6", platform: :ruby
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sequel"
 

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -9,7 +9,7 @@ gem "pry-stack_explorer", platform: :ruby
 gem "rails", "~> 5.0", require: "rails/all"
 gem "activerecord", "~> 5.0.0"
 gem "actionpack", "~> 5.0.0"
-gem "sqlite3", platform: :ruby
+gem "sqlite3", "~> 1.3.6", platform: :ruby
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sequel"
 

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -10,7 +10,7 @@ gem "rails", "~> 5.1.0", require: "rails/all"
 gem "puma"
 gem "capybara", "~> 2.13"
 gem "selenium-webdriver"
-gem "sqlite3", platform: :ruby
+gem "sqlite3", "~> 1.3.6", platform: :ruby
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sequel"
 

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -7,7 +7,7 @@ gem "ruby-prof", platform: :ruby
 gem "pry"
 gem "pry-stack_explorer", platform: :ruby
 gem "rails", "~> 5.2.0", require: "rails/all"
-gem "sqlite3", platform: :ruby
+gem "sqlite3", "~> 1.3.6", platform: :ruby
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sequel"
 

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -63,6 +63,16 @@ module GraphQL
       # @return [GraphQL::Schema:Field] an instance of `self
       # @see {.initialize} for other options
       def self.from_options(name = nil, type = nil, desc = nil, resolver: nil, mutation: nil, subscription: nil,**kwargs, &block)
+        if kwargs[:field]
+          if kwargs[:field] == GraphQL::Relay::Node.field
+            warn("Legacy-style `GraphQL::Relay::Node.field` is being added to a class-based type. See `GraphQL::Types::Relay::NodeField` for a replacement.")
+            return GraphQL::Types::Relay::NodeField
+          elsif kwargs[:field] == GraphQL::Relay::Node.plural_field
+            warn("Legacy-style `GraphQL::Relay::Node.plural_field` is being added to a class-based type. See `GraphQL::Types::Relay::NodesField` for a replacement.")
+            return GraphQL::Types::Relay::NodesField
+          end
+        end
+
         if (parent_config = resolver || mutation || subscription)
           # Get the parent config, merge in local overrides
           kwargs = parent_config.field_options.merge(kwargs)

--- a/lib/graphql/types/relay/node_field.rb
+++ b/lib/graphql/types/relay/node_field.rb
@@ -25,6 +25,7 @@ module GraphQL
         type: GraphQL::Types::Relay::Node,
         null: true,
         description: "Fetches an object given its ID.",
+        relay_node_field: true,
       ) do
         argument :id, "ID!", required: true,
           description: "ID of the object."

--- a/lib/graphql/types/relay/node_field.rb
+++ b/lib/graphql/types/relay/node_field.rb
@@ -4,13 +4,27 @@ module GraphQL
     module Relay
       # This can be used for implementing `Query.node(id: ...)`,
       # or use it for inspiration for your own field definition.
+      #
+      # @example Adding this field directly
+      #   add_field(GraphQL::Types::Relay::NodeField)
+      #
+      # @example Implementing a similar field in your own Query root
+      #
+      #   field :node, GraphQL::Types::Relay::Node, null: true,
+      #     description: "Fetches an object given its ID" do
+      #       argument :id, ID, required: true
+      #     end
+      #
+      #   def node(id:)
+      #     context.schema.object_from_id(context, id)
+      #   end
+      #
       NodeField = GraphQL::Schema::Field.new(
         name: "node",
         owner: nil,
         type: GraphQL::Types::Relay::Node,
         null: true,
         description: "Fetches an object given its ID.",
-        relay_node_field: true,
       ) do
         argument :id, "ID!", required: true,
           description: "ID of the object."

--- a/lib/graphql/types/relay/nodes_field.rb
+++ b/lib/graphql/types/relay/nodes_field.rb
@@ -4,14 +4,29 @@ module GraphQL
     module Relay
       # This can be used for implementing `Query.nodes(ids: ...)`,
       # or use it for inspiration for your own field definition.
-      # @see GraphQL::Types::Relay::NodeField
+      #
+      # @example Adding this field directly
+      #   add_field(GraphQL::Types::Relay::NodesField)
+      #
+      # @example Implementing a similar field in your own Query root
+      #
+      #   field :nodes, [GraphQL::Types::Relay::Node, null: true], null: false,
+      #     description: Fetches a list of objects given a list of IDs." do
+      #       argument :ids, [ID], required: true
+      #     end
+      #
+      #   def nodes(ids:)
+      #     ids.map do |id|
+      #       context.schema.object_from_id(context, id)
+      #     end
+      #   end
+      #
       NodesField = GraphQL::Schema::Field.new(
         name: "nodes",
         owner: nil,
         type: [GraphQL::Types::Relay::Node, null: true],
         null: false,
         description: "Fetches a list of objects given a list of IDs.",
-        relay_nodes_field: true,
       ) do
         argument :ids, "[ID!]!", required: true,
           description: "IDs of the objects."

--- a/lib/graphql/types/relay/nodes_field.rb
+++ b/lib/graphql/types/relay/nodes_field.rb
@@ -27,6 +27,7 @@ module GraphQL
         type: [GraphQL::Types::Relay::Node, null: true],
         null: false,
         description: "Fetches a list of objects given a list of IDs.",
+        relay_nodes_field: true,
       ) do
         argument :ids, "[ID!]!", required: true,
           description: "IDs of the objects."


### PR DESCRIPTION
Add a warning for legacy nodes fields  but try to support it. Improve docs. 

closes #2082 