### PR TITLE
[Documentation] Naming Fix - DataDog Tracing Docs

### DIFF
--- a/guides/queries/tracing.md
+++ b/guides/queries/tracing.md
@@ -142,7 +142,7 @@ You may provide `options` as a `Hash` with the following values:
 | --- | ----------- | ------- |
 | `analytics_enabled` | Enable analytics for spans. `true` for on, `nil` to defer to Datadog global setting, `false` for off. | `false` |
 | `analytics_sample_rate` | Rate which tracing data should be sampled for Datadog analytics. Must be a float between `0` and `1.0`. | `1.0` |
-| `service_name` | Service name used for `graphql` instrumentation | `'ruby-graphql'` |
+| `service` | Service name used for `graphql` instrumentation | `'ruby-graphql'` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |
 
 For more details about Datadog's tracing API, check out the [Ruby documentation](https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md) or the [APM documentation](https://docs.datadoghq.com/tracing/) for more product information.


### PR DESCRIPTION
In `GraphQL::Tracing::DataDogTracing`, we fetch the option `:service`
https://github.com/rmosolgo/graphql-ruby/blob/master/lib/graphql/tracing/data_dog_tracing.rb#L42

However, the docs currently [incorrectly] specify that the param is named `:service_name`.
I've updated the docs to be accurate!

Before:
https://github.com/rmosolgo/graphql-ruby/blob/master/guides/queries/tracing.md#datadog

After:
https://github.com/rmosolgo/graphql-ruby/blob/564b4f51046118a13571b4f3c9dbf0f2241b7486/guides/queries/tracing.md#datadog

(note that the example in the getting started guide is correct. https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md#graphql)