### PR TITLE
Fix bug in subscriptions#trigger

### DIFF
--- a/lib/graphql/subscriptions.rb
+++ b/lib/graphql/subscriptions.rb
@@ -43,7 +43,7 @@ module GraphQL
       event_name = event_name.to_s
 
       # Try with the verbatim input first:
-      field = @schema.get_field("Subscription", event_name)
+      field = @schema.get_field(@schema.subscription, event_name)
 
       if field.nil?
         # And if it wasn't found, normalize it:

--- a/lib/graphql/subscriptions.rb
+++ b/lib/graphql/subscriptions.rb
@@ -48,7 +48,7 @@ module GraphQL
       if field.nil?
         # And if it wasn't found, normalize it:
         normalized_event_name = normalize_name(event_name)
-        field = @schema.get_field("Subscription", normalized_event_name)
+        field = @schema.get_field(@schema.subscription, normalized_event_name)
         if field.nil?
           raise InvalidTriggerError, "No subscription matching trigger: #{event_name} (looked for #{@schema.subscription.graphql_name}.#{normalized_event_name})"
         end


### PR DESCRIPTION
See: #1882 

There's a bug when attempting to assign the field, it's using the hard-coded `Subscription` string instead of pulling the subscription from the schema.

This fixes it.