### PR TITLE
wip: support pagination in a single direction only

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -158,7 +158,7 @@ module GraphQL
       # @param subscription_scope [Symbol, String] A key in `context` which will be used to scope subscription payloads
       # @param extensions [Array<Class, Hash<Class => Object>>] Named extensions to apply to this field (see also {#extension})
       # @param trace [Boolean] If true, a {GraphQL::Tracing} tracer will measure this scalar field
-      def initialize(type: nil, name: nil, owner: nil, null: nil, field: nil, function: nil, description: nil, deprecation_reason: nil, method: nil, hash_key: nil, resolver_method: nil, resolve: nil, connection: nil, max_page_size: nil, scope: nil, introspection: false, camelize: true, trace: nil, complexity: 1, extras: [], extensions: [], resolver_class: nil, subscription_scope: nil, relay_node_field: false, relay_nodes_field: false, arguments: {}, &definition_block)
+      def initialize(type: nil, name: nil, owner: nil, null: nil, field: nil, function: nil, description: nil, deprecation_reason: nil, method: nil, hash_key: nil, resolver_method: nil, resolve: nil, connection: nil, max_page_size: nil, pagination_direction: nil, scope: nil, introspection: false, camelize: true, trace: nil, complexity: 1, extras: [], extensions: [], resolver_class: nil, subscription_scope: nil, relay_node_field: false, relay_nodes_field: false, arguments: {}, &definition_block)
         if name.nil?
           raise ArgumentError, "missing first `name` argument or keyword `name:`"
         end
@@ -212,6 +212,7 @@ module GraphQL
         @return_type_null = null
         @connection = connection
         @max_page_size = max_page_size
+        @pagination_direction = pagination_direction
         @introspection = introspection
         @extras = extras
         @resolver_class = resolver_class
@@ -350,6 +351,8 @@ module GraphQL
 
       # @return [Integer, nil] Applied to connections if present
       attr_reader :max_page_size
+
+      attr_reader :pagination_direction
 
       # @return [GraphQL::Field]
       def to_graphql

--- a/lib/graphql/schema/field/connection_extension.rb
+++ b/lib/graphql/schema/field/connection_extension.rb
@@ -5,10 +5,15 @@ module GraphQL
     class Field
       class ConnectionExtension < GraphQL::Schema::FieldExtension
         def apply
-          field.argument :after, "String", "Returns the elements in the list that come after the specified cursor.", required: false
-          field.argument :before, "String", "Returns the elements in the list that come before the specified cursor.", required: false
-          field.argument :first, "Int", "Returns the first _n_ elements from the list.", required: false
-          field.argument :last, "Int", "Returns the last _n_ elements from the list.", required: false
+          if field.pagination_direction != :backward
+            field.argument :after, "String", "Returns the elements in the list that come after the specified cursor.", required: false
+            field.argument :first, "Int", "Returns the first _n_ elements from the list.", required: false
+          end
+
+          if field.pagination_direction != :forward
+            field.argument :before, "String", "Returns the elements in the list that come before the specified cursor.", required: false
+            field.argument :last, "Int", "Returns the last _n_ elements from the list.", required: false
+          end
         end
 
         # Remove pagination args before passing it to a user method

--- a/spec/graphql/introspection/type_type_spec.rb
+++ b/spec/graphql/introspection/type_type_spec.rb
@@ -146,7 +146,7 @@ describe GraphQL::Introspection::TypeType do
         GRAPHQL
         type_result = res["data"]["__schema"]["types"].find { |t| t["name"] == "Faction" }
         field_result = type_result["fields"].find { |f| f["name"] == "bases" }
-        all_arg_names = ["after", "before", "first", "last", "nameIncludes", "complexOrder"]
+        all_arg_names = ["after", "first", "before", "last", "nameIncludes", "complexOrder"]
         returned_arg_names = field_result["args"].map { |a| a["name"] }
         assert_equal all_arg_names, returned_arg_names
       end

--- a/spec/integration/rails/graphql/relay/relation_connection_spec.rb
+++ b/spec/integration/rails/graphql/relay/relation_connection_spec.rb
@@ -326,6 +326,13 @@ describe GraphQL::Relay::RelationConnection do
       end
     end
 
+    describe "pagination_direction" do
+      it "limits what pagination arguments are added" do
+        assert_equal ["after", "first"],
+          StarWars::Schema.types["Faction"].fields["shipsWithPaginationDirection"].arguments.keys
+      end
+    end
+
     describe "applying default_max_page_size" do
       let(:query_string) {%|
         query getBases($first: Int, $after: String, $last: Int, $before: String){

--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -157,6 +157,11 @@ module StarWars
 
     field :shipsWithMaxPageSize, "Ships with max page size", max_page_size: 2, resolver: ShipsWithMaxPageSize
 
+    field :shipsWithPaginationDirection,
+      ShipConnectionWithParentType, "Ships with pagination direction",
+      method: :ships, connection: true, null: true,
+      pagination_direction: :forward
+
     field :bases, BasesConnectionWithTotalCountType, null: true, connection: true do
       argument :nameIncludes, String, required: false
       argument :complexOrder, Boolean, required: false


### PR DESCRIPTION
Hello,

I'm not super confident that this is the best approach, but I thought I would at least try to get some feedback.  Issue #2283 explains the basic rationale for this PR.

The actual use case I have for this is that I'm hitting a data store (dynamodb) that doesn't work with backwards pagination, so in an ideal world I would have some way to disable a pagination direction based on what class is handling the connection (but I realize we don't have that info at schema build time).

Anyway, let me know your thoughts and I will change this accordingly.