### PR TITLE
Isolate analyzer visits of fragment spreads

### DIFF
--- a/lib/graphql/analysis/ast/analyzer.rb
+++ b/lib/graphql/analysis/ast/analyzer.rb
@@ -41,7 +41,6 @@ module GraphQL
         build_visitor_hooks :document
         build_visitor_hooks :enum
         build_visitor_hooks :field
-        build_visitor_hooks :fragment_spread
         build_visitor_hooks :inline_fragment
         build_visitor_hooks :input_object
         build_visitor_hooks :list_type
@@ -52,6 +51,13 @@ module GraphQL
         build_visitor_hooks :variable_definition
         build_visitor_hooks :variable_identifier
         build_visitor_hooks :abstract_node
+
+        def on_enter_fragment_spread(node, _parent, visitor)
+          visitor.visit_fragment_spread_inline(node, self)
+        end
+
+        def on_leave_fragment_spread(_node, _parent, _visitor)
+        end
 
         protected
 

--- a/lib/graphql/analysis/ast/query_complexity.rb
+++ b/lib/graphql/analysis/ast/query_complexity.rb
@@ -50,14 +50,6 @@ module GraphQL
           end
         end
 
-        def on_enter_fragment_spread(node, _, visitor)
-          visitor.enter_fragment_spread_inline(node)
-        end
-
-        def on_leave_fragment_spread(node, _, visitor)
-          visitor.leave_fragment_spread_inline(node)
-        end
-
         # @return [Integer]
         def max_possible_complexity
           @complexities_on_type.last.max_possible_complexity

--- a/lib/graphql/analysis/ast/query_depth.rb
+++ b/lib/graphql/analysis/ast/query_depth.rb
@@ -60,14 +60,6 @@ module GraphQL
           end
         end
 
-        def on_enter_fragment_spread(node, _, visitor)
-          visitor.enter_fragment_spread_inline(node)
-        end
-
-        def on_leave_fragment_spread(node, _, visitor)
-          visitor.leave_fragment_spread_inline(node)
-        end
-
         def result
           @max_depth
         end

--- a/spec/graphql/analysis/ast/field_usage_spec.rb
+++ b/spec/graphql/analysis/ast/field_usage_spec.rb
@@ -48,4 +48,26 @@ describe GraphQL::Analysis::AST::FieldUsage do
       assert_equal ['Cheese.fatContent'], result[:used_deprecated_fields]
     end
   end
+
+  describe "query with deprecated fields in a fragment" do
+    let(:query_string) {%|
+      query {
+        cheese(id: 1) {
+         id
+         ...CheeseSelections
+        }
+      }
+      fragment CheeseSelections on Cheese {
+        fatContent
+      }
+    |}
+
+    it "keeps track of fields used in the fragment" do
+      assert_equal ['Cheese.id', 'Cheese.fatContent', 'Query.cheese'], result[:used_fields]
+    end
+
+    it "keeps track of deprecated fields used in the fragment" do
+      assert_equal ['Cheese.fatContent'], result[:used_deprecated_fields]
+    end
+  end
 end


### PR DESCRIPTION
This fixes #2419 by only allowing analyzers to perform isolated visits of fragment spreads which should prevent any unintended interactions between analyzers. I replaced the `enter_fragment_spread_inline` and `leave_fragment_spread_inline` methods on `GraphQL::Analysis::AST::Visitor` with a single `visit_fragment_spread_inline` method that only calls back into the specified `GraphQL::Analysis::AST::Analyzer` instance.  By default `GraphQL::Analysis::AST::Analyzer`s will automatically recurse into fragment spreads but this behavior can be changed by overriding `on_enter_fragment_spread`. This does add a performance hit because each analyzer is independently iterating over fragment spreads but I doubt that will be significant.

This also fixes an issue with the field usage analyzer not recursing into fragment spreads.