### PR TITLE
Typo in referencing an option

### DIFF
--- a/javascript_client/sync/__tests__/generateClientTest.js
+++ b/javascript_client/sync/__tests__/generateClientTest.js
@@ -3,7 +3,7 @@ var { generateClient } = require("../generateClient")
 it("returns generated code", function() {
   var code = generateClient({
     path: "./__tests__/documents/*.graphql",
-    clientName: "test-client",
+    client: "test-client",
   })
   expect(code).toMatchSnapshot()
 })

--- a/javascript_client/sync/generateClient.js
+++ b/javascript_client/sync/generateClient.js
@@ -24,7 +24,7 @@ var generators = {
 */
 function generateClient(options) {
   var payload = gatherOperations(options)
-  var generatedCode = generateClientCode(options.clientName, payload.operations, options.clientType)
+  var generatedCode = generateClientCode(options.client, payload.operations, options.clientType)
   return generatedCode
 }
 

--- a/javascript_client/sync/generateClient.js
+++ b/javascript_client/sync/generateClient.js
@@ -45,8 +45,6 @@ function gatherOperations(options) {
   var graphqlGlob = options.path || "./"
   var hashFunc = options.hash || md5
   var filesMode = options.mode || (graphqlGlob.indexOf("__generated__") > -1 ? "relay" : "project")
-  var clientName = options.client
-  var clientType = options.clientType
   var addTypename = options.addTypename
   var verbose = options.verbose
 

--- a/javascript_client/sync/index.js
+++ b/javascript_client/sync/index.js
@@ -1,7 +1,5 @@
 var sendPayload = require("./sendPayload")
-var prepareRelay = require("./prepareRelay")
-var prepareIsolatedFiles = require("./prepareIsolatedFiles")
-var prepareProject = require("./prepareProject")
+
 var { generateClientCode, gatherOperations } = require("./generateClient")
 var Logger = require("./logger")
 
@@ -68,7 +66,7 @@ function sync(options) {
 
   return new Promise(function(resolve, reject) {
     if (payload.operations.length === 0) {
-      logger.log("No operations found in " + graphqlGlob + ", not syncing anything")
+      logger.log("No operations found in " + options.path + ", not syncing anything")
       resolve(payload)
     } else {
       logger.log("Syncing " + payload.operations.length + " operations to " + logger.bright(url) + "...")

--- a/javascript_client/sync/prepareProject.js
+++ b/javascript_client/sync/prepareProject.js
@@ -14,6 +14,7 @@ var addTypenameToSelectionSet = require("./addTypenameToSelectionSet")
  */
 
 function prepareProject(filenames, addTypename) {
+  if(!filenames.length) { return []; }
   var allGraphQL = ""
   filenames.forEach(function(filename) {
     allGraphQL += fs.readFileSync(filename)


### PR DESCRIPTION
Hey @rmosolgo Happy Friday. I believe this is a typo. 

I finally got to using the `generateClient` function you exposed in https://github.com/rmosolgo/graphql-ruby/pull/1941 and noticed that in one place, there's a reference to `options.clientName` but it seems to be passed as `options.client` and documented as such. 

Btw, the `generateClient` function works brilliantly. 

Just additional context for posterity:

- The sync generates `operation-store-client.js` which has to be consumed by the Apollo client. 
- I'd like to make a webpack plugin to sync queries whenever a `.graphql` file changes in development. So the dev keeps making changes and keeps using persisted queries even in dev. We have this working with a custom webpack script.  
- The hard part is that since the sync task writes to disk during the sync, it generates a file change that causes webpack to recompile, ad infinitum. 

The current idea is to write virtual modules (no need to check in) and a json manifest somewhere (to be checked in) so it's easy to reference all the query aliases. 

Might submit a PR to break down the sync function :) 
