### PR TITLE
Autogenerate base_field.rb

### DIFF
--- a/lib/generators/graphql/install_generator.rb
+++ b/lib/generators/graphql/install_generator.rb
@@ -13,6 +13,7 @@ module Graphql
     #   - graphql/
     #     - resolvers/
     #     - types/
+    #       - base_field.rb
     #       - base_enum.rb
     #       - base_input_object.rb
     #       - base_interface.rb
@@ -93,7 +94,7 @@ module Graphql
         create_dir("#{options[:directory]}/types")
         template("schema.erb", schema_file_path)
 
-        ["base_object", "base_enum", "base_input_object", "base_interface", "base_scalar", "base_union"].each do |base_type|
+        ["base_object", "base_field", "base_enum", "base_input_object", "base_interface", "base_scalar", "base_union"].each do |base_type|
           template("#{base_type}.erb", "#{options[:directory]}/types/#{base_type}.rb")
         end
 

--- a/lib/generators/graphql/templates/base_field.erb
+++ b/lib/generators/graphql/templates/base_field.erb
@@ -1,0 +1,7 @@
+module Types
+  class BaseField < GraphQL::Schema::Field
+    def resolve_field(obj, args, ctx)
+      resolve(obj, args, ctx)
+    end
+  end
+end

--- a/lib/graphql/version.rb
+++ b/lib/graphql/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module GraphQL
-  VERSION = "1.9.3"
+  VERSION = "1.9.3.1"
 end

--- a/lib/graphql/version.rb
+++ b/lib/graphql/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module GraphQL
-  VERSION = "1.9.3.1"
+  VERSION = "1.9.3"
 end


### PR DESCRIPTION
In the documentation for Mutation Classes in 1.9.3 it specifies that you should build a Base Mutation.

https://graphql-ruby.org/mutations/mutation_classes.html#example-mutation-class

In the example mutation class it specifies:

field_class Types::BaseField

My install of graphql-ruby did not create a Types::BaseField at types/base_field.rb.

Therefore it throws an error when attempting to load graphiql:
```
uninitialized constant Types::BaseField
Did you mean?  Types::BaseInterface
```
The answer is no, no I did not.

The fix is to add the base_field.rb in the types/ directory.  This should be auto generated.  This patch makes it so.
```
# types/base_field.rb
module Types
  class BaseField < GraphQL::Schema::Field
    def resolve_field(obj, args, ctx)
      resolve(obj, args, ctx)
    end
  end
end
```