### PR TITLE
Allow resolvers to define field extensions

### DIFF
--- a/guides/fields/resolvers.md
+++ b/guides/fields/resolvers.md
@@ -200,3 +200,26 @@ end
 ```
 
 In doing so, you can defer the loading of the type class until the nested resolver has already been loaded.
+
+# Extensions
+
+In cases when you want your resolvers to add some extensions to the field they resolve, you can use `extension` method, which accepts extension class and options. Multiple extensions can be configured for a single resolver.
+
+```ruby
+class GreetingExtension < GraphQL::Schema::FieldExtension
+  def resolve(object:, arguments:, **rest)
+    name = yield(object, arguments)
+    "#{options[:greeting]}, #{name}!"
+  end
+end
+
+class ResolverWithExtension < BaseResolver
+  type String, null: false
+
+  extension GreetingExtension, greeting: "Hi"
+
+  def resolve
+    "Robert"
+  end
+end
+```

--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -267,6 +267,7 @@ module GraphQL
             arguments: arguments,
             null: null,
             complexity: complexity,
+            extensions: extensions,
           }
         end
 
@@ -318,6 +319,18 @@ module GraphQL
         def arguments_loads_as_type
           inherited_lookups = superclass.respond_to?(:arguments_loads_as_type) ? superclass.arguments_loads_as_type : {}
           inherited_lookups.merge(own_arguments_loads_as_type)
+        end
+
+        # Registers new extension
+        # @param extension [Class] Extension class
+        # @param options [Hash] Optional extension options
+        def extension(extension, **options)
+          extensions << {extension => options}
+        end
+
+        # @api private
+        def extensions
+          @extensions ||= []
         end
 
         private


### PR DESCRIPTION
I think it might be useful to have the ability to define field extensions inside resolvers for cases when some logic is shared between resolvers and types:


```ruby
class GreetingExtension < GraphQL::Schema::FieldExtension
  def resolve(object:, arguments:, **rest)
    name = yield(object, arguments)
    "#{options[:greeting]}, #{name}!"
  end
end

class ResolverWithExtension < BaseResolver
  type String, null: false

  extension GreetingExtension, greeting: "Hi"

  def resolve
    "Robert"
  end
end
```

Please let me know if it sounds worthless 🙂