### PR TITLE
Field extensions access the resolver's return value

### DIFF
--- a/guides/type_definitions/field_extensions.md
+++ b/guides/type_definitions/field_extensions.md
@@ -53,7 +53,7 @@ This way, an extension can encapsulate a behavior requiring several configuratio
 
 Extensions have two hooks that wrap field resolution. Since GraphQL-Ruby supports deferred execution, these hooks _might not_ be called back-to-back.
 
-First, {{ "GraphQL::Schema::FieldExtension#before_resolve" | api_doc }} is called. `before_resolve` should `yield(object, arguments)` to continue execution. If it doesn't `yield`, then the field won't resolve, and the methods return value will be returned to GraphQL instead.
+First, {{ "GraphQL::Schema::FieldExtension#before_resolve" | api_doc }} is called. `before_resolve` should `yield(object, arguments)` to continue execution. If it doesn't `yield`, then the field won't resolve, and the method's return value will be returned to GraphQL instead.
 
 After resolution, {{ "GraphQL::Schema::FieldExtension#after_resolve" | api_doc }} is called. Whatever that method returns will be used as the field's return value.
 

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -610,17 +610,11 @@ MSG
           original_obj = obj
 
           memos = []
-          @extensions.each do |ext|
-            ext.before_resolve(object: obj, arguments: args, context: ctx) do |extended_obj, extended_args, memo|
-              # update this scope with the yielded value
-              obj = extended_obj
-              args = extended_args
-              # record the memo (or nil if none was yielded)
-              memos << memo
-            end
+          value = run_extensions_before_resolve(memos, obj, args, ctx) do |extended_obj, extended_args|
+            obj = extended_obj
+            args = extended_args
+            yield(obj, args)
           end
-          # Call the block which actually calls resolve
-          value = yield(obj, args)
 
           ctx.schema.after_lazy(value) do |resolved_value|
             @extensions.each_with_index do |ext, idx|
@@ -630,6 +624,18 @@ MSG
             end
             resolved_value
           end
+        end
+      end
+
+      def run_extensions_before_resolve(memos, obj, args, ctx, idx: 0)
+        extension = @extensions[idx]
+        if extension
+          extension.before_resolve(object: obj, arguments: args, context: ctx) do |extended_obj, extended_args, memo|
+            memos << memo
+            run_extensions_before_resolve(memos, extended_obj, extended_args, ctx, idx: idx + 1) { yield(obj, args) }
+          end
+        else
+          yield(obj, args)
         end
       end
     end

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -611,9 +611,7 @@ MSG
 
           memos = []
           value = run_extensions_before_resolve(memos, obj, args, ctx) do |extended_obj, extended_args|
-            obj = extended_obj
-            args = extended_args
-            yield(obj, args)
+            yield(extended_obj, extended_args)
           end
 
           ctx.schema.after_lazy(value) do |resolved_value|
@@ -632,7 +630,7 @@ MSG
         if extension
           extension.before_resolve(object: obj, arguments: args, context: ctx) do |extended_obj, extended_args, memo|
             memos << memo
-            run_extensions_before_resolve(memos, extended_obj, extended_args, ctx, idx: idx + 1) { yield(obj, args) }
+            run_extensions_before_resolve(memos, extended_obj, extended_args, ctx, idx: idx + 1) { |o, a| yield(o, a) }
           end
         else
           yield(obj, args)

--- a/spec/graphql/schema/field_extension_spec.rb
+++ b/spec/graphql/schema/field_extension_spec.rb
@@ -30,6 +30,19 @@ describe GraphQL::Schema::FieldExtension do
       end
     end
 
+    class MultiplyByArgumentUsingResolve < GraphQL::Schema::FieldExtension
+      def apply
+        field.argument(:factor, Integer, required: true)
+      end
+
+      # `yield` returns the user-returned value
+      # This method's return value is passed along
+      def before_resolve(object:, arguments:, context:)
+        factor = arguments.delete(:factor)
+        yield(object, arguments) * factor
+      end
+    end
+
     class BaseObject < GraphQL::Schema::Object
     end
 
@@ -43,12 +56,16 @@ describe GraphQL::Schema::FieldExtension do
         input # return it as-is, it will be modified by extensions
       end
 
-      field :trippled_by_option, Integer, null: false, resolver_method: :pass_thru do
+      field :tripled_by_option, Integer, null: false, resolver_method: :pass_thru do
         extension(MultiplyByOption, factor: 3)
         argument :input, Integer, required: true
       end
 
       field :multiply_input, Integer, null: false, resolver_method: :pass_thru, extensions: [MultiplyByArgument] do
+        argument :input, Integer, required: true
+      end
+
+      field :multiply_input2, Integer, null: false, resolver_method: :pass_thru, extensions: [MultiplyByArgumentUsingResolve] do
         argument :input, Integer, required: true
       end
     end
@@ -79,10 +96,15 @@ describe GraphQL::Schema::FieldExtension do
       assert_equal 10, res["data"]["doubled"]
     end
 
+    it "returns the modified value from `yield`" do
+      res = exec_query("{ multiplyInput2(input: 5, factor: 5) }")
+      assert_equal 25, res["data"]["multiplyInput2"]
+    end
+
     it "has access to config options" do
       # The factor of three came from an option
-      res = exec_query("{ trippledByOption(input: 4) }")
-      assert_equal 12, res["data"]["trippledByOption"]
+      res = exec_query("{ tripledByOption(input: 4) }")
+      assert_equal 12, res["data"]["tripledByOption"]
     end
 
     it "can hide arguments from resolve methods" do


### PR DESCRIPTION
Oops, previously an extension could _access_ but not _modify_ a user-returned Promise. Now it can.