### PR TITLE
Include array indices in error paths

### DIFF
--- a/lib/graphql/static_validation/base_visitor.rb
+++ b/lib/graphql/static_validation/base_visitor.rb
@@ -145,6 +145,14 @@ module GraphQL
           @path.pop
         end
 
+        def on_input_object(node, parent)
+          is_list = @argument_definitions.last&.type&.list? == true
+
+          @path.push(parent.children.index(node)) if is_list
+          super
+          @path.pop if is_list
+        end
+
         # @return [GraphQL::BaseType] The current object type
         def type_definition
           @object_types.last

--- a/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
+++ b/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
@@ -47,7 +47,7 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
         input_object_field_error = {
           "message"=>"Argument 'source' on InputObject 'DairyProductInput' has an invalid value. Expected type 'DairyAnimal!'.",
           "locations"=>[{"line"=>6, "column"=>39}],
-          "path"=>["query getCheese", "badSource", "product", "source"],
+          "path"=>["query getCheese", "badSource", "product", 0, "source"],
           "extensions"=>{"code"=>"argumentLiteralsIncompatible", "typeName"=>"InputObject", "argumentName"=>"source"},
         }
         assert_includes(errors, input_object_field_error)
@@ -92,7 +92,7 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
         input_object_field_error = {
           "message"=>"Argument 'source' on InputObject 'DairyProductInput' has an invalid value. Expected type 'DairyAnimal!'.",
           "locations"=>[{"line"=>6, "column"=>39}],
-          "path"=>["query getCheese", "badSource", "product", "source"],
+          "path"=>["query getCheese", "badSource", "product", 0, "source"],
           "extensions"=>{"code"=>"argumentLiteralsIncompatible", "typeName"=>"InputObject", "argumentName"=>"source"},
         }
         assert_includes(errors, input_object_field_error)

--- a/spec/graphql/static_validation/rules/arguments_are_defined_spec.rb
+++ b/spec/graphql/static_validation/rules/arguments_are_defined_spec.rb
@@ -41,7 +41,7 @@ describe GraphQL::StaticValidation::ArgumentsAreDefined do
         input_obj_record = {
           "message"=>"InputObject 'DairyProductInput' doesn't accept argument 'wacky'",
           "locations"=>[{"line"=>5, "column"=>30}],
-          "path"=>["query getCheese", "searchDairy", "product", "wacky"],
+          "path"=>["query getCheese", "searchDairy", "product", 0, "wacky"],
           "extensions"=>{
             "code"=>"argumentNotAccepted",
             "name"=>"DairyProductInput",


### PR DESCRIPTION
  Fixes #2160 

`is_list = @argument_definitions.last&.type&.list? == true` feels a bit smelly, is there a more idiomatic way to achieve the same result?