### PR TITLE
Skip visitor hooks entirely if possible

### DIFF
--- a/lib/graphql/language/visitor.rb
+++ b/lib/graphql/language/visitor.rb
@@ -96,8 +96,8 @@ module GraphQL
         else
           # Run hooks if there are any
           new_node = node
-          begin_hooks_ok = @visitors.empty? || begin_visit(new_node, parent)
-          if begin_hooks_ok
+          no_hooks = !@visitors.key?(node.class)
+          if no_hooks || begin_visit(new_node, parent)
             node.children.each do |child_node|
               new_child_and_node = on_node_with_modifications(child_node, new_node)
               # Reassign `node` in case the child hook makes a modification
@@ -106,7 +106,7 @@ module GraphQL
               end
             end
           end
-          @visitors.any? && end_visit(new_node, parent)
+          end_visit(new_node, parent) unless no_hooks
 
           if new_node.equal?(node)
             nil


### PR DESCRIPTION
Similar to #2451

The visitor code is run a lot. Previously we could call `begin_visit`/`end_visit` even if there was no visitor configured for the class, this would end up allocating an empty NodeVisitor (3 objects) and inserting it into the hash.

Skipping all this should reduce allocations and avoiding the hash insertions and extra method calls should be faster.

Versus #2451, this reduces another 1.5 million allocations from our app boot (about 4%).