### PR TITLE
Fix unwrapping the input with InputObject

### DIFF
--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -168,7 +168,7 @@ module GraphQL
             memo[key] = unwrap_value(value)
             memo
           end
-        when GraphQL::Query::Arguments
+        when GraphQL::Query::Arguments, GraphQL::Schema::InputObject
           value.to_h
         else
           value


### PR DESCRIPTION
This is a copy of https://github.com/rmosolgo/graphql-ruby/pull/2094 for `1.8.x` branch.

### == Problem ==

`GraphQL::Schema::InputObject` instances are not unwrapped in `GraphQL::Query::Arguments`
### == Example ==

Without a change it produces the following value instead of `hash`.

```
#<#<Class:0x00007f925e6910c0>:0x00007f9266bc45f8 @context=#<Query::Context ...>, @arguments=#<#<Class:0x00007f9266b3f010>:0x00007f9266bc4580 @argument_values={"something"=>#<GraphQL::Query::Arguments::ArgumentValue:0x00007f9266bc4490 @key="something", @value="string", @definition=#<GraphQL::Argument:0x00007f925e690800 @prepare_proc=GraphQL::Argument::DefaultPrepare, @name="something", @clean_type=String, @dirty_type=#<Proc:0x00007f925e6907b0@/Users/evgeniydemin/RubymineProjects/graphql-ruby/lib/graphql/schema/argument.rb:88 (lambda)>, @description=nil, @metadata={:type_class=>#<GraphQL::Schema::Argument:0x00007f925e690d28 @name="something", @type_expr=String, @description=nil, @null=true, @default_value=:__no_default__, @owner=#<Class:0x00007f925e6910c0>, @as=nil, @keyword=:something, @prepare=nil, @graphql_definition=#<GraphQL::Argument:0x00007f925e690800 ...>, @type=GraphQL::Types::String>}, @as=nil, @expose_as="something">, @default_used=false>}, @to_h={"something"=>"string"}>, @ruby_style_hash={:something=>"string"}>
```

For more details, please have a look at integration spec.