### PR TITLE
Optimize complexity analysis memory usage

### DIFF
--- a/guides/development.md
+++ b/guides/development.md
@@ -176,7 +176,7 @@ The lexer and parser use a multistep build process:
 - Run the generator (Ragel or Racc) to create `.rb` files (`lexer.rb` or `parser.rb`)
 - `require` those `.rb` files in GraphQL-Ruby
 
-To update the lexer or parser, you should update their corresponding _definitions_ (`lexer.rl` or `parser.y`). Then, you can run `bundle exec build_parser` to re-generate the `.rb` files.
+To update the lexer or parser, you should update their corresponding _definitions_ (`lexer.rl` or `parser.y`). Then, you can run `bundle exec rake build_parser` to re-generate the `.rb` files.
 
 You will need Ragel to build the lexer (see above).
 

--- a/lib/graphql/analysis/ast/query_complexity.rb
+++ b/lib/graphql/analysis/ast/query_complexity.rb
@@ -4,11 +4,11 @@ module GraphQL
     # Calculate the complexity of a query, using {Field#complexity} values.
     module AST
       class QueryComplexity < Analyzer
-        # State for the query complexity calcuation:
+        # State for the query complexity calculation:
         # - `complexities_on_type` holds complexity scores for each type in an IRep node
         def initialize(query)
           super
-          @complexities_on_type = [TypeComplexity.new]
+          @complexities_on_type = [ConcreteTypeComplexity.new]
         end
 
         # Overide this method to use the complexity result
@@ -22,7 +22,11 @@ module GraphQL
           return if visitor.visiting_fragment_definition?
           return if visitor.skipping?
 
-          @complexities_on_type.push(TypeComplexity.new)
+          if visitor.type_definition.kind.abstract?
+            @complexities_on_type.push(AbstractTypeComplexity.new)
+          else
+            @complexities_on_type.push(ConcreteTypeComplexity.new)
+          end
         end
 
         def on_leave_field(node, parent, visitor)
@@ -35,17 +39,14 @@ module GraphQL
           child_complexity = type_complexities.max_possible_complexity
           own_complexity = get_complexity(node, visitor.field_definition, child_complexity, visitor)
 
-          parent_type = visitor.parent_type_definition
-          possible_types = if parent_type.kind.abstract?
-            query.possible_types(parent_type)
+          if @complexities_on_type.last.is_a?(AbstractTypeComplexity)
+            key = selection_key(visitor.response_path_str, visitor.query)
+            parent_type = visitor.parent_type_definition
+            query.possible_types(parent_type).each do |type|
+              @complexities_on_type.last.merge(type, key, own_complexity)
+            end
           else
-            [parent_type]
-          end
-
-          key = selection_key(visitor.response_path, visitor.query)
-
-          possible_types.each do |type|
-            @complexities_on_type.last.merge(type, key, own_complexity)
+            @complexities_on_type.last.merge(own_complexity)
           end
         end
 
@@ -68,7 +69,7 @@ module GraphQL
           # We add the query object id to support multiplex queries
           # even if they have the same response path, they should
           # always be added.
-          response_path.join(".") + "-#{query.object_id}"
+          "#{response_path}-#{query.object_id}"
         end
 
         # Get a complexity value for a field,
@@ -91,22 +92,37 @@ module GraphQL
 
         # Selections on an object may apply differently depending on what is _actually_ returned by the resolve function.
         # Find the maximum possible complexity among those combinations.
-        class TypeComplexity
+        class AbstractTypeComplexity
           def initialize
             @types = Hash.new { |h, k| h[k] = {} }
           end
 
           # Return the max possible complexity for types in this selection
           def max_possible_complexity
-            @types.map do |type, fields|
-              fields.values.inject(:+)
-            end.max
+            max = 0
+            @types.each_value do |fields|
+              complexity = fields.each_value.inject(:+)
+              max = complexity if complexity > max
+            end
+            max
           end
 
           # Store the complexity for the branch on `type_defn`.
           # Later we will see if this is the max complexity among branches.
           def merge(type_defn, key, complexity)
             @types[type_defn][key] = complexity
+          end
+        end
+
+        class ConcreteTypeComplexity
+          attr_reader :max_possible_complexity
+
+          def initialize
+            @max_possible_complexity = 0
+          end
+
+          def merge(complexity)
+            @max_possible_complexity += complexity
           end
         end
       end

--- a/lib/graphql/analysis/ast/query_complexity.rb
+++ b/lib/graphql/analysis/ast/query_complexity.rb
@@ -40,7 +40,7 @@ module GraphQL
           own_complexity = get_complexity(node, visitor.field_definition, child_complexity, visitor)
 
           if @complexities_on_type.last.is_a?(AbstractTypeComplexity)
-            key = selection_key(visitor.response_path_str, visitor.query)
+            key = selection_key(visitor.response_path, visitor.query)
             parent_type = visitor.parent_type_definition
             query.possible_types(parent_type).each do |type|
               @complexities_on_type.last.merge(type, key, own_complexity)
@@ -69,7 +69,7 @@ module GraphQL
           # We add the query object id to support multiplex queries
           # even if they have the same response path, they should
           # always be added.
-          "#{response_path}-#{query.object_id}"
+          "#{response_path.join(".")}-#{query.object_id}"
         end
 
         # Get a complexity value for a field,

--- a/lib/graphql/analysis/ast/visitor.rb
+++ b/lib/graphql/analysis/ast/visitor.rb
@@ -60,6 +60,11 @@ module GraphQL
           @response_path.dup
         end
 
+        # @return String The a stringified path to the response key for the current field
+        def response_path_str(separator = '.')
+          @response_path.join(separator)
+        end
+
         # Visitor Hooks
 
         def on_operation_definition(node, parent)

--- a/lib/graphql/analysis/ast/visitor.rb
+++ b/lib/graphql/analysis/ast/visitor.rb
@@ -60,11 +60,6 @@ module GraphQL
           @response_path.dup
         end
 
-        # @return String The a stringified path to the response key for the current field
-        def response_path_str(separator = '.')
-          @response_path.join(separator)
-        end
-
         # Visitor Hooks
 
         def on_operation_definition(node, parent)

--- a/lib/graphql/language/lexer.rb
+++ b/lib/graphql/language/lexer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GraphQL
 module Language
 module Lexer
@@ -1369,7 +1371,7 @@ end
 def self.record_comment(ts, te, meta)
 token = GraphQL::Language::Token.new(
 name: :COMMENT,
-value: meta[:data][ts...te].pack(PACK_DIRECTIVE).force_encoding(UTF_8_ENCODING),
+value: meta[:data][ts, te - ts].pack(PACK_DIRECTIVE).force_encoding(UTF_8_ENCODING),
 line: meta[:line],
 col: meta[:col],
 prev_token: meta[:previous_token],
@@ -1383,7 +1385,7 @@ end
 def self.emit(token_name, ts, te, meta)
 meta[:tokens] << token = GraphQL::Language::Token.new(
 name: token_name,
-value: meta[:data][ts...te].pack(PACK_DIRECTIVE).force_encoding(UTF_8_ENCODING),
+value: meta[:data][ts, te - ts].pack(PACK_DIRECTIVE).force_encoding(UTF_8_ENCODING),
 line: meta[:line],
 col: meta[:col],
 prev_token: meta[:previous_token],
@@ -1415,8 +1417,7 @@ UTF_8_ENCODING = "UTF-8"
 
 def self.emit_string(ts, te, meta, block:)
 quotes_length = block ? 3 : 1
-content_range = (ts + quotes_length)...(te - quotes_length)
-value = meta[:data][content_range].pack(PACK_DIRECTIVE).force_encoding(UTF_8_ENCODING) || ''
+value = meta[:data][ts + quotes_length, te - ts - 2 * quotes_length].pack(PACK_DIRECTIVE).force_encoding(UTF_8_ENCODING) || ''
 line_incr = 0
 if block && !value.length.zero?
 line_incr = value.count("\n")

--- a/lib/graphql/language/lexer.rl
+++ b/lib/graphql/language/lexer.rl
@@ -105,6 +105,7 @@
   *|;
 }%%
 
+# frozen_string_literal: true
 
 module GraphQL
   module Language
@@ -152,7 +153,7 @@ module GraphQL
       def self.record_comment(ts, te, meta)
         token = GraphQL::Language::Token.new(
           name: :COMMENT,
-          value: meta[:data][ts...te].pack(PACK_DIRECTIVE).force_encoding(UTF_8_ENCODING),
+          value: meta[:data][ts, te - ts].pack(PACK_DIRECTIVE).force_encoding(UTF_8_ENCODING),
           line: meta[:line],
           col: meta[:col],
           prev_token: meta[:previous_token],
@@ -166,7 +167,7 @@ module GraphQL
       def self.emit(token_name, ts, te, meta)
         meta[:tokens] << token = GraphQL::Language::Token.new(
           name: token_name,
-          value: meta[:data][ts...te].pack(PACK_DIRECTIVE).force_encoding(UTF_8_ENCODING),
+          value: meta[:data][ts, te - ts].pack(PACK_DIRECTIVE).force_encoding(UTF_8_ENCODING),
           line: meta[:line],
           col: meta[:col],
           prev_token: meta[:previous_token],
@@ -198,8 +199,7 @@ module GraphQL
 
       def self.emit_string(ts, te, meta, block:)
         quotes_length = block ? 3 : 1
-        content_range = (ts + quotes_length)...(te - quotes_length)
-        value = meta[:data][content_range].pack(PACK_DIRECTIVE).force_encoding(UTF_8_ENCODING) || ''
+        value = meta[:data][ts + quotes_length, te - ts - 2 * quotes_length].pack(PACK_DIRECTIVE).force_encoding(UTF_8_ENCODING) || ''
         line_incr = 0
         if block && !value.length.zero?
           line_incr = value.count("\n")


### PR DESCRIPTION
When profiling some common queries in our application I noticed a large amount of memory was being allocated by the analysis process. The graphql gem allocated 713,654 bytes during the execution of the query with the top 5 allocations by file being:

```
    257032  /Users/jturkel/.rvm/gems/ruby-2.6.3@dandelion/gems/graphql-1.9.6/lib/graphql/language/lexer.rb
    110094  /Users/jturkel/.rvm/gems/ruby-2.6.3@dandelion/gems/graphql-1.9.6/lib/graphql/analysis/ast/query_complexity.rb
     85112  /Users/jturkel/.rvm/gems/ruby-2.6.3@dandelion/gems/graphql-1.9.6/lib/graphql/language/nodes.rb
     79456  parser.y
     48400  /Users/jturkel/.rvm/gems/ruby-2.6.3@dandelion/gems/graphql-1.9.6/lib/graphql/static_validation/rules/fields_will_merge.rb
 ```

The worst offenders in lib/graphql/analysis/ast/query_complexity.rb were:
* [query_complexity.rb:96](https://github.com/rmosolgo/graphql-ruby/blob/v1.9.7/lib/graphql/analysis/ast/query_complexity.rb#L96) allocating 48,432 bytes via hashes
* [query_complexity.rb:71](https://github.com/rmosolgo/graphql-ruby/blob/v1.9.7/lib/graphql/analysis/ast/query_complexity.rb#L71) allocating 25,584 bytes via strings
* [query_complexity.rb:109](https://github.com/rmosolgo/graphql-ruby/blob/v1.9.7/lib/graphql/analysis/ast/query_complexity.rb#L109) allocating 12,295 bytes in hashes via the hashes defaulting function

The optimizations in this patch reduce the graphql gem allocations for this scenario down to 619,704 bytes (roughly 13%). The biggest win came from avoiding hash allocations altogether when a given node in the analysis can only have a single type. The other optimizations were just avoiding some array allocations.

An iterations/sec benchmark of my changes was faster but not statistically significant:

Before: 122.269  (±13.9%) i/s -    600.000  in   5.021482s
After: 127.342  (± 7.9%) i/s -    638.000  in   5.045393s