### PR TITLE
Add analytics tag to Datadog tracing

### DIFF
--- a/guides/queries/tracing.md
+++ b/guides/queries/tracing.md
@@ -132,9 +132,20 @@ To add [Datadog](https://www.datadoghq.com) instrumentation:
 
 ```ruby
 class MySchema < GraphQL::Schema
-  use(GraphQL::Tracing::DataDogTracing)
+  use(GraphQL::Tracing::DataDogTracing, options)
 end
 ```
+
+You may provide `options` as a `Hash` with the following values:
+
+| Key | Description | Default |
+| --- | ----------- | ------- |
+| `analytics_enabled` | Enable analytics for spans. `true` for on, `nil` to defer to Datadog global setting, `false` for off. | `false` |
+| `analytics_sample_rate` | Rate which tracing data should be sampled for Datadog analytics. Must be a float between `0` and `1.0`. | `1.0` |
+| `service_name` | Service name used for `graphql` instrumentation | `'ruby-graphql'` |
+| `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |
+
+For more details about Datadog's tracing API, check out the [Ruby documentation](https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md) or the [APM documentation](https://docs.datadoghq.com/tracing/) for more product information.
 
 ## Prometheus
 

--- a/lib/graphql/tracing/data_dog_tracing.rb
+++ b/lib/graphql/tracing/data_dog_tracing.rb
@@ -21,6 +21,11 @@ module GraphQL
           if key == 'execute_multiplex'
             operations = data[:multiplex].queries.map(&:selected_operation_name).join(', ')
             span.resource = operations unless operations.empty?
+
+            # For top span of query, set the analytics sample rate tag, if available.
+            if analytics_enabled?
+              Datadog::Contrib::Analytics.set_sample_rate(span, analytics_sample_rate)
+            end
           end
 
           if key == 'execute_query'
@@ -39,6 +44,20 @@ module GraphQL
 
       def tracer
         options.fetch(:tracer, Datadog.tracer)
+      end
+
+      def analytics_available?
+        defined?(Datadog::Contrib::Analytics) \
+          && Datadog::Contrib::Analytics.respond_to?(:enabled?) \
+          && Datadog::Contrib::Analytics.respond_to?(:set_sample_rate)
+      end
+
+      def analytics_enabled?
+        analytics_available? && Datadog::Contrib::Analytics.enabled?(options.fetch(:analytics_enabled, false))
+      end
+
+      def analytics_sample_rate
+        options.fetch(:analytics_sample_rate, 1.0)
       end
 
       def platform_field_key(type, field)


### PR DESCRIPTION
Datadog offers a trace search and analytics feature, which can make it easy to find and analyze measurements made by the tracing in GraphQL.

This pull request adds an `event_sample_rate` tag, to the span, if configured & available, so the trace will be sampled and indexed for use in search and analytics.

GraphQL users implementing Datadog's `ddtrace` gem version >= 0.20.0 will see the benefit of this new feature, while others using older versions of `ddtrace` will remain backwards compatible.