### PR TITLE
Add null option to node_type of Relay::BaseEdge

### DIFF
--- a/lib/graphql/types/relay/base_edge.rb
+++ b/lib/graphql/types/relay/base_edge.rb
@@ -28,14 +28,15 @@ module GraphQL
           # Get or set the Object type that this edge wraps.
           #
           # @param node_type [Class] A `Schema::Object` subclass
-          def node_type(node_type = nil)
+          # @param null [Boolean]
+          def node_type(node_type = nil, null: true)
             if node_type
               @node_type = node_type
               wrapped_type_name = node_type.graphql_name
               # Set this to be named like the node type, but suffixed with `Edge`
               graphql_name("#{wrapped_type_name}Edge")
               # Add a default `node` field
-              field :node, node_type, null: true, description: "The item at the end of the edge."
+              field :node, node_type, null: null, description: "The item at the end of the edge."
             end
             @node_type
           end

--- a/spec/graphql/schema/introspection_system_spec.rb
+++ b/spec/graphql/schema/introspection_system_spec.rb
@@ -52,5 +52,14 @@ describe GraphQL::Schema::IntrospectionSystem do
       ensembles_field = query_type["fields"].find { |f| f["name"] == "ensembles" }
       assert_equal [], ensembles_field["args"]
     end
+
+    it "runs the introspection query and the result contains a edge field that has non-nullable node" do
+      res = NonNullableDummy::Schema.execute(GraphQL::Introspection::INTROSPECTION_QUERY)
+      assert res
+      edge_type = res["data"]["__schema"]["types"].find { |t| t["name"] == "NonNullableNodeEdge" }
+      node_field = edge_type["fields"].find { |f| f["name"] == "node" }
+      assert_equal "NON_NULL", node_field["type"]["kind"]
+      assert_equal "NonNullableNode", node_field["type"]["ofType"]["name"]
+    end
   end
 end

--- a/spec/support/non_nullable_dummy.rb
+++ b/spec/support/non_nullable_dummy.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+module NonNullableDummy
+  class NonNullableNode < GraphQL::Schema::Object; end
+
+  class NonNullableNodeEdgeType < GraphQL::Types::Relay::BaseEdge
+    node_type(NonNullableNode, null: false)
+  end
+
+  class NonNullableNodeEdgeConnectionType < GraphQL::Types::Relay::BaseConnection
+    edge_type(NonNullableNodeEdgeType, nodes_field: false)
+  end
+
+  class Query < GraphQL::Schema::Object
+    field :connection, NonNullableNodeEdgeConnectionType, null: false
+  end
+
+  class Schema < GraphQL::Schema
+    query Query
+  end
+end


### PR DESCRIPTION
As discussed in the issue #1217, nullable requires extra code in typed languages, so it is important to have a way to avoid it. I submitted this PR because our private project ran into that problem.