### PR TITLE
Prevent argument names from overwriting Arguments methods

### DIFF
--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -19,7 +19,7 @@ module GraphQL
             method_names = [expose_as, expose_as_underscored].uniq
             method_names.each do |method_name|
               # Don't define a helper method if it would override something.
-              if instance_methods.include?(method_name)
+              if instance_methods.include?(method_name.to_sym)
                 warn(
                   "Unable to define a helper for argument with name '#{method_name}' "\
                   "as this is a reserved name. If you're using an argument such as "\

--- a/spec/graphql/schema/argument_spec.rb
+++ b/spec/graphql/schema/argument_spec.rb
@@ -14,6 +14,7 @@ describe GraphQL::Schema::Argument do
         argument :aliased_arg, String, required: false, as: :renamed
         argument :prepared_arg, Int, required: false, prepare: :multiply
         argument :prepared_by_proc_arg, Int, required: false, prepare: ->(val, context) { context[:multiply_by] * val }
+        argument :keys, [String], required: false
 
         class Multiply
           def call(val, context)
@@ -38,6 +39,13 @@ describe GraphQL::Schema::Argument do
       if TESTING_INTERPRETER
         use GraphQL::Execution::Interpreter
       end
+    end
+  end
+
+  describe "#keys" do
+    it "is not overwritten by the 'keys' argument" do
+      expected_keys = ["aliasedArg", "arg", "argWithBlock", "keys", "preparedArg", "preparedByCallableArg", "preparedByProcArg"]
+      assert_equal expected_keys, SchemaArgumentTest::Query.fields["field"].arguments.keys.sort
     end
   end
 


### PR DESCRIPTION
Prevent argument names like the ones below from overwriting existing methods on `GraphQL::Query::Arguments`.
```ruby
field :field, String, null: false do
  argument :to_h, String
  argument :keys, String
end
```

This prevents errors like this:
> NoMethodError: undefined method `any?' for nil:NilClass
>    /home/gabrielx/.rvm/rubies/ruby-2.5.3/lib/ruby/2.5.0/forwardable.rb:227:in `any?'
>    /home/gabrielx/projects/oss/graphql-ruby/lib/graphql/schema/field.rb:573:in `to_ruby_args'

And this:
> NoMethodError: undefined method `key?' for nil:NilClass
>    /home/gabrielx/projects/oss/graphql-ruby/lib/graphql/schema/field.rb:579:in `block in to_ruby_args'
>    /home/gabrielx/projects/oss/graphql-ruby/lib/graphql/schema/field.rb:577:in `each'