### PR TITLE
Add method_access: false to suppress warning about argument name

### DIFF
--- a/lib/graphql/argument.rb
+++ b/lib/graphql/argument.rb
@@ -35,13 +35,14 @@ module GraphQL
 
   class Argument
     include GraphQL::Define::InstanceDefinable
-    accepts_definitions :name, :type, :description, :default_value, :as, :prepare
+    accepts_definitions :name, :type, :description, :default_value, :as, :prepare, :method_access
     attr_reader :default_value
     attr_accessor :description, :name, :as
     attr_accessor :ast_node
+    attr_accessor :method_access
     alias :graphql_name :name
 
-    ensure_defined(:name, :description, :default_value, :type=, :type, :as, :expose_as, :prepare)
+    ensure_defined(:name, :description, :default_value, :type=, :type, :as, :expose_as, :prepare, :method_access)
 
     # @api private
     module DefaultPrepare
@@ -58,6 +59,11 @@ module GraphQL
 
     def default_value?
       !!@has_default_value
+    end
+
+    def method_access?
+      # Treat unset as true -- only `false` should override
+      @method_access != false
     end
 
     def default_value=(new_default_value)

--- a/lib/graphql/compatibility/lazy_execution_specification/lazy_schema.rb
+++ b/lib/graphql/compatibility/lazy_execution_specification/lazy_schema.rb
@@ -88,7 +88,7 @@ module GraphQL
             end
 
             connection :pushes, lazy_push_type.connection_type do
-              argument :values, types[types.Int]
+              argument :values, types[types.Int], method_access: false
               resolve ->(o, a, c) {
                 LazyPushCollection.new(c, a[:values])
               }

--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -14,21 +14,22 @@ module GraphQL
           self.argument_definitions = argument_definitions
 
           argument_definitions.each do |_arg_name, arg_definition|
-            expose_as = arg_definition.expose_as.to_s.freeze
-            expose_as_underscored = GraphQL::Schema::Member::BuildType.underscore(expose_as).freeze
-            method_names = [expose_as, expose_as_underscored].uniq
-            method_names.each do |method_name|
-              # Don't define a helper method if it would override something.
-              if method_defined?(method_name)
-                warn(
-                  "Unable to define a helper for argument with name '#{method_name}' "\
-                  "as this is a reserved name. If you're using an argument such as "\
-                  "`argument #{method_name}`, consider renaming this argument.`"
-                )
-              else
-                define_method(method_name) do
-                  # Always use `expose_as` here, since #[] doesn't accept underscored names
-                  self[expose_as]
+            if arg_definition.method_access?
+              expose_as = arg_definition.expose_as.to_s.freeze
+              expose_as_underscored = GraphQL::Schema::Member::BuildType.underscore(expose_as).freeze
+              method_names = [expose_as, expose_as_underscored].uniq
+              method_names.each do |method_name|
+                # Don't define a helper method if it would override something.
+                if method_defined?(method_name)
+                  warn(
+                    "Unable to define a helper for argument with name '#{method_name}' "\
+                    "as this is a reserved name. Add `method_access: false` to stop this warning."
+                  )
+                else
+                  define_method(method_name) do
+                    # Always use `expose_as` here, since #[] doesn't accept underscored names
+                    self[expose_as]
+                  end
                 end
               end
             end

--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -33,7 +33,8 @@ module GraphQL
       # @param as [Symbol] Override the keyword name when passed to a method
       # @param prepare [Symbol] A method to call to transform this argument's valuebefore sending it to field resolution
       # @param camelize [Boolean] if true, the name will be camelized when building the schema
-      def initialize(arg_name = nil, type_expr = nil, desc = nil, required:, type: nil, name: nil, loads: nil, description: nil, default_value: NO_DEFAULT, as: nil, camelize: true, prepare: nil, owner:, &definition_block)
+      # @param method_access [Boolean] If false, don't build method access on legacy {Query::Arguments} instances.
+      def initialize(arg_name = nil, type_expr = nil, desc = nil, required:, type: nil, name: nil, loads: nil, description: nil, default_value: NO_DEFAULT, as: nil, camelize: true, prepare: nil, method_access: true, owner:, &definition_block)
         arg_name ||= name
         name_str = camelize ? Member::BuildType.camelize(arg_name.to_s) : arg_name.to_s
         @name = name_str.freeze
@@ -46,6 +47,7 @@ module GraphQL
         @loads = loads
         @keyword = as || Schema::Member::BuildType.underscore(@name).to_sym
         @prepare = prepare
+        @method_access = method_access
 
         if definition_block
           if definition_block.arity == 1
@@ -94,6 +96,7 @@ module GraphQL
         argument.description = @description
         argument.metadata[:type_class] = self
         argument.as = @as
+        argument.method_access = @method_access
         if NO_DEFAULT != @default_value
           argument.default_value = @default_value
         end

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -232,6 +232,7 @@ module GraphQL
               name: input_argument.name,
               type: type_resolver.call(input_argument.type),
               description: input_argument.description,
+              method_access: false,
               **kwargs,
             )
 
@@ -269,6 +270,7 @@ module GraphQL
               name: directive_argument.name,
               type: type_resolver.call(directive_argument.type),
               description: directive_argument.description,
+              method_access: false,
               **kwargs,
             )
 
@@ -306,6 +308,7 @@ module GraphQL
                 name: argument.name,
                 description: argument.description,
                 type: type_resolver.call(argument.type),
+                method_access: false,
                 **kwargs,
               )
 

--- a/lib/graphql/schema/loader.rb
+++ b/lib/graphql/schema/loader.rb
@@ -148,6 +148,7 @@ module GraphQL
               name: type["name"],
               type: type_resolver.call(type["type"]),
               description: type["description"],
+              method_access: false,
               **kwargs
             )
           when "SCALAR"

--- a/spec/graphql/schema/argument_spec.rb
+++ b/spec/graphql/schema/argument_spec.rb
@@ -18,7 +18,7 @@ describe GraphQL::Schema::Argument do
           raise GraphQL::ExecutionError.new('boom!')
         end
 
-        argument :keys, [String], required: false
+        argument :keys, [String], required: false, method_access: false
 
         class Multiply
           def call(val, context)

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -1063,6 +1063,16 @@ SCHEMA
 
       assert_equal({ "str" => "abc", "int" => 123 }, result["data"])
     end
+
+    it "doesn't warn about method conflicts" do
+      assert_output "", "" do
+        GraphQL::Schema.from_definition "
+        type Query {
+          int(method: Int): Int
+        }
+        "
+      end
+    end
   end
 
   describe "executable schemas from string" do

--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -396,23 +396,25 @@ describe GraphQL::Schema::InputObject do
 
   describe "warning for method objects" do
     it "warns for method conflicts" do
-      class X < GraphQL::Schema::InputObject
+      input_object = Class.new(GraphQL::Schema::InputObject) do
+        graphql_name "X"
         argument :method, String, required: true
       end
 
       expected_warning = "Unable to define a helper for argument with name 'method' as this is a reserved name. Add `method_access: false` to stop this warning.\n"
       assert_output "", expected_warning do
-        X.graphql_definition
+        input_object.graphql_definition
       end
     end
 
     it "doesn't warn with `method_access: false`" do
-      class X < GraphQL::Schema::InputObject
+      input_object = Class.new(GraphQL::Schema::InputObject) do
+        graphql_name "X"
         argument :method, String, required: true, method_access: false
       end
 
       assert_output "", "" do
-        X.graphql_definition
+        input_object.graphql_definition
       end
     end
   end

--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -393,4 +393,27 @@ describe GraphQL::Schema::InputObject do
       assert_equal ["ensembleId", "stringValue", "nestedInput", "legacyInput"], input_type["inputFields"].map { |f| f["name"] }
     end
   end
+
+  describe "warning for method objects" do
+    it "warns for method conflicts" do
+      class X < GraphQL::Schema::InputObject
+        argument :method, String, required: true
+      end
+
+      expected_warning = "Unable to define a helper for argument with name 'method' as this is a reserved name. Add `method_access: false` to stop this warning.\n"
+      assert_output "", expected_warning do
+        X.graphql_definition
+      end
+    end
+
+    it "doesn't warn with `method_access: false`" do
+      class X < GraphQL::Schema::InputObject
+        argument :method, String, required: true, method_access: false
+      end
+
+      assert_output "", "" do
+        X.graphql_definition
+      end
+    end
+  end
 end

--- a/spec/graphql/schema/loader_spec.rb
+++ b/spec/graphql/schema/loader_spec.rb
@@ -275,7 +275,71 @@ describe GraphQL::Schema::Loader do
       assert type.arguments['sub'].default_value.nil?
     end
 
-    it "sets correct default values `null` on complex field arguments" do
+    it "doesnt warn about method conflicts (because it doesn't make method accesses)" do
+      assert_output "", "" do
+        GraphQL::Schema.from_introspection({
+          "data" => {
+            "__schema" => {
+              "queryType" => {
+                "name" => "Query"
+              },
+              "mutationType" => nil,
+              "subscriptionType" => nil,
+              "types" => [
+                {
+                  "kind" => "OBJECT",
+                  "name" => "Query",
+                  "description" => nil,
+                  "fields" => [
+                    {
+                      "name" => "int",
+                      "description" => nil,
+                      "args" => [
+                        {
+                          "name" => "method",
+                          "description" => nil,
+                          "type" => {
+                            "kind" => "SCALAR",
+                            "name" => "Int",
+                            "ofType" => nil
+                          },
+                          "defaultValue" => nil
+                        }
+                      ],
+                      "type" => {
+                        "kind" => "SCALAR",
+                        "name" => "Int",
+                        "ofType" => nil
+                      },
+                      "isDeprecated" => false,
+                      "deprecationReason" => nil
+                    }
+                  ],
+                  "inputFields" => nil,
+                  "interfaces" => [
+
+                  ],
+                  "enumValues" => nil,
+                  "possibleTypes" => nil
+                },
+                {
+                  "kind" => "SCALAR",
+                  "name" => "Int",
+                  "description" => "Represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
+                  "fields" => nil,
+                  "inputFields" => nil,
+                  "interfaces" => nil,
+                  "enumValues" => nil,
+                  "possibleTypes" => nil
+                },
+              ]
+            }
+          }
+        })
+      end
+    end
+
+    it "sets correct default values `nil` on complex field arguments" do
       type = loaded_schema.types['Query']
       field = type.fields['post']
       arg = field.arguments['variedWithNull']

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -445,7 +445,7 @@ module Dummy
   GLOBAL_VALUES = []
 
   class ReplaceValuesInput < BaseInputObject
-    argument :values, [Integer], required: true
+    argument :values, [Integer], required: true, method_access: false
   end
 
   class DairyAppMutation < BaseObject

--- a/spec/support/lazy_helpers.rb
+++ b/spec/support/lazy_helpers.rb
@@ -123,7 +123,7 @@ module LazyHelpers
     end
 
     field :list_sum, [LazySum, null: true], null: true do
-      argument :values, [Integer], required: true
+      argument :values, [Integer], required: true, method_access: false
     end
     def list_sum(values:)
       values.map { |v| v == MAGIC_NUMBER_THAT_RETURNS_NIL ? nil : v }


### PR DESCRIPTION
Oops, we added a warning but no way to quiet it when it wasn't necessary. Fixes #2358 