### PR TITLE
Reduce allocations in Schema::Validation.validate()

### DIFF
--- a/lib/graphql/schema/validation.rb
+++ b/lib/graphql/schema/validation.rb
@@ -12,11 +12,16 @@ module GraphQL
       # @param object [Object] something to be validated
       # @return [String, Nil] error message, if there was one
       def self.validate(object)
-        rules = RULES.reduce([]) do |memo, (parent_class, validations)|
-          memo + (object.is_a?(parent_class) ? validations : [])
+        RULES.each do |parent_class, validations|
+          if object.is_a?(parent_class)
+            validations.each do |rule|
+              if error = rule.call(object)
+                return error
+              end
+            end
+          end
         end
-        # Stops after the first error
-        rules.reduce(nil) { |memo, rule| memo || rule.call(object) }
+        nil
       end
 
       module Rules


### PR DESCRIPTION
While memory profiling our application boot I noticed an impressive amount of allocations coming from the `Validation.validate` method:

```
allocated objects by location
-----------------------------------
...
    713390  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/schema/validation.rb:16
```

700k allocations is quite a lot for a method that simply iterate over a constant hash. The cause is the many array concatenations inside the first `reduce`

By rewriting the method in a more imperative way it no longer allocated anything.

@rmosolgo 