### PR TITLE
Memoize generated GraphQL query strings

### DIFF
--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -73,7 +73,11 @@ module GraphQL
         end
 
         def to_query_string(printer: GraphQL::Language::Printer.new)
-          @query_string ||= printer.print(self)
+          if printer.is_a?(GraphQL::Language::Printer)
+            @query_string ||= printer.print(self)
+          else
+            printer.print(self)
+          end
         end
 
         # This creates a copy of `self`, with `new_options` applied.
@@ -83,7 +87,9 @@ module GraphQL
           copied_self = dup
           new_options.each do |key, value|
             copied_self.instance_variable_set(:"@#{key}", value)
-            copied_self.instance_variable_set(:@query_string, nil)
+            if copied_self.instance_variable_defined?(:@query_string)
+              copied_self.instance_variable_set(:@query_string, nil)
+            end
           end
           copied_self
         end

--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -73,7 +73,7 @@ module GraphQL
         end
 
         def to_query_string(printer: GraphQL::Language::Printer.new)
-          printer.print(self)
+          @query_string ||= printer.print(self)
         end
 
         # This creates a copy of `self`, with `new_options` applied.
@@ -83,6 +83,7 @@ module GraphQL
           copied_self = dup
           new_options.each do |key, value|
             copied_self.instance_variable_set(:"@#{key}", value)
+            copied_self.instance_variable_set(:@query_string, nil)
           end
           copied_self
         end


### PR DESCRIPTION
Diff between the benchmarks with and without caching:

Query & validation:
```
--- a/no_cache
+++ b/cache
@@ -1,31 +1,31 @@
 Warming up --------------------------------------
                query     2.000  i/100ms
 Calculating -------------------------------------
-               query     22.086  (± 4.5%) i/s -    110.000  in   5.003548s
+               query     22.323  (± 4.5%) i/s -    112.000  in   5.036334s
 Warming up --------------------------------------
 validate - introspection
-                        53.000  i/100ms
+                        56.000  i/100ms
 validate - abstract fragments
-                       108.000  i/100ms
+                       112.000  i/100ms
 validate - abstract fragments 2
-                        59.000  i/100ms
+                        60.000  i/100ms
 validate - big query     6.000  i/100ms
 Calculating -------------------------------------
 validate - introspection
-                        561.041  (± 6.8%) i/s -      2.809k in   5.030818s
+                        569.097  (± 6.7%) i/s -      2.856k in   5.041044s
 validate - abstract fragments
-                          1.097k (± 8.7%) i/s -      5.508k in   5.058356s
+                          1.137k (± 7.5%) i/s -      5.712k in   5.051612s
 validate - abstract fragments 2
-                        560.746  (±10.9%) i/s -      2.773k in   5.007613s
-validate - big query     52.351  (±17.2%) i/s -    258.000  in   5.097926s
+                        610.578  (± 8.0%) i/s -      3.060k in   5.045672s
+validate - big query     63.452  (± 6.3%) i/s -    318.000  in   5.036684s
```
