### PR TITLE
Support extensions with resolve procs

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -277,15 +277,6 @@ module GraphQL
           # Read the value
           @extensions
         else
-          if @resolve || @function
-            raise ArgumentError, <<-MSG
-Extensions are not supported with resolve procs or functions,
-but #{owner.name}.#{name} has: #{@resolve || @function}
-So, it can't have extensions: #{extensions}.
-Use a method or a Schema::Resolver instead.
-MSG
-          end
-
           # Normalize to a Hash of {name => options}
           extensions_with_options = if new_extensions.last.is_a?(Hash)
             new_extensions.pop
@@ -454,12 +445,16 @@ MSG
           # @see https://github.com/rmosolgo/graphql-ruby/issues/1990 before removing
           inner_obj = after_obj && after_obj.object
           if authorized?(inner_obj, query_ctx)
+            ruby_args = to_ruby_args(after_obj, args, ctx)
             # Then if it passed, resolve the field
             if @resolve_proc
               # Might be nil, still want to call the func in that case
-              @resolve_proc.call(inner_obj, args, ctx)
+              with_extensions(inner_obj, ruby_args, query_ctx) do |extended_obj, extended_args|
+                # Pass the GraphQL args here for compatibility:
+                @resolve_proc.call(extended_obj, args, ctx)
+              end
             else
-              public_send_field(after_obj, args, ctx)
+              public_send_field(after_obj, ruby_args, ctx)
             end
           else
             err = GraphQL::UnauthorizedFieldError.new(object: inner_obj, type: obj.class, context: ctx, field: self)
@@ -568,7 +563,13 @@ MSG
 
       NO_ARGS = {}.freeze
 
-      def public_send_field(obj, graphql_args, field_ctx)
+      # Convert a GraphQL arguments instance into a Ruby-style hash.
+      #
+      # @param obj [GraphQL::Schema::Object] The object where this field is being resolved
+      # @param graphql_args [GraphQL::Query::Arguments]
+      # @param field_ctx [GraphQL::Query::Context::FieldResolutionContext]
+      # @return [Hash<Symbol => Any>]
+      def to_ruby_args(obj, graphql_args, field_ctx)
         if graphql_args.any? || @extras.any?
           # Splat the GraphQL::Arguments to Ruby keyword arguments
           ruby_kwargs = graphql_args.to_kwargs
@@ -583,10 +584,14 @@ MSG
           @extras.each do |extra_arg|
             ruby_kwargs[extra_arg] = fetch_extra(extra_arg, field_ctx)
           end
-        else
-          ruby_kwargs = NO_ARGS
-        end
 
+          ruby_kwargs
+        else
+          NO_ARGS
+        end
+      end
+
+      def public_send_field(obj, ruby_kwargs, field_ctx)
         query_ctx = field_ctx.query.context
         with_extensions(obj, ruby_kwargs, query_ctx) do |extended_obj, extended_args|
           if @resolver_class

--- a/spec/graphql/schema/member/scoped_spec.rb
+++ b/spec/graphql/schema/member/scoped_spec.rb
@@ -57,8 +57,17 @@ describe GraphQL::Schema::Member::Scoped do
         resolver_method: :items
       field :french_items, [FrenchItem], null: false,
         resolver_method: :items
-      field :items_connection, Item.connection_type, null: false,
-        resolver_method: :items
+      if TESTING_INTERPRETER
+        field :items_connection, Item.connection_type, null: false,
+          resolver_method: :items
+      else
+        field :items_connection, Item.connection_type, null: false, resolve: ->(obj, args, ctx) {
+          [
+            OpenStruct.new(name: "Trombone"),
+            OpenStruct.new(name: "Paperclip"),
+          ]
+        }
+      end
 
       def items
         [
@@ -67,9 +76,20 @@ describe GraphQL::Schema::Member::Scoped do
         ]
       end
 
-      field :things, [Thing], null: false
-      def things
-        items + [OpenStruct.new(name: "Turbine")]
+      if TESTING_INTERPRETER
+        field :things, [Thing], null: false
+        def things
+          items + [OpenStruct.new(name: "Turbine")]
+        end
+      else
+        # Make sure it works with resolve procs, too
+        field :things, [Thing], null: false, resolve: ->(obj, args, ctx) {
+          [
+            OpenStruct.new(name: "Trombone"),
+            OpenStruct.new(name: "Paperclip"),
+            OpenStruct.new(name: "Turbine"),
+          ]
+        }
       end
     end
 


### PR DESCRIPTION
Fixes #2114 

Interestingly, support for `extensions:` with legacy resolve procs was already _halfway_ there. It just had to be ported to the other kind of resolution.