### PR TITLE
[1.8] Fix direct calls to .sync_lazy

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -1065,7 +1065,14 @@ module GraphQL
     # @param ctx [GraphQL::Query::Context] the context for this query
     # @return [Object] A GraphQL-ready (non-lazy) object
     def self.sync_lazy(value)
-      yield(value)
+      if block_given?
+        # This was already hit by the instance, just give it back
+        yield(value)
+      else
+        # This was called directly on the class, hit the instance
+        # which has the lazy method map
+        self.graphql_definition.sync_lazy(value)
+      end
     end
 
     # @see Schema.sync_lazy for a hook to override

--- a/spec/graphql/execution/lazy_spec.rb
+++ b/spec/graphql/execution/lazy_spec.rb
@@ -10,6 +10,13 @@ describe GraphQL::Execution::Lazy do
       assert_equal 3, res["data"]["int"]
     end
 
+    it "Works with Query.new" do
+      query_str = '{ int(value: 2, plus: 1) }'
+      query = GraphQL::Query.new(LazyHelpers::LazySchema, query_str)
+      res =  query.result
+      assert_equal 3, res["data"]["int"]
+    end
+
     it "can do nested lazy values" do
       res = run_query %|
       {


### PR DESCRIPTION
Try again to fix #1867 , cherry-picking a commit from 1.9 (38148d1c81076e011202b307c1879aaad84e6da0)