### PR TITLE
Fix typo compat -> compatibility[ci skip] 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### New Features
 
-- Better compat with legacy `.node` and `.nodes` fields #2089
+- Better compact with legacy `.node` and `.nodes` fields #2089
 - Allow field extensions to replace field return values #2092
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### New Features
 
-- Better compact with legacy `.node` and `.nodes` fields #2089
+- Better compatibility with legacy `.node` and `.nodes` fields #2089
 - Allow field extensions to replace field return values #2092
 
 ### Bug fixes


### PR DESCRIPTION
Fixed a typo in the contributing guides. 