### PR TITLE
Reduce memory and allocations

### DIFF
--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -44,11 +44,11 @@ module GraphQL
         # @api private
         def spawn_child(key:, irep_node:, object:)
           FieldResolutionContext.new(
-            context: @context,
-            parent: self,
-            object: object,
-            key: key,
-            irep_node: irep_node,
+            @context,
+            key,
+            irep_node,
+            self,
+            object
           )
         end
 
@@ -203,7 +203,7 @@ module GraphQL
         attr_reader :irep_node, :field, :parent_type, :query, :schema, :parent, :key, :type
         alias :selection :irep_node
 
-        def initialize(context:, key:, irep_node:, parent:, object:)
+        def initialize(context, key, irep_node, parent, object)
           @context = context
           @key = key
           @parent = parent


### PR DESCRIPTION
- reduce the hash allocations by using positional arguments instead of keyword arguments

The object allocations were measured with the allocation_tracer gem and ruby 2.5.0.

This reduces the memory allocated by our application by 100 MB when the response contains a large number of objects (16K in our case).