### PR TITLE
Properly serialize enum default values of input objects

### DIFF
--- a/spec/graphql/introspection/input_value_type_spec.rb
+++ b/spec/graphql/introspection/input_value_type_spec.rb
@@ -35,7 +35,7 @@ describe GraphQL::Introspection::InputValueType do
              "description" => "How much fat it has"},
             {"name"=>"organic", "type"=>{"kind"=>"SCALAR",  "name" => "Boolean"}, "defaultValue"=>"false",
              "description" => nil},
-            {"name"=>"order_by", "type"=>{"kind"=>"INPUT_OBJECT", "name"=>"ResourceOrderType"}, "defaultValue"=>"{direction:\"ASC\"}",
+            {"name"=>"order_by", "type"=>{"kind"=>"INPUT_OBJECT", "name"=>"ResourceOrderType"}, "defaultValue"=>"{direction: \"ASC\"}",
              "description" => nil},
           ]
         }

--- a/spec/graphql/introspection/type_type_spec.rb
+++ b/spec/graphql/introspection/type_type_spec.rb
@@ -123,7 +123,7 @@ describe GraphQL::Introspection::TypeType do
                 {"name"=>"originDairy", "type"=>{"kind"=>"SCALAR","name"=>"String"}, "defaultValue"=>"\"Sugar Hollow Dairy\""},
                 {"name"=>"fatContent", "type"=>{"kind"=>"SCALAR","name" => "Float"}, "defaultValue"=>"0.3"},
                 {"name"=>"organic", "type"=>{"kind"=>"SCALAR","name" => "Boolean"}, "defaultValue"=>"false"},
-                {"name"=>"order_by", "type"=>{"kind"=>"INPUT_OBJECT", "name"=>"ResourceOrderType"}, "defaultValue"=>"{direction:\"ASC\"}"},
+                {"name"=>"order_by", "type"=>{"kind"=>"INPUT_OBJECT", "name"=>"ResourceOrderType"}, "defaultValue"=>"{direction: \"ASC\"}"},
               ]
             }
           }}

--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -275,6 +275,45 @@ describe GraphQL::Schema::InputObject do
       res = Jazz::Schema.execute("{ defaultValueTest }")
       assert_equal "Jazz::InspectableInput -> {:string_value=>\"S\"}", res["data"]["defaultValueTest"]
     end
+
+    it "introspects in GraphQL language with enums" do
+      class InputDefaultSchema < GraphQL::Schema
+        class Letter < GraphQL::Schema::Enum
+          value "A"
+          value "B"
+        end
+
+        class InputObj < GraphQL::Schema::InputObject
+          argument :a, Letter, required: false
+          argument :b, Letter, required: false
+        end
+
+        class Query < GraphQL::Schema::Object
+          field :i, Int, null: true do
+            argument :arg, InputObj, required: false, default_value: { a: "A", b: "B" }
+          end
+        end
+
+        query(Query)
+        use GraphQL::Execution::Interpreter
+        use GraphQL::Analysis::AST
+      end
+
+      res = InputDefaultSchema.execute "
+      {
+        __type(name: \"Query\") {
+          fields {
+            name
+            args {
+              name
+              defaultValue
+            }
+          }
+        }
+      }
+      "
+      assert_equal "{a: A, b: B}", res["data"]["__type"]["fields"].first["args"].first["defaultValue"]
+    end
   end
 
   describe 'hash conversion behavior' do


### PR DESCRIPTION
Previously, default values with enums were being (wrongly) quoted, like 

```
{a:"A", b:"B"}
```

Now, they're unquoted (like GraphQL enums), with some space: 

```
{a: A, b: B}
```

(Which is spec-compliant!)