### PR TITLE
Fix resolver loads

### DIFF
--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -25,6 +25,11 @@ module GraphQL
       # @return [Class, Module, nil] If this argument should load an application object, this is the type of object to load
       attr_reader :loads
 
+      # @return [Boolean] true if a resolver defined this argument
+      def from_resolver?
+        @from_resolver
+      end
+
       # @param arg_name [Symbol]
       # @param type_expr
       # @param desc [String]
@@ -34,7 +39,8 @@ module GraphQL
       # @param as [Symbol] Override the keyword name when passed to a method
       # @param prepare [Symbol] A method to call to transform this argument's valuebefore sending it to field resolution
       # @param camelize [Boolean] if true, the name will be camelized when building the schema
-      def initialize(arg_name = nil, type_expr = nil, desc = nil, required:, type: nil, name: nil, loads: nil, description: nil, ast_node: nil, default_value: NO_DEFAULT, as: nil, camelize: true, prepare: nil, owner:, &definition_block)
+      # @param from_resolver [Boolean] if true, a Resolver class defined this argument
+      def initialize(arg_name = nil, type_expr = nil, desc = nil, required:, type: nil, name: nil, loads: nil, description: nil, ast_node: nil, default_value: NO_DEFAULT, as: nil, from_resolver: false, camelize: true, prepare: nil, owner:, &definition_block)
         arg_name ||= name
         name_str = camelize ? Member::BuildType.camelize(arg_name.to_s) : arg_name.to_s
         @name = name_str.freeze
@@ -48,6 +54,7 @@ module GraphQL
         @keyword = as || Schema::Member::BuildType.underscore(@name).to_sym
         @prepare = prepare
         @ast_node = ast_node
+        @from_resolver = from_resolver
 
         if definition_block
           if definition_block.arity == 1

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -23,7 +23,7 @@ module GraphQL
           ruby_kwargs_key = arg_defn.keyword
           loads = arg_defn.loads
 
-          if @ruby_style_hash.key?(ruby_kwargs_key) && loads
+          if @ruby_style_hash.key?(ruby_kwargs_key) && loads && !arg_defn.from_resolver?
             value = @ruby_style_hash[ruby_kwargs_key]
             @ruby_style_hash[ruby_kwargs_key] = if arg_defn.type.list?
               GraphQL::Execution::Lazy.all(value.map { |val| load_application_object(arg_defn, loads, val) })

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -99,8 +99,6 @@ module GraphQL
         attr_accessor :arguments_class
 
         def argument(*args, **kwargs, &block)
-          # Translate `loads:` to `as:` if needed`
-          *args, kwargs = argument_with_loads(*args, **kwargs, &block)
           argument_defn = super(*args, **kwargs, &block)
           # Add a method access
           method_name = argument_defn.keyword

--- a/lib/graphql/schema/member/has_arguments.rb
+++ b/lib/graphql/schema/member/has_arguments.rb
@@ -13,7 +13,11 @@ module GraphQL
           cls.include(ArgumentObjectLoader)
         end
 
-        def argument_with_loads(*args, **kwargs)
+
+        # @see {GraphQL::Schema::Argument#initialize} for parameters
+        # @return [GraphQL::Schema::Argument] An instance of {arguments_class}, created from `*args`
+        def argument(*args, **kwargs, &block)
+          kwargs[:owner] = self
           loads = kwargs[:loads]
           if loads
             name = args[0]
@@ -32,14 +36,6 @@ module GraphQL
 
             kwargs[:as] ||= inferred_arg_name
           end
-
-          return [*args, **kwargs]
-        end
-
-        # @see {GraphQL::Schema::Argument#initialize} for parameters
-        # @return [GraphQL::Schema::Argument] An instance of {arguments_class}, created from `*args`
-        def argument(*args, **kwargs, &block)
-          kwargs[:owner] = self
           arg_defn = self.argument_class.new(*args, **kwargs, &block)
           add_argument(arg_defn)
         end

--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -254,12 +254,12 @@ module GraphQL
         # Add an argument to this field's signature, but
         # also add some preparation hook methods which will be used for this argument
         # @see {GraphQL::Schema::Argument#initialize} for the signature
-        def argument(name, type, *rest, loads: nil, **kwargs, &block)
-          *args, kwargs = argument_with_loads(name, type, *rest, loads: loads, **kwargs, &block)
+        def argument(name, type, *rest, **kwargs, &block)
+          loads = kwargs[:loads]
+          *args, kwargs = argument_with_loads(name, type, *rest, **kwargs, &block)
           # Short-circuit the InputObject's own `loads:` implementation
           # so that we can support `#load_{x}` methods below.
-          kwargs.delete(:loads)
-          arg_defn = super(*args, **kwargs)
+          arg_defn = super(*args, from_resolver: true, **kwargs)
           own_arguments_loads_as_type[arg_defn.keyword] = loads if loads
 
           if loads && arg_defn.type.list?

--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -254,10 +254,9 @@ module GraphQL
         # Add an argument to this field's signature, but
         # also add some preparation hook methods which will be used for this argument
         # @see {GraphQL::Schema::Argument#initialize} for the signature
-        def argument(name, type, *rest, **kwargs, &block)
+        def argument(*args, **kwargs, &block)
           loads = kwargs[:loads]
-          *args, kwargs = argument_with_loads(name, type, *rest, **kwargs, &block)
-          # Short-circuit the InputObject's own `loads:` implementation
+          # Use `from_resolver: true` to short-circuit the InputObject's own `loads:` implementation
           # so that we can support `#load_{x}` methods below.
           arg_defn = super(*args, from_resolver: true, **kwargs)
           own_arguments_loads_as_type[arg_defn.keyword] = loads if loads

--- a/spec/graphql/schema/resolver_spec.rb
+++ b/spec/graphql/schema/resolver_spec.rb
@@ -555,6 +555,11 @@ describe GraphQL::Schema::Resolver do
       refute res.key?("errors"), "#{description}: silent auth failure (no top-level error)"
     end
 
+    it "keeps track of the `loads:` option" do
+      arg = ResolverTest::MutationWithNullableLoadsArgument.arguments["labelId"]
+      assert_equal ResolverTest::HasValue, arg.loads
+    end
+
     describe "ready?" do
       it "can raise errors" do
         res = exec_query("{ int: prepResolver5(int: 5) }")


### PR DESCRIPTION
Oops, resolver arguments that used `loads:` didn't actually have a value in `@loads`. 