### PR TITLE
Use exists? optimize RelationConnection.has_next_page for ActiveRecord relations

### DIFF
--- a/lib/graphql/relay/relation_connection.rb
+++ b/lib/graphql/relay/relation_connection.rb
@@ -23,9 +23,21 @@ module GraphQL
         end
       end
 
+      def record_exists?(record)
+        if(defined?(ActiveRecord::Relation) && record.is_a?(ActiveRecord::Relation))
+          record.exists?
+        else
+          !record.empty?
+        end
+      end
+
       def has_next_page
         if first
-          paged_nodes.length >= first && nodes.offset(first).exists?
+          if after
+            paged_nodes.length >= first && record_exists?(nodes.offset(first + offset_from_cursor(after)))
+          else
+            paged_nodes.length >= first && record_exists?(nodes.offset(first))
+          end
         elsif GraphQL::Relay::ConnectionType.bidirectional_pagination && last
           sliced_nodes_count >= last
         else

--- a/lib/graphql/relay/relation_connection.rb
+++ b/lib/graphql/relay/relation_connection.rb
@@ -23,26 +23,18 @@ module GraphQL
         end
       end
 
-      def record_exists?(record)
-        if(defined?(ActiveRecord::Relation) && record.is_a?(ActiveRecord::Relation))
-          record.exists?
-        else
-          !record.empty?
-        end
-      end
-
       def has_next_page
         if first
-          if after
-            paged_nodes.length >= first && record_exists?(nodes.offset(first + offset_from_cursor(after)))
-          else
-            paged_nodes.length >= first && record_exists?(nodes.offset(first))
+          if defined?(ActiveRecord::Relation) && nodes.is_a?(ActiveRecord::Relation)
+            initial_offset = after ? offset_from_cursor(after) : 0
+            return paged_nodes.length >= first && nodes.offset(first + initial_offset).exists?
           end
-        elsif GraphQL::Relay::ConnectionType.bidirectional_pagination && last
-          sliced_nodes_count >= last
-        else
-          false
+          return paged_nodes.length >= first && sliced_nodes_count > first
         end
+        if GraphQL::Relay::ConnectionType.bidirectional_pagination && last
+          return sliced_nodes_count >= last
+        end
+        false
       end
 
       def has_previous_page

--- a/lib/graphql/relay/relation_connection.rb
+++ b/lib/graphql/relay/relation_connection.rb
@@ -25,7 +25,7 @@ module GraphQL
 
       def has_next_page
         if first
-          paged_nodes.length >= first && sliced_nodes_count > first
+          paged_nodes.length >= first && nodes.offset(first).exists?
         elsif GraphQL::Relay::ConnectionType.bidirectional_pagination && last
           sliced_nodes_count >= last
         else


### PR DESCRIPTION
This is a followup from:
https://github.com/rmosolgo/graphql-ruby/pull/2513

Resolve:
https://github.com/rmosolgo/graphql-ruby/issues/2332

In this PR:
I use ```exists?``` if the nodes are a ```ActiveRecord::Relation```. Keep the original logic for ```Sequel::Dataset```.