### PR TITLE
Fix error when required args are not visible

### DIFF
--- a/lib/graphql/static_validation/rules/required_arguments_are_present.rb
+++ b/lib/graphql/static_validation/rules/required_arguments_are_present.rb
@@ -17,7 +17,7 @@ module GraphQL
 
       def assert_required_args(ast_node, defn)
         present_argument_names = ast_node.arguments.map(&:name)
-        required_argument_names = defn.arguments.values
+        required_argument_names = context.warden.arguments(defn)
           .select { |a| a.type.kind.non_null? }
           .map(&:name)
 

--- a/spec/graphql/static_validation/rules/required_arguments_are_present_spec.rb
+++ b/spec/graphql/static_validation/rules/required_arguments_are_present_spec.rb
@@ -70,4 +70,29 @@ describe GraphQL::StaticValidation::RequiredArgumentsArePresent do
       assert_equal(expected_errors, errors)
     end
   end
+
+  describe "when a required arg is hidden" do
+    class Query < GraphQL::Schema::Object
+      field :int, Integer, null: true do
+        argument :input, Integer, required: true do
+          def visible?(*)
+            false
+          end
+        end
+      end
+
+      def int(input: -1)
+        input
+      end
+    end
+
+    class HiddenArgSchema < GraphQL::Schema
+      query(Query)
+    end
+
+    it "Doesn't require a hidden input" do
+      res = HiddenArgSchema.execute("{ int }")
+      assert_equal -1, res["data"]["int"]
+    end
+  end
 end


### PR DESCRIPTION
If an argument is required, but not `visible?`, it should not cause an error for the query, because it _doesn't exist_ for the current query. 

Fixes #2392 and Fixes #1439