### PR TITLE
Use Types::BaseField in appropriate rails base templates

### DIFF
--- a/lib/generators/graphql/templates/base_interface.erb
+++ b/lib/generators/graphql/templates/base_interface.erb
@@ -1,5 +1,7 @@
 module Types
   module BaseInterface
     include GraphQL::Schema::Interface
+
+    field_class Types::BaseField
   end
 end

--- a/lib/generators/graphql/templates/base_object.erb
+++ b/lib/generators/graphql/templates/base_object.erb
@@ -1,4 +1,5 @@
 module Types
   class BaseObject < GraphQL::Schema::Object
+    field_class Types::BaseField
   end
 end

--- a/spec/integration/rails/generators/graphql/install_generator_spec.rb
+++ b/spec/integration/rails/generators/graphql/install_generator_spec.rb
@@ -19,9 +19,10 @@ class GraphQLGeneratorsInstallGeneratorTest < Rails::Generators::TestCase
 
     assert_file "app/graphql/types/.keep"
     assert_file "app/graphql/mutations/.keep"
-    ["base_object", "base_input_object", "base_enum", "base_scalar", "base_union", "base_interface"].each do |base_type|
+    ["base_input_object", "base_enum", "base_scalar", "base_union"].each do |base_type|
       assert_file "app/graphql/types/#{base_type}.rb"
     end
+
     expected_query_route = %|post "/graphql", to: "graphql#execute"|
     expected_graphiql_route = %|
   if Rails.env.development?
@@ -85,6 +86,26 @@ module Types
 end
 RUBY
     assert_file "app/graphql/types/base_argument.rb", expected_base_argument
+
+    expected_base_object = <<-RUBY
+module Types
+  class BaseObject < GraphQL::Schema::Object
+    field_class Types::BaseField
+  end
+end
+RUBY
+    assert_file "app/graphql/types/base_object.rb", expected_base_object
+
+    expected_base_interface = <<-RUBY
+module Types
+  module BaseInterface
+    include GraphQL::Schema::Interface
+
+    field_class Types::BaseField
+  end
+end
+RUBY
+    assert_file "app/graphql/types/base_interface.rb", expected_base_interface
   end
 
   test "it allows for a user-specified install directory" do


### PR DESCRIPTION
When running `rails g graphql:install` to setup Rails integration, make sure that `Types::BaseObject` and `Types::BaseInterface` set their field class to the generated `Types::BaseField`. (Similarly to how various templates call `argument_class`.)