### PR TITLE
Correct link to Getting Started from readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ $ rails generate graphql:install
 
 After this, you may need to run `bundle install` again, as by default graphiql-rails is added on installation.
 
-Or, see ["Getting Started"](https://graphql-ruby.org/).
+Or, see ["Getting Started"](https://graphql-ruby.org/getting_started.html).
 
 ## Upgrade
 


### PR DESCRIPTION
Diving into the graphql-ruby library was a bit frustrating because the "Getting Started" link in the readme didn't go to the Getting Started page on the website, but to the home page. 

Eventually I found it, but maybe this will save others the trouble.