### PR TITLE
Update AST visitor argument definition methods

### DIFF
--- a/lib/graphql/analysis/ast/visitor.rb
+++ b/lib/graphql/analysis/ast/visitor.rb
@@ -220,8 +220,11 @@ module GraphQL
 
         # @return [GraphQL::Argument, nil] The most-recently-entered GraphQL::Argument, if currently inside one
         def argument_definition
-          # Don't get the _last_ one because that's the current one.
-          # Get the second-to-last one, which is the parent of the current one.
+          @argument_definitions.last
+        end
+
+        # @return [GraphQL::Argument, nil] The previous GraphQL argument
+        def previous_argument_definition
           @argument_definitions[-2]
         end
 


### PR DESCRIPTION
Closes #2217 

Changes `argument_definition` to return the current argument definition and adds `previous_argument_definition`.

@rmosolgo I'm guessing this is what you had in mind?

cc @xuorig 