### PR TITLE
Make conflicting field name check use :original_name instead of :resolver_method

### DIFF
--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -53,8 +53,8 @@ module GraphQL
         # @param field_defn [GraphQL::Schema::Field]
         # @return [void]
         def add_field(field_defn)
-          if CONFLICT_FIELD_NAMES.include?(field_defn.resolver_method)
-            warn "#{self.graphql_name}'s `field :#{field_defn.name}` conflicts with a built-in method, use `resolver_method:` to pick a different resolver method for this field (for example, `resolver_method: :resolve_#{field_defn.resolver_method}` and `def resolve_#{field_defn.resolver_method}`)"
+          if CONFLICT_FIELD_NAMES.include?(field_defn.original_name) && field_defn.original_name == field_defn.resolver_method
+            warn "#{self.graphql_name}'s `field :#{field_defn.original_name}` conflicts with a built-in method, use `resolver_method:` to pick a different resolver method for this field (for example, `resolver_method: :resolve_#{field_defn.original_name}` and `def resolve_#{field_defn.original_name}`)"
           end
           own_fields[field_defn.name] = field_defn
           nil

--- a/spec/graphql/schema/object_spec.rb
+++ b/spec/graphql/schema/object_spec.rb
@@ -324,11 +324,30 @@ describe GraphQL::Schema::Object do
       end
     end
 
+    it "warns when override matches field name" do
+      expected_warning = "X's `field :object` conflicts with a built-in method, use `resolver_method:` to pick a different resolver method for this field (for example, `resolver_method: :resolve_object` and `def resolve_object`)\n"
+      assert_output "", expected_warning do
+        Class.new(GraphQL::Schema::Object) do
+          graphql_name "X"
+          field :object, String, null: true, resolver_method: :object
+        end
+      end
+    end
+
     it "doesn't warn with an override" do
       assert_output "", "" do
         Class.new(GraphQL::Schema::Object) do
           graphql_name "X"
           field :method, String, null: true, resolver_method: :resolve_method
+        end
+      end
+    end
+
+    it "doesn't warn when passing object through using resolver_method" do
+      assert_output "", "" do
+        Class.new(GraphQL::Schema::Object) do
+          graphql_name "X"
+          field :thing, String, null: true, resolver_method: :object
         end
       end
     end


### PR DESCRIPTION
# Proposal

For field definitions change how conflicting field names are checked. Instead of checking the `resolver_method`, check the field name directly using `original_name`.

With this change, you should be able to write the following:

```ruby
field :value, SomeType, null: false, resolver_method: :object # pass the object through no warning

field :object, SomeType, null: false, resolver_method: :resolve_object # override no warning

field :object, String, null: true, resolver_method: :object # warning because original_name and resolver_method match

field :object, SomeType, null: false # warning because object is conflicting field name
```

# Why

The gem, specifically in `has_fields.rb`, performs a check for every field being added to the schema to ensure that the field name does not conflict with some built-in methods in GraphQL-Ruby and Ruby. This list includes, `:object`, `:context`, `:method`, and `:class`. As a result, if you name a field using these names you will get a warning to utilize `resolver_method:` to give the resolver a different name so not to clash with the built-ins. 

This is a good check however the check in its current form does not check the field name but rather the `resolver_method` (which defaults to the field name). In specific cases where using `method: :itself` to pass the object through would not suffice because the gem interprets the `method:` value as a hash key (`object[:itself]`) instead of returning `object.itself` we would use `resolver_method: :object` to pass the object directly through. 

This causes the warning to present itself because `:object` is listed as a conflicting field, however this use case is actually ok. This change updates the check to use the original field name and not the resolver method to allow for `resolver_method: :object` to be a viable solution to pass the underlying object through.

# How

See the diff, essentially perform the check on `original_name` instead of `resolver_method`.
