### PR TITLE
Fix AST analysis documentation

### DIFF
--- a/guides/queries/ast_analysis.md
+++ b/guides/queries/ast_analysis.md
@@ -66,17 +66,6 @@ class BasicFieldAnalyzer < GraphQL::Analysis::AST::Analyzer
     end
   end
 
-  # We want to visit fragment spreads as soon as we hit them
-  # instead of visiting the definitions. The visitor provides helper
-  # methods to achieve that.
-  def on_enter_fragment_spread(node, parent, visitor)
-    visitor.enter_fragment_spread_inline(node)
-  end
-
-  def on_leave_fragment_definition(node, parent, visitor)
-    visitor.leave_fragment_spread_inline(node)
-  end
-
   def result
     @fields
   end

--- a/lib/graphql/analysis/ast/analyzer.rb
+++ b/lib/graphql/analysis/ast/analyzer.rb
@@ -25,15 +25,18 @@ module GraphQL
           raise NotImplementedError
         end
 
-        # Don't use make_visit_method because it breaks `super`
-        def self.build_visitor_hooks(member_name)
-          class_eval(<<-EOS, __FILE__, __LINE__ + 1)
-            def on_enter_#{member_name}(node, parent, visitor)
-            end
+        class << self
+          private
 
-            def on_leave_#{member_name}(node, parent, visitor)
-            end
-          EOS
+          def build_visitor_hooks(member_name)
+            class_eval(<<-EOS, __FILE__, __LINE__ + 1)
+              def on_enter_#{member_name}(node, parent, visitor)
+              end
+
+              def on_leave_#{member_name}(node, parent, visitor)
+              end
+            EOS
+          end
         end
 
         build_visitor_hooks :argument


### PR DESCRIPTION
# Proposal

Since https://github.com/rmosolgo/graphql-ruby/pull/2463/ we inline fragment spreads automatically in AST visits. As such, the example in the docs is no longer correct and would cause an error because `enter_fragment_spread_inline` and `leave_fragment_spread_inline` are now private methods on the `GraphQL::Analysis::AST::Visitor` class. So this updates that example in the docs to be correct.

In addition to that, I noticed in the [docs](https://graphql-ruby.org/api-doc/1.9.12/GraphQL/Analysis/AST/Analyzer) for `GraphQL::Analysis::AST::Analyzer` that `build_visitor_hooks` had a message to not use it, I think we should make it a private method and update the docs to be more clear.

