### PR TITLE
Add error handling to correctly report coercion errors in mutations

### DIFF
--- a/lib/graphql/query/variables.rb
+++ b/lib/graphql/query/variables.rb
@@ -29,7 +29,13 @@ module GraphQL
             provided_value = @provided_variables[variable_name]
             value_was_provided = @provided_variables.key?(variable_name)
 
-            validation_result = variable_type.validate_input(provided_value, ctx)
+            begin
+              validation_result = variable_type.validate_input(provided_value, ctx)
+            rescue GraphQL::CoercionError => ex
+              validation_result = Query::InputValidationResult.new
+              validation_result.add_problem(ex.message)
+            end
+
             if !validation_result.valid?
               # This finds variables that were required but not provided
               @errors << GraphQL::Query::VariableValidationError.new(ast_variable, variable_type, provided_value, validation_result)


### PR DESCRIPTION
We are currently pinned to a version of graphql-ruby prior to a bug fix
for the handling of coercion errors in mutation processing, until the
transition to Rails 4, and a subsequent upgrade of Ruby, is complete.

This commit applies that fix to the older version that we are using. The
fix is the one to the lib/grapqhl/query/variables.rb file here:

https://github.com/rmosolgo/graphql-ruby/pull/1602/commits/d20e28041f56c4f7f14aba6a123cdefa84779151

We will create a gem from this branch that will be used by
api.epublishing.com.

Re: https://epublishing.atlassian.net/browse/CMS-701