### PR TITLE
fix duplicate method in G::A::A::QueryComplexity

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,9 @@ Layout/EndAlignment:
 Lint/UselessAssignment:
   Enabled: true
 
+Lint/DuplicateMethods:
+  Enabled: true
+
 Metrics/ParameterLists:
   Max: 7
   CountKeywordArgs: false

--- a/lib/graphql/analysis/ast/max_query_complexity.rb
+++ b/lib/graphql/analysis/ast/max_query_complexity.rb
@@ -9,7 +9,7 @@ module GraphQL
         def result
           return if query.max_complexity.nil?
 
-          total_complexity = super
+          total_complexity = max_possible_complexity
 
           if total_complexity > query.max_complexity
             GraphQL::AnalysisError.new("Query has complexity of #{total_complexity}, which exceeds max complexity of #{query.max_complexity}")

--- a/lib/graphql/analysis/ast/query_complexity.rb
+++ b/lib/graphql/analysis/ast/query_complexity.rb
@@ -13,7 +13,7 @@ module GraphQL
 
         # Overide this method to use the complexity result
         def result
-          raise NotImplementedError
+          max_possible_complexity
         end
 
         def on_enter_field(node, parent, visitor)

--- a/lib/graphql/analysis/ast/query_complexity.rb
+++ b/lib/graphql/analysis/ast/query_complexity.rb
@@ -57,7 +57,8 @@ module GraphQL
           visitor.leave_fragment_spread_inline(node)
         end
 
-        def result
+        # @return [Integer]
+        def max_possible_complexity
           @complexities_on_type.last.max_possible_complexity
         end
 


### PR DESCRIPTION
AST::QueryComplexity has two `#result` methods so this PR fixes it.
