### PR TITLE
Reduce allocations in `apply_hooks`

### DIFF
--- a/lib/graphql/language/visitor.rb
+++ b/lib/graphql/language/visitor.rb
@@ -211,7 +211,10 @@ module GraphQL
 
       # If one of the visitors returns SKIP, stop visiting this node
       def self.apply_hooks(hooks, node, parent)
-        hooks.reduce(true) { |memo, proc| memo && (proc.call(node, parent) != SKIP) }
+        hooks.each do |proc|
+          return false if proc.call(node, parent) == SKIP
+        end
+        true
       end
 
       # Collect `enter` and `leave` hooks for classes in {GraphQL::Language::Nodes}


### PR DESCRIPTION
`apply_hooks` is an extremely hot method.  `inject` allocates an object
to keep track of the memo used for the "fold" operation.  We don't
really need a fold operation in this case, so I converted it to an
`each`.  This kills two birds with one stone in that:

1. There are zero allocations
2. We actually short circuit iteration if `SKIP` is returned

The previous code would loop through all elements every time, even if
one of them returned `SKIP` and the subsequent procs would no longer be
called.

This patch decreases our boot time allocations by about 10 million (or 23%):

```
[aaron@tc-lan-adapter ~/g/github (master)]$ env FASTDEV=1 bin/rails r 'p GC.stat(:total_allocated_objects)' ^ /dev/null
42948624
[aaron@tc-lan-adapter ~/g/github (master)]$ env FASTDEV=1 bin/rails r 'p GC.stat(:total_allocated_objects)' ^ /dev/null
32966793
[aaron@tc-lan-adapter ~/g/github (master)]$ ruby -e'p 42948624 - 32966793'
9981831
[aaron@tc-lan-adapter ~/g/github (master)]$ ruby -e'p 1 - 32966793 / 42948624.0'
0.23241328988793686
```