### PR TITLE
Add `modules` option to install generator for modular file structure

### DIFF
--- a/guides/schema/generators.md
+++ b/guides/schema/generators.md
@@ -42,6 +42,7 @@ After installing you can see your new schema by:
 
 - `--relay` will add [Relay](https://facebook.github.io/relay/)-specific code to your schema
 - `--batch` will add [GraphQL::Batch](https://github.com/Shopify/graphql-batch) to your gemfile and include the setup in your schema
+- `--modules` will set up a modular folder structure for the new files
 - `--no-graphiql` will exclude `graphiql-rails` from the setup
 - `--schema=MySchemaName` will be used for naming the schema (default is `#{app_name}Schema`)
 
@@ -54,7 +55,6 @@ Several generators will add GraphQL types to your project. Run them with `-h` to
 - `rails g graphql:union`
 - `rails g graphql:enum`
 - `rails g graphql:scalar`
-
 
 ## Scaffolding Mutations
 

--- a/lib/generators/graphql/core.rb
+++ b/lib/generators/graphql/core.rb
@@ -40,6 +40,29 @@ module Graphql
         end
       end
 
+      # Determines the name of the module in which a base type definition file lives
+      # Used in the erb template files
+      # @param file_name [String]
+      # @return string
+      def base_type_module_name(file_name)
+        return "Types" unless options[:modules]
+
+        module_name_dirty = file_name.split("_")[1]
+        module_name = module_name_dirty.capitalize + "s"
+
+        "Types::#{module_name}"
+      end
+
+      # Determines the name of the class in which a base type definition file lives
+      # Used in the erb template files
+      # @param file_name [String]
+      # @return string
+      def base_type_class_name(file_name)
+        module_name = base_type_module_name(file_name)
+
+        "#{module_name}::#{file_name.camelize}"
+      end
+
       private
 
       def schema_name

--- a/lib/generators/graphql/install_generator.rb
+++ b/lib/generators/graphql/install_generator.rb
@@ -74,7 +74,7 @@ module Graphql
     #
     # Accept a `--batch` option which adds `GraphQL::Batch` setup.
     #
-    # Accept a `--modules` option which sets up a modular file structure
+    # Accept a `--modules` option which sets up a modular file structure.
     #
     # Use `--no-graphiql` to skip `graphiql-rails` installation.
     #
@@ -130,7 +130,6 @@ module Graphql
         template("schema.erb", schema_file_path)
 
         ["base_object", "base_argument", "base_field", "base_enum", "base_input_object", "base_interface", "base_scalar", "base_union"].each do |base_type|
-          @template_module_name = base_module_name(base_type)
           template("#{base_type}.erb", base_type_directory(base_type))
         end
 
@@ -188,16 +187,6 @@ RUBY
       def gem(*args)
         @gemfile_modified = true
         super(*args)
-      end
-
-      # Determines the name of the module in which a base type definition file lives
-      # @param base_type [String]
-      # @return string
-      def base_module_name(base_type)
-        return "Types" unless options[:modules]
-
-        module_name = base_type.split("_")[1].capitalize + "s"
-        "Types::#{module_name}"
       end
 
       # Creates a directory for installation of base types based on the options provided to the generator

--- a/lib/generators/graphql/install_generator.rb
+++ b/lib/generators/graphql/install_generator.rb
@@ -130,6 +130,7 @@ module Graphql
         template("schema.erb", schema_file_path)
 
         ["base_object", "base_argument", "base_field", "base_enum", "base_input_object", "base_interface", "base_scalar", "base_union"].each do |base_type|
+          @template_module_name = base_module_name(base_type)
           template("#{base_type}.erb", base_type_directory(base_type))
         end
 
@@ -195,7 +196,7 @@ RUBY
       def base_module_name(base_type)
         return "Types" unless options[:modules]
 
-        module_name = base_type.split("_")[1].capitalize
+        module_name = base_type.split("_")[1].capitalize + "s"
         "Types::#{module_name}"
       end
 

--- a/lib/generators/graphql/install_generator.rb
+++ b/lib/generators/graphql/install_generator.rb
@@ -22,6 +22,7 @@ module Graphql
     #       - base_scalar.rb
     #       - base_union.rb
     #       - query_type.rb
+    #       - mutation_type.rb
     #     - loaders/
     #     - mutations/
     #     - {app_name}_schema.rb
@@ -34,6 +35,8 @@ module Graphql
     #   - graphql/
     #     - resolvers/
     #     - types/
+    #       - arguments/
+    #         - base_argument.rb
     #       - fields/
     #         - base_field.rb
     #       - enums/
@@ -49,6 +52,7 @@ module Graphql
     #       - unions/
     #         - base_union.rb
     #       - query_type.rb
+    #       - mutation_type.rb
     #     - loaders/
     #     - mutations/
     #     - {app_name}_schema.rb

--- a/lib/generators/graphql/templates/base_argument.erb
+++ b/lib/generators/graphql/templates/base_argument.erb
@@ -1,4 +1,4 @@
-module Types
+module <%= base_module_name(base_type) %>
   class BaseArgument < GraphQL::Schema::Argument
   end
 end

--- a/lib/generators/graphql/templates/base_argument.erb
+++ b/lib/generators/graphql/templates/base_argument.erb
@@ -1,4 +1,4 @@
-module <%= base_module_name(base_type) %>
+module <%= base_type_module_name("base_argument") %>
   class BaseArgument < GraphQL::Schema::Argument
   end
 end

--- a/lib/generators/graphql/templates/base_enum.erb
+++ b/lib/generators/graphql/templates/base_enum.erb
@@ -1,4 +1,4 @@
-module Types
+module <%= base_module_name(base_type) %>
   class BaseEnum < GraphQL::Schema::Enum
   end
 end

--- a/lib/generators/graphql/templates/base_enum.erb
+++ b/lib/generators/graphql/templates/base_enum.erb
@@ -1,4 +1,4 @@
-module <%= @template_module_name %>
+module <%= base_type_module_name("base_enum") %>
   class BaseEnum < GraphQL::Schema::Enum
   end
 end

--- a/lib/generators/graphql/templates/base_enum.erb
+++ b/lib/generators/graphql/templates/base_enum.erb
@@ -1,4 +1,4 @@
-module <%= base_module_name(base_type) %>
+module <%= @template_module_name %>
   class BaseEnum < GraphQL::Schema::Enum
   end
 end

--- a/lib/generators/graphql/templates/base_field.erb
+++ b/lib/generators/graphql/templates/base_field.erb
@@ -1,4 +1,4 @@
-module <%= @template_module_name %>
+module <%= base_type_module_name("base_field") %>
   class BaseField < GraphQL::Schema::Field
     argument_class Types::BaseArgument
 

--- a/lib/generators/graphql/templates/base_field.erb
+++ b/lib/generators/graphql/templates/base_field.erb
@@ -1,4 +1,4 @@
-module <%= base_module_name(base_type) %>
+module <%= @template_module_name %>
   class BaseField < GraphQL::Schema::Field
     argument_class Types::BaseArgument
 

--- a/lib/generators/graphql/templates/base_field.erb
+++ b/lib/generators/graphql/templates/base_field.erb
@@ -1,4 +1,4 @@
-module Types
+module <%= base_module_name(base_type) %>
   class BaseField < GraphQL::Schema::Field
     argument_class Types::BaseArgument
 

--- a/lib/generators/graphql/templates/base_input_object.erb
+++ b/lib/generators/graphql/templates/base_input_object.erb
@@ -1,4 +1,4 @@
-module <%= base_module_name(base_type) %>
+module <%= @template_module_name %>
   class BaseInputObject < GraphQL::Schema::InputObject
     argument_class Types::BaseArgument
   end

--- a/lib/generators/graphql/templates/base_input_object.erb
+++ b/lib/generators/graphql/templates/base_input_object.erb
@@ -1,4 +1,4 @@
-module <%= @template_module_name %>
+module <%= base_type_module_name("base_input_object") %>
   class BaseInputObject < GraphQL::Schema::InputObject
     argument_class Types::BaseArgument
   end

--- a/lib/generators/graphql/templates/base_input_object.erb
+++ b/lib/generators/graphql/templates/base_input_object.erb
@@ -1,4 +1,4 @@
-module Types
+module <%= base_module_name(base_type) %>
   class BaseInputObject < GraphQL::Schema::InputObject
     argument_class Types::BaseArgument
   end

--- a/lib/generators/graphql/templates/base_interface.erb
+++ b/lib/generators/graphql/templates/base_interface.erb
@@ -1,4 +1,4 @@
-module <%= @template_module_name %>
+module <%= base_type_module_name("base_interface") %>
   module BaseInterface
     include GraphQL::Schema::Interface
   end

--- a/lib/generators/graphql/templates/base_interface.erb
+++ b/lib/generators/graphql/templates/base_interface.erb
@@ -1,4 +1,4 @@
-module Types
+module <%= base_module_name(base_type) %>
   module BaseInterface
     include GraphQL::Schema::Interface
   end

--- a/lib/generators/graphql/templates/base_interface.erb
+++ b/lib/generators/graphql/templates/base_interface.erb
@@ -1,4 +1,4 @@
-module <%= base_module_name(base_type) %>
+module <%= @template_module_name %>
   module BaseInterface
     include GraphQL::Schema::Interface
   end

--- a/lib/generators/graphql/templates/base_object.erb
+++ b/lib/generators/graphql/templates/base_object.erb
@@ -1,4 +1,4 @@
-module <%= @template_module_name %>
+module <%= base_type_module_name("base_object") %>
   class BaseObject < GraphQL::Schema::Object
   end
 end

--- a/lib/generators/graphql/templates/base_object.erb
+++ b/lib/generators/graphql/templates/base_object.erb
@@ -1,4 +1,4 @@
-module Types
+module <%= base_module_name(base_type) %>
   class BaseObject < GraphQL::Schema::Object
   end
 end

--- a/lib/generators/graphql/templates/base_object.erb
+++ b/lib/generators/graphql/templates/base_object.erb
@@ -1,4 +1,4 @@
-module <%= base_module_name(base_type) %>
+module <%= @template_module_name %>
   class BaseObject < GraphQL::Schema::Object
   end
 end

--- a/lib/generators/graphql/templates/base_scalar.erb
+++ b/lib/generators/graphql/templates/base_scalar.erb
@@ -1,4 +1,4 @@
-module <%= @template_module_name %>
+module <%= base_type_module_name("base_scalar") %>
   class BaseScalar < GraphQL::Schema::Scalar
   end
 end

--- a/lib/generators/graphql/templates/base_scalar.erb
+++ b/lib/generators/graphql/templates/base_scalar.erb
@@ -1,4 +1,4 @@
-module <%= base_module_name(base_type) %>
+module <%= @template_module_name %>
   class BaseScalar < GraphQL::Schema::Scalar
   end
 end

--- a/lib/generators/graphql/templates/base_scalar.erb
+++ b/lib/generators/graphql/templates/base_scalar.erb
@@ -1,4 +1,4 @@
-module Types
+module <%= base_module_name(base_type) %>
   class BaseScalar < GraphQL::Schema::Scalar
   end
 end

--- a/lib/generators/graphql/templates/base_union.erb
+++ b/lib/generators/graphql/templates/base_union.erb
@@ -1,4 +1,4 @@
-module <%= base_module_name(base_type) %>
+module <%= @template_module_name %>
   class BaseUnion < GraphQL::Schema::Union
   end
 end

--- a/lib/generators/graphql/templates/base_union.erb
+++ b/lib/generators/graphql/templates/base_union.erb
@@ -1,4 +1,4 @@
-module Types
+module <%= base_module_name(base_type) %>
   class BaseUnion < GraphQL::Schema::Union
   end
 end

--- a/lib/generators/graphql/templates/base_union.erb
+++ b/lib/generators/graphql/templates/base_union.erb
@@ -1,4 +1,4 @@
-module <%= @template_module_name %>
+module <%= base_type_module_name("base_union") %>
   class BaseUnion < GraphQL::Schema::Union
   end
 end

--- a/lib/generators/graphql/templates/mutation_type.erb
+++ b/lib/generators/graphql/templates/mutation_type.erb
@@ -1,5 +1,5 @@
 module Types
-  class MutationType < Types::BaseObject
+  class MutationType < <%= base_type_class_name("base_object") %>
     # TODO: remove me
     field :test_field, String, null: false,
       description: "An example field added by the generator"

--- a/lib/generators/graphql/templates/query_type.erb
+++ b/lib/generators/graphql/templates/query_type.erb
@@ -1,5 +1,5 @@
 module Types
-  class QueryType < Types::BaseObject
+  class QueryType < <%= base_type_class_name("base_object") %>
     # Add root-level fields here.
     # They will be entry points for queries on your schema.
 

--- a/spec/integration/rails/generators/graphql/install_generator_spec.rb
+++ b/spec/integration/rails/generators/graphql/install_generator_spec.rb
@@ -184,8 +184,16 @@ RUBY
       assert_includes contents, "module Types::Unions"
     end
 
-    assert_file "app/graphql/types/arguments/base_arguments.rb" do |contents|
-      assert_includes "module Types::Arguments"
+    assert_file "app/graphql/types/arguments/base_argument.rb" do |contents|
+      assert_includes contents, "module Types::Arguments"
+    end
+
+    assert_file "app/graphql/types/query_type.rb" do |contents|
+      assert_includes contents, "class QueryType < Types::Objects::BaseObject"
+    end
+
+    assert_file "app/graphql/types/mutation_type.rb" do |contents|
+      assert_includes contents, "class MutationType < Types::Objects::BaseObject"
     end
   end
 

--- a/spec/integration/rails/generators/graphql/install_generator_spec.rb
+++ b/spec/integration/rails/generators/graphql/install_generator_spec.rb
@@ -157,49 +157,36 @@ RUBY
     run_generator(["--modules"])
 
     assert_file "app/graphql/types/enums/base_enum.rb" do |contents|
-      assert_includes "module Types::Enums"
+      assert_includes contents, "module Types::Enums"
     end
 
     assert_file "app/graphql/types/fields/base_field.rb" do |contents|
-      assert_includes "module Types::Fields"
+      assert_includes contents, "module Types::Fields"
     end
 
     assert_file "app/graphql/types/inputs/base_input_object.rb" do |contents|
-      assert_includes "module Types::Inputs"
+      assert_includes contents, "module Types::Inputs"
     end
 
     assert_file "app/graphql/types/interfaces/base_interface.rb" do |contents|
-      assert_includes "module Types::Interfaces"
+      assert_includes contents, "module Types::Interfaces"
     end
 
     assert_file "app/graphql/types/objects/base_object.rb" do |contents|
-      assert_includes "module Types::Objects"
+      assert_includes contents, "module Types::Objects"
     end
 
     assert_file "app/graphql/types/scalars/base_scalar.rb" do |contents|
-      assert_includes "module Types::Scalars"
+      assert_includes contents, "module Types::Scalars"
     end
 
     assert_file "app/graphql/types/unions/base_union.rb" do |contents|
-      assert_includes "module Types::Unions"
+      assert_includes contents, "module Types::Unions"
     end
 
     assert_file "app/graphql/types/arguments/base_arguments.rb" do |contents|
       assert_includes "module Types::Arguments"
     end
-  end
-
-  test "it adds `.keep` files to all the base type folders when given the `--modules` option" do
-    ["base_input_object",
-     "base_interface",
-     "base_argument",
-     "base_scalar",
-     "base_object",
-     "base_union",
-     "base_field",
-     "base_enum"].each do |base_type|
-        assert_file "app/graphql/types/#{base_type}/.keep"
-      end
   end
 
   EXPECTED_GRAPHQLS_CONTROLLER = <<-'RUBY'

--- a/spec/integration/rails/generators/graphql/install_generator_spec.rb
+++ b/spec/integration/rails/generators/graphql/install_generator_spec.rb
@@ -153,6 +153,55 @@ RUBY
     assert_file "app/controllers/graphql_controller.rb", /CustomSchema\.execute/
   end
 
+  test "it generates a modular folder structure when given the `--modules` option" do
+    run_generator(["--modules"])
+
+    assert_file "app/graphql/types/enums/base_enum.rb" do |contents|
+      assert_includes "module Types::Enums"
+    end
+
+    assert_file "app/graphql/types/fields/base_field.rb" do |contents|
+      assert_includes "module Types::Fields"
+    end
+
+    assert_file "app/graphql/types/inputs/base_input_object.rb" do |contents|
+      assert_includes "module Types::Inputs"
+    end
+
+    assert_file "app/graphql/types/interfaces/base_interface.rb" do |contents|
+      assert_includes "module Types::Interfaces"
+    end
+
+    assert_file "app/graphql/types/objects/base_object.rb" do |contents|
+      assert_includes "module Types::Objects"
+    end
+
+    assert_file "app/graphql/types/scalars/base_scalar.rb" do |contents|
+      assert_includes "module Types::Scalars"
+    end
+
+    assert_file "app/graphql/types/unions/base_union.rb" do |contents|
+      assert_includes "module Types::Unions"
+    end
+
+    assert_file "app/graphql/types/arguments/base_arguments.rb" do |contents|
+      assert_includes "module Types::Arguments"
+    end
+  end
+
+  test "it adds `.keep` files to all the base type folders when given the `--modules` option" do
+    ["base_input_object",
+     "base_interface",
+     "base_argument",
+     "base_scalar",
+     "base_object",
+     "base_union",
+     "base_field",
+     "base_enum"].each do |base_type|
+        assert_file "app/graphql/types/#{base_type}/.keep"
+      end
+  end
+
   EXPECTED_GRAPHQLS_CONTROLLER = <<-'RUBY'
 class GraphqlController < ApplicationController
   def execute


### PR DESCRIPTION
Add an option to the install generator so that a modular file structure is generated. Usage is as follows:

```bash
$ rails g graphql:install --modules
```

Which will create a file structure as follows:

```
     - app/
       - graphql/
         - resolvers/
         - types/
           - fields/
             - base_field.rb
           - enums/
             - base_enum.rb
           - inputs/
             - base_input_object.rb
           - interfaces/
             - base_interface.rb
           - objects/
             - base_object.rb
           - scalars/
             - base_scalar.rb
           - unions/
             - base_union.rb
           - query_type.rb
         - loaders/
         - mutations/
         - {app_name}_schema.rb
```

I think it would be nice to provide this options to users, and to my knowledge this shouldn't affect any of the other generators. Interested to hear others' thoughts!