### PR TITLE
Include query in interpreter tracing events for execute_field and execute_field_lazy

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -205,7 +205,7 @@ module GraphQL
 
             field_result = resolve_with_directives(object, ast_node) do
               # Actually call the field resolver and capture the result
-              app_result = query.trace("execute_field", {owner: owner_type, field: field_defn, path: next_path}) do
+              app_result = query.trace("execute_field", {owner: owner_type, field: field_defn, path: next_path, query: query}) do
                 field_defn.resolve(object, kwarg_arguments, context)
               end
               after_lazy(app_result, owner: owner_type, field: field_defn, path: next_path) do |inner_result|
@@ -398,7 +398,7 @@ module GraphQL
               @interpreter_context[:current_field] = field
               # Wrap the execution of _this_ method with tracing,
               # but don't wrap the continuation below
-              inner_obj = query.trace("execute_field_lazy", {owner: owner, field: field, path: path}) do
+              inner_obj = query.trace("execute_field_lazy", {owner: owner, field: field, path: path, query: query}) do
                 begin
                   schema.sync_lazy(obj)
                 rescue GraphQL::ExecutionError, GraphQL::UnauthorizedError => err

--- a/lib/graphql/tracing.rb
+++ b/lib/graphql/tracing.rb
@@ -47,7 +47,7 @@ module GraphQL
   #
   # Note that `execute_field` and `execute_field_lazy` receive different data in different settings:
   #
-  # - When using {GraphQL::Execution::Interpreter}, they receive `{field:, path:}`
+  # - When using {GraphQL::Execution::Interpreter}, they receive `{field:, path:, query:}`
   # - Otherwise, they receive `{context: ...}`
   #
   module Tracing

--- a/lib/graphql/tracing.rb
+++ b/lib/graphql/tracing.rb
@@ -42,8 +42,8 @@ module GraphQL
   # execute_multiplex | `{ multiplex: GraphQL::Execution::Multiplex }`
   # execute_query | `{ query: GraphQL::Query }`
   # execute_query_lazy | `{ query: GraphQL::Query?, multiplex: GraphQL::Execution::Multiplex? }`
-  # execute_field | `{ context: GraphQL::Query::Context::FieldResolutionContext?, owner: Class?, field: GraphQL::Schema::Field?, path: Array<String, Integer>?}`
-  # execute_field_lazy | `{ context: GraphQL::Query::Context::FieldResolutionContext?, owner: Class?, field: GraphQL::Schema::Field?, path: Array<String, Integer>?}`
+  # execute_field | `{ context: GraphQL::Query::Context::FieldResolutionContext?, owner: Class?, field: GraphQL::Schema::Field?, query: GraphQL::Query?, path: Array<String, Integer>?}`
+  # execute_field_lazy | `{ context: GraphQL::Query::Context::FieldResolutionContext?, owner: Class?, field: GraphQL::Schema::Field?, query: GraphqL::Query?, path: Array<String, Integer>?}`
   #
   # Note that `execute_field` and `execute_field_lazy` receive different data in different settings:
   #


### PR DESCRIPTION
This adds the current `GraphQL::Query` to tracing events for `execute_field` and `execute_field_lazy` when running with the interpreter which is useful for accessing the query, query context, etc. (see #2167 for one example use case). With the old runtime this information is available via the `context` key which has a `GraphQL::Query::Context::FieldResolutionContext` instance.