### PR TITLE
Getting Started page is not followed new version template generator.

### DIFF
--- a/guides/getting_started.md
+++ b/guides/getting_started.md
@@ -45,22 +45,26 @@ Types describe objects in your application and form the basis for [GraphQL's typ
 
 ```ruby
 # app/graphql/types/post_type.rb
-class Types::PostType < Types::BaseObject
-  description "A blog post"
-  field :id, ID, null: false
-  field :title, String, null: false
-  # fields should be queried in camel-case (this will be `truncatedPreview`)
-  field :truncated_preview, String, null: false
-  # Fields can return lists of other objects:
-  field :comments, [Types::CommentType], null: true,
-    # And fields can have their own descriptions:
-    description: "This post's comments, or null if this post has comments disabled."
+module Types
+  class PostType < Types::BaseObject
+    description "A blog post"
+    field :id, ID, null: false
+    field :title, String, null: false
+    # fields should be queried in camel-case (this will be `truncatedPreview`)
+    field :truncated_preview, String, null: false
+    # Fields can return lists of other objects:
+    field :comments, [Types::CommentType], null: true,
+      # And fields can have their own descriptions:
+      description: "This post's comments, or null if this post has comments disabled."
+  end
 end
 
 # app/graphql/types/comment_type.rb
-class Types::CommentType < Types::BaseObject
-  field :id, ID, null: false
-  field :post, PostType, null: false
+module Types
+  class CommentType < Types::BaseObject
+    field :id, ID, null: false
+    field :post, PostType, null: false
+  end
 end
 ```
 


### PR DESCRIPTION
## Problem

Result of executing the command `rails g graphql:object Post title:String rating:Int comments:[Comment]`  with reference to the [document](https://graphql-ruby.org/getting_started), graphql-ruby generate below code.

```ruby
module Types
  class PostType < Types::BaseObject
    # ...
  end
end
```

Current [document](https://graphql-ruby.org/getting_started#declare-types) differ generated file.

```ruby
class Types::PostType < Types::BaseObject
　# ...
end
```

## Solution
Improve getting started document.

## Ref
@bary822 commited [code](https://github.com/rmosolgo/graphql-ruby/commit/7279b5fc113627e4d01a6b0f39c0c520c69bd744#diff-a6f0315311fb9167ede5428eb5a574d3), to solve the issue of https://github.com/rmosolgo/graphql-ruby/issues/1591 .

## version

```
$ cat Gemfile.lock | grep graphql
graphql (1.9.12)
```