### PR TITLE
Support `max_complexity` AST analysis in multiplex 

### DIFF
--- a/lib/graphql/execution/multiplex.rb
+++ b/lib/graphql/execution/multiplex.rb
@@ -175,7 +175,11 @@ module GraphQL
             schema = multiplex.schema
             multiplex_analyzers = schema.multiplex_analyzers
             if multiplex.max_complexity
-              multiplex_analyzers += [GraphQL::Analysis::MaxQueryComplexity.new(multiplex.max_complexity)]
+              multiplex_analyzers += if schema.using_ast_analysis?
+                [GraphQL::Analysis::AST::MaxQueryComplexity]
+              else
+                [GraphQL::Analysis::MaxQueryComplexity.new(multiplex.max_complexity)]
+              end
             end
 
             schema.analysis_engine.analyze_multiplex(multiplex, multiplex_analyzers)

--- a/spec/graphql/execution/multiplex_spec.rb
+++ b/spec/graphql/execution/multiplex_spec.rb
@@ -134,6 +134,17 @@ describe GraphQL::Execution::Multiplex do
     end
   end
 
+  describe "max_complexity" do
+    it "can successfully calculate complexity" do
+      message = "Query has complexity of 11, which exceeds max complexity of 10"
+      results = multiplex(queries, max_complexity: 10)
+
+      results.each do |res|
+        assert_equal message, res["errors"][0]["message"]
+      end
+    end
+  end
+
   describe "after_query when errors are raised" do
     class InspectQueryInstrumentation
       class << self


### PR DESCRIPTION
Seems like `multiplex` does not support `GraphQL::Analysis::AST::MaxQueryComplexity`, it's only automatically add `GraphQL::Analysis::MaxQueryComplexity`:

https://github.com/rmosolgo/graphql-ruby/blob/85554e8f1c9bfa499fe14a912b92de8c83d99932/lib/graphql/execution/multiplex.rb#L177-L179

Failed test `TESTING_INTERPRETER=yes bundle exec rake test TEST=spec/graphql/execution/multiplex_spec.rb`:

```
Error:
GraphQL::Execution::Multiplex::max_complexity#test_0001_can successfully calculate complexity:
NoMethodError: undefined method `new' for #<GraphQL::Analysis::MaxQueryComplexity:0x00005638555aba20>
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/analysis/ast.rb:29:in `block in analyze_multiplex'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/analysis/ast.rb:29:in `map'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/analysis/ast.rb:29:in `analyze_multiplex'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/execution/multiplex.rb:181:in `block in instrument_and_analyze'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/execution/instrumentation.rb:29:in `block (2 levels) in apply_instrumenters'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/execution/instrumentation.rb:46:in `block (2 levels) in each_query_call_hooks'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/execution/instrumentation.rb:46:in `block (2 levels) in each_query_call_hooks'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/execution/instrumentation.rb:46:in `block (2 levels) in each_query_call_hooks'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/execution/instrumentation.rb:41:in `each_query_call_hooks'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/execution/instrumentation.rb:45:in `block in each_query_call_hooks'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/execution/instrumentation.rb:72:in `call_hooks'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/execution/instrumentation.rb:44:in `each_query_call_hooks'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/execution/instrumentation.rb:45:in `block in each_query_call_hooks'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/execution/instrumentation.rb:72:in `call_hooks'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/execution/instrumentation.rb:44:in `each_query_call_hooks'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/execution/instrumentation.rb:45:in `block in each_query_call_hooks'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/execution/instrumentation.rb:72:in `call_hooks'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/execution/instrumentation.rb:44:in `each_query_call_hooks'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/execution/instrumentation.rb:27:in `block in apply_instrumenters'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/execution/instrumentation.rb:72:in `call_hooks'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/execution/instrumentation.rb:26:in `apply_instrumenters'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/execution/multiplex.rb:174:in `instrument_and_analyze'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/execution/multiplex.rb:61:in `block in run_queries'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/tracing.rb:62:in `block in trace'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/tracing.rb:76:in `call_tracers'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/tracing.rb:62:in `trace'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/execution/multiplex.rb:59:in `run_queries'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/execution/multiplex.rb:49:in `run_all'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/schema.rb:376:in `block in multiplex'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/schema.rb:1205:in `with_definition_error_check'
    /media/sf_Ruby/!Other/graphql-ruby/lib/graphql/schema.rb:375:in `multiplex'
    /media/sf_Ruby/!Other/graphql-ruby/spec/graphql/execution/multiplex_spec.rb:6:in `multiplex'
    /media/sf_Ruby/!Other/graphql-ruby/spec/graphql/execution/multiplex_spec.rb:140:in `block (3 levels) in <top (required)>'

7 tests, 11 assertions, 0 failures, 1 errors, 0 skips

```