### PR TITLE
Change misleading field name [ci skip]

### DIFF
--- a/lib/graphql/types/iso_8601_date.rb
+++ b/lib/graphql/types/iso_8601_date.rb
@@ -6,7 +6,7 @@ module GraphQL
     #
     # Use it for fields or arguments as follows:
     #
-    #     field :created_at, GraphQL::Types::ISO8601Date, null: false
+    #     field :published_at, GraphQL::Types::ISO8601Date, null: false
     #
     #     argument :deliver_at, GraphQL::Types::ISO8601Date, null: false
     #


### PR DESCRIPTION
I just thought that `created_at`, which is probably in 100% of the apps a DateTime rather than Date, would be slightly misleading, so I changed it to something else.