### PR TITLE
Fix ArgumentError

### DIFF
--- a/lib/graphql/types/iso_8601_date_time.rb
+++ b/lib/graphql/types/iso_8601_date_time.rb
@@ -32,7 +32,7 @@ module GraphQL
       # @param value [DateTime]
       # @return [String]
       def self.coerce_result(value, _ctx)
-        value.iso8601(time_precision)
+        value.iso8601
       end
 
       # @param str_value [String]


### PR DESCRIPTION
This method does not take any argument. At least on ruby 2.4
Version 1.8.5 was calling this method without argument and we started getting into issues after upgrading the gem.