### PR TITLE
Remove errant frozen_string_literal directive.

### DIFF
--- a/lib/graphql/analysis/ast.rb
+++ b/lib/graphql/analysis/ast.rb
@@ -7,7 +7,6 @@ require "graphql/analysis/ast/max_query_complexity"
 require "graphql/analysis/ast/query_depth"
 require "graphql/analysis/ast/max_query_depth"
 
-# frozen_string_literal: true
 module GraphQL
   module Analysis
     module AST


### PR DESCRIPTION
The directive already appears higher in the file, so it is unnecessary here. Moreover, it is ignored if any tokens have been seen in the file before the directive is encountered.