### PR TITLE
Fix #2085 - Ensure lists are arrays

### DIFF
--- a/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb
+++ b/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb
@@ -22,7 +22,7 @@ module GraphQL
           # the same as the node we were checking here.
           matched = if arg_defn.type.kind.list?
             # for a list we claim an error if the node is contained in our list
-            node.value.include?(err.ast_value)
+            Array(node.value).include?(err.ast_value)
           elsif arg_defn.type.kind.input_object? && node.value.is_a?(GraphQL::Language::Nodes::InputObject)
             # for an input object we check the arguments
             node.value.arguments.include?(err.ast_value)

--- a/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
+++ b/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
@@ -10,7 +10,7 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
       stringCheese: cheese(id: "aasdlkfj") { ...cheeseFields }
       cheese(id: 1) { source @skip(if: "whatever") }
       yakSource: searchDairy(product: [{source: COW, fatContent: 1.1}]) { __typename }
-      badSource: searchDairy(product: [{source: 1.1}]) { __typename }
+      badSource: searchDairy(product: {source: 1.1}) { __typename }
       missingSource: searchDairy(product: [{fatContent: 1.1}]) { __typename }
       listCoerce: cheese(id: 1) { similarCheese(source: YAK) { __typename } }
       missingInputField: searchDairy(product: [{source: YAK, wacky: 1}]) { __typename }
@@ -43,7 +43,7 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
 
         input_object_field_error = {
           "message"=>"Argument 'source' on InputObject 'DairyProductInput' has an invalid value. Expected type 'DairyAnimal!'.",
-          "locations"=>[{"line"=>6, "column"=>40}],
+          "locations"=>[{"line"=>6, "column"=>39}],
           "fields"=>["query getCheese", "badSource", "product", "source"],
         }
         assert_includes(errors, input_object_field_error)
@@ -83,7 +83,7 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
 
         input_object_field_error = {
           "message"=>"Argument 'source' on InputObject 'DairyProductInput' has an invalid value. Expected type 'DairyAnimal!'.",
-          "locations"=>[{"line"=>6, "column"=>40}],
+          "locations"=>[{"line"=>6, "column"=>39}],
           "fields"=>["query getCheese", "badSource", "product", "source"],
         }
         assert_includes(errors, input_object_field_error)


### PR DESCRIPTION
Lists in GraphQL can omit the square brackets if there's only one item but the validation code was assuming it would be an array.

This coerces the node's `value` to ensure it is an array.

Note: I figured there might be a more proper fix for this in a different place but it can't be in the parser since there's no knowledge of the argument's type (correct me if I'm wrong). Is there another place I'm not thinking of?

This is also branched off of `v1.8.13`. If this is acceptable, could we backport and do a new 1.8.14 release? (since master is on 1.9 now)