### PR TITLE
Updating multiplex analyzer to better match the functionality of query analyzer

### DIFF
--- a/lib/graphql/analysis/ast/analyzer.rb
+++ b/lib/graphql/analysis/ast/analyzer.rb
@@ -5,10 +5,12 @@ module GraphQL
       # Query analyzer for query ASTs. Query analyzers respond to visitor style methods
       # but are prefixed by `enter` and `leave`.
       #
-      # @param [GraphQL::Query] The query to analyze
+      # @param query [GraphQL::Query] The queries to analyze
+      # @param multiplex [Graphql::Execute::Multiplex]
       class Analyzer
-        def initialize(query)
+        def initialize(query, multiplex: nil)
           @query = query
+          @multiplex = multiplex
         end
 
         # Analyzer hook to decide at analysis time whether a query should
@@ -23,6 +25,21 @@ module GraphQL
         # @return [Any] The analyzer result
         def result
           raise NotImplementedError
+        end
+
+        # Return true or false based on wether this Analyzer is being used as a
+        # multiplex analyzer or a query analyzer
+        # @return [Boolean] Is or is not a multiplex analyzer
+        def multiplex?
+          !multiplex.nil?
+        end
+
+        # Accessor to change what GraphQL::Query the @query variable points to. This
+        # is used in a multiplex query to change the current query being visited as each
+        # query is being analyzed.
+        # @param [GraphQL::Query] The current query being visited
+        def set_current_query(current_query)
+          @query = current_query
         end
 
         # Don't use make_visit_method because it breaks `super`
@@ -56,6 +73,7 @@ module GraphQL
         protected
 
         attr_reader :query
+        attr_reader :multiplex
       end
     end
   end

--- a/lib/graphql/analysis/ast/max_query_complexity.rb
+++ b/lib/graphql/analysis/ast/max_query_complexity.rb
@@ -7,12 +7,18 @@ module GraphQL
       # see {Schema#max_complexity} and {Query#max_complexity}
       class MaxQueryComplexity < QueryComplexity
         def result
-          return if query.max_complexity.nil?
+          max_complexity = if multiplex?
+            multiplex.max_complexity
+          else
+            query.max_complexity
+          end
+
+          return if max_complexity.nil?
 
           total_complexity = max_possible_complexity
 
-          if total_complexity > query.max_complexity
-            GraphQL::AnalysisError.new("Query has complexity of #{total_complexity}, which exceeds max complexity of #{query.max_complexity}")
+          if total_complexity > max_complexity
+            GraphQL::AnalysisError.new("Query has complexity of #{total_complexity}, which exceeds max complexity of #{max_complexity}")
           else
             nil
           end

--- a/lib/graphql/analysis/ast/max_query_depth.rb
+++ b/lib/graphql/analysis/ast/max_query_depth.rb
@@ -4,10 +4,16 @@ module GraphQL
     module AST
       class MaxQueryDepth < QueryDepth
         def result
-          return unless query.max_depth
+          max_suported_depth = if multiplex?
+            multiplex.schema.max_depth
+          else
+            query.max_depth
+          end
 
-          if @max_depth > query.max_depth
-            GraphQL::AnalysisError.new("Query has depth of #{@max_depth}, which exceeds max depth of #{query.max_depth}")
+          return if max_suported_depth.nil?
+
+          if @max_depth > max_suported_depth
+            GraphQL::AnalysisError.new("Query has depth of #{@max_depth}, which exceeds max depth of #{max_suported_depth}")
           else
             nil
           end

--- a/lib/graphql/analysis/ast/query_complexity.rb
+++ b/lib/graphql/analysis/ast/query_complexity.rb
@@ -6,7 +6,7 @@ module GraphQL
       class QueryComplexity < Analyzer
         # State for the query complexity calculation:
         # - `complexities_on_type` holds complexity scores for each type in an IRep node
-        def initialize(query)
+        def initialize(query, multiplex: nil)
           super
           @complexities_on_type = [ConcreteTypeComplexity.new]
         end

--- a/lib/graphql/analysis/ast/query_depth.rb
+++ b/lib/graphql/analysis/ast/query_depth.rb
@@ -15,7 +15,7 @@ module GraphQL
     #
     module AST
       class QueryDepth < Analyzer
-        def initialize(query)
+        def initialize(query, multiplex: nil)
           @max_depth = 0
           @current_depth = 0
           @skip_depth = 0


### PR DESCRIPTION
This PR is related to https://github.com/rmosolgo/graphql-ruby/issues/2388. 

In this PR the signature of the analyzer class will now take in the `GraphQL::Query` object along side the `GraphQL::Execution::Multiplex` object. Before this change when multiplex analyzers were initialized, the `GraphQL::Execution::Multiplex` was passed as the query variable. Now, when analyzing a multiplex query the current query being analyzed is updated in all multiplex analyzers, and the multiplex object is passed into the initialization of the class. This should more closely aline the functionality query & multiplex analyzers, as well as have a clear understand of what objects are being initialized.  

A change was also made to respect the`.analyze?` method in multiplex analyzers in the same way they currently work when being used as a query analyzer. Any multiplex analyzer will not run if `.analyze?` returns false to match the query analyzer behaviour. `GraphQL::Analysis::AST#analyze_multiplex` spec were also buffed up, as they seemed to sparse.

Look forward to your feedback, let me know if you would like any other changes made based on this one. 😄