### PR TITLE
Include introspective fields in query depth calculations

### DIFF
--- a/lib/graphql/analysis/ast/query_depth.rb
+++ b/lib/graphql/analysis/ast/query_depth.rb
@@ -29,35 +29,22 @@ module GraphQL
         def initialize(query)
           @max_depth = 0
           @current_depth = 0
-          @skip_depth = 0
           super
         end
 
         def on_enter_field(node, parent, visitor)
           return if visitor.skipping? || visitor.visiting_fragment_definition?
 
-          # Don't validate introspection fields or skipped nodes
-          if GraphQL::Schema::DYNAMIC_FIELDS.include?(visitor.field_definition.name)
-            @skip_depth += 1
-          elsif @skip_depth > 0
-            # we're inside an introspection query or skipped node
-          else
-            @current_depth += 1
-          end
+          @current_depth += 1
         end
 
         def on_leave_field(node, parent, visitor)
           return if visitor.skipping? || visitor.visiting_fragment_definition?
 
-          # Don't validate introspection fields or skipped nodes
-          if GraphQL::Schema::DYNAMIC_FIELDS.include?(visitor.field_definition.name)
-            @skip_depth -= 1
-          else
-            if @max_depth < @current_depth
-              @max_depth = @current_depth
-            end
-            @current_depth -= 1
+          if @max_depth < @current_depth
+            @max_depth = @current_depth
           end
+          @current_depth -= 1
         end
 
         def on_enter_fragment_spread(node, _, visitor)

--- a/lib/graphql/analysis/query_depth.rb
+++ b/lib/graphql/analysis/query_depth.rb
@@ -17,32 +17,19 @@ module GraphQL
         {
           max_depth: 0,
           current_depth: 0,
-          skip_depth: 0,
           query: query,
         }
       end
 
       def call(memo, visit_type, irep_node)
         if irep_node.ast_node.is_a?(GraphQL::Language::Nodes::Field)
-          # Don't validate introspection fields or skipped nodes
-          not_validated_node = GraphQL::Schema::DYNAMIC_FIELDS.include?(irep_node.definition_name)
           if visit_type == :enter
-            if not_validated_node
-              memo[:skip_depth] += 1
-            elsif memo[:skip_depth] > 0
-              # we're inside an introspection query or skipped node
-            else
-              memo[:current_depth] += 1
-            end
+            memo[:current_depth] += 1
           else
-            if not_validated_node
-              memo[:skip_depth] -= 1
-            else
-              if memo[:max_depth] < memo[:current_depth]
-                memo[:max_depth] = memo[:current_depth]
-              end
-              memo[:current_depth] -= 1
+            if memo[:max_depth] < memo[:current_depth]
+              memo[:max_depth] = memo[:current_depth]
             end
+            memo[:current_depth] -= 1
           end
         end
         memo

--- a/spec/graphql/analysis/ast/max_query_depth_spec.rb
+++ b/spec/graphql/analysis/ast/max_query_depth_spec.rb
@@ -47,6 +47,34 @@ describe GraphQL::Analysis::AST::MaxQueryDepth do
     end
   end
 
+  describe "When the query includes introspective fields" do
+    let(:query_string) { "
+    query allSchemaTypes {
+      __schema {
+         types {
+            fields {
+              type {
+                fields {
+                  type {
+                    fields {
+                      type {
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }
+         }
+      }
+    }
+  "}
+
+    it "adds an error message for a too-deep query" do
+      assert_equal "Query has depth of 9, which exceeds max depth of 5", result.message
+    end
+  end
+
   describe "When the query is not deeper than max_depth" do
     before do
       schema.max_depth(100)

--- a/spec/graphql/introspection/directive_type_spec.rb
+++ b/spec/graphql/introspection/directive_type_spec.rb
@@ -17,7 +17,12 @@ describe GraphQL::Introspection::DirectiveType do
       }
     }
   |}
-  let(:result) { Dummy::Schema.execute(query_string) }
+
+  let(:schema) { Class.new(Dummy::Schema) }
+  let(:result) { schema.execute(query_string) }
+  before do
+    schema.max_depth(100)
+  end
 
   it "shows directive info " do
     expected = { "data" => {

--- a/spec/graphql/introspection/introspection_query_spec.rb
+++ b/spec/graphql/introspection/introspection_query_spec.rb
@@ -2,14 +2,19 @@
 require "spec_helper"
 
 describe "GraphQL::Introspection::INTROSPECTION_QUERY" do
+  let(:schema)  { Class.new(Dummy::Schema) }
   let(:query_string) { GraphQL::Introspection::INTROSPECTION_QUERY }
-  let(:result) { Dummy::Schema.execute(query_string) }
+  let(:result) { schema.execute(query_string) }
+
+  before do
+    schema.max_depth = 15
+  end
 
   it "runs" do
     assert(result["data"])
   end
 
-  it "handles deeply nested (<= 7) schemas" do
+  it "is limited to the max query depth" do
     query_type =  GraphQL::ObjectType.define do
       name "DeepQuery"
        field :foo do


### PR DESCRIPTION
According to a Slack conversation with @rmosolgo , the exclusion of introspective fields from query depth calculation may be a bug. 

This PR removes that exclusion so all fields are included in the query depth calculation. 

I am happy for it also to be conditional -ie. passing something like `include_all_fields: true` invokes this behaviour and the current behaviour (filtering out introspective fields) remains the default to ensure it doesn't unreasonably break functionality.

Please feel free to edit/comment. 