### PR TITLE
Add link to blog post on parallel resolvers

### DIFF
--- a/guides/related_projects.md
+++ b/guides/related_projects.md
@@ -34,6 +34,7 @@ Want to add something? Please open a pull request [on GitHub](https://github.com
 - http://mgiroux.me/2015/getting-started-with-rails-graphql-relay/
 - http://mgiroux.me/2015/uploading-files-using-relay-with-rails/
 - http://mgiroux.me/2016/journey-into-graphql-ruby-query-execution/
+- https://jonsimpson.ca/parallel-graphql-resolvers-with-futures/
 
 ## Screencasts
 


### PR DESCRIPTION
I wrote a blog post a while back which goes over how to parallelize the execution of graphql-ruby resolvers by utilizing the concurrent-ruby library's Future class. It took a few tries to finally figure out how to get this to work, so I think it would be valuable for others in the same situation looking for a speed boost.

Let me know what you think! 😄 