### PR TITLE
Get query string from document if it wasn't passed in explicitly to `execute`

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -40,7 +40,7 @@ module GraphQL
     # @return [Boolean] if false, static validation is skipped (execution behavior for invalid queries is undefined)
     attr_accessor :validate
 
-    attr_accessor :query_string
+    attr_writer :query_string
 
     # @return [GraphQL::Language::Nodes::Document]
     def document
@@ -133,6 +133,11 @@ module GraphQL
       if @schema.respond_to?(:visible?)
         merge_filters(only: @schema.method(:visible?))
       end
+    end
+
+    # If a document was provided to `GraphQL::Schema#execute` instead of the raw query string, we will need to get it from the document
+    def query_string
+      @query_string || (document ? document.to_query_string : nil)
     end
 
     def_delegators :@schema, :interpreter?

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -137,7 +137,7 @@ module GraphQL
 
     # If a document was provided to `GraphQL::Schema#execute` instead of the raw query string, we will need to get it from the document
     def query_string
-      @query_string || (document ? document.to_query_string : nil)
+      @query_string ||= (document ? document.to_query_string : nil)
     end
 
     def_delegators :@schema, :interpreter?


### PR DESCRIPTION
Currently, subscriptions don't work (at least with `ActionCable`) if you're passing in a `document` rather than the explicit query string. Eg. we've overridden `execute` on our schema to look something like this:

```ruby
def execute(query_string, **kwargs)
  document = GraphQL.parse(query_string)
  # some logging stuff

  super(nil, document: document, **kwargs)
end
```

This works great until you try to pull in subscriptions, which will start (somewhat quietly) failing with a message saying something to the effect of "query string not present". Further research pointed me to this:

https://github.com/rmosolgo/graphql-ruby/blob/7fc54bf322ed9cde9db594c519ae41539d41b33b/lib/graphql/subscriptions/action_cable_subscriptions.rb#L128-L136

Where the relevant code is the call to `query.query_string`, which if you don't pass explicitly into `execute`, is `nil`. Of course, you can't pass both `query_string` and `document` into `execute` or it will raise an error since it doesn't know which one to use.

My solution to this here is to have an explicit `query_string` method that attempts to generate the query string from the `document` if it wasn't explicitly set. I've added a regression test that will fail if you remove the changes I made to the method.

Let me know if you think there's a better solution to this!