### PR TITLE
Add extensions in CoercionError

### DIFF
--- a/lib/graphql/coercion_error.rb
+++ b/lib/graphql/coercion_error.rb
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 module GraphQL
   class CoercionError < GraphQL::Error
+    # @return [Hash] Optional custom data for error objects which will be added
+    # under the `extensions` key.
+    attr_accessor :extensions
+
+    def initialize(message, extensions: nil)
+      @extensions = extensions
+      super(message)
+    end
   end
 end

--- a/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb
+++ b/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb
@@ -37,7 +37,7 @@ module GraphQL
                 # short-circuit here so we avoid bubbling this up to whatever input_object / array contains us
                 return super
               end
-              error = GraphQL::StaticValidation::ArgumentLiteralsAreCompatibleError.new(err.message, nodes: parent, type: "CoercionError")
+              error = GraphQL::StaticValidation::ArgumentLiteralsAreCompatibleError.new(err.message, nodes: parent, type: "CoercionError", extensions: err.extensions)
             rescue GraphQL::LiteralValidationError => err
               # check to see if the ast node that caused the error to be raised is
               # the same as the node we were checking here.

--- a/lib/graphql/static_validation/rules/argument_literals_are_compatible_error.rb
+++ b/lib/graphql/static_validation/rules/argument_literals_are_compatible_error.rb
@@ -5,10 +5,11 @@ module GraphQL
       attr_reader :type_name
       attr_reader :argument_name
 
-      def initialize(message, path: nil, nodes: [], type:, argument: nil)
+      def initialize(message, path: nil, nodes: [], type:, argument: nil, extensions: nil)
         super(message, path: path, nodes: nodes)
         @type_name = type
         @argument_name = argument
+        @extensions = extensions
       end
 
       # A hash representation of this Message
@@ -17,7 +18,7 @@ module GraphQL
           "code" => code,
           "typeName" => type_name
         }.tap { |h| h["argumentName"] = argument_name unless argument_name.nil? }
-
+        extensions.merge!(@extensions) unless @extensions.nil?
         super.merge({
           "extensions" => extensions
         })


### PR DESCRIPTION
The idea of Custom Scalars is great. 

In `raise GraphQL::CoercionError` used when the data is not correct, it seems better to be able to return optional keys and values to the client with `extensions`.

PR with reference to https://github.com/rmosolgo/graphql-ruby/issues/1621.
