### PR TITLE
[WIP] Passing in kwargs and block via implements method

### DIFF
--- a/lib/graphql/schema/object.rb
+++ b/lib/graphql/schema/object.rb
@@ -71,7 +71,7 @@ module GraphQL
       end
 
       class << self
-        def implements(*new_interfaces)
+        def implements(*new_interfaces, **kwargs, &block)
           new_interfaces.each do |int|
             if int.is_a?(Module)
               unless int.include?(GraphQL::Schema::Interface)


### PR DESCRIPTION
Upstream change to graphql-ruby to enable `implements` to pass in keyword args and procs.