### PR TITLE
Parse empty block strings correctly

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -62,7 +62,7 @@ ERR
   end
 
   assert_dependency_version("Ragel", "7.0.0.9", "ragel -v")
-  assert_dependency_version("Racc", "1.4.14", %|ruby -e "require 'racc'; puts Racc::VERSION"|)
+  assert_dependency_version("Racc", "1.4.15", %|ruby -e "require 'racc'; puts Racc::VERSION"|)
 
   `rm -f lib/graphql/language/parser.rb lib/graphql/language/lexer.rb `
   `racc lib/graphql/language/parser.y -o lib/graphql/language/parser.rb`

--- a/lib/graphql/language/lexer.rb
+++ b/lib/graphql/language/lexer.rb
@@ -1415,10 +1415,10 @@ UTF_8_ENCODING = "UTF-8"
 
 def self.emit_string(ts, te, meta, block:)
 quotes_length = block ? 3 : 1
-ts += quotes_length
-value = meta[:data][ts...te - quotes_length].pack(PACK_DIRECTIVE).force_encoding(UTF_8_ENCODING)
+content_range = (ts + quotes_length)...(te - quotes_length)
+value = meta[:data][content_range].pack(PACK_DIRECTIVE).force_encoding(UTF_8_ENCODING) || ''
 line_incr = 0
-if block
+if block && !value.length.zero?
 line_incr = value.count("\n")
 value = GraphQL::Language::BlockString.trim_whitespace(value)
 end

--- a/lib/graphql/language/lexer.rl
+++ b/lib/graphql/language/lexer.rl
@@ -198,10 +198,10 @@ module GraphQL
 
       def self.emit_string(ts, te, meta, block:)
         quotes_length = block ? 3 : 1
-        ts += quotes_length
-        value = meta[:data][ts...te - quotes_length].pack(PACK_DIRECTIVE).force_encoding(UTF_8_ENCODING)
+        content_range = (ts + quotes_length)...(te - quotes_length)
+        value = meta[:data][content_range].pack(PACK_DIRECTIVE).force_encoding(UTF_8_ENCODING) || ''
         line_incr = 0
-        if block
+        if block && !value.length.zero?
           line_incr = value.count("\n")
           value = GraphQL::Language::BlockString.trim_whitespace(value)
         end

--- a/spec/graphql/language/lexer_spec.rb
+++ b/spec/graphql/language/lexer_spec.rb
@@ -53,6 +53,13 @@ describe GraphQL::Language::Lexer do
         tokens = subject.tokenize('"""{"foo":"bar"}"""')
         assert_equal '{"foo":"bar"}', tokens[0].value
       end
+
+      it "tokenizes empty block strings correctly" do
+        empty_block_string = '""""""'
+        tokens = subject.tokenize(empty_block_string)
+
+        assert_equal '', tokens[0].value
+      end
     end
 
     it "unescapes escaped characters" do

--- a/spec/graphql/language/lexer_spec.rb
+++ b/spec/graphql/language/lexer_spec.rb
@@ -92,7 +92,7 @@ describe GraphQL::Language::Lexer do
       assert_equal 8, str_token.col
       assert_equal '(STRING "c" [1:8])', str_token.inspect
       rparen_token = tokens[6]
-      assert_equal '(RPAREN ")" [1:10])', rparen_token.inspect
+      assert_equal '(RPAREN ")" [1:11])', rparen_token.inspect
     end
 
     it "counts block string line properly" do


### PR DESCRIPTION
## What's up?

This is an attempt to resolve https://github.com/rmosolgo/graphql-ruby/issues/2373. 

```ruby
GraphQL.parse('{ t(x: """"""X"""""")}') # NoMethodError (undefined method `empty?' for nil:NilClass)
```

## The Problem 

During the lexing phase, `""""""x""""""` will actually be read as: 

```ruby
GraphQL::Language::Lexer.tokenize('""""""x""""""')
# Because a set of 6 quotes is an empty block string. So we get two strings and an identifier. This is invalid grammar and will be rejected by the parser later.
=> [(STRING "" [1:1]), (IDENTIFIER "x" [1:7]), (STRING "" [1:8])] 
```

That brings us to the underlying problem.

```ruby
GraphQL::Language::Lexer.tokenize('"""""") # empty block string
NoMethodError: undefined method `empty?' for nil:NilClass
```
The fix is not to do extra processing when dealing with an empty block string. 