### PR TITLE
Authorize arguments of input objects, too

### DIFF
--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -94,7 +94,17 @@ module GraphQL
       end
 
       def authorized?(obj, ctx)
-        true
+        arg_type = type.unwrap
+        if arg_type.kind.input_object? && arg_type != @owner
+          arg_type.arguments.each do |_name, input_obj_arg|
+            if !input_obj_arg.authorized?(obj, ctx)
+              return false
+            end
+          end
+          true
+        else
+          true
+        end
       end
 
       def to_graphql


### PR DESCRIPTION
Continue calling `.authorized?` on the arguments of input objects. 

Fixes #2509 