### PR TITLE
fix list validation error handling

### DIFF
--- a/lib/graphql/static_validation/literal_validator.rb
+++ b/lib/graphql/static_validation/literal_validator.rb
@@ -11,7 +11,7 @@ module GraphQL
       def validate(ast_value, type)
         if type.nil?
           # this means we're an undefined argument, see #present_input_field_values_are_valid
-          return maybe_raise_if_invalid(ast_value) do
+          maybe_raise_if_invalid(ast_value) do
             false
           end
         elsif ast_value.is_a?(GraphQL::Language::Nodes::NullValue)

--- a/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb
+++ b/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb
@@ -41,10 +41,15 @@ module GraphQL
             rescue GraphQL::LiteralValidationError => err
               # check to see if the ast node that caused the error to be raised is
               # the same as the node we were checking here.
-              matched = if arg_defn.type.kind.list?
+              arg_type = arg_defn.type
+              if arg_type.kind.non_null?
+                arg_type = arg_type.of_type
+              end
+
+              matched = if arg_type.kind.list?
                 # for a list we claim an error if the node is contained in our list
                 Array(node.value).include?(err.ast_value)
-              elsif arg_defn.type.kind.input_object? && node.value.is_a?(GraphQL::Language::Nodes::InputObject)
+              elsif arg_type.kind.input_object? && node.value.is_a?(GraphQL::Language::Nodes::InputObject)
                 # for an input object we check the arguments
                 node.value.arguments.include?(err.ast_value)
               else


### PR DESCRIPTION
Oops, our detection for errors from inner nodes wasn't handling non-nulls properly. 

fixes #2428 