### PR TITLE
Enable multiple execution errors for Fields defined to return a list …

### DIFF
--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -197,15 +197,12 @@ module GraphQL
             raw_value.path = field_ctx.path
             query.context.errors.push(raw_value)
           when Array
-            if !field_type.list?
-              # List type errors are handled above, this is for the case of fields returning an array of errors
-              list_errors = raw_value.each_with_index.select { |value, _| value.is_a?(GraphQL::ExecutionError) }
-              if list_errors.any?
-                list_errors.each do |error, index|
-                  error.ast_node = field_ctx.ast_node
-                  error.path = field_ctx.path + (field_ctx.type.list? ? [index] : [])
-                  query.context.errors.push(error)
-                end
+            list_errors = raw_value.each_with_index.select { |value, _| value.is_a?(GraphQL::ExecutionError) }
+            if list_errors.any?
+              list_errors.each do |error, index|
+                error.ast_node = field_ctx.ast_node
+                error.path = field_ctx.path + (field_ctx.type.list? ? [index] : [])
+                query.context.errors.push(error)
               end
             end
           end

--- a/spec/graphql/execution_error_spec.rb
+++ b/spec/graphql/execution_error_spec.rb
@@ -296,18 +296,6 @@ describe GraphQL::ExecutionError do
   describe "more than one ExecutionError" do
     let(:query_string) { %|{ multipleErrorsOnNonNullableField} |}
     it "the errors are inserted into the errors key and the data is nil even for a NonNullable field " do
-
-      # I Think the path here is _wrong_, since this is not an array field:
-      # expected_result = {
-      #     "data"=>nil,
-      #     "errors"=>
-      #         [{"message"=>"This is an error message for some error.",
-      #           "locations"=>[{"line"=>1, "column"=>3}],
-      #           "path"=>["multipleErrorsOnNonNullableField", 0]},
-      #          {"message"=>"This is another error message for a different error.",
-      #           "locations"=>[{"line"=>1, "column"=>3}],
-      #           "path"=>["multipleErrorsOnNonNullableField", 1]}]
-      # }
       expected_result = {
         "data"=>nil,
         "errors"=>
@@ -320,6 +308,22 @@ describe GraphQL::ExecutionError do
       }
       assert_equal(expected_result, result)
     end
-  end
 
+    describe "more than one ExecutionError on a field defined to return a list" do
+      let(:query_string) { %|{ multipleErrorsOnNonNullableListField} |}
+      it "the errors are inserted into the errors key and the data is nil even for a NonNullable field " do
+        expected_result = {
+          "data"=>nil,
+          "errors"=>
+            [{"message"=>"This is an error message for a field defined to return a list of strings.",
+              "locations"=>[{"line"=>1, "column"=>3}],
+              "path"=>["multipleErrorsOnNonNullableListField", 0]},
+             {"message"=>"This is another error message for a field defined to return a list of strings.",
+              "locations"=>[{"line"=>1, "column"=>3}],
+              "path"=>["multipleErrorsOnNonNullableListField", 1]}],
+        }
+        assert_equal(expected_result, result)
+      end
+    end
+  end
 end

--- a/spec/graphql/introspection/schema_type_spec.rb
+++ b/spec/graphql/introspection/schema_type_spec.rb
@@ -37,6 +37,7 @@ describe GraphQL::Introspection::SchemaType do
             {"name"=>"maybeNull"},
             {"name"=>"milk"},
             {"name"=>"multipleErrorsOnNonNullableField"},
+            {"name"=>"multipleErrorsOnNonNullableListField"},
             {"name"=>"root"},
             {"name"=>"searchDairy"},
             {"name"=>"tracingScalar"},

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -404,6 +404,14 @@ module Dummy
       ]
     end
 
+    field :multiple_errors_on_non_nullable_list_field, [String], null: false
+    def multiple_errors_on_non_nullable_list_field
+      [
+          GraphQL::ExecutionError.new("This is the first error message for a field defined to return a list of types."),
+          GraphQL::ExecutionError.new("This is the second error message for a field defined to return a list of types.")
+      ]
+    end
+
     field :execution_error_with_options, Integer, null: true
     def execution_error_with_options
       GraphQL::ExecutionError.new("Permission Denied!", options: { "code" => "permission_denied" })


### PR DESCRIPTION
Fields defined to return a **List** of some type should be able to return an Array of `GraphQL::ExecutionError`s instead. 
