### PR TITLE
Builtin default resolver for Boolean fields

### DIFF
--- a/guides/fields/introduction.md
+++ b/guides/fields/introduction.md
@@ -96,6 +96,14 @@ field :top_score, Integer, null: false
 
 The default behavior is to look for a `#top_score` method, or lookup a `Hash` key, `:top_score` (symbol) or `"top_score"` (string).
 
+In case field type is `Boolean` and object responds to `<field_name>?` (symbol) we will use that otherwise we will call `<field_name>` In following example:
+
+```ruby
+field :is_winner, Boolean, null: false
+```
+
+We first attempt calling `#is_winner?` if doesn't exist we attempt `#is_winner` and `Hash` key.
+
 You can override the method name with the `method:` keyword, or override the hash key with the `hash_key:` keyword, for example:
 
 ```ruby

--- a/lib/graphql/field/resolve.rb
+++ b/lib/graphql/field/resolve.rb
@@ -24,11 +24,12 @@ module GraphQL
       # Resolve the field by `public_send`ing `@method_name`
       class MethodResolve < BuiltInResolve
         def initialize(field)
-          @method_name = field.property.to_sym
+          @method_name = field.property
+          @is_boolean = field.type == BOOLEAN_TYPE
         end
 
         def call(obj, args, ctx)
-          obj.public_send(@method_name)
+          @is_boolean && obj.respond_to?("#{@method_name}?".to_sym) ? obj.public_send("#{@method_name}?".to_sym) : obj.public_send(@method_name.to_sym)
         end
       end
 

--- a/spec/graphql/field_spec.rb
+++ b/spec/graphql/field_spec.rb
@@ -32,6 +32,26 @@ describe GraphQL::Field do
     assert_equal([number], field.arguments)
   end
 
+  describe '#boolean_field' do
+    let(:field) do
+      GraphQL::Field.define do
+        name "Boolean Field"
+        type types.Boolean
+        property :boolean_prop
+      end
+    end
+    it 'resolve boolean fields with <field_name>? if exist' do
+      object = OpenStruct.new(boolean_prop?: true, boolean_prop: false)
+      resolved_boolean_prop = field.resolve(object, nil, nil)
+      assert_equal true, resolved_boolean_prop
+    end
+    it 'resolve boolean fields with <field_name> if <field_name>? does not exist' do
+      object = OpenStruct.new(boolean_prop: true)
+      resolved_boolean_prop = field.resolve(object, nil, nil)
+      assert_equal true, resolved_boolean_prop
+    end
+  end
+
   describe ".property " do
     let(:field) do
       GraphQL::Field.define do


### PR DESCRIPTION
# Change
Ruby prefers using `?` for class attributes/methods returning boolean. Currently when we define a field as `Boolean` by default we'll call `<field_name>` method or `hash` key on the object.

If the underlying field is using `?` we need to manually define that by something like
```ruby
field :boolean_property, Boolean, method: :boolean_property?
```

This PR updates the code to check for existence of `<field_name>?` method for Boolean fields and if they exist it would call that, otherwise fallbacks to existing logic.
