### PR TITLE
Optimise RelationConnection.has_next_page

### DIFF
--- a/lib/graphql/relay/relation_connection.rb
+++ b/lib/graphql/relay/relation_connection.rb
@@ -25,7 +25,7 @@ module GraphQL
 
       def has_next_page
         if first
-          paged_nodes.length >= first && sliced_nodes_count > first
+          paged_nodes.length >= first && nodes.offset(first).exists?
         elsif GraphQL::Relay::ConnectionType.bidirectional_pagination && last
           sliced_nodes_count >= last
         else


### PR DESCRIPTION
While computing `has_next_page` for queries with `first` argument, use `offset` with `exists?` which will fire query to select single row from table after the offset. This will be faster than the firing query to select all rows in table.

Closes: 2332