### PR TITLE
Remove indentation from heredoc so markdown doesn't treat it like code

### DIFF
--- a/guides/_plugins/api_doc.rb
+++ b/guides/_plugins/api_doc.rb
@@ -23,9 +23,9 @@ module GraphQLSite
     def link_to_img(img_path, img_title)
       full_img_path = "#{@context.registers[:site].baseurl}#{img_path}"
       <<-HTML
-        <a href="#{full_img_path}" target="_blank" class="img-link">
-          <img src="#{full_img_path}" title="#{img_title}" alt="#{img_title}" />
-        </a>
+<a href="#{full_img_path}" target="_blank" class="img-link">
+  <img src="#{full_img_path}" title="#{img_title}" alt="#{img_title}" />
+</a>
       HTML
     end
   end
@@ -75,7 +75,7 @@ module GraphQLSite
 
     def render(context)
       <<-HTML.chomp
-      <a href="#{context["site"]["baseurl"]}/#{@path}">#{@text}</a>
+<a href="#{context["site"]["baseurl"]}/#{@path}">#{@text}</a>
       HTML
     end
 


### PR DESCRIPTION
Trying to fix this: 

![image](https://user-images.githubusercontent.com/2231765/61885412-ca788180-aecb-11e9-9355-c71e99de9fed.png)
