### PR TITLE
Add `subscription_scope` method to `Subscription` class

### DIFF
--- a/lib/graphql/schema/subscription.rb
+++ b/lib/graphql/schema/subscription.rb
@@ -92,6 +92,25 @@ module GraphQL
       def unsubscribe
         raise UnsubscribedError
       end
+
+      # Call this method to provide a new subscription_scope; OR
+      # call it without an argument to get the subscription_scope
+      # @param new_scope [Symbol]
+      # @return [Symbol]
+      def self.subscription_scope(new_scope = nil)
+        if new_scope
+          @subscription_scope = new_scope
+        else
+          @subscription_scope || find_inherited_method(:subscription_scope, nil)
+        end
+      end
+
+      # Overriding Resolver#field_options to include subscription_scope
+      def self.field_options
+        super.merge(
+          subscription_scope: subscription_scope
+        )
+      end
     end
   end
 end

--- a/lib/graphql/schema/subscription.rb
+++ b/lib/graphql/schema/subscription.rb
@@ -97,11 +97,14 @@ module GraphQL
       # call it without an argument to get the subscription_scope
       # @param new_scope [Symbol]
       # @return [Symbol]
-      def self.subscription_scope(new_scope = nil)
-        if new_scope
+      READING_SCOPE = ::Object.new
+      def self.subscription_scope(new_scope = READING_SCOPE)
+        if new_scope != READING_SCOPE
           @subscription_scope = new_scope
+        elsif defined?(@subscription_scope)
+          @subscription_scope
         else
-          @subscription_scope || find_inherited_method(:subscription_scope, nil)
+          find_inherited_method(:subscription_scope, nil)
         end
       end
 

--- a/spec/graphql/schema/subscription_spec.rb
+++ b/spec/graphql/schema/subscription_spec.rb
@@ -483,9 +483,12 @@ describe GraphQL::Schema::Subscription do
       assert_equal expected_response, mailbox.first
     end
 
-    it "allows for proper inheritance of the class's configuration through `field_options`" do
-      direct_toot_options = SubscriptionFieldSchema::DirectTootWasTooted.field_options
-
+    it "allows for proper inheritance of the class's configuration in subclasses" do
+      # Make a subclass without an explicit configuration
+      class DirectTootSubclass < SubscriptionFieldSchema::DirectTootWasTooted
+      end
+      # Then check if the field options got the inherited value
+      direct_toot_options = DirectTootSubclass.field_options
       assert_equal :viewer, direct_toot_options[:subscription_scope]
     end
 

--- a/spec/graphql/schema/subscription_spec.rb
+++ b/spec/graphql/schema/subscription_spec.rb
@@ -33,6 +33,16 @@ describe GraphQL::Schema::Subscription do
     class BaseSubscription < GraphQL::Schema::Subscription
     end
 
+    class ScopedSubscription < BaseSubscription
+      field :test, Boolean, null: false
+
+      subscription_scope :test
+
+      def subscribe
+        { test: true }
+      end
+    end
+
     class TootWasTooted < BaseSubscription
       argument :handle, String, required: true, loads: User, as: :user
       field :toot, Toot, null: false
@@ -99,6 +109,7 @@ describe GraphQL::Schema::Subscription do
       field :toot_was_tooted, subscription: TootWasTooted
       field :users_joined, subscription: UsersJoined
       field :new_users_joined, subscription: NewUsersJoined
+      field :scoped_subscription, subscription: ScopedSubscription
     end
 
     class Mutation < GraphQL::Schema::Object
@@ -203,6 +214,13 @@ describe GraphQL::Schema::Subscription do
     assert_equal "UsersJoinedManualPayload", return_type.graphql_name
     assert_equal ["users"], return_type.fields.keys
     assert_equal SubscriptionFieldSchema::UsersJoined::UsersJoinedManualPayload, return_type
+  end
+
+  it "can set `subscription_scope` from the resolver" do
+    scoped_subscription = SubscriptionFieldSchema::get_field("Subscription", "scopedSubscription")
+
+    # The subscription should have a scope of value `:test`
+    assert_equal :test, scoped_subscription.subscription_scope
   end
 
   describe "initial subscription" do

--- a/spec/graphql/schema/subscription_spec.rb
+++ b/spec/graphql/schema/subscription_spec.rb
@@ -33,16 +33,6 @@ describe GraphQL::Schema::Subscription do
     class BaseSubscription < GraphQL::Schema::Subscription
     end
 
-    class ScopedSubscription < BaseSubscription
-      field :test, Boolean, null: false
-
-      subscription_scope :test
-
-      def subscribe
-        { test: true }
-      end
-    end
-
     class TootWasTooted < BaseSubscription
       argument :handle, String, required: true, loads: User, as: :user
       field :toot, Toot, null: false
@@ -78,6 +68,12 @@ describe GraphQL::Schema::Subscription do
       end
     end
 
+    class DirectTootWasTooted < BaseSubscription
+      subscription_scope :viewer
+      field :toot, Toot, null: false
+      field :user, User, null: false
+    end
+
     # Test initial response, which returns all users
     class UsersJoined < BaseSubscription
       class UsersJoinedManualPayload < GraphQL::Schema::Object
@@ -107,9 +103,9 @@ describe GraphQL::Schema::Subscription do
     class Subscription < GraphQL::Schema::Object
       extend GraphQL::Subscriptions::SubscriptionRoot
       field :toot_was_tooted, subscription: TootWasTooted
+      field :direct_toot_was_tooted, subscription: DirectTootWasTooted
       field :users_joined, subscription: UsersJoined
       field :new_users_joined, subscription: NewUsersJoined
-      field :scoped_subscription, subscription: ScopedSubscription
     end
 
     class Mutation < GraphQL::Schema::Object
@@ -214,13 +210,6 @@ describe GraphQL::Schema::Subscription do
     assert_equal "UsersJoinedManualPayload", return_type.graphql_name
     assert_equal ["users"], return_type.fields.keys
     assert_equal SubscriptionFieldSchema::UsersJoined::UsersJoinedManualPayload, return_type
-  end
-
-  it "can set `subscription_scope` from the resolver" do
-    scoped_subscription = SubscriptionFieldSchema::get_field("Subscription", "scopedSubscription")
-
-    # The subscription should have a scope of value `:test`
-    assert_equal :test, scoped_subscription.subscription_scope
   end
 
   describe "initial subscription" do
@@ -453,6 +442,61 @@ describe GraphQL::Schema::Subscription do
       assert_equal ["Can't subscribe to private user"], mailbox.last["errors"].map { |e| e["message"] }
       # The subscription remains in place
       assert_equal 1, in_memory_subscription_count
+    end
+  end
+
+  describe "`subscription_scope` method" do
+    it "provdes a subscription scope that is recognized in the schema" do
+      scoped_subscription = SubscriptionFieldSchema::get_field("Subscription", "directTootWasTooted")
+  
+      assert_equal :viewer, scoped_subscription.subscription_scope
+    end
+  
+    it "provides a subscription scope that is used in execution" do
+      res = exec_query <<-GRAPHQL, context: { viewer: :me }
+        subscription {
+          directTootWasTooted {
+            toot { body }
+          }
+        }
+      GRAPHQL
+      assert_equal 1, in_memory_subscription_count
+
+      # Only the subscription with scope :me should be in the mailbox
+      obj = OpenStruct.new(toot: { body: "Hello from matz!" }, user: SubscriptionFieldSchema::USERS["matz"])
+      SubscriptionFieldSchema.subscriptions.trigger(:direct_toot_was_tooted, {}, obj, scope: :me)
+      SubscriptionFieldSchema.subscriptions.trigger(:direct_toot_was_tooted, {}, obj, scope: :not_me)
+      mailbox = res.context[:subscription_mailbox]
+
+      assert_equal 1, mailbox.length
+
+      expected_response = {
+        "data" => {
+          "directTootWasTooted" => {
+            "toot" => {
+              "body" => "Hello from matz!"
+            }
+          }
+        }
+      }
+
+      assert_equal expected_response, mailbox.first
+    end
+
+    it "allows for proper inheritance of the class's configuration through `field_options`" do
+      direct_toot_options = SubscriptionFieldSchema::DirectTootWasTooted.field_options
+
+      assert_equal :viewer, direct_toot_options[:subscription_scope]
+    end
+
+    it "allows for setting the subscription scope value to nil" do
+      class PrivateSubscription < SubscriptionFieldSchema::BaseSubscription
+        subscription_scope :private
+      end
+
+      PrivateSubscription.subscription_scope nil
+
+      assert_nil PrivateSubscription.subscription_scope
     end
   end
 end


### PR DESCRIPTION
As of now, if you want to make a scoped subscription using the new `Subscription` class, the only way to do so is the following:


```ruby
  # my_subscription.rb
  class MySubscription < BaseSubscription
    ...
  end
```

```ruby
  # subscription_type.rb
  class SubscriptionType < GraphQL::Schema::BaseObject
    field :my_subscription, subscription: MySubscription, subscription_scope: :current_user_id
  end
```

My proposal is to add a `subscription_scope` method to the `Subscription` class so that all the options for the subscription can be defined within the class itself (more like the `Query` or `Mutation` class definitions). Using this change, the same example would become

```ruby
  # my_subscription.rb
  class MySubscription < BaseSubscription
    ...
    subscription_scope :current_user_id
  end
```

```ruby
  # subscription_type.rb
  class SubscriptionType < GraphQL::Schema::BaseObject
    field :my_subscription, subscription: MySubscription
  end
```