### PR TITLE
Forwarding field and object unauthorized errors

### DIFF
--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -128,6 +128,9 @@ module GraphQL
               field_ctx.trace("execute_field", { context: field_ctx }) do
                 field_ctx.schema.middleware.invoke([parent_type, object, field, arguments, field_ctx])
               end
+            rescue GraphQL::UnauthorizedFieldError => err
+              err.field ||= field
+              field_ctx.schema.unauthorized_field(err)
             rescue GraphQL::UnauthorizedError => err
               field_ctx.schema.unauthorized_object(err)
             end

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -504,6 +504,9 @@ module GraphQL
             err = GraphQL::UnauthorizedFieldError.new(object: application_object, type: object.class, context: ctx, field: self)
             ctx.schema.unauthorized_field(err)
           end
+        rescue GraphQL::UnauthorizedFieldError => err
+          err.field ||= self
+          ctx.schema.unauthorized_field(err)
         rescue GraphQL::UnauthorizedError => err
           ctx.schema.unauthorized_object(err)
         end

--- a/lib/graphql/schema/object.rb
+++ b/lib/graphql/schema/object.rb
@@ -37,8 +37,8 @@ module GraphQL
         def authorized_new(object, context)
           auth_val = begin
             authorized?(object, context)
-          # rescue GraphQL::UnauthorizedError => err
-          #   context.schema.unauthorized_object(err)
+          rescue GraphQL::UnauthorizedError => err
+            context.schema.unauthorized_object(err)
           end
 
           context.schema.after_lazy(auth_val) do |is_authorized|

--- a/lib/graphql/unauthorized_field_error.rb
+++ b/lib/graphql/unauthorized_field_error.rb
@@ -2,7 +2,7 @@
 module GraphQL
   class UnauthorizedFieldError < GraphQL::UnauthorizedError
     # @return [Field] the field that failed the authorization check
-    attr_reader :field
+    attr_accessor :field
 
     def initialize(message = nil, object: nil, type: nil, context: nil, field: nil)
       if message.nil? && [field, type].any?(&:nil?)


### PR DESCRIPTION
This allows to extend the use of `authorized?` in resolvers and objects by forwarding `UnauthorizedFieldError` and `UnauthorizedError` to `unauthorized_field` and `unauthorized_object` respectively.

Coming from #2157 