### PR TITLE
Automatically inline fragment spreads during AST visits

### DIFF
--- a/lib/graphql/analysis/ast/query_complexity.rb
+++ b/lib/graphql/analysis/ast/query_complexity.rb
@@ -50,14 +50,6 @@ module GraphQL
           end
         end
 
-        def on_enter_fragment_spread(node, _, visitor)
-          visitor.enter_fragment_spread_inline(node)
-        end
-
-        def on_leave_fragment_spread(node, _, visitor)
-          visitor.leave_fragment_spread_inline(node)
-        end
-
         # @return [Integer]
         def max_possible_complexity
           @complexities_on_type.last.max_possible_complexity

--- a/lib/graphql/analysis/ast/query_depth.rb
+++ b/lib/graphql/analysis/ast/query_depth.rb
@@ -47,14 +47,6 @@ module GraphQL
           @current_depth -= 1
         end
 
-        def on_enter_fragment_spread(node, _, visitor)
-          visitor.enter_fragment_spread_inline(node)
-        end
-
-        def on_leave_fragment_spread(node, _, visitor)
-          visitor.leave_fragment_spread_inline(node)
-        end
-
         def result
           @max_depth
         end

--- a/lib/graphql/analysis/ast/visitor.rb
+++ b/lib/graphql/analysis/ast/visitor.rb
@@ -158,7 +158,9 @@ module GraphQL
         def on_fragment_spread(node, parent)
           @path.push("... #{node.name}")
           call_analyzers(:on_enter_fragment_spread, node, parent)
+          enter_fragment_spread_inline(node)
           super
+          leave_fragment_spread_inline(node)
           call_analyzers(:on_leave_fragment_spread, node, parent)
           @path.pop
         end
@@ -167,30 +169,6 @@ module GraphQL
           call_analyzers(:on_enter_abstract_node, node, parent)
           super
           call_analyzers(:on_leave_abstract_node, node, parent)
-        end
-
-        # Visit a fragment spread inline instead of visiting the definition
-        # by itself.
-        def enter_fragment_spread_inline(fragment_spread)
-          fragment_def = query.fragments[fragment_spread.name]
-
-          object_type = if fragment_def.type
-            query.schema.types.fetch(fragment_def.type.name, nil)
-          else
-            object_types.last
-          end
-
-          object_types << object_type
-
-          fragment_def.selections.each do |selection|
-            visit_node(selection, fragment_def)
-          end
-        end
-
-        # Visit a fragment spread inline instead of visiting the definition
-        # by itself.
-        def leave_fragment_spread_inline(_fragment_spread)
-          object_types.pop
         end
 
         # @return [GraphQL::BaseType] The current object type
@@ -229,6 +207,30 @@ module GraphQL
         end
 
         private
+
+        # Visit a fragment spread inline instead of visiting the definition
+        # by itself.
+        def enter_fragment_spread_inline(fragment_spread)
+          fragment_def = query.fragments[fragment_spread.name]
+
+          object_type = if fragment_def.type
+            query.schema.types.fetch(fragment_def.type.name, nil)
+          else
+            object_types.last
+          end
+
+          object_types << object_type
+
+          fragment_def.selections.each do |selection|
+            visit_node(selection, fragment_def)
+          end
+        end
+
+        # Visit a fragment spread inline instead of visiting the definition
+        # by itself.
+        def leave_fragment_spread_inline(_fragment_spread)
+          object_types.pop
+        end
 
         def skip?(ast_node)
           dir = ast_node.directives

--- a/spec/graphql/analysis/ast/field_usage_spec.rb
+++ b/spec/graphql/analysis/ast/field_usage_spec.rb
@@ -48,4 +48,47 @@ describe GraphQL::Analysis::AST::FieldUsage do
       assert_equal ['Cheese.fatContent'], result[:used_deprecated_fields]
     end
   end
+
+  describe "query with deprecated fields in a fragment" do
+    let(:query_string) {%|
+      query {
+        cheese(id: 1) {
+         id
+         ...CheeseSelections
+        }
+      }
+      fragment CheeseSelections on Cheese {
+        fatContent
+      }
+    |}
+
+    it "keeps track of fields used in the fragment" do
+      assert_equal ['Cheese.id', 'Cheese.fatContent', 'Query.cheese'], result[:used_fields]
+    end
+
+    it "keeps track of deprecated fields used in the fragment" do
+      assert_equal ['Cheese.fatContent'], result[:used_deprecated_fields]
+    end
+  end
+
+  describe "query with deprecated fields in an inline fragment" do
+    let(:query_string) {%|
+      query {
+        cheese(id: 1) {
+         id
+         ... on Cheese {
+           fatContent
+         }
+        }
+      }
+    |}
+
+    it "keeps track of fields used in the fragment" do
+      assert_equal ['Cheese.id', 'Cheese.fatContent', 'Query.cheese'], result[:used_fields]
+    end
+
+    it "keeps track of deprecated fields used in the fragment" do
+      assert_equal ['Cheese.fatContent'], result[:used_deprecated_fields]
+    end
+  end
 end


### PR DESCRIPTION
This changes `GraphQL::Analysis::AST::Visitor` to automatically visit fragment spreads inline to fix #2419. It's an alternative to #2421 that avoids forking visitors for each analyzer when visiting fragment spreads. As part of this I made `GraphQL::Analysis::AST::Visitor#enter_fragment_spread_inline` and `GraphQL::Analysis::AST::Visitor#leave_fragment_spread_inline` private since they can cause an analyzer to screw up the iteration for other analyzers. I left the `fragment_spread` callbacks in `GraphQL::Analysis::AST::Analyzer` to be consistent with the `inline_fragment` callbacks but I'm not sure when these would actually be useful. This is hopefully a minimal change to fix #2419 which is a pretty unfortunate regression.