### PR TITLE
extend GraphQL::Schema::RescueMiddleware#attempt_rescue

### DIFF
--- a/lib/graphql/schema/rescue_middleware.rb
+++ b/lib/graphql/schema/rescue_middleware.rb
@@ -43,8 +43,13 @@ module GraphQL
       def attempt_rescue(err)
         rescue_table.each { |klass, handler|
           if klass.is_a?(Class) && err.is_a?(klass) && handler
-            message = handler.call(err)
-            return GraphQL::ExecutionError.new(message)
+            result = handler.call(err)
+            case result
+            when String
+              return GraphQL::ExecutionError.new(result)
+            when GraphQL::ExecutionError
+              return result
+            end
           end
         }
 

--- a/spec/graphql/schema/rescue_middleware_spec.rb
+++ b/spec/graphql/schema/rescue_middleware_spec.rb
@@ -49,6 +49,20 @@ describe GraphQL::Schema::RescueMiddleware do
         assert_equal("there was an example error: SecondSpecExampleError", result.message)
       end
     end
+
+    describe "with GraphQL::ExecutionError as an argument" do
+      let(:rescue_middleware) do
+        middleware = GraphQL::Schema::RescueMiddleware.new
+        middleware.rescue_from(SpecExampleError) { |err| GraphQL::ExecutionError.new("there was an example error: #{err.class.name}", extensions: { code: "EXAMPLE_ERROR" }) }
+        middleware
+      end
+
+      it "has the extensions key" do
+        result = middleware_chain.invoke([])
+        assert_equal("there was an example error: SpecExampleError", result.message)
+        assert_equal({ code: "EXAMPLE_ERROR" }, result.extensions)
+      end
+    end
   end
 
   describe "unknown errors" do


### PR DESCRIPTION
# Summary
Hi there. 
First of all this gem is AWESOME. Really appreciate the hard work you guys put in.

So let's get right into the topic. We are using `rescue_from` in our schema class like this↓ as a safety net to make sure responses are always in the same form.

```ruby
class SomeSchema < GraphQL::Schema
  rescue_from(StandardError) { 'INTERNAL_SERVER_ERROR' }
  ...
end
```

But we are using `extensions` entry to expand error responses in other fields.
So in order to get every error forms together we started to think that we need to be able to expand an error form with `extensions` entry in `rescue_from` method too like this↓

```ruby
class SomeSchema < GraphQL::Schema
  rescue_from(StandardError) { GraphQL::ExecutionError.new('internal server error', extensions: { code: 'INTERNAL_SERVER_ERROR' }) }
  ...
end
```

This PR enables this behavior.