### PR TITLE
Fix scoping nil

### DIFF
--- a/lib/graphql/schema/field/scope_extension.rb
+++ b/lib/graphql/schema/field/scope_extension.rb
@@ -5,11 +5,15 @@ module GraphQL
     class Field
       class ScopeExtension < GraphQL::Schema::FieldExtension
         def after_resolve(value:, context:, **rest)
-          ret_type = @field.type.unwrap
-          if ret_type.respond_to?(:scope_items)
-            ret_type.scope_items(value, context)
-          else
+          if value.nil?
             value
+          else
+            ret_type = @field.type.unwrap
+            if ret_type.respond_to?(:scope_items)
+              ret_type.scope_items(value, context)
+            else
+              value
+            end
           end
         end
       end

--- a/spec/graphql/schema/member/scoped_spec.rb
+++ b/spec/graphql/schema/member/scoped_spec.rb
@@ -13,7 +13,8 @@ describe GraphQL::Schema::Member::Scoped do
         elsif context[:english]
           items.select { |i| i.name == "Paperclip" }
         else
-          []
+          # boot everything
+          items.reject { true }
         end
       end
 
@@ -55,6 +56,12 @@ describe GraphQL::Schema::Member::Scoped do
       field :unscoped_items, [Item], null: false,
         scope: false,
         resolver_method: :items
+
+      field :nil_items, [Item], null: true
+      def nil_items
+        nil
+      end
+
       field :french_items, [FrenchItem], null: false,
         resolver_method: :items
       if TESTING_INTERPRETER
@@ -120,6 +127,20 @@ describe GraphQL::Schema::Member::Scoped do
 
     it "is bypassed when scope: false" do
       assert_equal ["Trombone", "Paperclip"], get_item_names_with_context({}, field_name: "unscopedItems")
+    end
+
+    it "returns null when the value is nil" do
+      query_str = "
+      {
+        nilItems {
+          name
+        }
+      }
+      "
+      res = ScopeSchema.execute(query_str)
+      pp res
+      refute res.key?("errors")
+      assert_nil res.fetch("data").fetch("nilItems")
     end
 
     it "is inherited" do

--- a/spec/graphql/schema/member/scoped_spec.rb
+++ b/spec/graphql/schema/member/scoped_spec.rb
@@ -138,7 +138,6 @@ describe GraphQL::Schema::Member::Scoped do
       }
       "
       res = ScopeSchema.execute(query_str)
-      pp res
       refute res.key?("errors")
       assert_nil res.fetch("data").fetch("nilItems")
     end


### PR DESCRIPTION
When a field returns `nil`, don't try to apply a scope to it.

Fixes #2129 