### PR TITLE
raise ParseError for GraphQL.parse(nil)

### DIFF
--- a/lib/graphql/language/parser.rb
+++ b/lib/graphql/language/parser.rb
@@ -15,6 +15,7 @@ module GraphQL
 module_eval(<<'...end parser.y/module_eval...', 'parser.y', 435)
 
 def initialize(query_string, filename:, tracer: Tracing::NullTracer)
+  raise GraphQL::ParseError.new("No query string was present", nil, nil, query_string) if query_string.nil?
   @query_string = query_string
   @filename = filename
   @tracer = tracer

--- a/lib/graphql/language/parser.y
+++ b/lib/graphql/language/parser.y
@@ -434,6 +434,7 @@ end
 ---- inner ----
 
 def initialize(query_string, filename:, tracer: Tracing::NullTracer)
+  raise GraphQL::ParseError.new("No query string was present", nil, nil, query_string) if query_string.nil?
   @query_string = query_string
   @filename = filename
   @tracer = tracer

--- a/spec/graphql/language/parser_spec.rb
+++ b/spec/graphql/language/parser_spec.rb
@@ -129,6 +129,14 @@ describe GraphQL::Language::Parser do
     assert_equal schema_string, document.to_query_string
   end
 
+  describe "parse errors" do
+    it "raises parse errors for nil" do
+      assert_raises(GraphQL::ParseError) {
+        GraphQL.parse(nil)
+      }
+    end
+  end
+
   describe ".parse_file" do
     it "assigns filename to all nodes" do
       example_filename = "spec/support/parser/filename_example.graphql"


### PR DESCRIPTION
I use `GraphQL.parse()` to prepare compiled GraphQL documents, and found that it raises NoMethoderror for `nil` by `query_string.unpack("c*")`.


I think it should raise `GraphQL::ParseError` for such cases. What do you think of it?
