### PR TITLE
Reduce memory allocations in Arguments.construct_arguments_class

### DIFF
--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -19,7 +19,7 @@ module GraphQL
             method_names = [expose_as, expose_as_underscored].uniq
             method_names.each do |method_name|
               # Don't define a helper method if it would override something.
-              if instance_methods.include?(method_name.to_sym)
+              if method_defined?(method_name)
                 warn(
                   "Unable to define a helper for argument with name '#{method_name}' "\
                   "as this is a reserved name. If you're using an argument such as "\


### PR DESCRIPTION
While memory profiling our application boot I noticed an important amount of allocations commit from `arguments.rb`:

```
allocated memory by location
-----------------------------------
...
  16.51 MB  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/query/arguments.rb:22
...
  12.18 MB  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.4/lib/graphql/query/arguments.rb:13
```

Line 22 is the `Class.new()`, I can't do much about it, however for line 3 I think they can easily be avoided.

`Module#instance_methods` instantiate a new array on each call, and since `Object.instance_methods` is quite big on an empty Rails app, it can quickly amount to an important amount.

### Solution

Since we access that array to do a lookup, `Module#method_defined?` is a much better replacement. First it doesn't allocate an array, and second it's `O(1)` rather than `O(n) `.

@rmosolgo 