### PR TITLE
Warn for field names that conflict; include suggestion for name override

### DIFF
--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -54,7 +54,7 @@ module GraphQL
         # @return [void]
         def add_field(field_defn)
           if CONFLICT_FIELD_NAMES.include?(field_defn.method_sym)
-            warn "#{self.graphql_name}'s `field :#{field_defn.name}` conflicts with a built-in method, use `method:` to pick a different resolver method for this field (for example, `method: :resolve_#{field_defn.method_sym}` and `def resolve_#{field_defn.method_sym}`)"
+            warn "#{self.graphql_name}'s `field :#{field_defn.name}` conflicts with a built-in method, use `method:` to pick a different resolver method for this field (for example, `resolver_method: :resolve_#{field_defn.method_sym}` and `def resolve_#{field_defn.method_sym}`)"
           end
           own_fields[field_defn.name] = field_defn
           nil

--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -38,10 +38,24 @@ module GraphQL
           end
         end
 
+        # A list of field names that we should advise users to pick a different
+        # resolve method name.
+        #
+        # @api private
+        CONFLICT_FIELD_NAMES = Set.new([
+          # GraphQL-Ruby conflicts
+          :context, :object,
+          # Ruby built-ins conflicts
+          :method, :class
+        ])
+
         # Register this field with the class, overriding a previous one if needed.
         # @param field_defn [GraphQL::Schema::Field]
         # @return [void]
         def add_field(field_defn)
+          if CONFLICT_FIELD_NAMES.include?(field_defn.method_sym)
+            warn "#{self.graphql_name}'s `field :#{field_defn.name}` conflicts with a built-in method, use `method:` to pick a different resolver method for this field (for example, `method: :resolve_#{field_defn.method_sym}` and `def resolve_#{field_defn.method_sym}`)"
+          end
           own_fields[field_defn.name] = field_defn
           nil
         end

--- a/spec/graphql/schema/object_spec.rb
+++ b/spec/graphql/schema/object_spec.rb
@@ -312,4 +312,25 @@ describe GraphQL::Schema::Object do
       assert_equal({"data" => skip_value }, res.to_h)
     end
   end
+
+  describe "when fields conflict with built-ins" do
+    it "warns when no override" do
+      expected_warning = "X's `field :method` conflicts with a built-in method, use `method:` to pick a different resolver method for this field (for example, `method: :resolve_method` and `def resolve_method`)\n"
+      assert_output "", expected_warning do
+        Class.new(GraphQL::Schema::Object) do
+          graphql_name "X"
+          field :method, String, null: true
+        end
+      end
+    end
+
+    it "doesn't warn with an override" do
+      assert_output "", "" do
+        Class.new(GraphQL::Schema::Object) do
+          graphql_name "X"
+          field :method, String, null: true, method: :resolve_method
+        end
+      end
+    end
+  end
 end

--- a/spec/graphql/schema/object_spec.rb
+++ b/spec/graphql/schema/object_spec.rb
@@ -315,7 +315,7 @@ describe GraphQL::Schema::Object do
 
   describe "when fields conflict with built-ins" do
     it "warns when no override" do
-      expected_warning = "X's `field :method` conflicts with a built-in method, use `method:` to pick a different resolver method for this field (for example, `method: :resolve_method` and `def resolve_method`)\n"
+      expected_warning = "X's `field :method` conflicts with a built-in method, use `method:` to pick a different resolver method for this field (for example, `resolver_method: :resolve_method` and `def resolve_method`)\n"
       assert_output "", expected_warning do
         Class.new(GraphQL::Schema::Object) do
           graphql_name "X"


### PR DESCRIPTION
Help people do the right thing when a `field` conflicts with an important method name. 

Also, make it possible to dismiss the warning somehow :P 

Fixes #1648 
Fixes #1320