### PR TITLE
Fix case statement

### DIFF
--- a/lib/graphql/filter.rb
+++ b/lib/graphql/filter.rb
@@ -33,14 +33,7 @@ module GraphQL
       end
 
       def self.build(onlies)
-        case onlies
-        when 0
-          nil
-        when 1
-          onlies[0]
-        else
-          onlies.reduce { |memo, only| self.new(memo, only) }
-        end
+        onlies.reduce { |memo, only| self.new(memo, only) }
       end
     end
 


### PR DESCRIPTION
The `build` method is only ever called with Arrays, so `onlies` can never be
equal to `0`, and if `onlies` == `1`, then `1[0]` wouldn't work, so I
think we can safely remove this code.

Was this supposed to be `onlies.length`?