### PR TITLE
Interpreter shouldn't recursively unwrap RelayClassicMutation inputs

### DIFF
--- a/lib/graphql/schema/relay_classic_mutation.rb
+++ b/lib/graphql/schema/relay_classic_mutation.rb
@@ -32,7 +32,7 @@ module GraphQL
         # Without the interpreter, the inputs are unwrapped by an instrumenter.
         # But when using the interpreter, no instrumenters are applied.
         if context.interpreter?
-          input = inputs[:input].to_h
+          input = inputs[:input].to_kwargs
           # Transfer these from the top-level hash to the
           # shortcutted `input:` object
           self.class.extras.each do |ext|

--- a/spec/graphql/schema/relay_classic_mutation_spec.rb
+++ b/spec/graphql/schema/relay_classic_mutation_spec.rb
@@ -37,6 +37,10 @@ describe GraphQL::Schema::RelayClassicMutation do
   end
 
   describe "execution" do
+    after do
+      Jazz::Models.reset
+    end
+
     it "works with no arguments" do
       res = Jazz::Schema.execute <<-GRAPHQL
       mutation {
@@ -49,6 +53,20 @@ describe GraphQL::Schema::RelayClassicMutation do
       GRAPHQL
 
       assert_equal "Sitar", res["data"]["addSitar"]["instrument"]["name"]
+    end
+
+    it "works with InputObject arguments" do
+      res = Jazz::Schema.execute <<-GRAPHQL
+      mutation {
+        addEnsembleRelay(input: { ensemble: { name: "Miles Davis Quartet" } }) {
+          ensemble {
+            name
+          }
+        }
+      }
+      GRAPHQL
+
+      assert_equal "Miles Davis Quartet", res["data"]["addEnsembleRelay"]["ensemble"]["name"]
     end
 
     it "supports extras" do

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -503,6 +503,17 @@ module Jazz
     end
   end
 
+  class AddEnsembleRelay < GraphQL::Schema::RelayClassicMutation
+    argument :ensemble, EnsembleInput, required: true
+    field :ensemble, Ensemble, null: false
+
+    def resolve(ensemble:)
+      ens = Models::Ensemble.new(ensemble.name)
+      Models.data["Ensemble"] << ens
+      { ensemble: ens }
+    end
+  end
+
   class AddSitar < GraphQL::Schema::RelayClassicMutation
     null true
     description "Get Sitar to musical instrument"
@@ -633,6 +644,7 @@ module Jazz
     end
 
     field :add_instrument, mutation: AddInstrument
+    field :add_ensemble_relay, mutation: AddEnsembleRelay
     field :add_sitar, mutation: AddSitar
     field :rename_ensemble, mutation: RenameEnsemble
     field :rename_named_entity, mutation: RenameNamedEntity


### PR DESCRIPTION
The interpreter runtime is recursively unwrapping inputs to `GraphQL::Schema::RelayClassicMutation` which is inconsistent with the old runtime. I'm assuming this was unintentional (at least it wasn't documented in the list of incompatibilities 😄) so this PR updates`GraphQL::Schema::RelayClassicMutation`to only unwrap the the top level of the input when using the interpreter.