### PR TITLE
Revert "Add nullify session CSRF protection"

### DIFF
--- a/lib/generators/graphql/templates/graphql_controller.erb
+++ b/lib/generators/graphql/templates/graphql_controller.erb
@@ -1,9 +1,4 @@
 class GraphqlController < ApplicationController
-  # If accessing from outside this domain, nullify the session
-  # This allows for outside API access while preventing CSRF attacks,
-  # but you'll have to authenticate your user separately
-  protect_from_forgery with: :null_session
-
   def execute
     variables = ensure_hash(params[:variables])
     query = params[:query]

--- a/spec/integration/rails/generators/graphql/install_generator_spec.rb
+++ b/spec/integration/rails/generators/graphql/install_generator_spec.rb
@@ -176,11 +176,6 @@ RUBY
 
   EXPECTED_GRAPHQLS_CONTROLLER = <<-'RUBY'
 class GraphqlController < ApplicationController
-  # If accessing from outside this domain, nullify the session
-  # This allows for outside API access while preventing CSRF attacks,
-  # but you'll have to authenticate your user separately
-  protect_from_forgery with: :null_session
-
   def execute
     variables = ensure_hash(params[:variables])
     query = params[:query]


### PR DESCRIPTION
Based on issue https://github.com/rmosolgo/graphql-ruby/issues/2548, it's probably better to revert this for now. 

If we wanted to inject the `protect_from_forgery`, the generator probably has to infer if  `ApplicationController` is in API mode