### PR TITLE
fix int-type coercion to not truncate floats

### DIFF
--- a/lib/graphql/types/int.rb
+++ b/lib/graphql/types/int.rb
@@ -10,7 +10,7 @@ module GraphQL
       MAX = (2**31) - 1
 
       def self.coerce_input(value, _ctx)
-        value.is_a?(Numeric) ? value.to_i : nil
+        value.is_a?(Integer) ? value.to_i : nil
       end
 
       def self.coerce_result(value, ctx)


### PR DESCRIPTION
Fixed type-float to not automatically coerce into into type-int by truncation

From https://graphql.github.io/graphql-spec/June2018/#sec-Int

> Input Coercion
> When expected as an input type, only integer input values are accepted. All other input values, including strings with numeric content, must raise a query error indicating an incorrect type.