### PR TITLE
Add more context to input validation error message

### DIFF
--- a/lib/graphql/query/variable_validation_error.rb
+++ b/lib/graphql/query/variable_validation_error.rb
@@ -9,6 +9,11 @@ module GraphQL
         @validation_result = validation_result
 
         msg = "Variable #{variable_ast.name} of type #{type} was provided invalid value"
+
+        if problem_fields.any?
+          msg += " for #{problem_fields.join(", ")}"
+        end
+
         super(msg)
         self.ast_node = variable_ast
       end
@@ -24,6 +29,15 @@ module GraphQL
             newValue
           end
         end
+      end
+
+      private
+
+      def problem_fields
+        @problem_fields ||= @validation_result
+          .problems
+          .reject { |problem| problem["path"].empty? }
+          .map { |problem| problem["path"].join(".") }
       end
     end
   end

--- a/lib/graphql/query/variable_validation_error.rb
+++ b/lib/graphql/query/variable_validation_error.rb
@@ -37,7 +37,7 @@ module GraphQL
         @problem_fields ||= @validation_result
           .problems
           .reject { |problem| problem["path"].empty? }
-          .map { |problem| problem["path"].join(".") }
+          .map { |problem| "#{problem['path'].join('.')} (#{problem['explanation']})" }
       end
     end
   end

--- a/spec/graphql/query/executor_spec.rb
+++ b/spec/graphql/query/executor_spec.rb
@@ -275,7 +275,7 @@ describe GraphQL::Query::Executor do
         expected = {
           "errors"=>[
             {
-              "message" => "Variable input of type ReplaceValuesInput! was provided invalid value",
+              "message" => "Variable input of type ReplaceValuesInput! was provided invalid value for values",
               "locations" => [{ "line" => 1, "column" => 13 }],
               "extensions" => {
                 "value" => {},
@@ -295,7 +295,7 @@ describe GraphQL::Query::Executor do
         expected = {
           "errors"=>[
             {
-              "message" => "Variable input of type [DairyProductInput] was provided invalid value",
+              "message" => "Variable input of type [DairyProductInput] was provided invalid value for 0.foo, 0.source",
               "locations" => [{ "line" => 1, "column" => 10 }],
               "extensions" => {
                 "value" => [{ "foo" => "bar" }],

--- a/spec/graphql/query/executor_spec.rb
+++ b/spec/graphql/query/executor_spec.rb
@@ -275,7 +275,7 @@ describe GraphQL::Query::Executor do
         expected = {
           "errors"=>[
             {
-              "message" => "Variable input of type ReplaceValuesInput! was provided invalid value for values",
+              "message" => "Variable input of type ReplaceValuesInput! was provided invalid value for values (Expected value to not be null)",
               "locations" => [{ "line" => 1, "column" => 13 }],
               "extensions" => {
                 "value" => {},
@@ -295,7 +295,7 @@ describe GraphQL::Query::Executor do
         expected = {
           "errors"=>[
             {
-              "message" => "Variable input of type [DairyProductInput] was provided invalid value for 0.foo, 0.source",
+              "message" => "Variable input of type [DairyProductInput] was provided invalid value for 0.foo (Field is not defined on DairyProductInput), 0.source (Expected value to not be null)",
               "locations" => [{ "line" => 1, "column" => 10 }],
               "extensions" => {
                 "value" => [{ "foo" => "bar" }],

--- a/spec/graphql/schema/warden_spec.rb
+++ b/spec/graphql/schema/warden_spec.rb
@@ -817,7 +817,7 @@ describe GraphQL::Schema::Warden do
       res = MaskHelpers.query_with_mask(query_string, mask, variables: { "manners" => ["STOP", "TRILL"] })
       # It's not a good error message ... but it's something!
       expected_errors = [
-        "Variable manners of type [Manner!]! was provided invalid value",
+        "Variable manners of type [Manner!]! was provided invalid value for 1",
       ]
       assert_equal expected_errors, error_messages(res)
     end

--- a/spec/graphql/schema/warden_spec.rb
+++ b/spec/graphql/schema/warden_spec.rb
@@ -817,7 +817,7 @@ describe GraphQL::Schema::Warden do
       res = MaskHelpers.query_with_mask(query_string, mask, variables: { "manners" => ["STOP", "TRILL"] })
       # It's not a good error message ... but it's something!
       expected_errors = [
-        "Variable manners of type [Manner!]! was provided invalid value for 1",
+        "Variable manners of type [Manner!]! was provided invalid value for 1 (Expected \"TRILL\" to be one of: STOP, AFFRICATE, FRICATIVE, APPROXIMANT, VOWEL)",
       ]
       assert_equal expected_errors, error_messages(res)
     end


### PR DESCRIPTION
When a GraphQL mutation gets invalid input, we raise an error with a message like

```
Variable input of type <InputType>! was provided invalid value
```

Reproducing these issues is not always obvious because which field was
invalid is not clear.

This change updates the error message to include the path to the invalid
field when it's present. The message now looks like:

```
Variable input of type <InputType>! was provided invalid value for field foo
```

Or

```
Variable input of type <InputType>! was provided invalid value for field 0.foo
```

if the field was in an array field.

There's likely some refactorings to be done here so I'm very open to
feedback. Thank you!