### PR TITLE
Disallow casting of Enums into scalar values

### DIFF
--- a/lib/graphql/scalar_type.rb
+++ b/lib/graphql/scalar_type.rb
@@ -117,8 +117,6 @@ module GraphQL
         value.to_h
       elsif value.is_a?(Array)
         value.map { |element| raw_coercion_input(element) }
-      elsif value.is_a?(GraphQL::Language::Nodes::Enum)
-        value.name
       else
         value
       end
@@ -126,7 +124,7 @@ module GraphQL
 
     def validate_non_null_input(value, ctx)
       result = Query::InputValidationResult.new
-      if coerce_non_null_input(value, ctx).nil?
+      if value.is_a?(GraphQL::Language::Nodes::Enum) || coerce_non_null_input(value, ctx).nil?
         result.add_problem("Could not coerce value #{GraphQL::Language.serialize(value)} to #{name}")
       end
       result

--- a/spec/graphql/float_type_spec.rb
+++ b/spec/graphql/float_type_spec.rb
@@ -2,6 +2,8 @@
 require "spec_helper"
 
 describe GraphQL::FLOAT_TYPE do
+  let(:enum) { GraphQL::Language::Nodes::Enum.new(name: 'MILK') }
+
   describe "coerce_input" do
     it "accepts ints and floats" do
       assert_equal 1.0, GraphQL::FLOAT_TYPE.coerce_isolated_input(1)
@@ -11,6 +13,7 @@ describe GraphQL::FLOAT_TYPE do
     it "rejects other types" do
       assert_nil GraphQL::FLOAT_TYPE.coerce_isolated_input("55")
       assert_nil GraphQL::FLOAT_TYPE.coerce_isolated_input(true)
+      assert_nil GraphQL::FLOAT_TYPE.coerce_isolated_input(enum)
     end
   end
 end

--- a/spec/graphql/id_type_spec.rb
+++ b/spec/graphql/id_type_spec.rb
@@ -22,10 +22,20 @@ describe GraphQL::ID_TYPE do
     end
   end
 
-  describe "coercion for other types" do
+  describe "coercion for float" do
     let(:query_string) { %|query getMilk { cow: milk(id: 1.0) { id } }| }
 
-    it "doesn't allow other types" do
+    it "results in an error" do
+      assert_nil result["data"]
+
+      assert_equal 1, result["errors"].length
+    end
+  end
+
+  describe "coercion for enum values" do
+    let(:query_string) { %|query getMilk { milk(id: dairy_rocks) { id } }|}
+
+    it "results in an error" do
       assert_nil result["data"]
       assert_equal 1, result["errors"].length
     end

--- a/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
+++ b/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
@@ -138,7 +138,7 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
   end
 
   describe "using enums for scalar arguments it adds an error" do
-    let(:query_string) { <<~GRAPHQL
+    let(:query_string) { <<-GRAPHQL
       {
         cheese(id: I_AM_ENUM_VALUE) {
           source
@@ -150,7 +150,7 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
     let(:enum_invalid_for_id_error) do
       {
         "message" => "Argument 'id' on Field 'cheese' has an invalid value. Expected type 'Int!'.",
-        "locations" => [{ "line" => 2, "column" => 3 }],
+        "locations" => [{ "line" => 2, "column" => 9 }],
         "path"=> ["query", "cheese", "id"],
         "extensions"=> { "code" => "argumentLiteralsIncompatible", "typeName" => "Field", "argumentName" => "id" }
       }

--- a/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
+++ b/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
@@ -137,6 +137,40 @@ describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
     end
   end
 
+  describe "using enums for scalar arguments it adds an error" do
+    let(:query_string) { <<~GRAPHQL
+      {
+        cheese(id: I_AM_ENUM_VALUE) {
+          source
+        }
+      }
+    GRAPHQL
+    }
+
+    let(:enum_invalid_for_id_error) do
+      {
+        "message" => "Argument 'id' on Field 'cheese' has an invalid value. Expected type 'Int!'.",
+        "locations" => [{ "line" => 2, "column" => 3 }],
+        "path"=> ["query", "cheese", "id"],
+        "extensions"=> { "code" => "argumentLiteralsIncompatible", "typeName" => "Field", "argumentName" => "id" }
+      }
+    end
+
+    it "works with error bubbling disabled" do
+      without_error_bubbling(schema) do
+        assert_includes(errors, enum_invalid_for_id_error)
+        assert_equal 1, errors.length
+      end
+    end
+
+    it "works with error bubbling enabled" do
+      with_error_bubbling(schema) do
+        assert_includes(errors, enum_invalid_for_id_error)
+        assert_equal 1, errors.length
+      end
+    end
+  end
+
   describe "null value" do
     describe "nullable arg" do
       let(:schema) {


### PR DESCRIPTION
## What's up?

Happy Hacktoberfest 🎃 ! This resolves #2371. 

In general, it seems that we allow raw enum values to be coerced into strings, code below. 

```ruby
# in lib/graphql/scalar_type.rb
def raw_coercion_input(value)
  if value.is_a?(GraphQL::Language::Nodes::InputObject)
    value.to_h
  elsif value.is_a?(Array)
    value.map { |element| raw_coercion_input(element) }
  elsif value.is_a?(GraphQL::Language::Nodes::Enum)
    value.name
  else
    value
  end
end
```

This means that enum's value (#name) will be taken as a `string` to go through input coercion. But it seems that enums are not scalars, neither string or number from the spec. 

Hence I attempted a solution to reject enums as scalars. 

During validation, this returns errors such as the below: 

```ruby
"message"=>"Argument 'id' on Field 'milk' has an invalid value. Expected type 'ID!'.", 
"locations"=>[{"line"=>1, "column"=>17}], "path"=>["query getMilk", "milk", "id"], 
"extensions"=>{"code"=>"argumentLiteralsIncompatible", "typeName"=>"Field", "argumentName"=>"id"}}
```