### PR TITLE
When using a resolver, don't re-authorize arguments

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -420,7 +420,7 @@ module GraphQL
       def authorized?(object, context)
         if @resolver_class
           # The resolver will check itself during `resolve()`
-          true
+          @resolver_class.authorized?(object, context)
         else
           # Faster than `.any?`
           arguments.each_value do |arg|

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -418,13 +418,10 @@ module GraphQL
       end
 
       def authorized?(object, context)
-        self_auth = if @resolver_class
-          @resolver_class.authorized?(object, context)
-        else
+        if @resolver_class
+          # The resolver will check itself during `resolve()`
           true
-        end
-
-        if self_auth
+        else
           # Faster than `.any?`
           arguments.each_value do |arg|
             if !arg.authorized?(object, context)
@@ -432,8 +429,6 @@ module GraphQL
             end
           end
           true
-        else
-          false
         end
       end
 

--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -123,12 +123,36 @@ module GraphQL
       # Called after arguments are loaded, but before resolving.
       #
       # Override it to check everything before calling the mutation.
-      # @param args [Hash] The input arguments
+      # @param inputs [Hash] The input arguments
       # @raise [GraphQL::ExecutionError] To add an error to the response
       # @raise [GraphQL::UnauthorizedError] To signal an authorization failure
       # @return [Boolean, early_return_data] If `false`, execution will stop (and `early_return_data` will be returned instead, if present.)
-      def authorized?(**args)
-        true
+      def authorized?(**inputs)
+        self.class.arguments.each_value do |argument|
+          arg_keyword = argument.keyword
+          if inputs.key?(arg_keyword) && !(value = inputs[arg_keyword]).nil? && (value != argument.default_value)
+            loads_type = @arguments_loads_as_type[arg_keyword]
+            # If this argument resulted in an object being loaded,
+            # then authorize this loaded object with its own policy.
+            #
+            # But if this argument was "just" a plain argument, like
+            # a boolean, then authorize it based on the mutation.
+            authorization_value = if loads_type
+              value
+            else
+              self
+            end
+
+            arg_auth, err = argument.authorized?(authorization_value, context)
+            if !arg_auth
+              return arg_auth, err
+            else
+              true
+            end
+          else
+            true
+          end
+        end
       end
 
       private

--- a/spec/graphql/schema/resolver_spec.rb
+++ b/spec/graphql/schema/resolver_spec.rb
@@ -186,12 +186,20 @@ describe GraphQL::Schema::Resolver do
     class IntegerWrapper < GraphQL::Schema::Object
       implements HasValue
       field :value, Integer, null: false, method: :itself
+
+      def self.authorized?(value, ctx)
+        if ctx[:max_value] && value > ctx[:max_value]
+          false
+        else
+          true
+        end
+      end
     end
 
     class PrepResolver9 < BaseResolver
       argument :int_id, ID, required: true, loads: HasValue
       # Make sure the lazy object is resolved properly:
-      type HasValue, null: false
+      type HasValue, null: true
       def object_from_id(type, id, ctx)
         # Make sure a lazy object is handled appropriately
         LazyBlock.new {
@@ -656,6 +664,22 @@ describe GraphQL::Schema::Resolver do
         it "works with no arguments for RelayClassicMutation" do
           res = exec_query("{ prepResolver14(input: {}) { number } }")
           assert_equal 1, res["data"]["prepResolver14"]["number"]
+        end
+
+        it "uses loaded objects" do
+          query_str = "{ prepResolver9(intId: 9) { value } }"
+          # This will cause an unauthorized response
+          # by `HasValue.authorized?`
+          context = { max_value: 8 }
+          res = exec_query(query_str, context: context)
+          assert_nil res["data"]["prepResolver9"]
+          # This is OK
+          context = { max_value: 900 }
+          res = exec_query(query_str, context: context)
+          assert_equal 51, res["data"]["prepResolver9"]["value"]
+          # This is the transformation applied by the resolver,
+          # just make sure it matches the response
+          assert_equal 51, (9 + "HasValue".size) * 3
         end
       end
     end


### PR DESCRIPTION
This code was moved from GraphQL-Pro to here because it's generally relevant, and besides, we can simplify `Field#authorized?` if we know that resolver classes do their own argument authorization. 

There's some chance this could be disruptive _if_: 

- Someone is using `loads:`
- Someone _doesn't want_ their loaded argument objects to be authorized automatically. (Previously they weren't, now they are.) 

I think this is a good improvement in any case, but maybe it could be pushed to 1.10 if it seems too disruptive. 

Fixes #2367 (which was worked around by the author) 