### PR TITLE
Backport String#-@ for Ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,10 @@ matrix:
     gemfile: spec/dummy/Gemfile
     script:
       - cd spec/dummy && bundle exec rails test:system
+  - rvm: 2.2.10
+    before_install:
+      - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+      - gem install bundler -v '< 2'
   - env:
       - TESTING_INTERPRETER=yes
     rvm: 2.4.3

--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,14 @@ gem 'bootsnap' # required by the Rails apps generated in tests
 gem 'ruby-prof', platform: :ruby
 gem 'pry'
 gem 'pry-stack_explorer', platform: :ruby
-gem 'pry-byebug'
+if RUBY_VERSION >= "2.3"
+  gem 'pry-byebug'
+end
 
 # Required for running `jekyll algolia ...` (via `rake site:update_search_index`)
 group :jekyll_plugins do
-  gem 'jekyll-algolia', '~> 1.0'
+  if RUBY_VERSION >= "2.3"
+    gem 'jekyll-algolia', '~> 1.0'
+  end
   gem 'jekyll-redirect-from'
 end

--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -37,6 +37,19 @@ module GraphQL
   def self.scan_with_ragel(graphql_string)
     GraphQL::Language::Lexer.tokenize(graphql_string)
   end
+
+  # Support Ruby 2.2 by implementing `-"str"`. If we drop 2.2 support, we can remove this backport.
+  module StringDedupBackport
+    refine String do
+      def -@
+        if frozen?
+          self
+        else
+          self.dup.freeze
+        end
+      end
+    end
+  end
 end
 
 # Order matters for these:

--- a/lib/graphql/language/token.rb
+++ b/lib/graphql/language/token.rb
@@ -4,6 +4,10 @@ module GraphQL
     # Emitted by the lexer and passed to the parser.
     # Contains type, value and position data.
     class Token
+      if !String.method_defined?(:-@)
+        using GraphQL::StringDedupBackport
+      end
+
       # @return [Symbol] The kind of token this is
       attr_reader :name
       # @return [String] The text of this token

--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -14,8 +14,8 @@ module GraphQL
           self.argument_definitions = argument_definitions
 
           argument_definitions.each do |_arg_name, arg_definition|
-            expose_as = -arg_definition.expose_as.to_s
-            expose_as_underscored = -GraphQL::Schema::Member::BuildType.underscore(expose_as)
+            expose_as = arg_definition.expose_as.to_s.freeze
+            expose_as_underscored = GraphQL::Schema::Member::BuildType.underscore(expose_as).freeze
             method_names = [expose_as, expose_as_underscored].uniq
             method_names.each do |method_name|
               # Don't define a helper method if it would override something.

--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -32,7 +32,8 @@ module GraphQL
       # @param camelize [Boolean] if true, the name will be camelized when building the schema
       def initialize(arg_name = nil, type_expr = nil, desc = nil, required:, type: nil, name: nil, description: nil, default_value: NO_DEFAULT, as: nil, camelize: true, prepare: nil, owner:, &definition_block)
         arg_name ||= name
-        @name = -(camelize ? Member::BuildType.camelize(arg_name.to_s) : arg_name.to_s)
+        name_str = camelize ? Member::BuildType.camelize(arg_name.to_s) : arg_name.to_s
+        @name = name_str.freeze
         @type_expr = type_expr || type
         @description = desc || description
         @null = !required

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -6,6 +6,10 @@ require "graphql/schema/field/scope_extension"
 module GraphQL
   class Schema
     class Field
+      if !String.method_defined?(:-@)
+        using GraphQL::StringDedupBackport
+      end
+
       include GraphQL::Schema::Member::CachedGraphQLDefinition
       include GraphQL::Schema::Member::AcceptsDefinition
       include GraphQL::Schema::Member::HasArguments


### PR DESCRIPTION
Oops, I intend to support Ruby 2.2, but this was breaking it. (The real problem is, I can't figure out how to run Ruby 2.2 on Travis CI.) I ran Ruby 2.2 locally and it passed after these changes. 

```
~/code/graphql-ruby $ ruby -v
ruby 2.2.8p477 (2017-09-14 revision 59906) [x86_64-darwin16]
~/code/graphql-ruby $ be rake test
# ...
1381 tests, 5871 assertions, 0 failures, 0 errors, 0 skips
```

