### PR TITLE
Fix list enum default values in introspection

### DIFF
--- a/lib/graphql/introspection/input_value_type.rb
+++ b/lib/graphql/introspection/input_value_type.rb
@@ -19,7 +19,11 @@ module GraphQL
           else
             coerced_default_value = @object.type.coerce_result(value, @context)
             if @object.type.unwrap.is_a?(GraphQL::EnumType)
-              coerced_default_value
+              if @object.type.list? 
+                "[#{coerced_default_value.join(", ")}]"
+              else
+                coerced_default_value
+              end
             else
               GraphQL::Language.serialize(coerced_default_value)
             end

--- a/spec/graphql/introspection/input_value_type_spec.rb
+++ b/spec/graphql/introspection/input_value_type_spec.rb
@@ -66,6 +66,46 @@ describe GraphQL::Introspection::InputValueType do
     assert_equal('["COW"]', arg['defaultValue'])
   end
 
+  focus
+  it "supports list of enum default values" do
+    schema = GraphQL::Schema.from_definition(%|
+      type Query {
+        hello(enums: [MyEnum] = [A, B]): String
+      }
+
+      enum MyEnum {
+        A
+        B
+      }
+    |)
+
+    result = schema.execute(%|
+      {
+        __type(name: "Query") {
+          fields {
+            args {
+              defaultValue
+            }
+          }
+        }
+      }
+    |)
+
+    expected = {
+      "data" => {
+        "__type" => {
+          "fields" => [{
+            "args" => [{
+              "defaultValue" => "[A, B]"
+            }]
+          }]
+        }
+      }
+    }
+
+    assert_equal expected, result
+  end
+
   it "supports null default values" do
     schema = GraphQL::Schema.from_definition(%|
       type Query {

--- a/spec/graphql/introspection/input_value_type_spec.rb
+++ b/spec/graphql/introspection/input_value_type_spec.rb
@@ -66,7 +66,6 @@ describe GraphQL::Introspection::InputValueType do
     assert_equal('["COW"]', arg['defaultValue'])
   end
 
-  focus
   it "supports list of enum default values" do
     schema = GraphQL::Schema.from_definition(%|
       type Query {

--- a/spec/graphql/introspection/input_value_type_spec.rb
+++ b/spec/graphql/introspection/input_value_type_spec.rb
@@ -63,7 +63,7 @@ describe GraphQL::Introspection::InputValueType do
     field = cheese_type['data']['__type']['fields'].detect { |f| f['name'] == 'similarCheese' }
     arg = field['args'].detect { |a| a['name'] == 'nullableSource' }
 
-    assert_equal('["COW"]', arg['defaultValue'])
+    assert_equal('[COW]', arg['defaultValue'])
   end
 
   it "supports list of enum default values" do


### PR DESCRIPTION
Fixes the introspection payload for default values where the type is a list of enums.

Example of issue:

```
{
  "name": "affiliations",
  "description": "Array of viewer's affiliation options for repositories returned from the connection. For example, OWNER will include only repositories that the current viewer owns.",
  "type": {
    "kind": "LIST",
    "name": null,
    "ofType": {
      "kind": "ENUM",
      "name": "RepositoryAffiliation",
      "ofType": null
    }
  },
  "defaultValue": "[\"OWNER\", \"COLLABORATOR\"]"
},
```

However:

> defaultValue may return a String encoding (using the GraphQL language) of the default value.

(https://graphql.github.io/graphql-spec/June2018/#sec-The-__InputValue-Type)

This was fixed a while ago for enum values, but the list edge case remained.