### PR TITLE
Use returned value of subscription field (breaking) 

### DIFF
--- a/lib/graphql/subscriptions/action_cable_subscriptions.rb
+++ b/lib/graphql/subscriptions/action_cable_subscriptions.rb
@@ -26,7 +26,7 @@ module GraphQL
     #       variables = ensure_hash(data["variables"])
     #       operation_name = data["operationName"]
     #       context = {
-    #         # Re-implement whatever context methods you need 
+    #         # Re-implement whatever context methods you need
     #         # in this channel or ApplicationCable::Channel
     #         # current_user: current_user,
     #         # Make sure the channel is in the context
@@ -41,7 +41,7 @@ module GraphQL
     #       })
     #
     #       payload = {
-    #         result: result.subscription? ? { data: nil } : result.to_h,
+    #         result: result.to_h,
     #         more: result.subscription?,
     #       }
     #

--- a/spec/graphql/subscriptions_spec.rb
+++ b/spec/graphql/subscriptions_spec.rb
@@ -185,9 +185,9 @@ class FromDefinitionInMemoryBackend < InMemoryBackend
 
   Resolvers = {
     "Subscription" => {
-      "payload" => ->(o,a,c) { o },
-      "myEvent" => ->(o,a,c) { o },
-      "event" => ->(o,a,c) { o },
+      "payload" => ->(o,a,c) { nil },
+      "myEvent" => ->(o,a,c) { nil },
+      "event" => ->(o,a,c) { nil },
       "failedEvent" => ->(o,a,c) { raise GraphQL::ExecutionError.new("unauthorized") },
     },
   }


### PR DESCRIPTION
Use the returned value of subscription root fields, even with the old runtime. 

Previously, the return value was ignored. (But raised errors were acknowledged.) Now, a returned value may be used. (Although `nil` might not, I'm not exactly sure what case that is.)

Closes #2294 
Closes #2145 
Closes #2319 
Closes #2261