### PR TITLE
Fix incorrect hasNextPage value when the last cursor belongs to the last element in the array

### DIFF
--- a/lib/graphql/relay/array_connection.rb
+++ b/lib/graphql/relay/array_connection.rb
@@ -13,7 +13,7 @@ module GraphQL
           sliced_nodes.count > first
         elsif GraphQL::Relay::ConnectionType.bidirectional_pagination && before
           # The original array is longer than the `before` index
-          index_from_cursor(before) < nodes.length
+          index_from_cursor(before) < nodes.length + 1
         else
           false
         end

--- a/spec/integration/rails/graphql/relay/array_connection_spec.rb
+++ b/spec/integration/rails/graphql/relay/array_connection_spec.rb
@@ -65,35 +65,7 @@ describe GraphQL::Relay::ArrayConnection do
       assert_equal("NQ", result["data"]["rebels"]["ships"]["pageInfo"]["endCursor"])
     end
 
-    it "provides bidirectional_pagination" do
-      result = star_wars_query(query_string, "first" => 1)
-      last_cursor = get_last_cursor(result)
 
-      # When going forwards, bi-directional pagination
-      # returns `true` even for `hasPreviousPage`
-      result = star_wars_query(query_string, "first" => 1, "after" => last_cursor)
-      assert_equal(true, get_page_info(result, "ships")["hasNextPage"])
-      assert_equal(false, get_page_info(result, "ships")["hasPreviousPage"])
-
-      result = with_bidirectional_pagination {
-        star_wars_query(query_string, "first" => 3, "after" => last_cursor)
-      }
-      assert_equal(true, get_page_info(result, "ships")["hasNextPage"])
-      assert_equal(true, get_page_info(result, "ships")["hasPreviousPage"])
-
-      # When going backwards, bi-directional pagination
-      # returns true for `hasNextPage`
-      last_cursor = get_last_cursor(result)
-      result = star_wars_query(query_string, "last" => 1, "before" => last_cursor)
-      assert_equal(false, get_page_info(result, "ships")["hasNextPage"])
-      assert_equal(true, get_page_info(result, "ships")["hasPreviousPage"])
-
-      result = with_bidirectional_pagination {
-        star_wars_query(query_string, "last" => 2, "before" => last_cursor)
-      }
-      assert_equal(true, get_page_info(result, "ships")["hasNextPage"])
-      assert_equal(true, get_page_info(result, "ships")["hasPreviousPage"])
-    end
 
     it 'slices the result' do
       result = star_wars_query(query_string, "first" => 1)
@@ -284,6 +256,53 @@ describe GraphQL::Relay::ArrayConnection do
 
         result = star_wars_query(query_string, "before" => fourth_cursor)
         assert_equal(first_second_and_third_names, get_names(result))
+      end
+    end
+
+    describe "bidirectional pagination" do
+      it "provides bidirectional_pagination" do
+        result = star_wars_query(query_string, "first" => 1)
+        last_cursor = get_last_cursor(result)
+
+        # When going forwards, bi-directional pagination
+        # returns `true` even for `hasPreviousPage`
+        result = star_wars_query(query_string, "first" => 1, "after" => last_cursor)
+        assert_equal(true, get_page_info(result, "ships")["hasNextPage"])
+        assert_equal(false, get_page_info(result, "ships")["hasPreviousPage"])
+
+        result = with_bidirectional_pagination {
+          star_wars_query(query_string, "first" => 3, "after" => last_cursor)
+        }
+        assert_equal(true, get_page_info(result, "ships")["hasNextPage"])
+        assert_equal(true, get_page_info(result, "ships")["hasPreviousPage"])
+
+        # When going backwards, bi-directional pagination
+        # returns true for `hasNextPage`
+        last_cursor = get_last_cursor(result)
+        result = star_wars_query(query_string, "last" => 1, "before" => last_cursor)
+        assert_equal(false, get_page_info(result, "ships")["hasNextPage"])
+        assert_equal(true, get_page_info(result, "ships")["hasPreviousPage"])
+
+        result = with_bidirectional_pagination {
+          star_wars_query(query_string, "last" => 2, "before" => last_cursor)
+        }
+        assert_equal(true, get_page_info(result, "ships")["hasNextPage"])
+        assert_equal(true, get_page_info(result, "ships")["hasPreviousPage"])
+      end
+
+      it "returns correct page info when the before cursor belongs to the last element in the array" do
+        result = with_bidirectional_pagination{
+          star_wars_query(query_string, "last" => 1)
+        }
+
+        last_cursor = get_last_cursor(result)
+
+        result = with_bidirectional_pagination{
+          star_wars_query(query_string, "before" => last_cursor, "last" => 1)
+        }
+
+        assert_equal(true, get_page_info(result, "ships")["hasNextPage"])
+        assert_equal(true, get_page_info(result, "ships")["hasPreviousPage"])
       end
     end
   end


### PR DESCRIPTION
### Background

The cursors for the items for ArrayConnection are generated by a 1 based index. (Index of origin is 1, not zero). 


However, when we compute the value for `has_next_page`, we were considering that it's a zero-based index. 

So it would return incorrect `hasNextPage` when the `before` cursor belongs to the last element int the array. 

I wrote a spec which would fail on the master branch because of this error. 

https://github.com/rmosolgo/graphql-ruby/blob/bb70bd88988d5cdf66dc7aea7427eca91274de04/spec/integration/rails/graphql/relay/array_connection_spec.rb#L293-L306


### Solution
When computing `has_next_page` value, consider the array to be based 1. 