### PR TITLE
Add method for disabling introspection entrypoints

### DIFF
--- a/guides/schema/introspection.md
+++ b/guides/schema/introspection.md
@@ -187,3 +187,13 @@ end
 ```
 
 Any fields defined there will be available in any selection, but ignored in introspection (just like `__typename`).
+
+## Disabling Introspection
+
+In case you want to turn off introspection entry points `__schema` and `__type` (for instance in the production environment) you can use a `#disable_introspection_entry_points` shorthand method:
+
+```ruby
+class MySchema < GraphQL::Schema
+  disable_introspection_entry_points if Rails.env.production?
+end
+```

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -90,7 +90,7 @@ module GraphQL
       :object_from_id, :id_from_object,
       :default_mask,
       :cursor_encoder,
-      :disable_introspection_entry_points,
+      disable_introspection_entry_points: ->(schema) { schema.disable_introspection_entry_points = true },
       directives: ->(schema, directives) { schema.directives = directives.reduce({}) { |m, d| m[d.name] = d; m } },
       directive: ->(schema, directive) { schema.directives[directive.graphql_name] = directive },
       instrument: ->(schema, type, instrumenter, after_built_ins: false) {
@@ -110,6 +110,8 @@ module GraphQL
       lazy_resolve: ->(schema, lazy_class, lazy_value_method) { schema.lazy_methods.set(lazy_class, lazy_value_method) },
       rescue_from: ->(schema, err_class, &block) { schema.rescue_from(err_class, &block) },
       tracer: ->(schema, tracer) { schema.tracers.push(tracer) }
+
+    ensure_defined :introspection_system
 
     attr_accessor \
       :query, :mutation, :subscription,

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -90,6 +90,7 @@ module GraphQL
       :object_from_id, :id_from_object,
       :default_mask,
       :cursor_encoder,
+      :disable_introspection_entry_points,
       directives: ->(schema, directives) { schema.directives = directives.reduce({}) { |m, d| m[d.name] = d; m } },
       directive: ->(schema, directive) { schema.directives[directive.graphql_name] = directive },
       instrument: ->(schema, type, instrumenter, after_built_ins: false) {
@@ -140,6 +141,9 @@ module GraphQL
     # @return [Class] Instantiated for each query
     attr_accessor :context_class
 
+    # [Boolean] True if this object disables the introspection entry point fields
+    attr_accessor :disable_introspection_entry_points
+
     class << self
       attr_writer :default_execution_strategy
     end
@@ -186,6 +190,7 @@ module GraphQL
       @introspection_system = nil
       @interpreter = false
       @error_bubbling = false
+      @disable_introspection_entry_points = false
     end
 
     # @return [Boolean] True if using the new {GraphQL::Execution::Interpreter}
@@ -712,7 +717,8 @@ module GraphQL
         :subscriptions,
         :union_memberships,
         :get_field, :root_types, :references_to, :type_from_ast,
-        :possible_types
+        :possible_types,
+        :disable_introspection_entry_points=
 
       def graphql_definition
         @graphql_definition ||= to_graphql
@@ -737,6 +743,7 @@ module GraphQL
         schema_defn.max_depth = max_depth
         schema_defn.default_max_page_size = default_max_page_size
         schema_defn.orphan_types = orphan_types
+        schema_defn.disable_introspection_entry_points = @disable_introspection_entry_points
 
         prepped_dirs = {}
         directives.each { |k, v| prepped_dirs[k] = v.graphql_definition}
@@ -885,6 +892,10 @@ module GraphQL
         else
           @max_depth
         end
+      end
+
+      def disable_introspection_entry_points
+        @disable_introspection_entry_points = true
       end
 
       def orphan_types(*new_orphan_types)

--- a/lib/graphql/schema/introspection_system.rb
+++ b/lib/graphql/schema/introspection_system.rb
@@ -18,7 +18,12 @@ module GraphQL
         @input_value_type = load_constant(:InputValueType).to_graphql
         @type_kind_enum = load_constant(:TypeKindEnum).to_graphql
         @directive_location_enum = load_constant(:DirectiveLocationEnum).to_graphql
-        @entry_point_fields = get_fields_from_class(class_sym: :EntryPoints)
+        @entry_point_fields =
+          if schema.disable_introspection_entry_points
+            {}
+          else
+            get_fields_from_class(class_sym: :EntryPoints)
+          end
         @dynamic_fields = get_fields_from_class(class_sym: :DynamicFields)
       end
 

--- a/spec/graphql/schema/introspection_system_spec.rb
+++ b/spec/graphql/schema/introspection_system_spec.rb
@@ -53,4 +53,28 @@ describe GraphQL::Schema::IntrospectionSystem do
       assert_equal [], ensembles_field["args"]
     end
   end
+
+  describe "#disable_introspection_entry_points" do
+    let(:schema) { Jazz::Schema }
+
+    it "allows entry point introspection by default" do
+      res = schema.execute("{ __schema { types { name } } }")
+      assert res
+
+      types = res["data"]["__schema"]["types"]
+      refute_empty types
+    end
+
+    describe "when entry points introspection is disabled" do
+      let(:schema) { Jazz::SchemaWithoutIntrospection }
+
+      it "returns error" do
+        res = schema.execute("{ __schema { types { name } } }")
+        assert res
+
+        assert_nil res["data"]
+        assert_equal ["Field '__schema' doesn't exist on type 'Query'"], res["errors"].map { |e| e["message"] }
+      end
+    end
+  end
 end

--- a/spec/integration/rails/graphql/schema_spec.rb
+++ b/spec/integration/rails/graphql/schema_spec.rb
@@ -129,6 +129,24 @@ describe GraphQL::Schema do
     end
   end
 
+  describe "#disable_introspection_entry_points" do
+    it "enables entry points by default" do
+      refute_empty empty_schema.introspection_system.entry_points
+    end
+
+    describe "when disable_introspection_entry_points is configured" do
+      let(:schema) do
+        GraphQL::Schema.define do
+          disable_introspection_entry_points
+        end
+      end
+
+      it "clears entry points" do
+        assert_empty schema.introspection_system.entry_points
+      end
+    end
+  end
+
   describe "object_from_id" do
     describe "when the hook wasn't implemented" do
       it "raises not implemented" do

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -769,4 +769,10 @@ module Jazz
       use GraphQL::Analysis::AST
     end
   end
+
+  class SchemaWithoutIntrospection < GraphQL::Schema
+    query(Query)
+
+    disable_introspection_entry_points
+  end
 end


### PR DESCRIPTION
That might be helpful to turn off introspection entry points, especially in the production environments. The shortest way to do it I found (given the fact that we don't have any custom entry points):

```ruby
class MySchema < GraphQL::Schema
  if Rails.env.production?
    introspection(Module.new do
      class EntryPoints < GraphQL::Introspection::EntryPoints
        def self.authorized?(*)
          false
        end
      end
    end)
  end
end
```

It looks a little bit verbose and does not hide entry points from the schema, just restricts the access. I've added a shorthand method `#disable_introspection_entry_points` which allows to skip generating entry points:

```ruby
class MySchema < GraphQL::Schema
  disable_introspection_entry_points Rails.env.production?
end
```