### PR TITLE
Use String#-@ in key places to reduce string duplications

### DIFF
--- a/lib/graphql/language/token.rb
+++ b/lib/graphql/language/token.rb
@@ -12,7 +12,7 @@ module GraphQL
 
       def initialize(value:, name:, line:, col:, prev_token:)
         @name = name
-        @value = value.freeze
+        @value = -value
         @line = line
         @col = col
         @prev_token = prev_token

--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -14,8 +14,8 @@ module GraphQL
           self.argument_definitions = argument_definitions
 
           argument_definitions.each do |_arg_name, arg_definition|
-            expose_as = arg_definition.expose_as.to_s
-            expose_as_underscored = GraphQL::Schema::Member::BuildType.underscore(expose_as)
+            expose_as = -arg_definition.expose_as.to_s
+            expose_as_underscored = -GraphQL::Schema::Member::BuildType.underscore(expose_as)
             method_names = [expose_as, expose_as_underscored].uniq
             method_names.each do |method_name|
               # Don't define a helper method if it would override something.

--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -32,7 +32,7 @@ module GraphQL
       # @param camelize [Boolean] if true, the name will be camelized when building the schema
       def initialize(arg_name = nil, type_expr = nil, desc = nil, required:, type: nil, name: nil, description: nil, default_value: NO_DEFAULT, as: nil, camelize: true, prepare: nil, owner:, &definition_block)
         arg_name ||= name
-        @name = camelize ? Member::BuildType.camelize(arg_name.to_s) : arg_name.to_s
+        @name = -(camelize ? Member::BuildType.camelize(arg_name.to_s) : arg_name.to_s)
         @type_expr = type_expr || type
         @description = desc || description
         @null = !required

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -173,8 +173,8 @@ module GraphQL
           raise ArgumentError, "keyword `extras:` may only be used with method-based resolve and class-based field such as mutation class, please remove `field:`, `function:` or `resolve:`"
         end
         @original_name = name
-        @underscored_name = Member::BuildType.underscore(name.to_s)
-        @name = camelize ? Member::BuildType.camelize(name.to_s) : name.to_s
+        @underscored_name = -Member::BuildType.underscore(name.to_s)
+        @name = -(camelize ? Member::BuildType.camelize(name.to_s) : name.to_s)
         @description = description
         if field.is_a?(GraphQL::Schema::Field)
           raise ArgumentError, "Instead of passing a field as `field:`, use `add_field(field)` to add an already-defined field."


### PR DESCRIPTION
While memory profiling our application, I noticed a lot of duplicated strings being help by graphql structs:

```
Retained String Report
-----------------------------------
1600  "userErrors"
 391  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/schema/member/build_type.rb:120
 391  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/schema/member/has_fields.rb:45
 391  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/schema/traversal.rb:206
 390  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/schema/object.rb:123
  25  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/language/lexer.rb:1386
   9  /tmp/bundle/ruby/2.5.0/gems/graphql-client-0.14.0/lib/graphql/client/schema/object_type.rb:57
   1  /tmp/bundle/ruby/2.5.0/bundler/gems/json-b5f423ccf08f/lib/json/common.rb:155
   1  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/schema/loader.rb:116
   1  /tmp/bundle/ruby/2.5.0/gems/graphql-client-0.14.0/lib/graphql/client/schema.rb:118

 1571  "name"
 1253  [UNRELATED]
  125  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/schema/member/build_type.rb:164
   81  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/schema/field.rb:177
   31  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/schema/argument.rb:35
   24  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/language/lexer.rb:1386

 1406  "code"
 1336  [UNRELATED]
   26  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/schema/member/build_type.rb:164
   20  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/schema/field.rb:177
    6  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/schema/argument.rb:35

  901  "id"
  310  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/schema/member/build_type.rb:164
  238  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/schema/argument.rb:35
  156  [REDACTED]
   62  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/schema/field.rb:177
   41  [UNRELATED]
   38  [REDACTED]
   27  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/language/lexer.rb:1386

 496  "first"
 257  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/schema/member/build_type.rb:164
 236  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/schema/argument.rb:35
   1  /tmp/bundle/ruby/2.5.0/gems/bootsnap-1.4.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22
   1  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/language/lexer.rb:1386

 437  "after"
 225  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/schema/member/build_type.rb:164
 204  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/schema/argument.rb:35

 429  "before"
 221  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/schema/member/build_type.rb:164
 200  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/schema/argument.rb:35

```

And the list goes on.

After applying this patch the duplications are gone and the app memory usage is reduced by ~1.5MB.