### PR TITLE
Avoid recomputation of field keys during tracing

### DIFF
--- a/lib/graphql/tracing/platform_tracing.rb
+++ b/lib/graphql/tracing/platform_tracing.rb
@@ -21,6 +21,7 @@ module GraphQL
       def trace(key, data)
         case key
         when "lex", "parse", "validate", "analyze_query", "analyze_multiplex", "execute_query", "execute_query_lazy", "execute_multiplex"
+          data.fetch(:query).context.namespace(self.class)[:platform_key_cache] = {} if key == "execute_query"
           platform_key = @platform_keys.fetch(key)
           platform_trace(platform_key, key, data) do
             yield
@@ -32,9 +33,11 @@ module GraphQL
             trace_field = true # implemented with instrumenter
           else
             field = data[:field]
-            owner = data[:owner]
-            # Lots of duplicated work here, can this be done ahead of time?
-            platform_key = platform_field_key(owner, field)
+            platform_key_cache = data.fetch(:query).context.namespace(self.class).fetch(:platform_key_cache)
+            platform_key = platform_key_cache.fetch(field) do
+              platform_key_cache[field] = platform_field_key(data[:owner], field)
+            end
+
             return_type = field.type.unwrap
             # Handle LateBoundTypes, which don't have `#kind`
             trace_field = if return_type.respond_to?(:kind) && (return_type.kind.scalar? || return_type.kind.enum?)


### PR DESCRIPTION
Profiling of some of our queries showed we were spending a decent amount of time and allocating a fair amount of memory generating field trace keys. Caching this information within the scope of a query execution shaved 5.8% off of our query latency and saved 1MB in memory allocations. 