### PR TITLE
Fix args compatibility in 1.9.13

### DIFF
--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -118,6 +118,8 @@ module GraphQL
         ruby_kwargs
       end
 
+      alias :to_hash :to_kwargs
+
       private
 
       class ArgumentValue


### PR DESCRIPTION
I really don't know how this was introduced. But apparently we've been generating code like this, and it should still work, one way or another. 

Fixes #2537 