### PR TITLE
[WIP] Implementing extend keyword + request for input Schema Extension API

### DIFF
--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -47,6 +47,25 @@ module GraphQL
             when GraphQL::Language::Nodes::SchemaDefinition
               raise InvalidDocumentError.new('Must provide only one schema definition.') if schema_definition
               schema_definition = definition
+
+            when GraphQL::Language::Nodes::ScalarTypeExtension
+              raise "ScalarTypeExtension"
+
+            when GraphQL::Language::Nodes::ObjectTypeExtension
+              raise "ObjectTypeExtension"
+
+            when GraphQL::Language::Nodes::InterfaceTypeExtension
+              raise "InterfaceTypeExtension"
+
+            when GraphQL::Language::Nodes::UnionTypeExtension
+              raise "UnionTypeExtension"
+
+            when GraphQL::Language::Nodes::EnumTypeExtension
+              raise "EnumTypeExtension"
+
+            when GraphQL::Language::Nodes::InputObjectTypeExtension
+              raise "InputObjectTypeExtension"
+
             when GraphQL::Language::Nodes::EnumTypeDefinition
               types[definition.name] = build_enum_type(definition, type_resolver)
             when GraphQL::Language::Nodes::ObjectTypeDefinition

--- a/spec/graphql/language/document_from_schema_definition_spec.rb
+++ b/spec/graphql/language/document_from_schema_definition_spec.rb
@@ -6,6 +6,36 @@ describe GraphQL::Language::DocumentFromSchemaDefinition do
 
   describe "#document" do
     let(:schema_idl) { <<-GRAPHQL
+      type User {
+        name: String
+      }
+      extend type User {
+        email: String!
+      }
+      type Query {
+        user: User
+      }
+      GRAPHQL
+    }
+
+    let(:expected_document) { GraphQL.parse(schema_idl) }
+    let(:schema) { GraphQL::Schema.from_definition(schema_idl) }
+
+    let(:document) {
+        a = subject.new(
+          schema
+        ).document
+      }
+
+      it "returns the IDL without introspection, built ins and schema root" do
+        assert equivalent_node?(expected_document, document)
+      end
+      it "extends types"
+      it "generates IDL with extends keywords"
+  end
+
+  describe "#document" do
+    let(:schema_idl) { <<-GRAPHQL
       type QueryType {
         foo: Foo
       }


### PR DESCRIPTION
Hi all 👋 

In this PR I would like to add support for type extensions which are described in the  https://graphql.github.io/graphql-spec/June2018/#sec-Type-Extensions which allows for building your schema in parts (handy if you're merging a schema from multiple files for instance)

I am however wondering how to do this elegantly and hoping for some of your input.

How do the `ObjectType` and other extended types look like when they are extended in the API? 

Consider the following:

```graphql
type User {
  name: String
}

extend type User {
  email: String
}
```

- Would the User `ObjectType` then just list all the fields combined? 
- Would it need to be traceable where the fields came from? Any suggestions how we could do set that up?
- How would one add extensions trough the current API? 
- Would printing the schema also show the extends, i.e. not the flatten types? (I guess so)
- Is the order important of the extended types? 

Hope you can shed some light on this. Thanks a lot! 

This is how they solve it in JS:
- https://github.com/graphql/graphql-js/blob/master/src/utilities/__tests__/extendSchema-test.js



