### PR TITLE
Fix late query string assignment

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -44,7 +44,12 @@ module GraphQL
 
     # @return [GraphQL::Language::Nodes::Document]
     def document
-      with_prepared_ast { @document }
+      # It's ok if this hasn't been assigned yet
+      if @query_string || @document
+        with_prepared_ast { @document }
+      else
+        nil
+      end
     end
 
     def inspect


### PR DESCRIPTION
Oops, a recent change broke the way that GraphQL-Pro's operation store interacts with runtime 🤦‍♂ . Should have had a test like this from the start!