### PR TITLE
Make ISO8601DateTime work with Date

### DIFF
--- a/guides/type_definitions/scalars.md
+++ b/guides/type_definitions/scalars.md
@@ -16,6 +16,7 @@ Scalars are "leaf" values in GraphQL. There are several built-in scalars, and yo
 - `Boolean`, like a JSON or Ruby boolean (`true` or `false`)
 - `ID`, which a specialized `String` for representing unique object identifiers
 - `ISO8601DateTime`, an ISO 8601-encoded datetime
+- `ISO8601Date`, an ISO 8601-encoded date
 - `JSON`, ⚠ This returns arbitrary JSON (Ruby hashes, arrays, strings, integers, floats, booleans and nils). Take care: by using this type, you completely lose all GraphQL type safety. Consider building object types for your data instead.
 
 Fields can return built-in scalars by referencing them by name:
@@ -35,6 +36,8 @@ field :is_top_ranked, Boolean, null: false
 field :id, ID, null: false
 # ISO8601DateTime field
 field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+# ISO8601Date field
+field :birthday, GraphQL::Types::ISO8601Date, null: false
 # JSON field ⚠
 field :parameters, GraphQL::Types::JSON, null: false
 ```

--- a/lib/graphql/types/iso_8601_date.rb
+++ b/lib/graphql/types/iso_8601_date.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+module GraphQL
+  module Types
+    # This scalar takes `Date`s and transmits them as strings,
+    # using ISO 8601 format.
+    #
+    # Use it for fields or arguments as follows:
+    #
+    #     field :created_at, GraphQL::Types::ISO8601Date, null: false
+    #
+    #     argument :deliver_at, GraphQL::Types::ISO8601Date, null: false
+    #
+    # Alternatively, use this built-in scalar as inspiration for your
+    # own Date type.
+    class ISO8601Date < GraphQL::Schema::Scalar
+      description "An ISO 8601-encoded date"
+
+      # @param value [Date]
+      # @return [String]
+      def self.coerce_result(value, _ctx)
+        value.iso8601
+      end
+
+      # @param str_value [String]
+      # @return [Date]
+      def self.coerce_input(str_value, _ctx)
+        Date.iso8601(str_value)
+      rescue ArgumentError
+        # Invalid input
+        nil
+      end
+    end
+  end
+end

--- a/lib/graphql/types/iso_8601_date_time.rb
+++ b/lib/graphql/types/iso_8601_date_time.rb
@@ -33,6 +33,8 @@ module GraphQL
       # @return [String]
       def self.coerce_result(value, _ctx)
         value.iso8601(time_precision)
+      rescue ArgumentError
+        raise GraphQL::Error, "An incompatible object (#{value.class}) was given to #{self}. Make sure that only DateTimes are used with this type."
       end
 
       # @param str_value [String]

--- a/spec/graphql/types/iso_8601_date_spec.rb
+++ b/spec/graphql/types/iso_8601_date_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+require "spec_helper"
+require "graphql/types/iso_8601_date"
+describe GraphQL::Types::ISO8601Date do
+  module DateTest
+    class DateObject < GraphQL::Schema::Object
+      field :year, Integer, null: false
+      field :month, Integer, null: false
+      field :day, Integer, null: false
+      field :iso8601, GraphQL::Types::ISO8601Date, null: false, method: :itself
+    end
+
+    class Query < GraphQL::Schema::Object
+      field :parse_date, DateObject, null: true do
+        argument :date, GraphQL::Types::ISO8601Date, required: true
+      end
+
+      def parse_date(date:)
+        # Date is parsed by the scalar, so it's already a DateTime
+        date
+      end
+    end
+
+
+    class Schema < GraphQL::Schema
+      query(Query)
+      if TESTING_INTERPRETER
+        use GraphQL::Execution::Interpreter
+      end
+    end
+  end
+
+
+  describe "as an input" do
+
+    def parse_date(date_str)
+      query_str = <<-GRAPHQL
+      query($date: ISO8601Date!){
+        parseDate(date: $date) {
+          year
+          month
+          day
+        }
+      }
+      GRAPHQL
+      full_res = DateTest::Schema.execute(query_str, variables: { date: date_str })
+      full_res["errors"] || full_res["data"]["parseDate"]
+    end
+
+    it "parses valid dates" do
+      res = parse_date("2018-06-07")
+      expected_res = {
+        "year" => 2018,
+        "month" => 6,
+        "day" => 7,
+      }
+      assert_equal(expected_res, res)
+    end
+
+    it "adds an error for invalid dates" do
+      expected_errors = ["Variable date of type ISO8601Date! was provided invalid value"]
+
+      assert_equal expected_errors, parse_date("2018-26-07").map { |e| e["message"] }
+      assert_equal expected_errors, parse_date("xyz").map { |e| e["message"] }
+      assert_equal expected_errors, parse_date(nil).map { |e| e["message"] }
+    end
+  end
+
+  describe "as an output" do
+    it "returns a string" do
+      query_str = <<-GRAPHQL
+      query($date: ISO8601Date!){
+        parseDate(date: $date) {
+          iso8601
+        }
+      }
+      GRAPHQL
+
+      date_str = "2010-02-02"
+      full_res = DateTest::Schema.execute(query_str, variables: { date: date_str })
+      assert_equal date_str, full_res["data"]["parseDate"]["iso8601"]
+    end
+  end
+
+  describe "structure" do
+    it "is in introspection" do
+      introspection_res = DateTest::Schema.execute <<-GRAPHQL
+      {
+        __type(name: "ISO8601Date") {
+          name
+          kind
+        }
+      }
+      GRAPHQL
+
+      expected_res = { "name" => "ISO8601Date", "kind" => "SCALAR"}
+      assert_equal expected_res, introspection_res["data"]["__type"]
+    end
+  end
+end

--- a/spec/graphql/types/iso_8601_date_time_spec.rb
+++ b/spec/graphql/types/iso_8601_date_time_spec.rb
@@ -19,9 +19,15 @@ describe GraphQL::Types::ISO8601DateTime do
         argument :date, GraphQL::Types::ISO8601DateTime, required: true
       end
 
+      field :constant_date, DateTimeObject, null: false
+
       def parse_date(date:)
         # Date is parsed by the scalar, so it's already a DateTime
         date
+      end
+
+      def constant_date
+        Date.new(2019, 9, 10)
       end
     end
 
@@ -115,6 +121,23 @@ describe GraphQL::Types::ISO8601DateTime do
         date_str = "2010-02-02T22:30:30.123-06:00"
         full_res = DateTimeTest::Schema.execute(query_str, variables: { date: date_str })
         assert_equal date_str, full_res["data"]["parseDate"]["iso8601"]
+      end
+    end
+
+    describe "with Date value" do
+      it "raises an error" do
+        query_str = <<-GRAPHQL
+        query {
+          constantDate {
+            iso8601
+          }
+        }
+        GRAPHQL
+
+        err = assert_raises(GraphQL::Error) do
+          DateTimeTest::Schema.execute(query_str)
+        end
+        assert_equal err.message, "An incompatible object (Date) was given to GraphQL::Types::ISO8601DateTime. Make sure that only DateTimes are used with this type."
       end
     end
   end


### PR DESCRIPTION
I've figured out that `ISO8601DateTime` handles `Date` objects in a funny way – it fails with `ArgumentError` (because `Date#iso8601` does not accept any arguments), but from the controller:

```ruby
ArgumentError (wrong number of arguments (given 1, expected 0)):

app/controllers/graphql_controller.rb:10:in `execute'
...
```

When I figured out what's going on, I've written my own implementation for `Date` and decided to open up this PR – the idea is that now `ISO8601DateTime` can accept `Date` too. There are another options of what we can do here: I can write a separate scalar type for Dates or just fix the docs to make it clear that the current type doesn't work with dates. What do you think of it?