### PR TITLE
Use #graphql_name over name in case a Type class is given

### DIFF
--- a/guides/relay/object_identification.md
+++ b/guides/relay/object_identification.md
@@ -39,7 +39,7 @@ An unencrypted ID generator is provided in the gem. It uses `Base64` to encode v
 class MySchema < GraphQL::Schema
   # Create UUIDs by joining the type name & ID, then base64-encoding it
   def self.id_from_object(object, type_definition, query_ctx)
-    GraphQL::Schema::UniqueWithinType.encode(type_definition.name, object.id)
+    GraphQL::Schema::UniqueWithinType.encode(type_definition.graphql_name, object.id)
   end
 
   def self.object_from_id(id, query_ctx)

--- a/spec/integration/mongoid/star_trek/schema.rb
+++ b/spec/integration/mongoid/star_trek/schema.rb
@@ -412,7 +412,7 @@ module StarTrek
     end
 
     def self.id_from_object(object, type, ctx)
-      GraphQL::Schema::UniqueWithinType.encode(type.name, object.id)
+      GraphQL::Schema::UniqueWithinType.encode(type.graphql_name, object.id)
     end
 
     lazy_resolve(LazyWrapper, :value)

--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -452,7 +452,7 @@ module StarWars
     end
 
     def self.id_from_object(object, type, ctx)
-      GraphQL::Schema::UniqueWithinType.encode(type.name, object.id)
+      GraphQL::Schema::UniqueWithinType.encode(type.graphql_name, object.id)
     end
 
     lazy_resolve(LazyWrapper, :value)


### PR DESCRIPTION
In [Integration testing guide](https://github.com/rmosolgo/graphql-ruby/blame/d491c1722f4920b346f4f807ed02878e834a7fa7/guides/testing/integration_tests.md#L56), I found `MySchema.id_from_object(post, Types::Post, {}))`  which was exactly what I needed in a mutation integration test. 

(I had to use the blame view to get line highlighting on Markdown files)

But it seems that normally `.id_from_object` receives a type_definition(`SomeType.graphql_definition`) instead of the type class (`SomeType < BaseObject`)

Subtle difference: 

```ruby
SomeType.name # "My::Module::Namespace::SomeType"
SomeType.graphql_definition.name # "Some"
```
In the former case, it's a bit iffy that because the fully qualified name leaks into the IDs vs the GraphQL type name, which is usually already exposed.

I saw two ways of fixing this: 

1. In the integration testing docs, use `Types::PostType.to_graphql` 
2. Use `graphql_name` in examples that implement `.id_from_object`

I took approach 2 here assuming `#graphql_name` is supported first class while `to_graphql` is like an interop (forgot where I got this impression from)