### PR TITLE
performance: Replace use of Enumerable#none? without a block with empty?

### DIFF
--- a/lib/graphql/execution/interpreter/hash_response.rb
+++ b/lib/graphql/execution/interpreter/hash_response.rb
@@ -21,7 +21,7 @@ module GraphQL
         # Add `value` at `path`.
         # @return [void]
         def write(path, value)
-          if path.size == 0 # faster than #none?
+          if path.empty?
             @result = value
           elsif (write_target = @result)
             i = 0

--- a/lib/graphql/execution/lookahead.rb
+++ b/lib/graphql/execution/lookahead.rb
@@ -215,7 +215,7 @@ module GraphQL
         case node
         when GraphQL::Language::Nodes::Field
           if node.name == field_name
-            if arguments.nil? || arguments.none?
+            if arguments.nil? || arguments.empty?
               # No constraint applied
               matches << node
             else

--- a/lib/graphql/internal_representation/rewrite.rb
+++ b/lib/graphql/internal_representation/rewrite.rb
@@ -102,13 +102,13 @@ module GraphQL
           @rewrite_skip_nodes.add(node)
         end
 
-        if @rewrite_skip_nodes.none?
+        if @rewrite_skip_nodes.empty?
           @rewrite_scopes_stack.push(@rewrite_scopes_stack.last.enter(context.type_definition))
         end
 
         super
 
-        if @rewrite_skip_nodes.none?
+        if @rewrite_skip_nodes.empty?
           @rewrite_scopes_stack.pop
         end
 
@@ -122,7 +122,7 @@ module GraphQL
           @rewrite_skip_nodes.add(ast_node)
         end
 
-        if @rewrite_skip_nodes.none?
+        if @rewrite_skip_nodes.empty?
           node_name = ast_node.alias || ast_node.name
           parent_nodes = @rewrite_nodes_stack.last
           next_nodes = []
@@ -156,7 +156,7 @@ module GraphQL
 
         super
 
-        if @rewrite_skip_nodes.none?
+        if @rewrite_skip_nodes.empty?
           @rewrite_nodes_stack.pop
           @rewrite_scopes_stack.pop
         end
@@ -167,7 +167,7 @@ module GraphQL
       end
 
       def on_fragment_spread(ast_node, ast_parent)
-        if @rewrite_skip_nodes.none? && !skip?(ast_node)
+        if @rewrite_skip_nodes.empty? && !skip?(ast_node)
           # Register the irep nodes that depend on this AST node:
           @rewrite_spread_parents[ast_node].merge(@rewrite_nodes_stack.last)
           @rewrite_spread_scopes[ast_node] = @rewrite_scopes_stack.last

--- a/lib/graphql/language/parser.rb
+++ b/lib/graphql/language/parser.rb
@@ -28,7 +28,7 @@ def parse_document
     end
     # From the tokens, build an AST
     @tracer.trace("parse", {query_string: @query_string}) do
-      if @tokens.none?
+      if @tokens.empty?
         make_node(:Document, definitions: [], filename: @filename)
       else
         do_parse

--- a/lib/graphql/language/parser.y
+++ b/lib/graphql/language/parser.y
@@ -447,7 +447,7 @@ def parse_document
     end
     # From the tokens, build an AST
     @tracer.trace("parse", {query_string: @query_string}) do
-      if @tokens.none?
+      if @tokens.empty?
         make_node(:Document, definitions: [], filename: @filename)
       else
         do_parse

--- a/lib/graphql/language/printer.rb
+++ b/lib/graphql/language/printer.rb
@@ -135,7 +135,7 @@ module GraphQL
         if (schema.query.nil? || schema.query == 'Query') &&
            (schema.mutation.nil? || schema.mutation == 'Mutation') &&
            (schema.subscription.nil? || schema.subscription == 'Subscription') &&
-           (schema.directives.none?)
+           (schema.directives.empty?)
           return
         end
 

--- a/lib/graphql/language/visitor.rb
+++ b/lib/graphql/language/visitor.rb
@@ -96,7 +96,7 @@ module GraphQL
         else
           # Run hooks if there are any
           new_node = node
-          begin_hooks_ok = @visitors.none? || begin_visit(new_node, parent)
+          begin_hooks_ok = @visitors.empty? || begin_visit(new_node, parent)
           if begin_hooks_ok
             node.children.each do |child_node|
               new_child_and_node = on_node_with_modifications(child_node, new_node)

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -239,7 +239,7 @@ module GraphQL
 
     attr_accessor :analysis_errors
     def valid?
-      validation_pipeline.valid? && analysis_errors.none?
+      validation_pipeline.valid? && analysis_errors.empty?
     end
 
     def warden

--- a/lib/graphql/query/arguments_cache.rb
+++ b/lib/graphql/query/arguments_cache.rb
@@ -8,7 +8,7 @@ module GraphQL
         Hash.new do |h1, irep_or_ast_node|
           h1[irep_or_ast_node] = Hash.new do |h2, definition|
             ast_node = irep_or_ast_node.is_a?(GraphQL::InternalRepresentation::Node) ? irep_or_ast_node.ast_node : irep_or_ast_node
-            h2[definition] = if definition.arguments.none?
+            h2[definition] = if definition.arguments.empty?
               GraphQL::Query::Arguments::NO_ARGS
             else
               GraphQL::Query::LiteralInput.from_arguments(

--- a/lib/graphql/query/validation_pipeline.rb
+++ b/lib/graphql/query/validation_pipeline.rb
@@ -76,11 +76,11 @@ module GraphQL
           @validation_errors.concat(validation_result[:errors])
           @internal_representation = validation_result[:irep]
 
-          if @validation_errors.none?
+          if @validation_errors.empty?
             @validation_errors.concat(@query.variables.errors)
           end
 
-          if @validation_errors.none?
+          if @validation_errors.empty?
             @query_analyzers = build_analyzers(
               @schema,
               @max_depth,
@@ -89,7 +89,7 @@ module GraphQL
           end
         end
 
-        @valid = @validation_errors.none?
+        @valid = @validation_errors.empty?
       end
 
       # If there are max_* values, add them,

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -602,7 +602,7 @@ MSG
       # Written iteratively to avoid big stack traces.
       # @return [Object] Whatever the
       def with_extensions(obj, args, ctx)
-        if @extensions.none?
+        if @extensions.empty?
           yield(obj, args)
         else
           # Save these so that the originals can be re-given to `after_resolve` handlers.

--- a/lib/graphql/schema/mutation.rb
+++ b/lib/graphql/schema/mutation.rb
@@ -65,7 +65,7 @@ module GraphQL
       class << self
         # Override this method to handle legacy-style usages of `MyMutation.field`
         def field(*args, &block)
-          if args.none?
+          if args.empty?
             raise ArgumentError, "#{name}.field is used for adding fields to this mutation. Use `mutation: #{name}` to attach this mutation instead."
           else
             super

--- a/lib/graphql/static_validation/base_visitor.rb
+++ b/lib/graphql/static_validation/base_visitor.rb
@@ -35,7 +35,7 @@ module GraphQL
       # @param rewrite [Boolean] if `false`, don't include rewrite
       # @return [Class] A class for validating `rules` during visitation
       def self.including_rules(rules, rewrite: true)
-        if rules.none?
+        if rules.empty?
           if rewrite
             NoValidateVisitor
           else

--- a/lib/graphql/static_validation/definition_dependencies.rb
+++ b/lib/graphql/static_validation/definition_dependencies.rb
@@ -134,7 +134,7 @@ module GraphQL
           # That way, we can use the remainder to identify cycles
           @defdep_immediate_dependencies.delete(fragment_node)
           fragment_usages = @defdep_dependent_definitions[fragment_node]
-          if fragment_usages.none?
+          if fragment_usages.empty?
             # If we didn't record any usages during the visit,
             # then this fragment is unused.
             dependency_map.unused_dependencies << @defdep_node_paths[fragment_node]
@@ -151,7 +151,7 @@ module GraphQL
               if block_given?
                 yield(definition_node, removed, fragment_node)
               end
-              if remaining.none? && definition_node.is_a?(GraphQL::Language::Nodes::FragmentDefinition)
+              if remaining.empty? && definition_node.is_a?(GraphQL::Language::Nodes::FragmentDefinition)
                 # If all of this definition's dependencies have
                 # been resolved, we can now resolve its
                 # own dependents.
@@ -171,7 +171,7 @@ module GraphQL
               deps.delete(spread)
             end
           end
-          if deps.none?
+          if deps.empty?
             @defdep_immediate_dependencies.delete(defn_node)
           end
         end

--- a/lib/graphql/static_validation/literal_validator.rb
+++ b/lib/graphql/static_validation/literal_validator.rb
@@ -87,7 +87,7 @@ module GraphQL
         present_field_names = ast_node.arguments.map(&:name)
         missing_required_field_names = required_field_names - present_field_names
         if @context.schema.error_bubbling
-          missing_required_field_names.none?
+          missing_required_field_names.empty?
         else
           missing_required_field_names.all? do |name|
             validate(GraphQL::Language::Nodes::NullValue.new(name: name), @warden.arguments(type).find { |f| f.name == name }.type )

--- a/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb
+++ b/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb
@@ -31,7 +31,7 @@ module GraphQL
           else
             "Selections can't be made on scalars (%{node_name} returns #{resolved_type.name} but has selections [#{ast_node.selections.map(&:name).join(", ")}])"
           end
-        elsif resolved_type.kind.fields? && ast_node.selections.none?
+        elsif resolved_type.kind.fields? && ast_node.selections.empty?
           "Field must have selections (%{node_name} returns #{resolved_type.name} but has no selections. Did you mean '#{ast_node.name} { ... }'?)"
         else
           nil

--- a/lib/graphql/static_validation/rules/fields_will_merge.rb
+++ b/lib/graphql/static_validation/rules/fields_will_merge.rb
@@ -300,7 +300,7 @@ module GraphQL
       NO_SELECTIONS = [{}.freeze, [].freeze].freeze
 
       def fields_and_fragments_from_selection(node, owner_type:, parents:)
-        if node.selections.none?
+        if node.selections.empty?
           NO_SELECTIONS
         else
           fields, fragment_spreads = find_fields_and_fragments(node.selections, owner_type: owner_type, parents: parents, fields: [], fragment_spreads: [])

--- a/lib/graphql/static_validation/validator.rb
+++ b/lib/graphql/static_validation/validator.rb
@@ -44,7 +44,7 @@ module GraphQL
           end
 
 
-          irep = if errors.none? && context
+          irep = if errors.empty? && context
             # Only return this if there are no errors and validation was actually run
             context.visitor.rewrite_document
           else


### PR DESCRIPTION
Enumerable#none? was being used without a block to check if enumerables were empty, even though its behaviour is documented as

> If the block is not given, none? will return true only if none of the collection members is true.

so `Enumerable#none?` should only be used if this is actually the behaviour we want.  A comment in the code (`if path.size == 0 # faster than #none?`) both shows that this is significant to performance and that `none?` was being used when `empty?` was more appropriate.

Let me know if any of the replaced `none?` calls were actually needed to handle falsey values.  If so, then the tests should reflect this.