### PR TITLE
Support ruby 2.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
 
 AllCops:
   DisabledByDefault: true
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.2
   Exclude:
     - 'lib/graphql/language/lexer.rb'
     - 'lib/graphql/language/parser.rb'

--- a/Rakefile
+++ b/Rakefile
@@ -34,8 +34,6 @@ end
 
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
-require 'rubocop/version'
-puts "RUBOCOP_VERSION: #{RuboCop::Version.version}"
 
 default_tasks = [:test, :rubocop, "js:all"]
 if ENV["SYSTEM_TESTS"]

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 require "bundler/setup"
+Bundler.require
 Bundler::GemHelper.install_tasks
 
 require "rake/testtask"
 require_relative "guides/_tasks/site"
 require_relative "lib/graphql/rake_task/validate"
 
-Bundler.require
 
 Rake::TestTask.new do |t|
   t.libs << "spec" << "lib"
@@ -34,6 +34,8 @@ end
 
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
+require 'rubocop/version'
+puts "RUBOCOP_VERSION: #{RuboCop::Version.version}"
 
 default_tasks = [:test, :rubocop, "js:all"]
 if ENV["SYSTEM_TESTS"]

--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest-reporters", "~>1.0"
   s.add_development_dependency "racc", "~> 1.4"
   s.add_development_dependency "rake", "~> 11"
-  s.add_development_dependency "rubocop", "0.69" # for Ruby 2.2 enforcement
+  s.add_development_dependency "rubocop", "0.68" # for Ruby 2.2 enforcement
   # following are required for relay helpers
   s.add_development_dependency "appraisal"
   # required for upgrader

--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest-reporters", "~>1.0"
   s.add_development_dependency "racc", "~> 1.4"
   s.add_development_dependency "rake", "~> 11"
-  s.add_development_dependency "rubocop", "~> 0.45"
+  s.add_development_dependency "rubocop", "0.69" # for Ruby 2.2 enforcement
   # following are required for relay helpers
   s.add_development_dependency "appraisal"
   # required for upgrader

--- a/guides/_plugins/api_doc.rb
+++ b/guides/_plugins/api_doc.rb
@@ -22,7 +22,7 @@ module GraphQLSite
 
     def link_to_img(img_path, img_title)
       full_img_path = "#{@context.registers[:site].baseurl}#{img_path}"
-      <<~HTML
+      <<-HTML
         <a href="#{full_img_path}" target="_blank" class="img-link">
           <img src="#{full_img_path}" title="#{img_title}" alt="#{img_title}" />
         </a>
@@ -74,7 +74,7 @@ module GraphQLSite
     end
 
     def render(context)
-      <<~HTML.chomp
+      <<-HTML.chomp
       <a href="#{context["site"]["baseurl"]}/#{@path}">#{@text}</a>
       HTML
     end

--- a/lib/graphql/static_validation/base_visitor.rb
+++ b/lib/graphql/static_validation/base_visitor.rb
@@ -146,11 +146,14 @@ module GraphQL
         end
 
         def on_input_object(node, parent)
-          is_list = @argument_definitions.last&.type&.list? == true
-
-          @path.push(parent.children.index(node)) if is_list
-          super
-          @path.pop if is_list
+          arg_defn = @argument_definitions.last
+          if arg_defn && arg_defn.type.list?
+            @path.push(parent.children.index(node))
+            super
+            @path.pop
+          else
+            super
+          end
         end
 
         # @return [GraphQL::BaseType] The current object type

--- a/spec/graphql/execution/lookahead_spec.rb
+++ b/spec/graphql/execution/lookahead_spec.rb
@@ -356,7 +356,7 @@ describe GraphQL::Execution::Lookahead do
     end
 
     it "avoids merging selections for same field name on distinct types" do
-      query = GraphQL::Query.new(LookaheadTest::Schema, <<~GRAPHQL)
+      query = GraphQL::Query.new(LookaheadTest::Schema, <<-GRAPHQL)
         query {
           node(id: "Cardinal") {
             ... on BirdSpecies {


### PR DESCRIPTION
Oops, Travis started installing Bundler 2 (which requires Ruby 2.3+) by default, and I really couldn't figure out how to run Bundler 1 instead, so I bumped the CI Ruby versions to 2.3+. But there's no reason we can't support Ruby 2.2, except that since we didn't have CI, some incompatible syntax was introduced. 

I decreased the Rubocop Ruby version which found the error in #2235 and a couple others.