### PR TITLE
Add GraphQL::Query#executed? method

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -194,6 +194,10 @@ module GraphQL
       @result ||= Query::Result.new(query: self, values: @result_values)
     end
 
+    def executed?
+      @executed
+    end
+
     def static_errors
       validation_errors + analysis_errors + context.errors
     end

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -276,6 +276,17 @@ describe GraphQL::Query do
     end
   end
 
+  describe '#executed?' do
+    it "returns false if the query hasn't been executed" do
+      refute query.executed?
+    end
+
+    it "returns true if the query has been executed" do
+      query.result
+      assert query.executed?
+    end
+  end
+
   it "uses root_value as the object for the root type" do
     result = GraphQL::Query.new(schema, '{ root }', root_value: "I am root").result
     assert_equal 'I am root', result.fetch('data').fetch('root')


### PR DESCRIPTION
Calling `query.result` in an instrumentation `after_query` hook results in an infinite recursion if the query fails with an exception. See this [gist](https://gist.github.com/jturkel/bf40ba28ccf7a5686136a92590312894) which demonstrates the problem and generates the following stacktrace:

```
SystemStackError: stack level too deep:
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/execution/instrumentation.rb:74:in `ensure in call_hooks'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/execution/instrumentation.rb:75:in `call_hooks'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/execution/instrumentation.rb:26:in `apply_instrumenters'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/execution/multiplex.rb:174:in `instrument_and_analyze'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/execution/multiplex.rb:61:in `block in run_queries'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/tracing.rb:62:in `block in trace'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/tracing.rb:76:in `call_tracers'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/tracing.rb:62:in `trace'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/execution/multiplex.rb:59:in `run_queries'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/query.rb:191:in `block in result'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/query.rb:381:in `with_prepared_ast'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/query.rb:190:in `result'
         # analyzer_exception.rb:32:in `after_query'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/execution/instrumentation.rb:82:in `public_send'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/execution/instrumentation.rb:82:in `block in call_after_hooks'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/execution/instrumentation.rb:80:in `each'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/execution/instrumentation.rb:80:in `call_after_hooks'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/execution/instrumentation.rb:74:in `ensure in call_hooks'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/execution/instrumentation.rb:75:in `call_hooks'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/execution/instrumentation.rb:44:in `each_query_call_hooks'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/execution/instrumentation.rb:27:in `block in apply_instrumenters'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/execution/instrumentation.rb:72:in `call_hooks'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/execution/instrumentation.rb:26:in `apply_instrumenters'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/execution/multiplex.rb:174:in `instrument_and_analyze'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/execution/multiplex.rb:61:in `block in run_queries'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/tracing.rb:62:in `block in trace'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/tracing.rb:76:in `call_tracers'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/tracing.rb:62:in `trace'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/execution/multiplex.rb:59:in `run_queries'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/query.rb:191:in `block in result'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/query.rb:381:in `with_prepared_ast'
         # /Users/jturkel/.rvm/gems/ruby-2.5.3@bugs/gems/graphql-1.9.12/lib/graphql/query.rb:190:in `result'
         # analyzer_exception.rb:32:in `after_query'
        # ...
```

The query is going to fail no mater what but the `SystemStackError` masks the underlying problem making these bugs hard to fix. This PR adds a `GraphQL::Query#executed?` method so instrumentation can guard against the problem without reaching into `GraphQL::Query` instance variables. Alternatively we could stop invoking `after_query` hooks if the query fails with an exception but that might break instrumentation assumptions about always calling `after_query` if `before_query` has been invoked.