### PR TITLE
Correct http header in example

### DIFF
--- a/guides/testing/integration_tests.md
+++ b/guides/testing/integration_tests.md
@@ -117,7 +117,7 @@ it "loads user token into the viewer" do
   user = create(:user)
   post graphql_path,
     params: { query: query_string },
-    headers: { "Authentication" => "Bearer #{user.auth_token}" }
+    headers: { "Authorization" => "Bearer #{user.auth_token}" }
 
   json_response = JSON.parse(@response.body)
   assert_equal user.username, json_response["data"]["viewer"], "Authenticated requests load the viewer"


### PR DESCRIPTION
In the last example on [this doc page](https://graphql-ruby.org/testing/integration_tests.html#testing-transport-level-behaviors), the http header name used for the token is incorrect.

"Authentication" should be "Authorization"