### PR TITLE
Make extensions kwarg on field on more flexible

### DIFF
--- a/spec/graphql/schema/field_extension_spec.rb
+++ b/spec/graphql/schema/field_extension_spec.rb
@@ -72,6 +72,11 @@ describe GraphQL::Schema::FieldExtension do
         argument :input, Integer, required: true
       end
 
+      field :tripled_by_option2, Integer, null: false, resolver_method: :pass_thru,
+        extensions: [{ MultiplyByOption => { factor: 3 } }] do
+          argument :input, Integer, required: true
+        end
+
       field :multiply_input, Integer, null: false, resolver_method: :pass_thru, extensions: [MultiplyByArgument] do
         argument :input, Integer, required: true
       end
@@ -83,6 +88,11 @@ describe GraphQL::Schema::FieldExtension do
       def pass_thru(input:, **args)
         input # return it as-is, it will be modified by extensions
       end
+
+      field :multiple_extensions, Integer, null: false, resolver_method: :pass_thru,
+        extensions: [DoubleFilter, { MultiplyByOption => { factor: 3 } }] do
+          argument :input, Integer, required: true
+        end
     end
 
     class Schema < GraphQL::Schema
@@ -122,7 +132,13 @@ describe GraphQL::Schema::FieldExtension do
       assert_equal 12, res["data"]["tripledByOption"]
     end
 
-    it "provides an empty hash as default options" do 
+    it "supports extension with options via extensions kwarg" do
+      # The factor of three came from an option
+      res = exec_query("{ tripledByOption2(input: 4) }")
+      assert_equal 12, res["data"]["tripledByOption2"]
+    end
+
+    it "provides an empty hash as default options" do
       res = exec_query("{ square(input: 4) }")
       assert_equal 16, res["data"]["square"]
       res = exec_query("{ cube(input: 4) }")
@@ -132,6 +148,12 @@ describe GraphQL::Schema::FieldExtension do
     it "can hide arguments from resolve methods" do
       res = exec_query("{ multiplyInput(input: 3, factor: 5) }")
       assert_equal 15, res["data"]["multiplyInput"]
+    end
+
+    it "supports multiple extensions via extensions kwarg" do
+      # doubled then multiplied by 3 specified via option
+      res = exec_query("{ multipleExtensions(input: 3) }")
+      assert_equal 18, res["data"]["multipleExtensions"]
     end
   end
 end


### PR DESCRIPTION
Currently its only possible to specify one extension with options when using the `extensions` kwarg in a field and it has to be the *last* extension specified.

This improves handling of `extension` and allows for a mix of extension classes and extensions with options which no longer have to come last.