### PR TITLE
Thread `owner:` through field tracing

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -388,7 +388,7 @@ module GraphQL
           @interpreter_context[:current_path] = path
           @interpreter_context[:current_field] = field
           if schema.lazy?(obj)
-            lazy = GraphQL::Execution::Lazy.new(owner: owner, path: path, field: field) do
+            lazy = GraphQL::Execution::Lazy.new(path: path, field: field) do
               @interpreter_context[:current_path] = path
               @interpreter_context[:current_field] = field
               # Wrap the execution of _this_ method with tracing,

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -200,10 +200,10 @@ module GraphQL
 
             field_result = resolve_with_directives(object, ast_node) do
               # Actually call the field resolver and capture the result
-              app_result = query.trace("execute_field", {field: field_defn, path: next_path}) do
+              app_result = query.trace("execute_field", {owner: owner_type, field: field_defn, path: next_path}) do
                 field_defn.resolve(object, kwarg_arguments, context)
               end
-              after_lazy(app_result, field: field_defn, path: next_path) do |inner_result|
+              after_lazy(app_result, owner: owner_type, field: field_defn, path: next_path) do |inner_result|
                 continue_value = continue_value(next_path, inner_result, field_defn, return_type.non_null?, ast_node)
                 if HALT != continue_value
                   continue_field(next_path, continue_value, field_defn, return_type, ast_node, next_selections, false)
@@ -277,7 +277,7 @@ module GraphQL
             r
           when "UNION", "INTERFACE"
             resolved_type_or_lazy = query.resolve_type(type, value)
-            after_lazy(resolved_type_or_lazy, path: path, field: field) do |resolved_type|
+            after_lazy(resolved_type_or_lazy, owner: type, path: path, field: field) do |resolved_type|
               possible_types = query.possible_types(type)
 
               if !possible_types.include?(resolved_type)
@@ -297,7 +297,7 @@ module GraphQL
             rescue GraphQL::ExecutionError => err
               err
             end
-            after_lazy(object_proxy, path: path, field: field) do |inner_object|
+            after_lazy(object_proxy, owner: type, path: path, field: field) do |inner_object|
               continue_value = continue_value(path, inner_object, field, is_non_null, ast_node)
               if HALT != continue_value
                 response_hash = {}
@@ -318,7 +318,7 @@ module GraphQL
               idx += 1
               set_type_at_path(next_path, inner_type)
               # This will update `response_list` with the lazy
-              after_lazy(inner_value, path: next_path, field: field) do |inner_inner_value|
+              after_lazy(inner_value, owner: inner_type, path: next_path, field: field) do |inner_inner_value|
                 # reset `is_non_null` here and below, because the inner type will have its own nullability constraint
                 continue_value = continue_value(next_path, inner_inner_value, field, false, ast_node)
                 if HALT != continue_value
@@ -384,23 +384,23 @@ module GraphQL
         # @param field [GraphQL::Schema::Field]
         # @param eager [Boolean] Set to `true` for mutation root fields only
         # @return [GraphQL::Execution::Lazy, Object] If loading `object` will be deferred, it's a wrapper over it.
-        def after_lazy(obj, field:, path:, eager: false)
+        def after_lazy(obj, owner:, field:, path:, eager: false)
           @interpreter_context[:current_path] = path
           @interpreter_context[:current_field] = field
           if schema.lazy?(obj)
-            lazy = GraphQL::Execution::Lazy.new(path: path, field: field) do
+            lazy = GraphQL::Execution::Lazy.new(owner: owner, path: path, field: field) do
               @interpreter_context[:current_path] = path
               @interpreter_context[:current_field] = field
               # Wrap the execution of _this_ method with tracing,
               # but don't wrap the continuation below
-              inner_obj = query.trace("execute_field_lazy", {field: field, path: path}) do
+              inner_obj = query.trace("execute_field_lazy", {owner: owner, field: field, path: path}) do
                 begin
                   schema.sync_lazy(obj)
                 rescue GraphQL::ExecutionError, GraphQL::UnauthorizedError => err
                   yield(err)
                 end
               end
-              after_lazy(inner_obj, field: field, path: path, eager: eager) do |really_inner_obj|
+              after_lazy(inner_obj, owner: owner, field: field, path: path, eager: eager) do |really_inner_obj|
                 yield(really_inner_obj)
               end
             end

--- a/lib/graphql/tracing.rb
+++ b/lib/graphql/tracing.rb
@@ -42,8 +42,8 @@ module GraphQL
   # execute_multiplex | `{ multiplex: GraphQL::Execution::Multiplex }`
   # execute_query | `{ query: GraphQL::Query }`
   # execute_query_lazy | `{ query: GraphQL::Query?, multiplex: GraphQL::Execution::Multiplex? }`
-  # execute_field | `{ context: GraphQL::Query::Context::FieldResolutionContext?, field: GraphQL::Schema::Field?, path: Array<String, Integer>?}`
-  # execute_field_lazy | `{ context: GraphQL::Query::Context::FieldResolutionContext?, field: GraphQL::Schema::Field?, path: Array<String, Integer>?}`
+  # execute_field | `{ context: GraphQL::Query::Context::FieldResolutionContext?, owner: Class?, field: GraphQL::Schema::Field?, path: Array<String, Integer>?}`
+  # execute_field_lazy | `{ context: GraphQL::Query::Context::FieldResolutionContext?, owner: Class?, field: GraphQL::Schema::Field?, path: Array<String, Integer>?}`
   #
   # Note that `execute_field` and `execute_field_lazy` receive different data in different settings:
   #

--- a/lib/graphql/tracing/platform_tracing.rb
+++ b/lib/graphql/tracing/platform_tracing.rb
@@ -32,8 +32,9 @@ module GraphQL
             trace_field = true # implemented with instrumenter
           else
             field = data[:field]
+            owner = data[:owner]
             # Lots of duplicated work here, can this be done ahead of time?
-            platform_key = platform_field_key(field.owner, field)
+            platform_key = platform_field_key(owner, field)
             return_type = field.type.unwrap
             # Handle LateBoundTypes, which don't have `#kind`
             trace_field = if return_type.respond_to?(:kind) && (return_type.kind.scalar? || return_type.kind.enum?)

--- a/spec/graphql/tracing/new_relic_tracing_spec.rb
+++ b/spec/graphql/tracing/new_relic_tracing_spec.rb
@@ -3,7 +3,13 @@ require "spec_helper"
 
 describe GraphQL::Tracing::NewRelicTracing do
   module NewRelicTest
+    class Thing < GraphQL::Schema::Object
+      implements GraphQL::Types::Relay::Node
+    end
+
     class Query < GraphQL::Schema::Object
+      add_field GraphQL::Types::Relay::NodeField
+
       field :int, Integer, null: false
 
       def int
@@ -14,6 +20,16 @@ describe GraphQL::Tracing::NewRelicTracing do
     class SchemaWithoutTransactionName < GraphQL::Schema
       query(Query)
       use(GraphQL::Tracing::NewRelicTracing)
+      orphan_types(Thing)
+
+      def self.object_from_id(_id, _ctx)
+        :thing
+      end
+
+      def self.resolve_type(_type, _obj, _ctx)
+        Thing
+      end
+
       if TESTING_INTERPRETER
         use GraphQL::Execution::Interpreter
       end
@@ -35,6 +51,11 @@ describe GraphQL::Tracing::NewRelicTracing do
 
   before do
     NewRelic.clear_all
+  end
+
+  it "works with the built-in node field, even though it doesn't have an @owner" do
+    res = NewRelicTest::SchemaWithoutTransactionName.execute '{ node(id: "1") { __typename } }'
+    assert_equal "Think", res["data"]["node"]["__typename"]
   end
 
   it "can leave the transaction name in place" do

--- a/spec/graphql/tracing/new_relic_tracing_spec.rb
+++ b/spec/graphql/tracing/new_relic_tracing_spec.rb
@@ -55,7 +55,7 @@ describe GraphQL::Tracing::NewRelicTracing do
 
   it "works with the built-in node field, even though it doesn't have an @owner" do
     res = NewRelicTest::SchemaWithoutTransactionName.execute '{ node(id: "1") { __typename } }'
-    assert_equal "Think", res["data"]["node"]["__typename"]
+    assert_equal "Thing", res["data"]["node"]["__typename"]
   end
 
   it "can leave the transaction name in place" do


### PR DESCRIPTION
Fixes #2153  

The problem is, not _all_ fields have `.owner`s. Some fields are built before the owner is available (ok, probably just `Types::Relay::Node{s}Field`). 

So, we can get the owner from here. Also, I wouldn't be surprised if mutation fields had the wrong owner, since those use `add_field` too. This will fix the situation here, but add_field might need more work down the line.