### PR TITLE
Interpreter: Sequential mutation root fields

### DIFF
--- a/lib/graphql/execution/interpreter/resolve.rb
+++ b/lib/graphql/execution/interpreter/resolve.rb
@@ -4,6 +4,8 @@ module GraphQL
   module Execution
     class Interpreter
       module Resolve
+        # Continue field results in `results` until there's nothing else to continue.
+        # @return [void]
         def self.resolve_all(results)
           while results.any?
             results = resolve(results)

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -192,17 +192,26 @@ module GraphQL
               field_ast_nodes.each { |f| next_selections.concat(f.selections) }
             end
 
-            resolve_with_directives(object, ast_node) do
+            field_result = resolve_with_directives(object, ast_node) do
               # Actually call the field resolver and capture the result
               app_result = query.trace("execute_field", {field: field_defn, path: next_path}) do
                 field_defn.resolve(object, kwarg_arguments, context)
               end
-              after_lazy(app_result, field: field_defn, path: next_path, eager: root_operation_type == "mutation") do |inner_result|
+              after_lazy(app_result, field: field_defn, path: next_path) do |inner_result|
                 continue_value = continue_value(next_path, inner_result, field_defn, return_type.non_null?, ast_node)
                 if HALT != continue_value
                   continue_field(next_path, continue_value, field_defn, return_type, ast_node, next_selections, false)
                 end
               end
+            end
+
+            # If this field is a root mutation field, immediately resolve
+            # all of its child fields before moving on to the next root mutation field.
+            # (Subselections of this mutation will still be resolved level-by-level.)
+            if root_operation_type == "mutation"
+              Interpreter::Resolve.resolve_all([field_result])
+            else
+              field_result
             end
           end
         end


### PR DESCRIPTION
Oops, make sure that mutation root selections are evaluated in sequence, so that each root field and its subselections are evaluated _before_ proceeding to the next mutation. (Otherwise the reads that follow a mutation might not reflect the state that the mutation had just created!)