### PR TITLE
[1.10] Schema.build_from_definition should make classes

### DIFF
--- a/lib/graphql/backtrace/table.rb
+++ b/lib/graphql/backtrace/table.rb
@@ -84,10 +84,14 @@ module GraphQL
           field_name = "#{ctx.irep_node.owner_type.name}.#{ctx.field.name}"
           position = "#{ctx.ast_node.line}:#{ctx.ast_node.col}"
           field_alias = ctx.ast_node.alias
+          object = ctx.object
+          if object.is_a?(GraphQL::Schema::Object)
+            object = object.object
+          end
           rows << [
             "#{position}",
             "#{field_name}#{field_alias ? " as #{field_alias}" : ""}",
-            "#{ctx.object.inspect}",
+            "#{object.inspect}",
             ctx.irep_node.arguments.to_h.inspect,
             Backtrace::InspectResult.inspect_result(top && @override_value ? @override_value : ctx.value),
           ]
@@ -104,10 +108,14 @@ module GraphQL
             position = "?:?"
           end
           op_name = query.selected_operation_name
+          object = query.root_value
+          if object.is_a?(GraphQL::Schema::Object)
+            object = object.object
+          end
           rows << [
             "#{position}",
             "#{op_type}#{op_name ? " #{op_name}" : ""}",
-            "#{query.root_value.inspect}",
+            "#{object.inspect}",
             query.variables.to_h.inspect,
             Backtrace::InspectResult.inspect_result(query.context.value),
           ]

--- a/lib/graphql/language/document_from_schema_definition.rb
+++ b/lib/graphql/language/document_from_schema_definition.rb
@@ -150,7 +150,7 @@ module GraphQL
 
       def build_directive_node(directive)
         GraphQL::Language::Nodes::DirectiveDefinition.new(
-          name: directive.name,
+          name: directive.graphql_name,
           arguments: build_argument_nodes(warden.arguments(directive)),
           locations: build_directive_location_nodes(directive.locations),
           description: directive.description,

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -79,6 +79,7 @@ module GraphQL
   class Schema
     extend Forwardable
     extend GraphQL::Schema::Member::AcceptsDefinition
+    extend GraphQL::Schema::Member::HasAstNode
     include GraphQL::Define::InstanceDefinable
     accepts_definitions \
       :query, :mutation, :subscription,
@@ -1008,7 +1009,7 @@ module GraphQL
 
       def directives(new_directives = nil)
         if new_directives
-          @directives = new_directives.reduce({}) { |m, d| m[d.name] = d; m }
+          @directives = new_directives.reduce({}) { |m, d| m[d.graphql_name] = d; m }
         end
 
         @directives ||= default_directives

--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -5,6 +5,7 @@ module GraphQL
       include GraphQL::Schema::Member::CachedGraphQLDefinition
       include GraphQL::Schema::Member::AcceptsDefinition
       include GraphQL::Schema::Member::HasPath
+      include GraphQL::Schema::Member::HasAstNode
 
       NO_DEFAULT = :__no_default__
 
@@ -30,7 +31,7 @@ module GraphQL
       # @param as [Symbol] Override the keyword name when passed to a method
       # @param prepare [Symbol] A method to call to transform this argument's valuebefore sending it to field resolution
       # @param camelize [Boolean] if true, the name will be camelized when building the schema
-      def initialize(arg_name = nil, type_expr = nil, desc = nil, required:, type: nil, name: nil, description: nil, default_value: NO_DEFAULT, as: nil, camelize: true, prepare: nil, owner:, &definition_block)
+      def initialize(arg_name = nil, type_expr = nil, desc = nil, required:, type: nil, name: nil, description: nil, ast_node: nil, default_value: NO_DEFAULT, as: nil, camelize: true, prepare: nil, owner:, &definition_block)
         arg_name ||= name
         @name = camelize ? Member::BuildType.camelize(arg_name.to_s) : arg_name.to_s
         @type_expr = type_expr || type
@@ -41,6 +42,7 @@ module GraphQL
         @as = as
         @keyword = as || Schema::Member::BuildType.underscore(@name).to_sym
         @prepare = prepare
+        @ast_node = ast_node
 
         if definition_block
           if definition_block.arity == 1
@@ -89,6 +91,7 @@ module GraphQL
         argument.description = @description
         argument.metadata[:type_class] = self
         argument.as = @as
+        argument.ast_node = ast_node
         if NO_DEFAULT != @default_value
           argument.default_value = @default_value
         end

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -48,15 +48,15 @@ module GraphQL
               raise InvalidDocumentError.new('Must provide only one schema definition.') if schema_definition
               schema_definition = definition
             when GraphQL::Language::Nodes::EnumTypeDefinition
-              types[definition.name] = build_enum_type(definition, type_resolver)
+              types[definition.name] = build_enum_type(definition, type_resolver).graphql_definition
             when GraphQL::Language::Nodes::ObjectTypeDefinition
-              types[definition.name] = build_object_type(definition, type_resolver, default_resolve: default_resolve)
+              types[definition.name] = build_object_type(definition, type_resolver, default_resolve: default_resolve).graphql_definition
             when GraphQL::Language::Nodes::InterfaceTypeDefinition
-              types[definition.name] = build_interface_type(definition, type_resolver)
+              types[definition.name] = build_interface_type(definition, type_resolver).graphql_definition
             when GraphQL::Language::Nodes::UnionTypeDefinition
-              types[definition.name] = build_union_type(definition, type_resolver)
+              types[definition.name] = build_union_type(definition, type_resolver).graphql_definition
             when GraphQL::Language::Nodes::ScalarTypeDefinition
-              types[definition.name] = build_scalar_type(definition, type_resolver, default_resolve: default_resolve)
+              types[definition.name] = build_scalar_type(definition, type_resolver, default_resolve: default_resolve).graphql_definition
             when GraphQL::Language::Nodes::InputObjectTypeDefinition
               types[definition.name] = build_input_object_type(definition, type_resolver)
             when GraphQL::Language::Nodes::DirectiveDefinition
@@ -114,29 +114,21 @@ module GraphQL
           raise(NotImplementedError, "Generated Schema cannot use Interface or Union types for execution. Implement resolve_type on your resolver.")
         }
 
-        NullScalarCoerce = ->(val, _ctx) { val }
-
         def build_enum_type(enum_type_definition, type_resolver)
-          enum = GraphQL::EnumType.define(
-            name: enum_type_definition.name,
-            description: enum_type_definition.description,
-            values: enum_type_definition.values.map do |enum_value_definition|
-              value = EnumType::EnumValue.define(
-                name: enum_value_definition.name,
+          builder = self
+          Class.new(GraphQL::Schema::Enum) do
+            graphql_name(enum_type_definition.name)
+            description(enum_type_definition.description)
+            ast_node(enum_type_definition)
+            enum_type_definition.values.each do |enum_value_definition|
+              value(enum_value_definition.name,
                 value: enum_value_definition.name,
-                deprecation_reason: build_deprecation_reason(enum_value_definition.directives),
+                deprecation_reason: builder.build_deprecation_reason(enum_value_definition.directives),
                 description: enum_value_definition.description,
+                ast_node: enum_value_definition,
               )
-
-              value.ast_node = enum_value_definition
-
-              value
             end
-          )
-
-          enum.ast_node = enum_type_definition
-
-          enum
+          end
         end
 
         def build_deprecation_reason(directives)
@@ -150,47 +142,49 @@ module GraphQL
         end
 
         def build_scalar_type(scalar_type_definition, type_resolver, default_resolve:)
-          scalar_type = GraphQL::ScalarType.define(
-            name: scalar_type_definition.name,
-            description: scalar_type_definition.description,
-            coerce: NullScalarCoerce,
-          )
+          Class.new(GraphQL::Schema::Scalar) do
+            graphql_name(scalar_type_definition.name)
+            description(scalar_type_definition.description)
+            ast_node(scalar_type_definition)
 
-          scalar_type.ast_node = scalar_type_definition
+            if default_resolve.respond_to?(:coerce_input)
+              define_singleton_method(:coerce_input) do |val, ctx|
+                default_resolve.coerce_input(self, val, ctx)
+              end
 
-          if default_resolve.respond_to?(:coerce_input)
-            scalar_type = scalar_type.redefine(
-              coerce_input: ->(val, ctx) { default_resolve.coerce_input(scalar_type, val, ctx) },
-              coerce_result: ->(val, ctx) { default_resolve.coerce_result(scalar_type, val, ctx) },
-            )
+              define_singleton_method(:coerce_result) do |val, ctx|
+                default_resolve.coerce_result(self, val, ctx)
+              end
+            end
           end
-
-          scalar_type
         end
 
         def build_union_type(union_type_definition, type_resolver)
-          union = GraphQL::UnionType.define(
-            name: union_type_definition.name,
-            description: union_type_definition.description,
-            possible_types: union_type_definition.types.map{ |type_name| type_resolver.call(type_name) },
-          )
-
-          union.ast_node = union_type_definition
-
-          union
+          Class.new(GraphQL::Schema::Union) do
+            graphql_name(union_type_definition.name)
+            description(union_type_definition.description)
+            possible_types(*union_type_definition.types.map { |type_name| type_resolver.call(type_name) })
+            ast_node(union_type_definition)
+          end
         end
 
         def build_object_type(object_type_definition, type_resolver, default_resolve:)
+          builder = self
           type_def = nil
-          typed_resolve_fn = ->(field, obj, args, ctx) { default_resolve.call(type_def, field, obj, args, ctx) }
-          type_def = GraphQL::ObjectType.define(
-            name: object_type_definition.name,
-            description: object_type_definition.description,
-            fields: Hash[build_fields(object_type_definition.fields, type_resolver, default_resolve: typed_resolve_fn)],
-            interfaces: object_type_definition.interfaces.map{ |interface_name| type_resolver.call(interface_name) },
-          )
-          type_def.ast_node = object_type_definition
-          type_def
+          typed_resolve_fn = ->(field, obj, args, ctx) { default_resolve.call(type_def.graphql_definition, field, obj, args, ctx) }
+          Class.new(GraphQL::Schema::Object) do
+            type_def = self
+            graphql_name(object_type_definition.name)
+            description(object_type_definition.description)
+            ast_node(object_type_definition)
+
+            object_type_definition.interfaces.each do |interface_name|
+              interface_defn = type_resolver.call(interface_name)
+              implements(interface_defn)
+            end
+
+            builder.build_fields(self, object_type_definition.fields, type_resolver, default_resolve: typed_resolve_fn)
+          end
         end
 
         def build_input_object_type(input_object_type_definition, type_resolver)
@@ -282,52 +276,51 @@ module GraphQL
         end
 
         def build_interface_type(interface_type_definition, type_resolver)
-          interface = GraphQL::InterfaceType.define(
-            name: interface_type_definition.name,
-            description: interface_type_definition.description,
-            fields: Hash[build_fields(interface_type_definition.fields, type_resolver, default_resolve: nil)],
-          )
+          builder = self
+          Module.new do
+            include GraphQL::Schema::Interface
+            graphql_name(interface_type_definition.name)
+            description(interface_type_definition.description)
+            ast_node(interface_type_definition)
 
-          interface.ast_node = interface_type_definition
-
-          interface
+            builder.build_fields(self, interface_type_definition.fields, type_resolver, default_resolve: nil)
+          end
         end
 
-        def build_fields(field_definitions, type_resolver, default_resolve:)
+        def build_fields(owner, field_definitions, type_resolver, default_resolve:)
+          builder = self
+
           field_definitions.map do |field_definition|
-            field_arguments = Hash[field_definition.arguments.map do |argument|
-              kwargs = {}
+            type_name = resolve_type_name(field_definition.type)
 
-              if !argument.default_value.nil?
-                kwargs[:default_value] = build_default_value(argument.default_value)
-              end
-
-              arg = GraphQL::Argument.define(
-                name: argument.name,
-                description: argument.description,
-                type: type_resolver.call(argument.type),
-                **kwargs,
-              )
-
-              arg.ast_node = argument
-
-              [argument.name, arg]
-            end]
-
-            field = GraphQL::Field.define(
-              name: field_definition.name,
+            field = owner.field(
+              field_definition.name,
               description: field_definition.description,
               type: type_resolver.call(field_definition.type),
-              arguments: field_arguments,
-              resolve: ->(obj, args, ctx) { default_resolve.call(field, obj, args, ctx) },
+              null: true,
+              connection: type_name.end_with?("Connection"),
+              resolve: ->(obj, args, ctx) { default_resolve.call(field.graphql_definition, obj, args, ctx) },
               deprecation_reason: build_deprecation_reason(field_definition.directives),
-            )
+              ast_node: field_definition,
+              camelize: false,
+            ) do
+              field_definition.arguments.map do |argument_defn|
+                default_value_kwargs = {}
+                if !argument_defn.default_value.nil?
+                  default_value_kwargs[:default_value] = builder.build_default_value(argument_defn.default_value)
+                end
 
-            field.ast_node = field_definition
-
-            type_name = resolve_type_name(field_definition.type)
-            field.connection = type_name.end_with?("Connection")
-            [field_definition.name, field]
+                argument(
+                  argument_defn.name,
+                  type: type_resolver.call(argument_defn.type),
+                  required: false,
+                  description: argument_defn.description,
+                  ast_node: argument_defn,
+                  camelize: false,
+                  **default_value_kwargs
+                )
+              end
+            end
           end
         end
 

--- a/lib/graphql/schema/build_from_definition/resolve_map.rb
+++ b/lib/graphql/schema/build_from_definition/resolve_map.rb
@@ -14,6 +14,12 @@ module GraphQL
       #
       # @api private
       class ResolveMap
+        module NullScalarCoerce
+          def self.call(val, _ctx)
+            val
+          end
+        end
+
         def initialize(user_resolve_hash)
           @resolve_hash = Hash.new do |h, k|
             # For each type name, provide a new hash if one wasn't given:
@@ -21,7 +27,7 @@ module GraphQL
               if k2 == "coerce_input" || k2 == "coerce_result"
                 # This isn't an object field, it's a scalar coerce function.
                 # Use a passthrough
-                Builder::NullScalarCoerce
+                NullScalarCoerce
               else
                 # For each field, provide a resolver that will
                 # make runtime checks & replace itself
@@ -53,16 +59,16 @@ module GraphQL
         end
 
         def call(type, field, obj, args, ctx)
-          resolver = @resolve_hash[type.name][field.name]
+          resolver = @resolve_hash[type.graphql_name][field.graphql_name]
           resolver.call(obj, args, ctx)
         end
 
         def coerce_input(type, value, ctx)
-          @resolve_hash[type.name]["coerce_input"].call(value, ctx)
+          @resolve_hash[type.graphql_name]["coerce_input"].call(value, ctx)
         end
 
         def coerce_result(type, value, ctx)
-          @resolve_hash[type.name]["coerce_result"].call(value, ctx)
+          @resolve_hash[type.graphql_name]["coerce_result"].call(value, ctx)
         end
       end
     end

--- a/lib/graphql/schema/build_from_definition/resolve_map/default_resolve.rb
+++ b/lib/graphql/schema/build_from_definition/resolve_map/default_resolve.rb
@@ -20,7 +20,7 @@ module GraphQL
           def call(obj, args, ctx)
             method_name = @field_name
             if !obj.respond_to?(method_name)
-              raise KeyError, "Can't resolve field #{method_name} on #{obj}"
+              raise KeyError, "Can't resolve field #{method_name} on #{obj.inspect}"
             else
               method_arity = obj.method(method_name).arity
               resolver = case method_arity

--- a/lib/graphql/schema/directive.rb
+++ b/lib/graphql/schema/directive.rb
@@ -31,6 +31,10 @@ module GraphQL
           end
         end
 
+        def default_directive?
+          default_directive
+        end
+
         def to_graphql
           defn = GraphQL::Directive.new
           defn.name = self.graphql_name

--- a/lib/graphql/schema/directive.rb
+++ b/lib/graphql/schema/directive.rb
@@ -37,6 +37,7 @@ module GraphQL
           defn.description = self.description
           defn.locations = self.locations
           defn.default_directive = self.default_directive
+          defn.ast_node = ast_node
           defn.metadata[:type_class] = self
           arguments.each do |name, arg_defn|
             arg_graphql = arg_defn.to_graphql

--- a/lib/graphql/schema/enum.rb
+++ b/lib/graphql/schema/enum.rb
@@ -53,6 +53,7 @@ module GraphQL
           enum_type.name = graphql_name
           enum_type.description = description
           enum_type.introspection = introspection
+          enum_type.ast_node = ast_node
           values.each do |name, val|
             enum_type.add_value(val.to_graphql)
           end

--- a/lib/graphql/schema/enum_value.rb
+++ b/lib/graphql/schema/enum_value.rb
@@ -28,6 +28,7 @@ module GraphQL
     class EnumValue < GraphQL::Schema::Member
       include GraphQL::Schema::Member::AcceptsDefinition
       include GraphQL::Schema::Member::HasPath
+      include GraphQL::Schema::Member::HasAstNode
 
       attr_reader :graphql_name
 
@@ -37,12 +38,13 @@ module GraphQL
       # @return [String] Explains why this value was deprecated (if present, this will be marked deprecated in introspection)
       attr_accessor :deprecation_reason
 
-      def initialize(graphql_name, desc = nil, owner:, description: nil, value: nil, deprecation_reason: nil, &block)
+      def initialize(graphql_name, desc = nil, owner:, ast_node: nil, description: nil, value: nil, deprecation_reason: nil, &block)
         @graphql_name = graphql_name.to_s
         @description = desc || description
         @value = value.nil? ? @graphql_name : value
         @deprecation_reason = deprecation_reason
         @owner = owner
+        @ast_node = ast_node
 
         if block_given?
           instance_eval(&block)
@@ -71,6 +73,7 @@ module GraphQL
         enum_value.value = @value
         enum_value.deprecation_reason = @deprecation_reason
         enum_value.metadata[:type_class] = self
+        enum_value.ast_node = ast_node
         enum_value
       end
 

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -9,6 +9,7 @@ module GraphQL
       include GraphQL::Schema::Member::CachedGraphQLDefinition
       include GraphQL::Schema::Member::AcceptsDefinition
       include GraphQL::Schema::Member::HasArguments
+      include GraphQL::Schema::Member::HasAstNode
       include GraphQL::Schema::Member::HasPath
 
       # @return [String] the GraphQL name for this field, camelized unless `camelize: false` is provided
@@ -157,7 +158,8 @@ module GraphQL
       # @param subscription_scope [Symbol, String] A key in `context` which will be used to scope subscription payloads
       # @param extensions [Array<Class>] Named extensions to apply to this field (see also {#extension})
       # @param trace [Boolean] If true, a {GraphQL::Tracing} tracer will measure this scalar field
-      def initialize(type: nil, name: nil, owner: nil, null: nil, field: nil, function: nil, description: nil, deprecation_reason: nil, method: nil, hash_key: nil, resolver_method: nil, resolve: nil, connection: nil, max_page_size: nil, scope: nil, introspection: false, camelize: true, trace: nil, complexity: 1, extras: [], extensions: [], resolver_class: nil, subscription_scope: nil, relay_node_field: false, relay_nodes_field: false, arguments: {}, &definition_block)
+      # @param ast_node [Language::Nodes::FieldDefinition, nil] If this schema was parsed from definition, this AST node defined the field
+      def initialize(type: nil, name: nil, owner: nil, null: nil, field: nil, function: nil, description: nil, deprecation_reason: nil, method: nil, hash_key: nil, resolver_method: nil, resolve: nil, connection: nil, max_page_size: nil, scope: nil, introspection: false, camelize: true, trace: nil, complexity: 1, ast_node: nil, extras: [], extensions: [], resolver_class: nil, subscription_scope: nil, relay_node_field: false, relay_nodes_field: false, arguments: {}, &definition_block)
         if name.nil?
           raise ArgumentError, "missing first `name` argument or keyword `name:`"
         end
@@ -218,6 +220,7 @@ module GraphQL
         @trace = trace
         @relay_node_field = relay_node_field
         @relay_nodes_field = relay_nodes_field
+        @ast_node = ast_node
 
         # Override the default from HasArguments
         @own_arguments = {}
@@ -370,6 +373,7 @@ module GraphQL
         field_defn.introspection = @introspection
         field_defn.complexity = @complexity
         field_defn.subscription_scope = @subscription_scope
+        field_defn.ast_node = ast_node
 
         arguments.each do |name, defn|
           arg_graphql = defn.to_graphql

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -97,6 +97,7 @@ module GraphQL
           type_defn.description = description
           type_defn.metadata[:type_class] = self
           type_defn.mutation = mutation
+          type_defn.ast_node = ast_node
           arguments.each do |name, arg|
             type_defn.arguments[arg.graphql_definition.name] = arg.graphql_definition
           end

--- a/lib/graphql/schema/interface.rb
+++ b/lib/graphql/schema/interface.rb
@@ -12,6 +12,7 @@ module GraphQL
         include GraphQL::Schema::Member::HasPath
         include GraphQL::Schema::Member::RelayShortcuts
         include GraphQL::Schema::Member::Scoped
+        include GraphQL::Schema::Member::HasAstNode
 
         # Methods defined in this block will be:
         # - Added as class methods to this interface
@@ -89,6 +90,7 @@ module GraphQL
           type_defn.name = graphql_name
           type_defn.description = description
           type_defn.orphan_types = orphan_types
+          type_defn.ast_node = ast_node
           fields.each do |field_name, field_inst|
             field_defn = field_inst.graphql_definition
             type_defn.fields[field_defn.name] = field_defn

--- a/lib/graphql/schema/member.rb
+++ b/lib/graphql/schema/member.rb
@@ -3,6 +3,7 @@ require 'graphql/schema/member/accepts_definition'
 require 'graphql/schema/member/base_dsl_methods'
 require 'graphql/schema/member/cached_graphql_definition'
 require 'graphql/schema/member/graphql_type_names'
+require 'graphql/schema/member/has_ast_node'
 require 'graphql/schema/member/has_path'
 require 'graphql/schema/member/relay_shortcuts'
 require 'graphql/schema/member/scoped'
@@ -24,6 +25,7 @@ module GraphQL
       extend Scoped
       extend RelayShortcuts
       extend HasPath
+      extend HasAstNode
     end
   end
 end

--- a/lib/graphql/schema/member/build_type.rb
+++ b/lib/graphql/schema/member/build_type.rb
@@ -72,6 +72,8 @@ module GraphQL
               # Eg `String` => GraphQL::STRING_TYPE
               parse_type(type_expr.name, null: true)
             end
+          when Proc
+            parse_type(type_expr.call, null: true)
           when false
             raise ArgumentError, "Received `false` instead of a type, maybe a `!` should be replaced with `null: true` (for fields) or `required: true` (for arguments)"
           end

--- a/lib/graphql/schema/member/build_type.rb
+++ b/lib/graphql/schema/member/build_type.rb
@@ -64,6 +64,8 @@ module GraphQL
             else
               raise ArgumentError, LIST_TYPE_ERROR
             end
+          when GraphQL::Schema::NonNull, GraphQL::Schema::List
+            type_expr
           when Module
             # This is a way to check that it's the right kind of module:
             if type_expr.respond_to?(:graphql_definition)

--- a/lib/graphql/schema/member/has_ast_node.rb
+++ b/lib/graphql/schema/member/has_ast_node.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+module GraphQL
+  class Schema
+    class Member
+      module HasAstNode
+        # If this schema was parsed from a `.graphql` file (or other SDL),
+        # this is the AST node that defined this part of the schema.
+        def ast_node(new_ast_node = nil)
+          if new_ast_node
+            @ast_node = new_ast_node
+          end
+          @ast_node
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -6,11 +6,11 @@ module GraphQL
       module HasFields
         # Add a field to this object or interface with the given definition
         # @see {GraphQL::Schema::Field#initialize} for method signature
-        # @return [void]
+        # @return [GraphQL::Schema::Field]
         def field(*args, **kwargs, &block)
           field_defn = field_class.from_options(*args, owner: self, **kwargs, &block)
           add_field(field_defn)
-          nil
+          field_defn
         end
 
         # @return [Hash<String => GraphQL::Schema::Field>] Fields on this object, keyed by name, including inherited fields

--- a/lib/graphql/schema/object.rb
+++ b/lib/graphql/schema/object.rb
@@ -118,6 +118,7 @@ module GraphQL
           obj_type.interfaces = interfaces
           obj_type.introspection = introspection
           obj_type.mutation = mutation
+          obj_type.ast_node = ast_node
           fields.each do |field_name, field_inst|
             field_defn = field_inst.to_graphql
             obj_type.fields[field_defn.name] = field_defn

--- a/lib/graphql/schema/scalar.rb
+++ b/lib/graphql/schema/scalar.rb
@@ -24,6 +24,7 @@ module GraphQL
           type_defn.coerce_input = method(:coerce_input)
           type_defn.metadata[:type_class] = self
           type_defn.default_scalar = default_scalar
+          type_defn.ast_node = ast_node
           type_defn
         end
 

--- a/lib/graphql/schema/type_expression.rb
+++ b/lib/graphql/schema/type_expression.rb
@@ -9,25 +9,35 @@ module GraphQL
       # @param ast_node [GraphQL::Language::Nodes::AbstractNode]
       # @return [GraphQL::BaseType, nil]
       def self.build_type(types, ast_node)
-        case ast_node
-        when GraphQL::Language::Nodes::TypeName
-          types.fetch(ast_node.name, nil)
-        when GraphQL::Language::Nodes::NonNullType
-          ast_inner_type = ast_node.of_type
-          inner_type = build_type(types, ast_inner_type)
-          wrap_type(inner_type, GraphQL::NonNullType)
-        when GraphQL::Language::Nodes::ListType
-          ast_inner_type = ast_node.of_type
-          inner_type = build_type(types, ast_inner_type)
-          wrap_type(inner_type, GraphQL::ListType)
-        end
+        t = type_from_ast(types, ast_node)
+        # maybe nil:
+        t ? t.graphql_definition : t
       end
 
-      def self.wrap_type(type, wrapper)
-        if type.nil?
-          nil
-        else
-          wrapper.new(of_type: type)
+      class << self
+        private
+
+        def type_from_ast(types, ast_node)
+          case ast_node
+          when GraphQL::Language::Nodes::TypeName
+            types.fetch(ast_node.name, nil)
+          when GraphQL::Language::Nodes::NonNullType
+            ast_inner_type = ast_node.of_type
+            inner_type = build_type(types, ast_inner_type)
+            wrap_type(inner_type, GraphQL::Schema::NonNull)
+          when GraphQL::Language::Nodes::ListType
+            ast_inner_type = ast_node.of_type
+            inner_type = build_type(types, ast_inner_type)
+            wrap_type(inner_type, GraphQL::Schema::List)
+          end
+        end
+
+        def wrap_type(of_type, wrapper)
+          if of_type.nil?
+            nil
+          else
+            wrapper.new(of_type)
+          end
         end
       end
     end

--- a/lib/graphql/schema/union.rb
+++ b/lib/graphql/schema/union.rb
@@ -20,6 +20,7 @@ module GraphQL
           type_defn.name = graphql_name
           type_defn.description = description
           type_defn.possible_types = possible_types
+          type_defn.ast_node = ast_node
           if respond_to?(:resolve_type)
             type_defn.resolve_type = method(:resolve_type)
           end

--- a/lib/graphql/schema/validation.rb
+++ b/lib/graphql/schema/validation.rb
@@ -120,7 +120,7 @@ module GraphQL
 
         TYPE_IS_VALID_INPUT_TYPE = ->(type) {
           outer_type = type.type
-          inner_type = outer_type.is_a?(GraphQL::BaseType) ? outer_type.unwrap : nil
+          inner_type = outer_type.respond_to?(:unwrap) ? outer_type.unwrap : nil
 
           case inner_type
           when GraphQL::ScalarType, GraphQL::InputObjectType, GraphQL::EnumType

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -1164,7 +1164,7 @@ SCHEMA
         schema = GraphQL::Schema.from_definition(schema_defn, default_resolve: AppResolver.new)
         schema.execute("mutation { todoAdd: todo_add(text: \"Buy Milk\") { text } }", context: {context_value: "bar"})
         result = schema.execute("query { allTodos: all_todos { text, from_context } }")
-        assert_equal(result.to_json, '{"data":{"allTodos":[{"text":"Pay the bills.","from_context":null},{"text":"Buy Milk","from_context":"bar"}]}}')
+        assert_equal('{"data":{"allTodos":[{"text":"Pay the bills.","from_context":null},{"text":"Buy Milk","from_context":"bar"}]}}', result.to_json)
       end
     end
 

--- a/spec/graphql/schema/warden_spec.rb
+++ b/spec/graphql/schema/warden_spec.rb
@@ -447,7 +447,7 @@ describe GraphQL::Schema::Warden do
       "
 
       schema = GraphQL::Schema.from_definition(sdl)
-      schema.orphan_types = []
+      schema.orphan_types.clear
 
       query_string = %|
         {
@@ -470,7 +470,7 @@ describe GraphQL::Schema::Warden do
       assert_equal [], res["data"]["Query"]["fields"]
 
       # Unreferenced but still visible because orphan type
-      schema.orphan_types = [schema.find("BagOfThings")]
+      schema.graphql_definition.orphan_types = [schema.find("BagOfThings")]
       res = schema.execute(query_string, except: ->(m, _) { m.name == "bag" })
       assert res["data"]["BagOfThings"]
     end

--- a/spec/integration/rails/graphql/schema_spec.rb
+++ b/spec/integration/rails/graphql/schema_spec.rb
@@ -224,7 +224,7 @@ type Query {
 
     it "builds from a file" do
       schema = GraphQL::Schema.from_definition("spec/support/magic_cards/schema.graphql")
-      assert_instance_of GraphQL::Schema, schema
+      assert_instance_of Class, schema
       expected_types =  ["Card", "Color", "Expansion", "Printing"]
       assert_equal expected_types, (expected_types & schema.types.keys)
     end

--- a/spec/support/error_bubbling_helpers.rb
+++ b/spec/support/error_bubbling_helpers.rb
@@ -1,23 +1,37 @@
 # frozen_string_literal: true
-# helpers to enable / disable error bubbling in a block scope
+# helpers to enable / disable error bubbling in a block scope.
+#
+# Some schemas are made with `.define`, others are `class`, so we have to support both.
 module ErrorBubblingHelpers
   def without_error_bubbling(schema)
     original_error_bubbling = schema.error_bubbling
     begin
-      schema.error_bubbling = false
+      if schema.is_a?(Class)
+        schema.error_bubbling(false)
+      end
+      schema.graphql_definition.error_bubbling = false
       yield if block_given?
     ensure
-      schema.error_bubbling = original_error_bubbling
+      if schema.is_a?(Class)
+        schema.error_bubbling(original_error_bubbling)
+      end
+      schema.graphql_definition.error_bubbling = original_error_bubbling
     end
   end
 
   def with_error_bubbling(schema)
     original_error_bubbling = schema.error_bubbling
     begin
-      schema.error_bubbling = true
+      if schema.is_a?(Class)
+        schema.error_bubbling(true)
+      end
+      schema.graphql_definition.error_bubbling = true
       yield if block_given?
     ensure
-      schema.error_bubbling = original_error_bubbling
+      if schema.is_a?(Class)
+        schema.error_bubbling(original_error_bubbling)
+      end
+      schema.graphql_definition.error_bubbling = original_error_bubbling
     end
   end
 end


### PR DESCRIPTION
This is a pretty big change for anyone using `.from_definition` to build their schemas. Now, `.from_definition` builds a class-based schema out of dynamically-created, anonymous classes. 

That means, at _least_, that the `ctx` passed into resolvers will be a `GraphQL::Query::Context` instead of a `GraphQL::Query::Context::FieldResolutionContext`. Resolvers won't have access to metadata anymore. Maybe we'll need a followup to somehow support `extras`.