### PR TITLE
Don't warn about field name conflicts when parsing a schema from SDL

### DIFF
--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -277,6 +277,7 @@ module GraphQL
               resolve: ->(obj, args, ctx) { default_resolve.call(field.graphql_definition, obj, args, ctx) },
               deprecation_reason: build_deprecation_reason(field_definition.directives),
               ast_node: field_definition,
+              method_conflict_warning: false,
               camelize: false,
             ) do
               builder.build_arguments(self, field_definition.arguments, type_resolver)

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -139,6 +139,11 @@ module GraphQL
         end
       end
 
+      # @return [Boolean] Should we warn if this field's name conflicts with a built-in method?
+      def method_conflict_warning?
+        @method_conflict_warning
+      end
+
       # @param name [Symbol] The underscore-cased version of this field name (will be camelized for the GraphQL API)
       # @param type [Class, GraphQL::BaseType, Array] The return type of this field
       # @param owner [Class] The type that this field belongs to
@@ -163,7 +168,8 @@ module GraphQL
       # @param extensions [Array<Class>] Named extensions to apply to this field (see also {#extension})
       # @param trace [Boolean] If true, a {GraphQL::Tracing} tracer will measure this scalar field
       # @param ast_node [Language::Nodes::FieldDefinition, nil] If this schema was parsed from definition, this AST node defined the field
-      def initialize(type: nil, name: nil, owner: nil, null: nil, field: nil, function: nil, description: nil, deprecation_reason: nil, method: nil, hash_key: nil, resolver_method: nil, resolve: nil, connection: nil, max_page_size: nil, scope: nil, introspection: false, camelize: true, trace: nil, complexity: 1, ast_node: nil, extras: [], extensions: [], resolver_class: nil, subscription_scope: nil, relay_node_field: false, relay_nodes_field: false, arguments: {}, &definition_block)
+      # @param method_conflict_warning [Boolean] If false, skip the warning if this field's method conflicts with a built-in method
+      def initialize(type: nil, name: nil, owner: nil, null: nil, field: nil, function: nil, description: nil, deprecation_reason: nil, method: nil, hash_key: nil, resolver_method: nil, resolve: nil, connection: nil, max_page_size: nil, scope: nil, introspection: false, camelize: true, trace: nil, complexity: 1, ast_node: nil, extras: [], extensions: [], resolver_class: nil, subscription_scope: nil, relay_node_field: false, relay_nodes_field: false, method_conflict_warning: true, arguments: {}, &definition_block)
         if name.nil?
           raise ArgumentError, "missing first `name` argument or keyword `name:`"
         end
@@ -225,6 +231,7 @@ module GraphQL
         @relay_node_field = relay_node_field
         @relay_nodes_field = relay_nodes_field
         @ast_node = ast_node
+        @method_conflict_warning = method_conflict_warning
 
         # Override the default from HasArguments
         @own_arguments = {}

--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -53,8 +53,8 @@ module GraphQL
         # @param field_defn [GraphQL::Schema::Field]
         # @return [void]
         def add_field(field_defn)
-          if CONFLICT_FIELD_NAMES.include?(field_defn.resolver_method)
-            warn "#{self.graphql_name}'s `field :#{field_defn.name}` conflicts with a built-in method, use `resolver_method:` to pick a different resolver method for this field (for example, `resolver_method: :resolve_#{field_defn.resolver_method}` and `def resolve_#{field_defn.resolver_method}`)"
+          if CONFLICT_FIELD_NAMES.include?(field_defn.resolver_method) && field_defn.method_conflict_warning?
+            warn "#{self.graphql_name}'s `field :#{field_defn.name}` conflicts with a built-in method, use `resolver_method:` to pick a different resolver method for this field (for example, `resolver_method: :resolve_#{field_defn.resolver_method}` and `def resolve_#{field_defn.resolver_method}`). Or use `method_conflict_warning: false` to suppress this warning."
           end
           own_fields[field_defn.name] = field_defn
           nil

--- a/spec/graphql/schema/object_spec.rb
+++ b/spec/graphql/schema/object_spec.rb
@@ -315,7 +315,7 @@ describe GraphQL::Schema::Object do
 
   describe "when fields conflict with built-ins" do
     it "warns when no override" do
-      expected_warning = "X's `field :method` conflicts with a built-in method, use `resolver_method:` to pick a different resolver method for this field (for example, `resolver_method: :resolve_method` and `def resolve_method`)\n"
+      expected_warning = "X's `field :method` conflicts with a built-in method, use `resolver_method:` to pick a different resolver method for this field (for example, `resolver_method: :resolve_method` and `def resolve_method`). Or use `method_conflict_warning: false` to suppress this warning.\n"
       assert_output "", expected_warning do
         Class.new(GraphQL::Schema::Object) do
           graphql_name "X"
@@ -330,6 +330,26 @@ describe GraphQL::Schema::Object do
           graphql_name "X"
           field :method, String, null: true, resolver_method: :resolve_method
         end
+      end
+    end
+
+    it "doesn't warn with a suppression" do
+      assert_output "", "" do
+        Class.new(GraphQL::Schema::Object) do
+          graphql_name "X"
+          field :method, String, null: true, method_conflict_warning: false
+        end
+      end
+    end
+
+    it "doesn't warn when parsing a schema" do
+      assert_output "", "" do
+        schema = GraphQL::Schema.from_definition <<-GRAPHQL
+        type Query {
+          method: String
+        }
+        GRAPHQL
+        assert_equal ["method"], schema.query.fields.keys
       end
     end
   end


### PR DESCRIPTION
It's nice to have warnings when things might go wrong. It's also nice to _not_ have warnings when nothing's going wrong 😬 

This test didn't fail on master, so I'm PR-ing 1.10-dev. I think it's because I ported `build_from_definition` on this branch.