### PR TITLE
Add InputObject#as_json for Rails via Railtie

### DIFF
--- a/lib/graphql/rails_integration/serialize_as_json.rb
+++ b/lib/graphql/rails_integration/serialize_as_json.rb
@@ -1,0 +1,9 @@
+module GraphQL
+  module RailsIntegration
+    module SerializeAsJSON
+      def as_json(*)
+        to_h
+      end
+    end
+  end
+end

--- a/lib/graphql/railtie.rb
+++ b/lib/graphql/railtie.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
-
+require 'graphql/rails_integration/serialize_as_json'
 
 module GraphQL
   class Railtie < Rails::Railtie
+    initializer 'graphql.active_support extensions' do
+      GraphQL::Schema::InputObject.include RailsIntegration::SerializeAsJSON
+    end
+
     rake_tasks do
       # Defer this so that you only need the `parser` gem when you _run_ the upgrader
       def load_upgraders


### PR DESCRIPTION
## What's up? 

This is an attempt to resolve https://github.com/rmosolgo/graphql-ruby/issues/2214. 

I've bumped into it a few times myself calling `input_object.to_json`. I guess it's a fairly common use case to serialize this for error reporting etc or when you try to serialize all the args for a query. 

## The Issue 

The last resort of Rails to fulfill `to_json` serialization of PORO Ruby objects is to use instance variables. 

https://github.com/rails/rails/blob/b2eb1d1c55a59fee1e6c4cba7030d8ceb524267c/activesupport/lib/active_support/core_ext/object/json.rb#L57

https://github.com/rails/rails/blob/b2eb1d1c55a59fee1e6c4cba7030d8ceb524267c/activesupport/lib/active_support/core_ext/object/instance_variables.rb#L15

I think in the case of `InputObject`, the instance variables references the object itself, causing a `CircularReferenceError` or a `SystemStackError` error.  Weird, I've seen both. 

Given that there's a bunch of machinery (e.g. `#unwrap_value`) in the class, it doesn't seem worth it to try to make `InputObject` a serializable PORO.

## The potential fixes

1. Define `#as_json(*)` and that calls `#to_h` under the hood. This PR does that via Railtie. 
2. Implement the implicit conversion method `#to_hash` which will be used by ActiveSupport in `#to_json` [Link](https://github.com/rails/rails/blob/b2eb1d1c55a59fee1e6c4cba7030d8ceb524267c/activesupport/lib/active_support/core_ext/object/json.rb#L55). Calling `#to_json` on `GraphQL::Query::Context` actually works because of this, `to_hash` is defined there. 

I personally think (2) is cleaner, but it also makes this implicit assumption that `InputObject` is implicitly a hash. Would like @rmosolgo 's opinion on that. Example [blog post](https://zverok.github.io/blog/2016-01-18-implicit-vs-expicit.html) about this. 
