### PR TITLE
Schema class inheritance support

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -3,6 +3,7 @@ require "graphql/schema/base_64_encoder"
 require "graphql/schema/catchall_middleware"
 require "graphql/schema/default_parse_error"
 require "graphql/schema/default_type_error"
+require "graphql/schema/find_inherited_value"
 require "graphql/schema/finder"
 require "graphql/schema/invalid_type_error"
 require "graphql/schema/introspection_system"
@@ -81,6 +82,8 @@ module GraphQL
     extend Forwardable
     extend GraphQL::Schema::Member::AcceptsDefinition
     include GraphQL::Define::InstanceDefinable
+    extend GraphQL::Schema::FindInheritedValue
+
     accepts_definitions \
       :query, :mutation, :subscription,
       :query_execution_strategy, :mutation_execution_strategy, :subscription_execution_strategy,
@@ -159,7 +162,9 @@ module GraphQL
     # @see {Query#tracers} for query-specific tracers
     attr_reader :tracers
 
-    DYNAMIC_FIELDS = ["__type", "__typename", "__schema"]
+    DYNAMIC_FIELDS = ["__type", "__typename", "__schema"].freeze
+    EMPTY_ARRAY = [].freeze
+    EMPTY_HASH = {}.freeze
 
     attr_reader :static_validator, :object_from_id_proc, :id_from_object_proc, :resolve_type_proc
 
@@ -728,11 +733,11 @@ module GraphQL
       end
 
       def use(plugin, options = {})
-        plugins << [plugin, options]
+        own_plugins << [plugin, options]
       end
 
       def plugins
-        @plugins ||= []
+        find_inherited_value(:plugins, EMPTY_ARRAY) + own_plugins
       end
 
       def to_graphql
@@ -746,7 +751,7 @@ module GraphQL
         schema_defn.max_depth = max_depth
         schema_defn.default_max_page_size = default_max_page_size
         schema_defn.orphan_types = orphan_types
-        schema_defn.disable_introspection_entry_points = @disable_introspection_entry_points
+        schema_defn.disable_introspection_entry_points = disable_introspection_entry_points?
 
         prepped_dirs = {}
         directives.each { |k, v| prepped_dirs[k] = v.graphql_definition}
@@ -758,15 +763,15 @@ module GraphQL
         schema_defn.type_error = method(:type_error)
         schema_defn.context_class = context_class
         schema_defn.cursor_encoder = cursor_encoder
-        schema_defn.tracers.concat(defined_tracers)
-        schema_defn.query_analyzers.concat(defined_query_analyzers)
+        schema_defn.tracers.concat(tracers)
+        schema_defn.query_analyzers.concat(query_analyzers)
 
-        schema_defn.middleware.concat(defined_middleware)
-        schema_defn.multiplex_analyzers.concat(defined_multiplex_analyzers)
+        schema_defn.middleware.concat(all_middleware)
+        schema_defn.multiplex_analyzers.concat(multiplex_analyzers)
         schema_defn.query_execution_strategy = query_execution_strategy
         schema_defn.mutation_execution_strategy = mutation_execution_strategy
         schema_defn.subscription_execution_strategy = subscription_execution_strategy
-        defined_instrumenters.each do |step, insts|
+        all_instrumenters.each do |step, insts|
           insts.each do |inst|
             schema_defn.instrumenters[step] << inst
           end
@@ -774,10 +779,8 @@ module GraphQL
         lazy_classes.each do |lazy_class, value_method|
           schema_defn.lazy_methods.set(lazy_class, value_method)
         end
-        if @rescues
-          @rescues.each do |err_class, handler|
-            schema_defn.rescue_from(err_class, &handler)
-          end
+        rescues.each do |err_class, handler|
+          schema_defn.rescue_from(err_class, &handler)
         end
 
         if plugins.any?
@@ -806,7 +809,8 @@ module GraphQL
         if new_query_object
           @query_object = new_query_object
         else
-          @query_object.respond_to?(:graphql_definition) ? @query_object.graphql_definition : @query_object
+          query_object = @query_object || find_inherited_value(:query)
+          query_object.respond_to?(:graphql_definition) ? query_object.graphql_definition : query_object
         end
       end
 
@@ -814,7 +818,8 @@ module GraphQL
         if new_mutation_object
           @mutation_object = new_mutation_object
         else
-          @mutation_object.respond_to?(:graphql_definition) ? @mutation_object.graphql_definition : @mutation_object
+          mutation_object = @mutation_object || find_inherited_value(:mutation)
+          mutation_object.respond_to?(:graphql_definition) ? mutation_object.graphql_definition : mutation_object
         end
       end
 
@@ -822,7 +827,8 @@ module GraphQL
         if new_subscription_object
           @subscription_object = new_subscription_object
         else
-          @subscription_object.respond_to?(:graphql_definition) ? @subscription_object.graphql_definition : @subscription_object
+          subscription_object = @subscription_object || find_inherited_value(:subscription)
+          subscription_object.respond_to?(:graphql_definition) ? subscription_object.graphql_definition : subscription_object
         end
       end
 
@@ -830,7 +836,7 @@ module GraphQL
         if new_introspection_namespace
           @introspection = new_introspection_namespace
         else
-          @introspection
+          @introspection || find_inherited_value(:introspection)
         end
       end
 
@@ -838,14 +844,14 @@ module GraphQL
         if new_encoder
           @cursor_encoder = new_encoder
         end
-        @cursor_encoder || Base64Encoder
+        @cursor_encoder || find_inherited_value(:cursor_encoder, Base64Encoder)
       end
 
       def default_max_page_size(new_default_max_page_size = nil)
         if new_default_max_page_size
           @default_max_page_size = new_default_max_page_size
         else
-          @default_max_page_size
+          @default_max_page_size || find_inherited_value(:default_max_page_size)
         end
       end
 
@@ -853,7 +859,7 @@ module GraphQL
         if new_query_execution_strategy
           @query_execution_strategy = new_query_execution_strategy
         else
-          @query_execution_strategy || self.default_execution_strategy
+          @query_execution_strategy || find_inherited_value(:query_execution_strategy, self.default_execution_strategy)
         end
       end
 
@@ -861,7 +867,7 @@ module GraphQL
         if new_mutation_execution_strategy
           @mutation_execution_strategy = new_mutation_execution_strategy
         else
-          @mutation_execution_strategy || self.default_execution_strategy
+          @mutation_execution_strategy || find_inherited_value(:mutation_execution_strategy, self.default_execution_strategy)
         end
       end
 
@@ -869,7 +875,7 @@ module GraphQL
         if new_subscription_execution_strategy
           @subscription_execution_strategy = new_subscription_execution_strategy
         else
-          @subscription_execution_strategy || self.default_execution_strategy
+          @subscription_execution_strategy || find_inherited_value(:subscription_execution_strategy, self.default_execution_strategy)
         end
       end
 
@@ -877,7 +883,7 @@ module GraphQL
         if max_complexity
           @max_complexity = max_complexity
         else
-          @max_complexity
+          @max_complexity || find_inherited_value(:max_complexity)
         end
       end
 
@@ -885,7 +891,7 @@ module GraphQL
         if !new_error_bubbling.nil?
           @error_bubbling = new_error_bubbling
         else
-          @error_bubbling
+          @error_bubbling.nil? ? find_inherited_value(:error_bubbling) : @error_bubbling
         end
       end
 
@@ -893,7 +899,7 @@ module GraphQL
         if new_max_depth
           @max_depth = new_max_depth
         else
-          @max_depth
+          @max_depth || find_inherited_value(:max_depth)
         end
       end
 
@@ -901,12 +907,20 @@ module GraphQL
         @disable_introspection_entry_points = true
       end
 
+      def disable_introspection_entry_points?
+        if instance_variable_defined?(:@disable_introspection_entry_points)
+          @disable_introspection_entry_points
+        else
+          find_inherited_value(:disable_introspection_entry_points?, false)
+        end
+      end
+
       def orphan_types(*new_orphan_types)
         if new_orphan_types.any?
-          @orphan_types = new_orphan_types.flatten
-        else
-          @orphan_types || []
+          own_orphan_types.concat(new_orphan_types.flatten)
         end
+
+        find_inherited_value(:orphan_types, EMPTY_ARRAY) + own_orphan_types
       end
 
       def default_execution_strategy
@@ -921,15 +935,18 @@ module GraphQL
         if new_context_class
           @context_class = new_context_class
         else
-          @context_class || GraphQL::Query::Context
+          @context_class || find_inherited_value(:context_class, GraphQL::Query::Context)
         end
       end
 
       def rescue_from(*err_classes, &handler_block)
-        @rescues ||= {}
         err_classes.each do |err_class|
-          @rescues[err_class] = handler_block
+          own_rescues[err_class] = handler_block
         end
+      end
+
+      def rescues
+        find_inherited_value(:rescues, EMPTY_HASH).merge(own_rescues)
       end
 
       def resolve_type(type, obj, ctx)
@@ -1017,19 +1034,20 @@ module GraphQL
         else
           instrument_step
         end
-        defined_instrumenters[step] << instrumenter
+
+        own_instrumenters[step] << instrumenter
       end
 
       def directives(new_directives = nil)
         if new_directives
-          @directives = new_directives.reduce({}) { |m, d| m[d.name] = d; m }
+          new_directives.each {|d| directive(d) }
         end
 
-        @directives ||= default_directives
+        find_inherited_value(:directives, default_directives).merge(own_directives)
       end
 
       def directive(new_directive)
-        directives[new_directive.graphql_name] = new_directive
+        own_directives[new_directive.graphql_name] = new_directive
       end
 
       def default_directives
@@ -1041,26 +1059,38 @@ module GraphQL
       end
 
       def tracer(new_tracer)
-        defined_tracers << new_tracer
+        own_tracers << new_tracer
+      end
+
+      def tracers
+        find_inherited_value(:tracers, EMPTY_ARRAY) + own_tracers
       end
 
       def query_analyzer(new_analyzer)
         if new_analyzer == GraphQL::Authorization::Analyzer
           warn("The Authorization query analyzer is deprecated. Authorizing at query runtime is generally a better idea.")
         end
-        defined_query_analyzers << new_analyzer
+        own_query_analyzers << new_analyzer
+      end
+
+      def query_analyzers
+        find_inherited_value(:query_analyzers, EMPTY_ARRAY) + own_query_analyzers
       end
 
       def middleware(new_middleware = nil)
         if new_middleware
-          defined_middleware << new_middleware
+          own_middleware << new_middleware
         else
           graphql_definition.middleware
         end
       end
 
       def multiplex_analyzer(new_analyzer)
-        defined_multiplex_analyzers << new_analyzer
+        own_multiplex_analyzers << new_analyzer
+      end
+
+      def multiplex_analyzers
+        find_inherited_value(:multiplex_analyzers, EMPTY_ARRAY) + own_multiplex_analyzers
       end
 
       private
@@ -1069,24 +1099,51 @@ module GraphQL
         @lazy_classes ||= {}
       end
 
-      def defined_instrumenters
-        @defined_instrumenters ||= Hash.new { |h,k| h[k] = [] }
+      def own_plugins
+        @own_plugins ||= []
       end
 
-      def defined_tracers
-        @defined_tracers ||= []
+      def own_rescues
+        @own_rescues ||= {}
       end
 
-      def defined_query_analyzers
+      def own_orphan_types
+        @own_orphan_types ||= []
+      end
+
+      def own_directives
+        @own_directives ||= {}
+      end
+
+      def all_instrumenters
+        inherited_instrumenters = find_inherited_value(:all_instrumenters) || Hash.new { |h,k| h[k] = [] }
+        inherited_instrumenters.merge(own_instrumenters) do |_step, inherited, own|
+          inherited + own
+        end
+      end
+
+      def own_instrumenters
+        @own_instrumenters ||= Hash.new { |h,k| h[k] = [] }
+      end
+
+      def own_tracers
+        @own_tracers ||= []
+      end
+
+      def own_query_analyzers
         @defined_query_analyzers ||= []
       end
 
-      def defined_middleware
-        @defined_middleware ||= []
+      def all_middleware
+        find_inherited_value(:all_middleware, EMPTY_ARRAY) + own_middleware
       end
 
-      def defined_multiplex_analyzers
-        @defined_multiplex_analyzers ||= []
+      def own_middleware
+        @own_middleware ||= []
+      end
+
+      def own_multiplex_analyzers
+        @own_multiplex_analyzers ||= []
       end
 
       # Given this schema member, find the class-based definition object

--- a/lib/graphql/schema/find_inherited_value.rb
+++ b/lib/graphql/schema/find_inherited_value.rb
@@ -1,0 +1,20 @@
+module GraphQL
+  class Schema
+    module FindInheritedValue
+      private
+
+      def find_inherited_value(method_name, default_value = nil)
+        if self.is_a?(Class)
+          superclass.respond_to?(method_name, true) ? superclass.send(method_name) : default_value
+        else
+          ancestors[1..-1].each do |ancestor|
+            if ancestor.respond_to?(method_name, true)
+              return ancestor.send(method_name)
+            end
+          end
+          default_value
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/schema/member/base_dsl_methods.rb
+++ b/lib/graphql/schema/member/base_dsl_methods.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "graphql/schema/find_inherited_value"
+
 module GraphQL
   class Schema
     class Member
@@ -7,6 +9,8 @@ module GraphQL
       # @api private
       # @see Classes that extend this, eg {GraphQL::Schema::Object}
       module BaseDSLMethods
+        include GraphQL::Schema::FindInheritedValue
+
         # Call this with a new name to override the default name for this schema member; OR
         # call it without an argument to get the name of this schema member
         #
@@ -42,7 +46,7 @@ module GraphQL
           if new_description
             @description = new_description
           else
-            @description || find_inherited_method(:description, nil)
+            @description || find_inherited_value(:description)
           end
         end
 
@@ -51,7 +55,7 @@ module GraphQL
           if !new_introspection.nil?
             @introspection = new_introspection
           else
-            @introspection || find_inherited_method(:introspection, false)
+            @introspection || find_inherited_value(:introspection, false)
           end
         end
 
@@ -76,7 +80,7 @@ module GraphQL
         alias :unwrap :itself
 
         def overridden_graphql_name
-          @graphql_name || find_inherited_method(:overridden_graphql_name, nil)
+          @graphql_name || find_inherited_value(:overridden_graphql_name)
         end
 
         # Creates the default name for a schema member.
@@ -111,21 +115,6 @@ module GraphQL
             @mutation.authorized?(object, context)
           else
             true
-          end
-        end
-
-        private
-
-        def find_inherited_method(method_name, default_value)
-          if self.is_a?(Class)
-            superclass.respond_to?(method_name) ? superclass.public_send(method_name) : default_value
-          else
-            ancestors[1..-1].each do |ancestor|
-              if ancestor.respond_to?(method_name)
-                return ancestor.public_send(method_name)
-              end
-            end
-            default_value
           end
         end
       end

--- a/lib/graphql/schema/member/relay_shortcuts.rb
+++ b/lib/graphql/schema/member/relay_shortcuts.rb
@@ -8,7 +8,7 @@ module GraphQL
           if new_edge_type_class
             @edge_type_class = new_edge_type_class
           else
-            @edge_type_class || find_inherited_method(:edge_type_class, Types::Relay::BaseEdge)
+            @edge_type_class || find_inherited_value(:edge_type_class, Types::Relay::BaseEdge)
           end
         end
 
@@ -16,7 +16,7 @@ module GraphQL
           if new_connection_type_class
             @connection_type_class = new_connection_type_class
           else
-            @connection_type_class || find_inherited_method(:connection_type_class, Types::Relay::BaseConnection)
+            @connection_type_class || find_inherited_value(:connection_type_class, Types::Relay::BaseConnection)
           end
         end
 

--- a/lib/graphql/schema/resolver/has_payload_type.rb
+++ b/lib/graphql/schema/resolver/has_payload_type.rb
@@ -27,7 +27,7 @@ module GraphQL
           if new_class
             @field_class = new_class
           else
-            @field_class || find_inherited_method(:field_class, GraphQL::Schema::Field)
+            @field_class || find_inherited_value(:field_class, GraphQL::Schema::Field)
           end
         end
 
@@ -37,8 +37,9 @@ module GraphQL
         def object_class(new_class = nil)
           if new_class
             @object_class = new_class
+          else
+            @object_class || find_inherited_value(:object_class, GraphQL::Schema::Object)
           end
-          @object_class || (superclass.respond_to?(:object_class) ? superclass.object_class : GraphQL::Schema::Object)
         end
 
         private

--- a/lib/graphql/schema/subscription.rb
+++ b/lib/graphql/schema/subscription.rb
@@ -104,7 +104,7 @@ module GraphQL
         elsif defined?(@subscription_scope)
           @subscription_scope
         else
-          find_inherited_method(:subscription_scope, nil)
+          find_inherited_value(:subscription_scope)
         end
       end
 

--- a/spec/graphql/analysis/analyze_query_spec.rb
+++ b/spec/graphql/analysis/analyze_query_spec.rb
@@ -31,6 +31,8 @@ describe GraphQL::Analysis do
     end
   end
 
+  let(:schema) { Class.new(Dummy::Schema) }
+
   describe ".analyze_query" do
     let(:node_counter) {
       ->(memo, visit_type, irep_node) {
@@ -43,7 +45,7 @@ describe GraphQL::Analysis do
     let(:analyzers) { [type_collector, node_counter] }
     let(:reduce_result) { GraphQL::Analysis.analyze_query(query, analyzers) }
     let(:variables) { {} }
-    let(:query) { GraphQL::Query.new(Dummy::Schema, query_string, variables: variables) }
+    let(:query) { GraphQL::Query.new(schema, query_string, variables: variables) }
     let(:query_string) {%|
       {
         cheese(id: 1) {
@@ -58,7 +60,7 @@ describe GraphQL::Analysis do
       let(:analyzers) { [type_collector, conditional_analyzer] }
 
       describe "when analyze? returns false" do
-        let(:query) { GraphQL::Query.new(Dummy::Schema, query_string, variables: variables, context: { analyze: false }) }
+        let(:query) { GraphQL::Query.new(schema, query_string, variables: variables, context: { analyze: false }) }
 
         it "does not run the analyzer" do
           # Only type_collector ran
@@ -67,7 +69,7 @@ describe GraphQL::Analysis do
       end
 
       describe "when analyze? returns true" do
-        let(:query) { GraphQL::Query.new(Dummy::Schema, query_string, variables: variables, context: { analyze: true }) }
+        let(:query) { GraphQL::Query.new(schema, query_string, variables: variables, context: { analyze: true }) }
 
         it "it runs the analyzer" do
           # Both analyzers ran
@@ -93,7 +95,7 @@ describe GraphQL::Analysis do
       it "emits traces" do
         traces = TestTracing.with_trace do
           ctx = { tracers: [TestTracing] }
-          Dummy::Schema.execute(query_string, context: ctx)
+          schema.execute(query_string, context: ctx)
         end
 
         # The query_trace is on the list _first_ because it finished first
@@ -119,14 +121,7 @@ describe GraphQL::Analysis do
       let(:variable_accessor) { ->(memo, visit_type, irep_node) { query.variables["cheeseId"] } }
 
       before do
-        @previous_query_analyzers = Dummy::Schema.query_analyzers.dup
-        Dummy::Schema.query_analyzers.clear
-        Dummy::Schema.query_analyzers << variable_accessor
-      end
-
-      after do
-        Dummy::Schema.query_analyzers.clear
-        Dummy::Schema.query_analyzers.push(*@previous_query_analyzers)
+        schema.query_analyzer(variable_accessor)
       end
 
       it "returns an error" do
@@ -213,7 +208,7 @@ describe GraphQL::Analysis do
     let(:flavor_catcher) { FlavorCatcher.new }
     let(:analyzers) { [id_catcher, flavor_catcher] }
     let(:reduce_result) { GraphQL::Analysis.analyze_query(query, analyzers) }
-    let(:query) { GraphQL::Query.new(Dummy::Schema, query_string) }
+    let(:query) { GraphQL::Query.new(schema, query_string) }
     let(:query_string) {%|
       {
         cheese(id: 1) {
@@ -222,7 +217,12 @@ describe GraphQL::Analysis do
         }
       }
     |}
-    let(:schema) { Dummy::Schema }
+    let(:schema) do
+      schema = Class.new(Dummy::Schema)
+      schema.query_analyzer(id_catcher)
+      schema.query_analyzer(flavor_catcher)
+      schema
+    end
     let(:result) { schema.execute(query_string) }
     let(:query_string) {%|
       {
@@ -232,17 +232,6 @@ describe GraphQL::Analysis do
         }
       }
     |}
-
-    before do
-      @previous_query_analyzers = Dummy::Schema.query_analyzers.dup
-      Dummy::Schema.query_analyzers.clear
-      Dummy::Schema.query_analyzers << id_catcher << flavor_catcher
-    end
-
-    after do
-      Dummy::Schema.query_analyzers.clear
-      Dummy::Schema.query_analyzers.push(*@previous_query_analyzers)
-    end
 
     it "groups all errors together" do
       data = result["data"]

--- a/spec/graphql/analysis/ast/max_query_complexity_spec.rb
+++ b/spec/graphql/analysis/ast/max_query_complexity_spec.rb
@@ -2,14 +2,7 @@
 require "spec_helper"
 
 describe GraphQL::Analysis::AST::MaxQueryComplexity do
-  before do
-    @prev_max_complexity = Dummy::Schema.max_complexity
-  end
-
-  after do
-    Dummy::Schema.max_complexity = @prev_max_complexity
-  end
-
+  let(:schema) { Class.new(Dummy::Schema) }
   let(:query_string) {%|
     {
       a: cheese(id: 1) { id }
@@ -19,7 +12,7 @@ describe GraphQL::Analysis::AST::MaxQueryComplexity do
       e: cheese(id: 1) { id }
     }
   |}
-  let(:query) { GraphQL::Query.new(Dummy::Schema, query_string, variables: {}, max_complexity: max_complexity) }
+  let(:query) { GraphQL::Query.new(schema, query_string, variables: {}, max_complexity: max_complexity) }
   let(:result) {
     GraphQL::Analysis::AST.analyze_query(query, [GraphQL::Analysis::AST::MaxQueryComplexity]).first
   }
@@ -52,7 +45,7 @@ describe GraphQL::Analysis::AST::MaxQueryComplexity do
 
   describe "when max_complexity is decreased at query-level" do
     before do
-      Dummy::Schema.max_complexity = 100
+      schema.max_complexity = 100
     end
 
     let(:max_complexity) { 7 }
@@ -65,7 +58,7 @@ describe GraphQL::Analysis::AST::MaxQueryComplexity do
 
   describe "when max_complexity is increased at query-level" do
     before do
-      Dummy::Schema.max_complexity = 1
+      schema.max_complexity = 1
     end
 
     let(:max_complexity) { 10 }
@@ -77,22 +70,17 @@ describe GraphQL::Analysis::AST::MaxQueryComplexity do
 
   describe "across a multiplex" do
     before do
-      @old_analysis_engine = Dummy::Schema.analysis_engine
-      Dummy::Schema.analysis_engine = GraphQL::Analysis::AST
-    end
-
-    after do
-      Dummy::Schema.analysis_engine = @old_analysis_engine
+      schema.analysis_engine = GraphQL::Analysis::AST
     end
 
     let(:queries) {
       5.times.map { |n|
-        GraphQL::Query.new(Dummy::Schema, "{ cheese(id: #{n}) { id } }", variables: {})
+        GraphQL::Query.new(schema, "{ cheese(id: #{n}) { id } }", variables: {})
       }
     }
 
     let(:max_complexity) { 9 }
-    let(:multiplex) { GraphQL::Execution::Multiplex.new(schema: Dummy::Schema, queries: queries, context: {}, max_complexity: max_complexity) }
+    let(:multiplex) { GraphQL::Execution::Multiplex.new(schema: schema, queries: queries, context: {}, max_complexity: max_complexity) }
     let(:analyze_multiplex) {
       GraphQL::Analysis::AST.analyze_multiplex(multiplex, [GraphQL::Analysis::AST::MaxQueryComplexity])
     }

--- a/spec/graphql/analysis/ast/max_query_depth_spec.rb
+++ b/spec/graphql/analysis/ast/max_query_depth_spec.rb
@@ -2,14 +2,7 @@
 require "spec_helper"
 
 describe GraphQL::Analysis::AST::MaxQueryDepth do
-  before do
-    @prev_max_depth = Dummy::Schema.max_depth
-  end
-
-  after do
-    Dummy::Schema.max_depth = @prev_max_depth
-  end
-
+  let(:schema) { Class.new(Dummy::Schema) }
   let(:query_string) { "
     {
       cheese(id: 1) {
@@ -30,7 +23,7 @@ describe GraphQL::Analysis::AST::MaxQueryDepth do
   let(:max_depth) { nil }
   let(:query) {
     GraphQL::Query.new(
-      Dummy::Schema.graphql_definition,
+      schema.graphql_definition,
       query_string,
       variables: {},
       max_depth: max_depth
@@ -58,7 +51,7 @@ describe GraphQL::Analysis::AST::MaxQueryDepth do
 
   describe "When the query is not deeper than max_depth" do
     before do
-      Dummy::Schema.max_depth = 100
+      schema.max_depth = 100
     end
 
     it "doesn't add an error" do
@@ -68,7 +61,7 @@ describe GraphQL::Analysis::AST::MaxQueryDepth do
 
   describe "when the max depth isn't set" do
     before do
-      Dummy::Schema.max_depth = nil
+      schema.max_depth = nil
     end
 
     it "doesn't add an error message" do
@@ -78,7 +71,7 @@ describe GraphQL::Analysis::AST::MaxQueryDepth do
 
   describe "when a fragment exceeds max depth" do
     before do
-      Dummy::Schema.max_depth = 4
+      schema.max_depth = 4
     end
 
     let(:query_string) { "

--- a/spec/graphql/analysis/max_query_complexity_spec.rb
+++ b/spec/graphql/analysis/max_query_complexity_spec.rb
@@ -2,16 +2,8 @@
 require "spec_helper"
 
 describe GraphQL::Analysis::MaxQueryComplexity do
-  before do
-    @prev_max_complexity = Dummy::Schema.max_complexity
-  end
-
-  after do
-    Dummy::Schema.max_complexity = @prev_max_complexity
-  end
-
-
-  let(:result) { Dummy::Schema.execute(query_string) }
+  let(:schema) { Class.new(Dummy::Schema) }
+  let(:result) { schema.execute(query_string) }
   let(:query_string) {%|
     {
       a: cheese(id: 1) { id }
@@ -24,7 +16,7 @@ describe GraphQL::Analysis::MaxQueryComplexity do
 
   describe "when a query goes over max complexity" do
     before do
-      Dummy::Schema.max_complexity = 9
+      schema.max_complexity = 9
     end
 
     it "returns an error" do
@@ -34,7 +26,7 @@ describe GraphQL::Analysis::MaxQueryComplexity do
 
   describe "when there is no max complexity" do
     before do
-      Dummy::Schema.max_complexity = nil
+      schema.max_complexity = nil
     end
     it "doesn't error" do
       assert_nil result["errors"]
@@ -43,7 +35,7 @@ describe GraphQL::Analysis::MaxQueryComplexity do
 
   describe "when the query is less than the max complexity" do
     before do
-      Dummy::Schema.max_complexity = 99
+      schema.max_complexity = 99
     end
     it "doesn't error" do
       assert_nil result["errors"]
@@ -52,9 +44,9 @@ describe GraphQL::Analysis::MaxQueryComplexity do
 
   describe "when max_complexity is decreased at query-level" do
     before do
-      Dummy::Schema.max_complexity = 100
+      schema.max_complexity = 100
     end
-    let(:result) { Dummy::Schema.execute(query_string, max_complexity: 7) }
+    let(:result) {schema.execute(query_string, max_complexity: 7) }
 
     it "is applied" do
       assert_equal "Query has complexity of 10, which exceeds max complexity of 7", result["errors"][0]["message"]
@@ -63,9 +55,9 @@ describe GraphQL::Analysis::MaxQueryComplexity do
 
   describe "when max_complexity is increased at query-level" do
     before do
-      Dummy::Schema.max_complexity = 1
+      schema.max_complexity = 1
     end
-    let(:result) { Dummy::Schema.execute(query_string, max_complexity: 10) }
+    let(:result) {schema.execute(query_string, max_complexity: 10) }
 
     it "doesn't error" do
       assert_nil result["errors"]
@@ -74,13 +66,13 @@ describe GraphQL::Analysis::MaxQueryComplexity do
 
   describe "across a multiplex" do
     before do
-      Dummy::Schema.max_complexity = 9
+      schema.max_complexity = 9
     end
 
     let(:queries) { 5.times.map { |n|  { query: "{ cheese(id: #{n}) { id } }" } } }
 
     it "returns errors for all queries" do
-      results = Dummy::Schema.multiplex(queries)
+      results = schema.multiplex(queries)
       assert_equal 5, results.length
       err_msg = "Query has complexity of 10, which exceeds max complexity of 9"
       results.each do |res|
@@ -90,7 +82,7 @@ describe GraphQL::Analysis::MaxQueryComplexity do
 
     describe "with a local override" do
       it "uses the override" do
-        results = Dummy::Schema.multiplex(queries, max_complexity: 10)
+        results = schema.multiplex(queries, max_complexity: 10)
         assert_equal 5, results.length
         results.each do |res|
           assert_equal true, res.key?("data")

--- a/spec/graphql/analysis/max_query_depth_spec.rb
+++ b/spec/graphql/analysis/max_query_depth_spec.rb
@@ -2,15 +2,8 @@
 require "spec_helper"
 
 describe GraphQL::Analysis::MaxQueryDepth do
-  before do
-    @prev_max_depth = Dummy::Schema.max_depth
-  end
-
-  after do
-    Dummy::Schema.max_depth = @prev_max_depth
-  end
-
-  let(:result) { Dummy::Schema.execute(query_string) }
+  let(:schema) { Class.new(Dummy::Schema) }
+  let(:result) { schema.execute(query_string) }
   let(:query_string) { "
     {
       cheese(id: 1) {
@@ -36,7 +29,7 @@ describe GraphQL::Analysis::MaxQueryDepth do
   end
 
   describe "when the query specifies a different max_depth" do
-    let(:result) { Dummy::Schema.execute(query_string, max_depth: 100) }
+    let(:result) { schema.execute(query_string, max_depth: 100) }
 
     it "obeys that max_depth" do
       assert_nil result["errors"]
@@ -45,7 +38,7 @@ describe GraphQL::Analysis::MaxQueryDepth do
 
   describe "When the query is not deeper than max_depth" do
     before do
-      Dummy::Schema.max_depth = 100
+      schema.max_depth = 100
     end
 
     it "doesn't add an error" do
@@ -55,7 +48,7 @@ describe GraphQL::Analysis::MaxQueryDepth do
 
   describe "when the max depth isn't set" do
     before do
-      Dummy::Schema.max_depth = nil
+      schema.max_depth = nil
     end
 
     it "doesn't add an error message" do
@@ -65,7 +58,7 @@ describe GraphQL::Analysis::MaxQueryDepth do
 
   describe "when a fragment exceeds max depth" do
     before do
-      Dummy::Schema.max_depth = 4
+      schema.max_depth = 4
     end
 
     let(:query_string) { "

--- a/spec/graphql/schema/catchall_middleware_spec.rb
+++ b/spec/graphql/schema/catchall_middleware_spec.rb
@@ -2,16 +2,13 @@
 require "spec_helper"
 
 describe GraphQL::Schema::CatchallMiddleware do
-  let(:result) { Dummy::Schema.execute(query_string) }
+  let(:schema) do
+    Class.new(Dummy::Schema) do
+      middleware GraphQL::Schema::CatchallMiddleware
+    end
+  end
+  let(:result) { schema.execute(query_string) }
   let(:query_string) {%| query noMilk { error }|}
-
-  before do
-    Dummy::Schema.middleware << GraphQL::Schema::CatchallMiddleware
-  end
-
-  after do
-    Dummy::Schema.middleware.delete(GraphQL::Schema::CatchallMiddleware)
-  end
 
   if TESTING_RESCUE_FROM
     describe "rescuing errors" do

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::Schema do
+  describe "inheritance" do
+    class DummyFeature1 < GraphQL::Schema::Directive::Feature
+      
+    end
+
+    class DummyFeature2 < GraphQL::Schema::Directive::Feature
+
+    end
+    
+    let(:base_schema) do
+      Class.new(GraphQL::Schema) do
+        query GraphQL::Schema::Object
+        mutation GraphQL::Schema::Object
+        subscription GraphQL::Schema::Object
+        max_complexity 1
+        max_depth 2
+        default_max_page_size 3
+        error_bubbling false
+        disable_introspection_entry_points
+        orphan_types Jazz::Ensemble
+        introspection Module.new
+        cursor_encoder Object.new
+        query_execution_strategy Object.new
+        mutation_execution_strategy Object.new
+        subscription_execution_strategy Object.new
+        context_class Class.new
+        directives [DummyFeature1]
+        tracer GraphQL::Tracing::DataDogTracing
+        query_analyzer Object.new
+        multiplex_analyzer Object.new
+        rescue_from(StandardError) { }
+        instrument :field, GraphQL::Relay::EdgesInstrumentation
+        middleware (Proc.new {})
+        use GraphQL::Backtrace
+      end
+    end
+
+    it "inherits configuration from its superclass" do
+      schema = Class.new(base_schema)
+      assert_equal base_schema.query, schema.query
+      assert_equal base_schema.mutation, schema.mutation
+      assert_equal base_schema.subscription, schema.subscription
+      assert_equal base_schema.introspection, schema.introspection
+      assert_equal base_schema.cursor_encoder, schema.cursor_encoder
+      assert_equal base_schema.query_execution_strategy, schema.query_execution_strategy
+      assert_equal base_schema.mutation_execution_strategy, schema.mutation_execution_strategy
+      assert_equal base_schema.subscription_execution_strategy, schema.subscription_execution_strategy
+      assert_equal base_schema.max_complexity, schema.max_complexity
+      assert_equal base_schema.max_depth, schema.max_depth
+      assert_equal base_schema.default_max_page_size, schema.default_max_page_size
+      assert_equal base_schema.error_bubbling, schema.error_bubbling
+      assert_equal base_schema.orphan_types, schema.orphan_types
+      assert_equal base_schema.context_class, schema.context_class
+      assert_equal base_schema.directives, schema.directives
+      assert_equal base_schema.tracers, schema.tracers
+      assert_equal base_schema.query_analyzers, schema.query_analyzers
+      assert_equal base_schema.multiplex_analyzers, schema.multiplex_analyzers
+      assert_equal base_schema.rescues, schema.rescues
+      assert_equal base_schema.instrumenters, schema.instrumenters
+      assert_equal base_schema.middleware.steps.size, schema.middleware.steps.size
+      assert_equal base_schema.disable_introspection_entry_points?, schema.disable_introspection_entry_points?
+      assert_equal [GraphQL::Backtrace], schema.plugins.map(&:first)
+    end
+
+    it "can override configuration from its superclass" do
+      schema = Class.new(base_schema)
+      query = Class.new(GraphQL::Schema::Object) do
+        graphql_name 'Query'
+      end
+      schema.query(query)
+      mutation = Class.new(GraphQL::Schema::Object) do
+        graphql_name 'Mutation'
+      end
+      schema.mutation(mutation)
+      subscription = Class.new(GraphQL::Schema::Object) do
+        graphql_name 'Subscription'
+      end
+      schema.subscription(subscription)
+      introspection = Module.new
+      schema.introspection(introspection)
+      cursor_encoder = Object.new
+      schema.cursor_encoder(cursor_encoder)
+      query_execution_strategy = Object.new
+      schema.query_execution_strategy(query_execution_strategy)
+      mutation_execution_strategy = Object.new
+      schema.mutation_execution_strategy(mutation_execution_strategy)
+      subscription_execution_strategy = Object.new
+      schema.subscription_execution_strategy(subscription_execution_strategy)
+      context_class = Class.new
+      schema.context_class(context_class)
+      schema.max_complexity(10)
+      schema.max_depth(20)
+      schema.default_max_page_size(30)
+      schema.error_bubbling(true)
+      schema.orphan_types(Jazz::InstrumentType)
+      schema.directives([DummyFeature2])
+      query_analyzer = Object.new
+      schema.query_analyzer(query_analyzer)
+      multiplex_analyzer = Object.new
+      schema.multiplex_analyzer(multiplex_analyzer)
+      schema.use(GraphQL::Execution::Interpreter)
+      schema.instrument(:field, GraphQL::Relay::ConnectionInstrumentation)
+      schema.rescue_from(GraphQL::ExecutionError)
+      schema.tracer(GraphQL::Tracing::NewRelicTracing)
+      schema.middleware(Proc.new {})
+
+      assert_equal query.graphql_definition, schema.query
+      assert_equal mutation.graphql_definition, schema.mutation
+      assert_equal subscription.graphql_definition, schema.subscription
+      assert_equal introspection, schema.introspection
+      assert_equal cursor_encoder, schema.cursor_encoder
+      assert_equal query_execution_strategy, schema.query_execution_strategy
+      assert_equal mutation_execution_strategy, schema.mutation_execution_strategy
+      assert_equal subscription_execution_strategy, schema.subscription_execution_strategy
+      assert_equal context_class, schema.context_class
+      assert_equal 10, schema.max_complexity
+      assert_equal 20, schema.max_depth
+      assert_equal 30, schema.default_max_page_size
+      assert schema.error_bubbling
+      assert_equal [Jazz::Ensemble, Jazz::InstrumentType], schema.orphan_types
+      assert_equal schema.directives, GraphQL::Schema.default_directives.merge(DummyFeature1.graphql_name => DummyFeature1, DummyFeature2.graphql_name => DummyFeature2)
+      assert_equal base_schema.query_analyzers + [query_analyzer], schema.query_analyzers
+      assert_equal base_schema.multiplex_analyzers + [multiplex_analyzer], schema.multiplex_analyzers
+      assert_equal [GraphQL::Backtrace, GraphQL::Execution::Interpreter], schema.plugins.map(&:first)
+      assert_equal [GraphQL::Relay::EdgesInstrumentation, GraphQL::Relay::ConnectionInstrumentation], schema.instrumenters[:field]
+      assert_equal [GraphQL::ExecutionError, StandardError], schema.rescues.keys.sort_by(&:name)
+      assert_equal [GraphQL::Tracing::DataDogTracing, GraphQL::Tracing::NewRelicTracing], schema.tracers
+      assert_equal 3, schema.middleware.steps.size
+    end
+  end
+end


### PR DESCRIPTION
This is a first stab at support for inheriting `GraphQL::Schema` settings (i.e. fixing #1627) e.g.

```ruby
class BaseSchema < GraphQL::Schema
  use GraphQL::Tracing::NewRelicTracing
  use GraphQL::Execution::Interpreter
  use GraphQL::Analysis::AST
  max_complexity 5000
end

class ServiceSchema < BaseSchema
  # ...
end

class AdminSchema < BaseSchema
  # ...
end
```

I took a pretty naive approach to the implementation and just leveraged the existing `find_inherited_method` method from`GraphQL::Schema::Member::BaseDSLMethods` to walk up the superclass chain looking for non-null setting values. It's a bit tedious and it's error prone as new settings are added but it works. There appears to be more generic frameworks for defining inheritable settings in `GraphQL::Schema::Member::AcceptsDefinition` and `GraphQL::Define::InstanceDefinable` and I briefly considered a simplified port of ActiveSupport's [class_attribute](https://api.rubyonrails.org/classes/Class.html#method-i-class_attribute) but I'm assuming these weren't leveraged here for a good reason? I still need to finish the tests but I was hoping to get some high level feedback on the approach before I spend too much more time on it. Thanks!
