### PR TITLE
Fix ActionCableLink when there are errors but no data

### DIFF
--- a/javascript_client/subscriptions/ActionCableLink.js
+++ b/javascript_client/subscriptions/ActionCableLink.js
@@ -32,7 +32,7 @@ function ActionCableLink(options) {
           )
         },
         received: function(payload) {
-          if (payload.result.data) {
+          if (payload.result.data || payload.result.errors) {
             observer.next(payload.result)
           }
 


### PR DESCRIPTION
We ran into an issue where Apollo is not notified when sending bad queries that return errors but no data.