### PR TITLE
Added default missing_field_resolver to avoid nil pointer exceptions and to provide better error messages

### DIFF
--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -284,10 +284,13 @@ module GraphQL
         end
 
         def build_interface_type(interface_type_definition, type_resolver)
+          missing_field_resolver = ->(field, obj, args, ctx) {
+            raise InvalidDocumentError.new("Type \"#{ctx.parent_type.name}\" is missing field \"#{field.name}\".")
+          }
           interface = GraphQL::InterfaceType.define(
             name: interface_type_definition.name,
             description: interface_type_definition.description,
-            fields: Hash[build_fields(interface_type_definition.fields, type_resolver, default_resolve: nil)],
+            fields: Hash[build_fields(interface_type_definition.fields, type_resolver, default_resolve: missing_field_resolver)],
           )
 
           interface.ast_node = interface_type_definition


### PR DESCRIPTION
While experimenting with GraphQL, I accidentally added a non-existent field to an interface.  The results was an obscure nil pointer exception.  I had a very hard time finding the root cause.

To make it easier the next time, this PR adds a default `missing_field_resolver` to interface types.

Here's a minimal example to reproduce the error:

```ruby
require 'graphql'
require 'ostruct'

definition_string = %{
  interface Animal {
    name: String
    weight: Int
  }

  type Monkey implements Animal {
    name: String
  }

  type Bird implements Animal {
    name: String
  }

  type Query {
    animals: [Animal]
  }
}

resolver = {
  "Query" => {
    "animals" => ->(obj, args, ctx) {
      [
        { "name" => "a bird", "weight" => 10 },
        { "name" => "a monkey", "weight" => 2 },
      ].map{ |a| OpenStruct.new(a) }
    },
  },
  "resolve_type" => ->(type, obj, ctx) {
    ctx.schema.possible_types(type)[0]
  },
}

query_string = "
query {
  animals {
    name
    weight
  }
}"

schema = GraphQL::Schema::BuildFromDefinition.from_definition(
  definition_string, default_resolve: resolver
)

puts schema.execute(query_string).to_h
```

And here's the error the emitted before this PR:

```
/Users/xavi_ramirez/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/graphql-1.9.6/lib/graphql/schema/build_from_definition.rb:325:in `block (2 levels) in build_fields': undefined method `call' for nil:NilClass (NoMethodError)
Did you mean?  caller
	from /Users/xavi_ramirez/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/graphql-1.9.6/lib/graphql/field.rb:248:in `resolve'
	from /Users/xavi_ramirez/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/graphql-1.9.6/lib/graphql/execution/execute.rb:321:in `call'
...snip...
```

Here's the error after:

```
/Users/xavi_ramirez/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/graphql-1.9.6/lib/graphql/schema/build_from_definition.rb:286:in `block in build_interface_type': Type "Bird" is missing field "weight". (GraphQL::Schema::InvalidDocumentError)
	from /Users/xavi_ramirez/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/graphql-1.9.6/lib/graphql/schema/build_from_definition.rb:325:in `block (2 levels) in build_fields'
	from /Users/xavi_ramirez/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/graphql-1.9.6/lib/graphql/field.rb:248:in `resolve'
...snip...
```