### PR TITLE
[Docs] Add note about default complexity.

### DIFF
--- a/guides/queries/complexity_and_depth.md
+++ b/guides/queries/complexity_and_depth.md
@@ -10,7 +10,7 @@ index: 4
 
 ## Prevent complex queries
 
-Fields have a "complexity" value which can be configured in their definition. It can be a constant (numeric) value, or a proc. It can be defined as a keyword _or_ inside the configuration block. For example:
+Fields have a "complexity" value which can be configured in their definition. It can be a constant (numeric) value, or a proc. If no `complexity` is defined for a field, it will default to a value of `1`. It can be defined as a keyword _or_ inside the configuration block. For example:
 
 ```ruby
 # Constant complexity:


### PR DESCRIPTION
This recently bit me as I added a `max_complexity` restriction to my schema and my introspection queries began failing.
My assumption that fields are all scored as complexity "1" by default is based on the code here: https://github.com/rmosolgo/graphql-ruby/blob/a9f334b171a6caaa64bac683f54cedea76d91b28/lib/graphql/schema/resolver.rb#L233