### PR TITLE
Implement #to_hash so input objects can be serialized/splatted

### DIFF
--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -53,6 +53,10 @@ module GraphQL
         end
       end
 
+      def to_hash
+        to_h
+      end
+
       def unwrap_value(value)
         case value
         when Array

--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -277,7 +277,7 @@ describe GraphQL::Schema::InputObject do
     end
   end
 
-  describe "#to_h" do
+  describe 'hash conversion behavior' do
     module InputObjectToHTest
       class TestInput1 < GraphQL::Schema::InputObject
         graphql_name "TestInput1"
@@ -297,18 +297,29 @@ describe GraphQL::Schema::InputObject do
       TestInput2.to_graphql
     end
 
-    it "returns a symbolized, aliased, ruby keyword style hash" do
+    before do
       arg_values = {a: 1, b: 2, c: { d: 3, e: 4, instrumentId: "Instrument/Drum Kit"}}
 
-      input_object = InputObjectToHTest::TestInput2.new(
+      @input_object = InputObjectToHTest::TestInput2.new(
         arg_values,
         context: OpenStruct.new(schema: Jazz::Schema),
         defaults_used: Set.new
       )
+    end
 
-      assert_equal({ a: 1, b: 2, input_object: { d: 3, e: 4, instrument: Jazz::Models::Instrument.new("Drum Kit", "PERCUSSION") } }, input_object.to_h)
+    describe "#to_h" do
+      it "returns a symbolized, aliased, ruby keyword style hash" do
+        assert_equal({ a: 1, b: 2, input_object: { d: 3, e: 4, instrument: Jazz::Models::Instrument.new("Drum Kit", "PERCUSSION") } }, @input_object.to_h)
+      end
+    end
+
+    describe "#to_hash" do
+      it "returns the same results as #to_h (aliased)" do
+        assert_equal(@input_object.to_h, @input_object.to_hash)
+      end
     end
   end
+
 
   describe "#dig" do
     module InputObjectDigTest

--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -320,7 +320,6 @@ describe GraphQL::Schema::InputObject do
     end
   end
 
-
   describe "#dig" do
     module InputObjectDigTest
       class TestInput1 < GraphQL::Schema::InputObject

--- a/spec/integration/rails/graphql/input_object_spec.rb
+++ b/spec/integration/rails/graphql/input_object_spec.rb
@@ -11,7 +11,7 @@ describe GraphQL::Schema::InputObject do
 
   describe '#to_json' do
     it 'returns JSON serialized representation of the variables hash' do
-      # Regression note: Previously, calling `to_json` on arugment objects caused failures
+      # Regression note: Previously, calling `to_json` on input objects caused stack too deep errors
       assert_equal input_object.to_json, { source: "COW", fat_content: 0.8 }.to_json
     end
   end

--- a/spec/integration/rails/graphql/input_object_spec.rb
+++ b/spec/integration/rails/graphql/input_object_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::Schema::InputObject do
+  let(:input_object) do
+    Dummy::DairyProductInput.new(
+      { source: 'COW',  fatContent: 0.8 },
+      defaults_used: Set.new,
+      context: GraphQL::Query::NullContext)
+  end
+
+  describe '#to_json' do
+    it 'returns JSON serialized representation of the variables hash' do
+      # Regression note: Previously, calling `to_json` on arugment objects caused failures
+      assert_equal input_object.to_json, { source: "COW", fat_content: 0.8 }.to_json
+    end
+  end
+end
+


### PR DESCRIPTION
## What's up? 

This is a continuation of https://github.com/rmosolgo/graphql-ruby/pull/2313. I accidentally deleted the fork so a new PR is needed :smiley_cat:. 

I've used the `#to_hash` approach here to be consistent with an accepted PR https://github.com/rmosolgo/graphql-ruby/pull/1955 that implements `#to_hash` in context. 

## What this solves 
- You can call `input_object.to_json` now without a stack too deep error. 
- You can also splat input objects to get their hashes

### Some concerns before merging
- [x] Am I initializing the dummy input object correctly in the test? 
- [x] A little confused about the different between `InputObjectType` and `GraphQL::Schema::InputObject` 
