### PR TITLE
Just a couple clean-ups wrt ivars

### DIFF
--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -61,6 +61,7 @@ module GraphQL
         def initialize_copy(other)
           @children = nil
           @scalars = nil
+          @query_string = nil
         end
 
         # @return [Symbol] the method to call on {Language::Visitor} for this node
@@ -87,9 +88,6 @@ module GraphQL
           copied_self = dup
           new_options.each do |key, value|
             copied_self.instance_variable_set(:"@#{key}", value)
-            if copied_self.instance_variable_defined?(:@query_string)
-              copied_self.instance_variable_set(:@query_string, nil)
-            end
           end
           copied_self
         end

--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -85,11 +85,7 @@ module GraphQL
         # @param new_options [Hash]
         # @return [AbstractNode] a shallow copy of `self`
         def merge(new_options)
-          copied_self = dup
-          new_options.each do |key, value|
-            copied_self.instance_variable_set(:"@#{key}", value)
-          end
-          copied_self
+          dup.merge!(new_options)
         end
 
         # Copy `self`, but modify the copy so that `previous_child` is replaced by `new_child`
@@ -125,6 +121,15 @@ module GraphQL
           copy_of_self = merge(method_name => new_children)
           # Return the copy:
           copy_of_self
+        end
+
+        protected
+
+        def merge!(new_options)
+          new_options.each do |key, value|
+            instance_variable_set(:"@#{key}", value)
+          end
+          self
         end
 
         class << self


### PR DESCRIPTION
I like it better when objects don't set internal state on other objects, so in these patches I've moved around the instance variable manipulation so that it's done inside the object rather than being done from the outside.