### PR TITLE
Fix disabling of max_complexity and max_depth during query execution

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -78,7 +78,7 @@ module GraphQL
     # @param max_complexity [Numeric] the maximum field complexity for this query (falls back to schema-level value)
     # @param except [<#call(schema_member, context)>] If provided, objects will be hidden from the schema when `.call(schema_member, context)` returns truthy
     # @param only [<#call(schema_member, context)>] If provided, objects will be hidden from the schema when `.call(schema_member, context)` returns false
-    def initialize(schema, query_string = nil, query: nil, document: nil, context: nil, variables: nil, validate: true, subscription_topic: nil, operation_name: nil, root_value: nil, max_depth: nil, max_complexity: nil, except: nil, only: nil)
+    def initialize(schema, query_string = nil, query: nil, document: nil, context: nil, variables: nil, validate: true, subscription_topic: nil, operation_name: nil, root_value: nil, max_depth: schema.max_depth, max_complexity: schema.max_complexity, except: nil, only: nil)
       # Even if `variables: nil` is passed, use an empty hash for simpler logic
       variables ||= {}
       @schema = schema
@@ -127,8 +127,8 @@ module GraphQL
       @operation_name = operation_name
       @prepared_ast = false
       @validation_pipeline = nil
-      @max_depth = max_depth || schema.max_depth
-      @max_complexity = max_complexity || schema.max_complexity
+      @max_depth = max_depth
+      @max_complexity = max_complexity
 
       @result_values = nil
       @executed = false
@@ -368,7 +368,7 @@ module GraphQL
         parse_error: parse_error,
         operation_name_error: operation_name_error,
         max_depth: @max_depth,
-        max_complexity: @max_complexity || schema.max_complexity,
+        max_complexity: @max_complexity
       )
     end
 

--- a/spec/graphql/analysis/ast/max_query_complexity_spec.rb
+++ b/spec/graphql/analysis/ast/max_query_complexity_spec.rb
@@ -45,7 +45,7 @@ describe GraphQL::Analysis::AST::MaxQueryComplexity do
 
   describe "when max_complexity is decreased at query-level" do
     before do
-      schema.max_complexity = 100
+      schema.max_complexity(100)
     end
 
     let(:max_complexity) { 7 }
@@ -58,12 +58,24 @@ describe GraphQL::Analysis::AST::MaxQueryComplexity do
 
   describe "when max_complexity is increased at query-level" do
     before do
-      schema.max_complexity = 1
+      schema.max_complexity(1)
     end
 
     let(:max_complexity) { 10 }
 
     it "doesn't error" do
+      assert_nil result
+    end
+  end
+
+  describe "when max_complexity is nil at query-level" do
+    let(:max_complexity) { nil }
+
+    before do
+      schema.max_complexity(1)
+    end
+
+    it "is applied" do
       assert_nil result
     end
   end

--- a/spec/graphql/analysis/ast/max_query_depth_spec.rb
+++ b/spec/graphql/analysis/ast/max_query_depth_spec.rb
@@ -20,29 +20,27 @@ describe GraphQL::Analysis::AST::MaxQueryDepth do
       }
     }
   "}
-  let(:max_depth) { nil }
-  let(:query) {
-    GraphQL::Query.new(
-      schema.graphql_definition,
-      query_string,
-      variables: {},
-      max_depth: max_depth
-    )
-  }
+  let(:query) { GraphQL::Query.new(schema, query_string) }
   let(:result) {
     GraphQL::Analysis::AST.analyze_query(query, [GraphQL::Analysis::AST::MaxQueryDepth]).first
   }
 
   describe "when the query is deeper than max depth" do
-    let(:max_depth) { 5 }
-
     it "adds an error message for a too-deep query" do
       assert_equal "Query has depth of 7, which exceeds max depth of 5", result.message
     end
   end
 
   describe "when the query specifies a different max_depth" do
-    let(:max_depth) { 100 }
+    let(:query) { GraphQL::Query.new(schema, query_string, max_depth: 100) }
+
+    it "obeys that max_depth" do
+      assert_nil result
+    end
+  end
+
+  describe "when the query disables max_depth" do
+    let(:query) { GraphQL::Query.new(schema, query_string, max_depth: nil) }
 
     it "obeys that max_depth" do
       assert_nil result
@@ -51,7 +49,7 @@ describe GraphQL::Analysis::AST::MaxQueryDepth do
 
   describe "When the query is not deeper than max_depth" do
     before do
-      schema.max_depth = 100
+      schema.max_depth(100)
     end
 
     it "doesn't add an error" do
@@ -61,7 +59,8 @@ describe GraphQL::Analysis::AST::MaxQueryDepth do
 
   describe "when the max depth isn't set" do
     before do
-      schema.max_depth = nil
+      # Yuck - Can't override GraphQL::Schema.max_depth to return nil if it has already been set
+      schema.define_singleton_method(:max_depth) { |*| nil }
     end
 
     it "doesn't add an error message" do
@@ -71,7 +70,7 @@ describe GraphQL::Analysis::AST::MaxQueryDepth do
 
   describe "when a fragment exceeds max depth" do
     before do
-      schema.max_depth = 4
+      schema.max_depth(4)
     end
 
     let(:query_string) { "

--- a/spec/graphql/analysis/max_query_complexity_spec.rb
+++ b/spec/graphql/analysis/max_query_complexity_spec.rb
@@ -16,7 +16,7 @@ describe GraphQL::Analysis::MaxQueryComplexity do
 
   describe "when a query goes over max complexity" do
     before do
-      schema.max_complexity = 9
+      schema.max_complexity(9)
     end
 
     it "returns an error" do
@@ -25,9 +25,6 @@ describe GraphQL::Analysis::MaxQueryComplexity do
   end
 
   describe "when there is no max complexity" do
-    before do
-      schema.max_complexity = nil
-    end
     it "doesn't error" do
       assert_nil result["errors"]
     end
@@ -35,7 +32,7 @@ describe GraphQL::Analysis::MaxQueryComplexity do
 
   describe "when the query is less than the max complexity" do
     before do
-      schema.max_complexity = 99
+      schema.max_complexity(99)
     end
     it "doesn't error" do
       assert_nil result["errors"]
@@ -44,7 +41,7 @@ describe GraphQL::Analysis::MaxQueryComplexity do
 
   describe "when max_complexity is decreased at query-level" do
     before do
-      schema.max_complexity = 100
+      schema.max_complexity(100)
     end
     let(:result) {schema.execute(query_string, max_complexity: 7) }
 
@@ -55,7 +52,7 @@ describe GraphQL::Analysis::MaxQueryComplexity do
 
   describe "when max_complexity is increased at query-level" do
     before do
-      schema.max_complexity = 1
+      schema.max_complexity(1)
     end
     let(:result) {schema.execute(query_string, max_complexity: 10) }
 
@@ -64,9 +61,20 @@ describe GraphQL::Analysis::MaxQueryComplexity do
     end
   end
 
+  describe "when max_complexity is nil query-level" do
+    before do
+      schema.max_complexity(1)
+    end
+    let(:result) {schema.execute(query_string, max_complexity: nil) }
+
+    it "is applied" do
+      assert_nil result["errors"]
+    end
+  end
+
   describe "across a multiplex" do
     before do
-      schema.max_complexity = 9
+      schema.max_complexity(9)
     end
 
     let(:queries) { 5.times.map { |n|  { query: "{ cheese(id: #{n}) { id } }" } } }

--- a/spec/graphql/analysis/max_query_depth_spec.rb
+++ b/spec/graphql/analysis/max_query_depth_spec.rb
@@ -36,9 +36,17 @@ describe GraphQL::Analysis::MaxQueryDepth do
     end
   end
 
+  describe "when the query specifies a nil max_depth" do
+    let(:result) { schema.execute(query_string, max_depth: nil) }
+
+    it "obeys that max_depth" do
+      assert_nil result["errors"]
+    end
+  end
+
   describe "When the query is not deeper than max_depth" do
     before do
-      schema.max_depth = 100
+      schema.max_depth(100)
     end
 
     it "doesn't add an error" do
@@ -48,7 +56,8 @@ describe GraphQL::Analysis::MaxQueryDepth do
 
   describe "when the max depth isn't set" do
     before do
-      schema.max_depth = nil
+      # Yuck - Can't override GraphQL::Schema.max_depth to return nil if it has already been set
+      schema.define_singleton_method(:max_depth) { |*| nil }
     end
 
     it "doesn't add an error message" do
@@ -58,7 +67,7 @@ describe GraphQL::Analysis::MaxQueryDepth do
 
   describe "when a fragment exceeds max depth" do
     before do
-      schema.max_depth = 4
+      schema.max_depth(4)
     end
 
     let(:query_string) { "

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -30,7 +30,6 @@ describe GraphQL::Query do
     }
   |}
   let(:operation_name) { nil }
-  let(:max_depth) { nil }
   let(:query_variables) { {"cheeseId" => 2} }
   let(:schema) { Dummy::Schema }
   let(:document) { GraphQL.parse(query_string) }
@@ -39,8 +38,7 @@ describe GraphQL::Query do
     schema,
     query_string,
     variables: query_variables,
-    operation_name: operation_name,
-    max_depth: max_depth,
+    operation_name: operation_name
   )}
   let(:result) { query.result }
 
@@ -71,8 +69,7 @@ describe GraphQL::Query do
       res = GraphQL::Query.new(
         schema,
         variables: query_variables,
-        operation_name: operation_name,
-        max_depth: max_depth,
+        operation_name: operation_name
       ).result
       assert_equal 1, res["errors"].length
       assert_equal "No query string was present", res["errors"][0]["message"]
@@ -82,8 +79,7 @@ describe GraphQL::Query do
       query = GraphQL::Query.new(
         schema,
         variables: query_variables,
-        operation_name: operation_name,
-        max_depth: max_depth,
+        operation_name: operation_name
       )
       query.query_string = '{ __type(name: """Cheese""") { name } }'
       assert_equal "Cheese", query.result["data"] ["__type"]["name"]
@@ -174,8 +170,7 @@ describe GraphQL::Query do
       schema,
       document: document,
       variables: query_variables,
-      operation_name: operation_name,
-      max_depth: max_depth,
+      operation_name: operation_name
     )}
 
     it "runs the query using the already parsed document" do
@@ -560,7 +555,15 @@ describe GraphQL::Query do
     end
 
     describe "overriding max_depth" do
-      let(:max_depth) { 12 }
+      let(:query) {
+        GraphQL::Query.new(
+          schema,
+          query_string,
+          variables: query_variables,
+          operation_name: operation_name,
+          max_depth: 12
+        )
+      }
 
       it "overrides the schema's max_depth" do
         assert result["data"].key?("cheese")


### PR DESCRIPTION
The [doc](https://graphql-ruby.org/queries/complexity_and_depth) states that passing an explicit `max_complexity` or `max_depth` of nil will disable any schema level settings for `max_complexity` or `max_depth` but that wasn't working. This should fix that :)

I also fixed a problem with my changes in #2384 invoking `GraphQL::Schema.max_depth=(new_value)` rather than `GraphQL::Schema.max_depth(new_value = nil)` and a similar problem for `max_complexity`.