### PR TITLE
Normalize root types when using define/class

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -94,9 +94,9 @@ module GraphQL
       :default_mask,
       :cursor_encoder,
       # If these are given as classes, normalize them. Accept `nil` when building from string.
-      query: -> (schema, t) { schema.query = t.respond_to?(:graphql_definition) ? t.graphql_definition : t },
-      mutation: -> (schema, t) { schema.mutation = t.respond_to?(:graphql_definition) ? t.graphql_definition : t },
-      subscription: -> (schema, t) { schema.subscription = t.respond_to?(:graphql_definition) ? t.graphql_definition : t },
+      query: ->(schema, t) { schema.query = t.respond_to?(:graphql_definition) ? t.graphql_definition : t },
+      mutation: ->(schema, t) { schema.mutation = t.respond_to?(:graphql_definition) ? t.graphql_definition : t },
+      subscription: ->(schema, t) { schema.subscription = t.respond_to?(:graphql_definition) ? t.graphql_definition : t },
       disable_introspection_entry_points: ->(schema) { schema.disable_introspection_entry_points = true },
       directives: ->(schema, directives) { schema.directives = directives.reduce({}) { |m, d| m[d.name] = d; m } },
       directive: ->(schema, directive) { schema.directives[directive.graphql_name] = directive },

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -85,7 +85,6 @@ module GraphQL
     extend GraphQL::Schema::FindInheritedValue
 
     accepts_definitions \
-      :query, :mutation, :subscription,
       :query_execution_strategy, :mutation_execution_strategy, :subscription_execution_strategy,
       :max_depth, :max_complexity, :default_max_page_size,
       :orphan_types, :resolve_type, :type_error, :parse_error,
@@ -94,6 +93,10 @@ module GraphQL
       :object_from_id, :id_from_object,
       :default_mask,
       :cursor_encoder,
+      # If these are given as classes, normalize them. Accept `nil` when building from string.
+      query: -> (schema, t) { schema.query = t.respond_to?(:graphql_definition) ? t.graphql_definition : t },
+      mutation: -> (schema, t) { schema.mutation = t.respond_to?(:graphql_definition) ? t.graphql_definition : t },
+      subscription: -> (schema, t) { schema.subscription = t.respond_to?(:graphql_definition) ? t.graphql_definition : t },
       disable_introspection_entry_points: ->(schema) { schema.disable_introspection_entry_points = true },
       directives: ->(schema, directives) { schema.directives = directives.reduce({}) { |m, d| m[d.name] = d; m } },
       directive: ->(schema, directive) { schema.directives[directive.graphql_name] = directive },


### PR DESCRIPTION
I think a `.define`-based schema will choke if the root types are class-based. 