### PR TITLE
Add the ability to pass in context on Schema.validate

### DIFF
--- a/guides/authorization/authorization.md
+++ b/guides/authorization/authorization.md
@@ -13,7 +13,7 @@ While a query is running, you can check each object to see whether the current u
 
 Schema members have `.authorized?(value, context)` methods which will be called during execution:
 
-- Type and mutation classes have `.authorized?(value, context)` class methods
+- Type classes have `.authorized?(value, context)` class methods
 - Fields and arguments have `#authorized?(value, context)` instance methods
 
 These methods are called with:

--- a/guides/mutations/mutation_authorization.md
+++ b/guides/mutations/mutation_authorization.md
@@ -25,6 +25,8 @@ This check can be implemented using the `#ready?` method in a mutation:
 ```ruby
 class Mutations::PromoteEmployee < Mutations::BaseMutation
   def ready?(**args)
+    # Called with mutation args.
+    # Use keyword args such as employee_id: or **args to collect them
     if !context[:current_user].admin?
       raise GraphQL::ExecutionError, "Only admins can run this mutation"
     else

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -246,13 +246,13 @@ module GraphQL
     # Validate a query string according to this schema.
     # @param string_or_document [String, GraphQL::Language::Nodes::Document]
     # @return [Array<GraphQL::StaticValidation::Error >]
-    def validate(string_or_document, rules: nil)
+    def validate(string_or_document, rules: nil, context: nil)
       doc = if string_or_document.is_a?(String)
         GraphQL.parse(string_or_document)
       else
         string_or_document
       end
-      query = GraphQL::Query.new(self, document: doc)
+      query = GraphQL::Query.new(self, document: doc, context: context)
       validator_opts = { schema: self }
       rules && (validator_opts[:rules] = rules)
       validator = GraphQL::StaticValidation::Validator.new(validator_opts)

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -11,6 +11,12 @@ module Dummy
     accepts_definition :joins
   end
 
+  class AdminField < GraphQL::Schema::Field
+    def visible?(context)
+      context[:admin] == true
+    end
+  end
+
   module BaseInterface
     include GraphQL::Schema::Interface
   end
@@ -427,6 +433,15 @@ module Dummy
     def deep_non_null; :deep_non_null; end
   end
 
+  class AdminDairyAppQuery < BaseObject
+    field_class AdminField
+
+    field :admin_only_message, String, null: true
+    def admin_only_message
+      "This field is only visible to admin"
+    end
+  end
+
   GLOBAL_VALUES = []
 
   class ReplaceValuesInput < BaseInputObject
@@ -488,5 +503,9 @@ module Dummy
     if TESTING_INTERPRETER
       use GraphQL::Execution::Interpreter
     end
+  end
+
+  class AdminSchema < GraphQL::Schema
+    query AdminDairyAppQuery
   end
 end


### PR DESCRIPTION
## What's up

This resolves #2251. Discussion on the issue is over there. 

## "Bonus"?
- Documentation improvements to resolve #2231 

## What this does 
Allows `.validate` to accept a `context:` hash argument. 

This is passed to Query#initialize and in the function and the rest of the machinery should work as expected.

## What is missing 
- Documentation on the context args?
- Test is a little indirect 
- Not sure if I ran all the tests correctly, assuming there's a PR CI 

