### PR TITLE
Treat defined but empty schema.query type as invalid

### DIFF
--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -87,8 +87,12 @@ module GraphQL
             subscription_root_type = types['Subscription']
           end
 
-          unless query_root_type && query_root_type.fields.any?
+          unless query_root_type
             raise InvalidDocumentError.new('Must provide schema definition with query type or a type named Query.')
+          end
+
+          unless query_root_type.fields.any?
+            raise InvalidDocumentError.new('Schema definition Query type must define at least one field.')
           end
 
           schema = Schema.define do

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -87,13 +87,7 @@ module GraphQL
             subscription_root_type = types['Subscription']
           end
 
-          unless query_root_type
-            raise InvalidDocumentError.new('Must provide schema definition with query type or a type named Query.')
-          end
-
-          unless query_root_type.fields.any?
-            raise InvalidDocumentError.new('Schema definition Query type must define at least one field.')
-          end
+          raise InvalidDocumentError.new('Must provide schema definition with query type or a type named Query.') unless query_root_type
 
           schema = Schema.define do
             raise_definition_error true

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -87,7 +87,9 @@ module GraphQL
             subscription_root_type = types['Subscription']
           end
 
-          raise InvalidDocumentError.new('Must provide schema definition with query type or a type named Query.') unless query_root_type
+          unless query_root_type && query_root_type.fields.any?
+            raise InvalidDocumentError.new('Must provide schema definition with query type or a type named Query.')
+          end
 
           schema = Schema.define do
             raise_definition_error true

--- a/lib/graphql/schema/printer.rb
+++ b/lib/graphql/schema/printer.rb
@@ -60,7 +60,9 @@ module GraphQL
 
       # Return the GraphQL schema string for the introspection type system
       def self.print_introspection_schema
-        query_root = ObjectType.define(name: "Root")
+        query_root = ObjectType.define(name: "Root") do
+          field :throwaway_field, types.String
+        end
         schema = GraphQL::Schema.define(query: query_root)
 
         introspection_schema_ast = GraphQL::Language::DocumentFromSchemaDefinition.new(

--- a/lib/graphql/schema/validation.rb
+++ b/lib/graphql/schema/validation.rb
@@ -77,6 +77,18 @@ module GraphQL
           }
         end
 
+        def self.count_at_least(item_name, minimum_count, get_items_proc)
+          ->(type) {
+            items = get_items_proc.call(type)
+
+            if items.size < minimum_count
+              "#{type.name} must define at least #{minimum_count} #{item_name}. #{items.size} defined."
+            else
+              nil
+            end
+          }
+        end
+
         def self.assert_named_items_are_valid(item_name, get_items_proc)
           ->(type) {
             items = get_items_proc.call(type)
@@ -92,6 +104,7 @@ module GraphQL
           }
         end
 
+        HAS_AT_LEAST_ONE_FIELD = Rules.count_at_least("field", 1, ->(type) { type.all_fields })
         FIELDS_ARE_VALID = Rules.assert_named_items_are_valid("field", ->(type) { type.all_fields })
 
         HAS_ONE_OR_MORE_POSSIBLE_TYPES = ->(type) {
@@ -260,6 +273,7 @@ module GraphQL
           Rules::DESCRIPTION_IS_STRING_OR_NIL,
         ],
         GraphQL::ObjectType => [
+          Rules::HAS_AT_LEAST_ONE_FIELD,
           Rules.assert_property_list_of(:interfaces, GraphQL::InterfaceType),
           Rules::FIELDS_ARE_VALID,
           Rules::INTERFACES_ARE_IMPLEMENTED,

--- a/spec/graphql/authorization_spec.rb
+++ b/spec/graphql/authorization_spec.rb
@@ -104,6 +104,8 @@ describe GraphQL::Authorization do
       def self.visible?(ctx)
         super && !ctx[:hide]
       end
+
+      field :some_field, String, null: true
     end
 
     class RelayObject < BaseObject
@@ -118,6 +120,8 @@ describe GraphQL::Authorization do
       def self.authorized?(_val, ctx)
         super && !ctx[:unauthorized_relay]
       end
+
+      field :some_field, String, null: true
     end
 
     # TODO test default behavior for abstract types,
@@ -140,6 +144,8 @@ describe GraphQL::Authorization do
       def self.resolve_type(obj, ctx)
         InaccessibleObject
       end
+
+      field :some_field, String, null: true
     end
 
     class InaccessibleObject < BaseObject
@@ -148,6 +154,8 @@ describe GraphQL::Authorization do
       def self.accessible?(ctx)
         super && !ctx[:hide]
       end
+
+      field :some_field, String, null: true
     end
 
     class UnauthorizedObject < BaseObject
@@ -359,6 +367,8 @@ describe GraphQL::Authorization do
       def self.visible?(ctx)
         super && !ctx[:hidden_mutation]
       end
+
+      field :some_return_field, String, null: true
     end
 
     class DoInaccessibleStuff < GraphQL::Schema::RelayClassicMutation

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -841,6 +841,21 @@ SCHEMA
       assert_equal 'Must provide schema definition with query type or a type named Query.', err.message
     end
 
+    it 'Requires a query type that defines at least one field' do
+      schema = <<-SCHEMA
+schema {
+  query: Hello
+}
+
+type Hello { }
+SCHEMA
+
+      err = assert_raises(GraphQL::Schema::InvalidDocumentError) do
+        GraphQL::Schema.from_definition(schema)
+      end
+      assert_equal 'Must provide schema definition with query type or a type named Query.', err.message
+    end
+
     it 'Unknown type referenced' do
       schema = <<-SCHEMA
 schema {

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -850,10 +850,10 @@ schema {
 type Hello { }
 SCHEMA
 
-      err = assert_raises(GraphQL::Schema::InvalidDocumentError) do
+      err = assert_raises(GraphQL::Schema::InvalidTypeError) do
         GraphQL::Schema.from_definition(schema)
       end
-      assert_equal 'Schema definition Query type must define at least one field.', err.message
+      assert_equal 'Hello is invalid: Hello must define at least 1 field. 0 defined.', err.message
     end
 
     it 'Unknown type referenced' do

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -720,15 +720,6 @@ type Query {
       build_schema_and_compare_output(schema.chop)
     end
 
-    it 'supports empty types' do
-      schema = <<-SCHEMA
-type Query {
-}
-      SCHEMA
-
-      build_schema_and_compare_output(schema.chop)
-    end
-
     it "tracks original AST node" do
       schema_definition = <<-GRAPHQL
 schema @custom(thing: true) {

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -853,7 +853,7 @@ SCHEMA
       err = assert_raises(GraphQL::Schema::InvalidDocumentError) do
         GraphQL::Schema.from_definition(schema)
       end
-      assert_equal 'Must provide schema definition with query type or a type named Query.', err.message
+      assert_equal 'Schema definition Query type must define at least one field.', err.message
     end
 
     it 'Unknown type referenced' do

--- a/spec/graphql/schema/member/accepts_definition_spec.rb
+++ b/spec/graphql/schema/member/accepts_definition_spec.rb
@@ -56,6 +56,8 @@ describe GraphQL::Schema::Member::AcceptsDefinition do
 
     class SomeObject < BaseObject
       metadata :a, :aaa
+
+      field :some_field, String, null: true
     end
 
     class SomeObject2 < SomeObject

--- a/spec/graphql/schema/traversal_spec.rb
+++ b/spec/graphql/schema/traversal_spec.rb
@@ -103,11 +103,13 @@ describe GraphQL::Schema::Traversal do
     let(:type_1) {
       GraphQL::ObjectType.define do
         name "MyType"
+        field :some_field, types.String
       end
     }
     let(:type_2) {
       GraphQL::ObjectType.define do
         name "MyType"
+        field :some_field, types.String
       end
     }
     it "raises an error" do
@@ -165,10 +167,12 @@ describe GraphQL::Schema::Traversal do
   it "finds unions from which types are members" do
     b_type = GraphQL::ObjectType.define do
       name "B"
+      field :some_field, types.String
     end
 
     c_type = GraphQL::ObjectType.define do
       name "C"
+      field :some_field, types.String
     end
 
     union = GraphQL::UnionType.define do
@@ -192,10 +196,12 @@ describe GraphQL::Schema::Traversal do
   it "finds orphan types from interfaces" do
     b_type = GraphQL::ObjectType.define do
       name "B"
+      field :some_field, types.String
     end
 
     c_type = GraphQL::ObjectType.define do
       name "C"
+      field :some_field, types.String
     end
 
     interface = GraphQL::InterfaceType.define do

--- a/spec/graphql/schema/validation_spec.rb
+++ b/spec/graphql/schema/validation_spec.rb
@@ -122,6 +122,8 @@ describe GraphQL::Schema::Validation do
       GraphQL::ObjectType.define do
         name "InvalidInterfaceMember"
         interfaces [:not_an_interface]
+
+        field :foo, :string
       end
     }
 
@@ -132,12 +134,25 @@ describe GraphQL::Schema::Validation do
       end
     }
 
+    let(:invalid_object_without_fields) {
+      GraphQL::ObjectType.define do
+        name "InvalidObjectWithoutFields"
+      end
+    }
+
     it "requires an Array for interfaces" do
       assert_error_includes invalid_interface_member_object, "must contain GraphQL::InterfaceType, not Symbol"
     end
 
     it "validates the fields" do
       assert_error_includes invalid_field_object, "must return GraphQL::BaseType, not Symbol"
+    end
+
+    it "validates that Object types define at least one field" do
+      assert_error_includes(
+        invalid_object_without_fields,
+        "InvalidObjectWithoutFields must define at least 1 field. 0 defined."
+      )
     end
 
     it "requires interfaces to be implemented" do

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -11,11 +11,23 @@ describe GraphQL::Schema do
 
     end
 
+    class Query < GraphQL::Schema::Object
+      field :some_field, String, null: true
+    end
+
+    class Mutation < GraphQL::Schema::Object
+      field :some_field, String, null: true
+    end
+
+    class Subscription < GraphQL::Schema::Object
+      field :some_field, String, null: true
+    end
+
     let(:base_schema) do
       Class.new(GraphQL::Schema) do
-        query GraphQL::Schema::Object
-        mutation GraphQL::Schema::Object
-        subscription GraphQL::Schema::Object
+        query Query
+        mutation Mutation
+        subscription Subscription
         max_complexity 1
         max_depth 2
         default_max_page_size 3
@@ -70,14 +82,17 @@ describe GraphQL::Schema do
       schema = Class.new(base_schema)
       query = Class.new(GraphQL::Schema::Object) do
         graphql_name 'Query'
+        field :some_field, String, null: true
       end
       schema.query(query)
       mutation = Class.new(GraphQL::Schema::Object) do
         graphql_name 'Mutation'
+        field :some_field, String, null: true
       end
       schema.mutation(mutation)
       subscription = Class.new(GraphQL::Schema::Object) do
         graphql_name 'Subscription'
+        field :some_field, String, null: true
       end
       schema.subscription(subscription)
       introspection = Module.new

--- a/spec/graphql/types/relay/base_edge_spec.rb
+++ b/spec/graphql/types/relay/base_edge_spec.rb
@@ -3,7 +3,9 @@ require "spec_helper"
 
 describe GraphQL::Types::Relay::BaseEdge do
   module NonNullableDummy
-    class NonNullableNode < GraphQL::Schema::Object; end
+    class NonNullableNode < GraphQL::Schema::Object
+      field :some_field, String, null: true
+    end
 
     class NonNullableNodeEdgeType < GraphQL::Types::Relay::BaseEdge
       node_type(NonNullableNode, null: false)


### PR DESCRIPTION
Closes https://github.com/rmosolgo/graphql-ruby/issues/2461

See the above issue for background, expected vs. actual, and repro steps.

# The fix

This PR. I think we should not only ensure schema.query is defined, but that it has at least one fields defined on it.

```ruby
schema_doc = "type Query { }"
GraphQL::Schema.from_definition(schema_doc) # 💥"Schema definition Query type must define at least one field."
```

# TODO (edit: Done)

~This change, however, conflicts with an existing test case that now fails: https://github.com/chrisbutcher/graphql-ruby/blob/error-when-query-defined-but-empty/spec/graphql/schema/build_from_definition_spec.rb#L723-L730~

~I may be missing some important context on why `it 'supports empty types'`, or maybe this is just outdated and a case that this gem shouldn't support any longer.~

edit: The most recent commit, to add a new Rule entry now breaks a lot more tests (45 errors, 2 failures)

edit 2: Removed the no longer valid test case, and fixed all existing instances where object types were defined without at least one field defined.