### PR TITLE
Guides: Repurpose class API guide 

### DIFF
--- a/guides/schema/class_based_api.md
+++ b/guides/schema/class_based_api.md
@@ -4,13 +4,13 @@ doc_stub: false
 search: true
 section: Schema
 title: Class-based API Migration
-desc: Migrate from legacy .define block based schemas.
+desc: Migrate from legacy .define DSL to Ruby classes.
 index: 6
 ---
 
 In GraphQL `1.8`+, you can use Ruby classes to build your schema. You can __mix__ class-style and `.define`-style type definitions in a schema.
 
-The `.define` based API is deprecated and will be removed at version 2.0.
+The `.define` DSL is deprecated and will be removed at version 2.0.
 
 You can get an overview of this new feature:
 

--- a/guides/schema/class_based_api.md
+++ b/guides/schema/class_based_api.md
@@ -3,12 +3,14 @@ layout: guide
 doc_stub: false
 search: true
 section: Schema
-title: Class-based API
-desc: Define your GraphQL schema with Ruby classes (1.8.x alpha releases)
-index: 10
+title: Class-based API Migration
+desc: Migrate from legacy .define block based schemas.
+index: 6
 ---
 
 In GraphQL `1.8`+, you can use Ruby classes to build your schema. You can __mix__ class-style and `.define`-style type definitions in a schema.
+
+The `.define` based API is deprecated and will be removed at version 2.0.
 
 You can get an overview of this new feature:
 

--- a/guides/schema/introspection.md
+++ b/guides/schema/introspection.md
@@ -5,7 +5,7 @@ search: true
 title: Introspection
 section: Schema
 desc: GraphQL has an introspection system that tells about the schema.
-index: 2
+index: 3
 ---
 
 A GraphQL schema has a [built-in introspection system](https://graphql.org/learn/introspection/) that publishes the schema's structure. In fact, the introspection system can be queried using GraphQL, for example:

--- a/guides/schema/lazy_execution.md
+++ b/guides/schema/lazy_execution.md
@@ -4,7 +4,8 @@ doc_stub: false
 search: true
 title: Lazy Execution
 section: Schema
-desc: Resolve functions can return "unfinished" results. GraphQL will defer finishing them until other fields have been resolved.
+desc: Resolve functions can return "unfinished" results that are deferred for batch resolution.
+index: 4
 ---
 
 With lazy execution, you can optimize access to external services (such as databases) by making batched calls. Building a lazy loader has three steps:

--- a/guides/schema/limiting_visibility.md
+++ b/guides/schema/limiting_visibility.md
@@ -5,6 +5,7 @@ search: true
 title: Limiting Visibility
 section: Schema
 desc: Flag types and fields so that only some clients can see them.
+index: 5
 ---
 
 Sometimes, you want to hide schema elements from some users. For example:

--- a/guides/schema/root_types.md
+++ b/guides/schema/root_types.md
@@ -5,9 +5,10 @@ search: true
 section: Schema
 title: Root Types
 desc: Root types are the entry points for queries, mutations and subscriptions.
+index: 2
 ---
 
-GraphQL queries begin from [root types](https://graphql.org/learn/schema/#the-query-and-mutation-types): `query`, `mutation`, and `subscription` (experimental).
+GraphQL queries begin from [root types](https://graphql.org/learn/schema/#the-query-and-mutation-types): `query`, `mutation`, and `subscription`.
 
 Attach these to your schema using methods with the same name:
 

--- a/guides/schema/root_types.md
+++ b/guides/schema/root_types.md
@@ -27,16 +27,16 @@ The types are `GraphQL::Schema::Object` classes, for example:
 ```ruby
 # app/graphql/types/query_type.rb
 class Types::QueryType < GraphQL::Schema::Object
-  # ...
+  field :all_posts, [PostType], 'Returns all blog posts', null: false
 end
 
 # Similarly:
 class Types::MutationType < GraphQL::Schema::Object
-  # ...
+  field :create_post, mutation: Mutations::AddPost
 end
 # and
 class Types::SubscriptionType < GraphQL::Schema::Object
-  # ...
+  field :comment_added, subscription: Subscriptions::CommentAdded
 end
 ```
 


### PR DESCRIPTION
## What's up? 

Was going through the Guides with a colleague and the Class-based API guide made it sound like it's a new feature where it's actually the new norm now. 

Suggesting to rename it as the migration guide and put it at the bottom of the page. 

The thought is that it remains available for people who are still using the define DSL but does not confuse people who are new to graphql-ruby. 

### Reordered Schema Section
<img width="1078" alt="Screen Shot 2019-10-09 at 10 58 24 AM" src="https://user-images.githubusercontent.com/1251946/66493889-cf89ad80-ea84-11e9-8ce6-9f5ef6504718.png">

### Class migration guide with deprecation message
<img width="1062" alt="Screen Shot 2019-10-09 at 11 06 47 AM" src="https://user-images.githubusercontent.com/1251946/66493950-e6c89b00-ea84-11e9-94db-7c7321f6f8a2.png">
