### PR TITLE
fix printing schema classes

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -705,7 +705,7 @@ module GraphQL
       # Eventually, the methods will be moved into this class, removing the need for the singleton.
       def_delegators :graphql_definition,
         # Schema structure
-        :as_json, :to_json, :to_document, :to_definition,
+        :as_json, :to_json, :to_document, :to_definition, :ast_node,
         # Execution
         :execute, :multiplex,
         :static_validator, :introspection_system,

--- a/spec/graphql/schema/printer_spec.rb
+++ b/spec/graphql/schema/printer_spec.rb
@@ -866,4 +866,18 @@ SCHEMA
       assert_equal expected.chomp, GraphQL::Schema::Printer.new(schema, context: context, only: only_filter).print_schema
     end
   end
+
+  it "prints schemas from class" do
+    class TestPrintSchema < GraphQL::Schema
+      class OddlyNamedQuery < GraphQL::Schema::Object
+        field :int, Int, null: false
+      end
+
+      query(OddlyNamedQuery)
+    end
+
+
+    str = GraphQL::Schema::Printer.print_schema TestPrintSchema
+    assert_equal "schema {\n  query: OddlyNamedQuery\n}\n\ntype OddlyNamedQuery {\n  int: Int!\n}", str
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/rmosolgo/graphql-ruby/issues/2301

This will be fixed better in 1.10 when the class has its own AST node since it's built directly.