### PR TITLE
Fix another mishandling of unicode in the lexer

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -62,7 +62,7 @@ ERR
   end
 
   assert_dependency_version("Ragel", "7.0.0.9", "ragel -v")
-  assert_dependency_version("Racc", "1.4.14", %|ruby -e "require 'racc'; puts Racc::VERSION"|)
+  assert_dependency_version("Racc", "1.4.15", %|ruby -e "require 'racc'; puts Racc::VERSION"|)
 
   `rm -f lib/graphql/language/parser.rb lib/graphql/language/lexer.rb `
   `racc lib/graphql/language/parser.y -o lib/graphql/language/parser.rb`

--- a/lib/graphql/language/lexer.rb
+++ b/lib/graphql/language/lexer.rb
@@ -1435,6 +1435,15 @@ prev_token: meta[:previous_token],
 else
 replace_escaped_characters_in_place(value)
 
+if !value.valid_encoding?
+meta[:tokens] << token = GraphQL::Language::Token.new(
+name: :BAD_UNICODE_ESCAPE,
+value: value,
+line: meta[:line],
+col: meta[:col],
+prev_token: meta[:previous_token],
+)
+else
 meta[:tokens] << token = GraphQL::Language::Token.new(
 name: :STRING,
 value: value,
@@ -1442,6 +1451,7 @@ line: meta[:line],
 col: meta[:col],
 prev_token: meta[:previous_token],
 )
+end
 end
 
 meta[:previous_token] = token

--- a/lib/graphql/language/lexer.rb
+++ b/lib/graphql/language/lexer.rb
@@ -1436,22 +1436,22 @@ else
 replace_escaped_characters_in_place(value)
 
 if !value.valid_encoding?
-meta[:tokens] << token = GraphQL::Language::Token.new(
-name: :BAD_UNICODE_ESCAPE,
-value: value,
-line: meta[:line],
-col: meta[:col],
-prev_token: meta[:previous_token],
-)
-else
-meta[:tokens] << token = GraphQL::Language::Token.new(
-name: :STRING,
-value: value,
-line: meta[:line],
-col: meta[:col],
-prev_token: meta[:previous_token],
-)
-end
+	meta[:tokens] << token = GraphQL::Language::Token.new(
+	name: :BAD_UNICODE_ESCAPE,
+	value: value,
+	line: meta[:line],
+	col: meta[:col],
+	prev_token: meta[:previous_token],
+	)
+	else
+	meta[:tokens] << token = GraphQL::Language::Token.new(
+	name: :STRING,
+	value: value,
+	line: meta[:line],
+	col: meta[:col],
+	prev_token: meta[:previous_token],
+	)
+	end
 end
 
 meta[:previous_token] = token

--- a/lib/graphql/language/lexer.rl
+++ b/lib/graphql/language/lexer.rl
@@ -218,13 +218,23 @@ module GraphQL
         else
           replace_escaped_characters_in_place(value)
 
-          meta[:tokens] << token = GraphQL::Language::Token.new(
-            name: :STRING,
-            value: value,
-            line: meta[:line],
-            col: meta[:col],
-            prev_token: meta[:previous_token],
-          )
+          if !value.valid_encoding?
+            meta[:tokens] << token = GraphQL::Language::Token.new(
+              name: :BAD_UNICODE_ESCAPE,
+              value: value,
+              line: meta[:line],
+              col: meta[:col],
+              prev_token: meta[:previous_token],
+            )
+          else
+            meta[:tokens] << token = GraphQL::Language::Token.new(
+              name: :STRING,
+              value: value,
+              line: meta[:line],
+              col: meta[:col],
+              prev_token: meta[:previous_token],
+            )
+          end
         end
 
         meta[:previous_token] = token

--- a/spec/graphql/language/lexer_spec.rb
+++ b/spec/graphql/language/lexer_spec.rb
@@ -72,6 +72,12 @@ describe GraphQL::Language::Lexer do
       assert_equal :BAD_UNICODE_ESCAPE, subject.tokenize(File.read(error_filename)).first.name
     end
 
+    it "rejects unicode that's well-formed but results in invalidly-encoded strings" do
+      # when the string here gets tokenized into an actual `:STRING`, it results in `valid_encoding?` being false for
+      # the ruby string so application code usually blows up trying to manipulate it
+      assert_equal :BAD_UNICODE_ESCAPE, subject.tokenize('"\\ud83c\\udf2c"').first.name
+    end
+
     it "clears the previous_token between runs" do
       tok_2 = subject.tokenize(query_string)
       assert_nil tok_2[0].prev_token


### PR DESCRIPTION
@swalkinshaw @rmosolgo Found another one, though I'm a little less confident that my solution here is correct.

A string constant that is validly encoded initially, and also passes the `VALID_STRING` regex, can end up invalidly encoded after passing through `replace_escaped_characters_in_place`.

This PR just does a second check for `valid_encoding?` after that call, but potentially the real fix belongs in the `VALID_STRING` regex or the crazy mess that is `replace_escaped_characters_in_place`?