### PR TITLE
Rename FieldExtension#before_resolve -> FieldExtension#resolve

### DIFF
--- a/guides/type_definitions/field_extensions.md
+++ b/guides/type_definitions/field_extensions.md
@@ -53,18 +53,18 @@ This way, an extension can encapsulate a behavior requiring several configuratio
 
 Extensions have two hooks that wrap field resolution. Since GraphQL-Ruby supports deferred execution, these hooks _might not_ be called back-to-back.
 
-First, {{ "GraphQL::Schema::FieldExtension#before_resolve" | api_doc }} is called. `before_resolve` should `yield(object, arguments)` to continue execution. If it doesn't `yield`, then the field won't resolve, and the method's return value will be returned to GraphQL instead.
+First, {{ "GraphQL::Schema::FieldExtension#resolve" | api_doc }} is called. `resolve` should `yield(object, arguments)` to continue execution. If it doesn't `yield`, then the underlying field won't be called. Whatever `#resolve` returns will be used for continuing execution.
 
-After resolution, {{ "GraphQL::Schema::FieldExtension#after_resolve" | api_doc }} is called. Whatever that method returns will be used as the field's return value.
+After resolution and _after_ syncing lazy values (like `Promise`s from `graphql-batch`), {{ "GraphQL::Schema::FieldExtension#after_resolve" | api_doc }} is called. Whatever that method returns will be used as the field's return value.
 
 See the linked API docs for the parameters of those methods.
 
 #### Execution "memo"
 
-One parameter to `after_resolve` deserves special attention: `memo:`. `before_resolve` _may_ yield a third value. For example:
+One parameter to `after_resolve` deserves special attention: `memo:`. `resolve` _may_ yield a third value. For example:
 
 ```ruby
-def before_resolve(object:, arguments:, **rest)
+def resolve(object:, arguments:, **rest)
   # yield the current time as `memo`
   yield(object, arguments, Time.now.to_i)
 end
@@ -80,7 +80,7 @@ def after_resolve(value:, memo:, **rest)
 end
 ```
 
-This allows the `before_resolve` hook to pass data to `after_resolve`.
+This allows the `resolve` hook to pass data to `after_resolve`.
 
 Instance variables may not be used because, in a given GraphQL query, the same field may be resolved several times concurrently, and that would result in overriding the instance variable in an unpredictable way. (In fact, extensions are frozen to prevent instance variable writes.)
 

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -638,7 +638,7 @@ MSG
       def run_extensions_before_resolve(memos, obj, args, ctx, idx: 0)
         extension = @extensions[idx]
         if extension
-          extension.before_resolve(object: obj, arguments: args, context: ctx) do |extended_obj, extended_args, memo|
+          extension.resolve(object: obj, arguments: args, context: ctx) do |extended_obj, extended_args, memo|
             memos << memo
             run_extensions_before_resolve(memos, extended_obj, extended_args, ctx, idx: idx + 1) { |o, a| yield(o, a) }
           end

--- a/lib/graphql/schema/field/connection_extension.rb
+++ b/lib/graphql/schema/field/connection_extension.rb
@@ -12,7 +12,7 @@ module GraphQL
         end
 
         # Remove pagination args before passing it to a user method
-        def before_resolve(object:, arguments:, context:)
+        def resolve(object:, arguments:, context:)
           next_args = arguments.dup
           next_args.delete(:first)
           next_args.delete(:last)

--- a/lib/graphql/schema/field_extension.rb
+++ b/lib/graphql/schema/field_extension.rb
@@ -33,25 +33,33 @@ module GraphQL
       end
 
       # Called before resolving {#field}. It should either:
+      #
       # - `yield` values to continue execution; OR
       # - return something else to shortcut field execution.
+      #
+      # Whatever this method returns will be used for execution.
+      #
       # @param object [Object] The object the field is being resolved on
       # @param arguments [Hash] Ruby keyword arguments for resolving this field
       # @param context [Query::Context] the context for this query
       # @yieldparam object [Object] The object to continue resolving the field on
       # @yieldparam arguments [Hash] The keyword arguments to continue resolving with
       # @yieldparam memo [Object] Any extension-specific value which will be passed to {#after_resolve} later
-      def before_resolve(object:, arguments:, context:)
+      # @return [Object] The return value for this field.
+      def resolve(object:, arguments:, context:)
         yield(object, arguments, nil)
       end
 
-      # Called after {#field} was resolved, but before the value was added to the GraphQL response.
+      # Called after {#field} was resolved, and after any lazy values (like `Promise`s) were synced,
+      # but before the value was added to the GraphQL response.
+      #
       # Whatever this hook returns will be used as the return value.
+      #
       # @param object [Object] The object the field is being resolved on
       # @param arguments [Hash] Ruby keyword arguments for resolving this field
       # @param context [Query::Context] the context for this query
       # @param value [Object] Whatever the field previously returned
-      # @param memo [Object] The third value yielded by {#before_resolve}, or `nil` if there wasn't one
+      # @param memo [Object] The third value yielded by {#resolve}, or `nil` if there wasn't one
       # @return [Object] The return value for this field.
       def after_resolve(object:, arguments:, context:, value:, memo:)
         value

--- a/spec/graphql/schema/field_extension_spec.rb
+++ b/spec/graphql/schema/field_extension_spec.rb
@@ -20,7 +20,7 @@ describe GraphQL::Schema::FieldExtension do
         field.argument(:factor, Integer, required: true)
       end
 
-      def before_resolve(object:, arguments:, context:)
+      def resolve(object:, arguments:, context:)
         factor = arguments.delete(:factor)
         yield(object, arguments, factor)
       end
@@ -37,7 +37,7 @@ describe GraphQL::Schema::FieldExtension do
 
       # `yield` returns the user-returned value
       # This method's return value is passed along
-      def before_resolve(object:, arguments:, context:)
+      def resolve(object:, arguments:, context:)
         factor = arguments.delete(:factor)
         yield(object, arguments) * factor
       end


### PR DESCRIPTION
Renamed to reflect it's new role returning a value for execution (since #2092), also update docs