### PR TITLE
Add nullify session CSRF protection

### DIFF
--- a/lib/generators/graphql/templates/graphql_controller.erb
+++ b/lib/generators/graphql/templates/graphql_controller.erb
@@ -3,7 +3,7 @@ class GraphqlController < ApplicationController
   # This allows for outside API access while preventing CSRF attacks,
   # but you'll have to authenticate your user separately
   protect_from_forgery with: :null_session
-                                               
+
   def execute
     variables = ensure_hash(params[:variables])
     query = params[:query]

--- a/lib/generators/graphql/templates/graphql_controller.erb
+++ b/lib/generators/graphql/templates/graphql_controller.erb
@@ -1,4 +1,9 @@
 class GraphqlController < ApplicationController
+  # If accessing from outside this domain, nullify the session
+  # This allows for outside API access while preventing CSRF attacks,
+  # but you'll have to authenticate your user separately
+  protect_from_forgery with: :null_session
+                                               
   def execute
     variables = ensure_hash(params[:variables])
     query = params[:query]

--- a/spec/integration/rails/generators/graphql/install_generator_spec.rb
+++ b/spec/integration/rails/generators/graphql/install_generator_spec.rb
@@ -176,6 +176,11 @@ RUBY
 
   EXPECTED_GRAPHQLS_CONTROLLER = <<-'RUBY'
 class GraphqlController < ApplicationController
+  # If accessing from outside this domain, nullify the session
+  # This allows for outside API access while preventing CSRF attacks,
+  # but you'll have to authenticate your user separately
+  protect_from_forgery with: :null_session
+
   def execute
     variables = ensure_hash(params[:variables])
     query = params[:query]


### PR DESCRIPTION
This change allows for outside API access (say, from a mobile app) while continuing to have protections against CSRF attacks.

Essentially, if the request comes from outside of the current domain, it'll nullify the session. This means that you'll have to get the current_user or other session data some other way (usually a token on the request), which is safer than just checking your current browsing session.

See more here: https://marcgg.com/blog/2016/08/22/csrf-rails/