### PR TITLE
Tune parser for query with lots of nested fields

### DIFF
--- a/lib/graphql/language/lexer.rb
+++ b/lib/graphql/language/lexer.rb
@@ -314,7 +314,7 @@ def self.run_lexer(query_string)
 									begin
 										te = p+1;
 										begin
-											emit(:RCURLY, ts, te, meta) 
+											emit(:RCURLY, ts, te, meta, "}") 
 										end
 										
 									end
@@ -328,7 +328,7 @@ def self.run_lexer(query_string)
 									begin
 										te = p+1;
 										begin
-											emit(:LCURLY, ts, te, meta) 
+											emit(:LCURLY, ts, te, meta, "{") 
 										end
 										
 									end
@@ -342,7 +342,7 @@ def self.run_lexer(query_string)
 									begin
 										te = p+1;
 										begin
-											emit(:RPAREN, ts, te, meta) 
+											emit(:RPAREN, ts, te, meta, ")") 
 										end
 										
 									end
@@ -356,7 +356,7 @@ def self.run_lexer(query_string)
 									begin
 										te = p+1;
 										begin
-											emit(:LPAREN, ts, te, meta) 
+											emit(:LPAREN, ts, te, meta, "(")
 										end
 										
 									end
@@ -370,7 +370,7 @@ def self.run_lexer(query_string)
 									begin
 										te = p+1;
 										begin
-											emit(:RBRACKET, ts, te, meta) 
+											emit(:RBRACKET, ts, te, meta, "]") 
 										end
 										
 									end
@@ -384,7 +384,7 @@ def self.run_lexer(query_string)
 									begin
 										te = p+1;
 										begin
-											emit(:LBRACKET, ts, te, meta) 
+											emit(:LBRACKET, ts, te, meta, "[") 
 										end
 										
 									end
@@ -398,7 +398,7 @@ def self.run_lexer(query_string)
 									begin
 										te = p+1;
 										begin
-											emit(:COLON, ts, te, meta) 
+											emit(:COLON, ts, te, meta, ":") 
 										end
 										
 									end
@@ -440,7 +440,7 @@ def self.run_lexer(query_string)
 									begin
 										te = p+1;
 										begin
-											emit(:VAR_SIGN, ts, te, meta) 
+											emit(:VAR_SIGN, ts, te, meta, "$") 
 										end
 										
 									end
@@ -454,7 +454,7 @@ def self.run_lexer(query_string)
 									begin
 										te = p+1;
 										begin
-											emit(:DIR_SIGN, ts, te, meta) 
+											emit(:DIR_SIGN, ts, te, meta, "@") 
 										end
 										
 									end
@@ -468,7 +468,7 @@ def self.run_lexer(query_string)
 									begin
 										te = p+1;
 										begin
-											emit(:ELLIPSIS, ts, te, meta) 
+											emit(:ELLIPSIS, ts, te, meta, "...") 
 										end
 										
 									end
@@ -482,7 +482,7 @@ def self.run_lexer(query_string)
 									begin
 										te = p+1;
 										begin
-											emit(:EQUALS, ts, te, meta) 
+											emit(:EQUALS, ts, te, meta, "=") 
 										end
 										
 									end
@@ -496,7 +496,7 @@ def self.run_lexer(query_string)
 									begin
 										te = p+1;
 										begin
-											emit(:BANG, ts, te, meta) 
+											emit(:BANG, ts, te, meta, "!") 
 										end
 										
 									end
@@ -510,7 +510,7 @@ def self.run_lexer(query_string)
 									begin
 										te = p+1;
 										begin
-											emit(:PIPE, ts, te, meta) 
+											emit(:PIPE, ts, te, meta, "|") 
 										end
 										
 									end
@@ -524,7 +524,7 @@ def self.run_lexer(query_string)
 									begin
 										te = p+1;
 										begin
-											emit(:AMP, ts, te, meta) 
+											emit(:AMP, ts, te, meta, "&") 
 										end
 										
 									end
@@ -738,7 +738,7 @@ def self.run_lexer(query_string)
 										begin
 											p = ((te))-1;
 											begin
-												emit(:ON, ts, te, meta) 
+												emit(:ON, ts, te, meta, "on") 
 											end
 											
 										end
@@ -746,7 +746,7 @@ def self.run_lexer(query_string)
 										begin
 											p = ((te))-1;
 											begin
-												emit(:FRAGMENT, ts, te, meta) 
+												emit(:FRAGMENT, ts, te, meta, "fragment") 
 											end
 											
 										end
@@ -754,7 +754,7 @@ def self.run_lexer(query_string)
 										begin
 											p = ((te))-1;
 											begin
-												emit(:TRUE, ts, te, meta) 
+												emit(:TRUE, ts, te, meta, "true") 
 											end
 											
 										end
@@ -762,7 +762,7 @@ def self.run_lexer(query_string)
 										begin
 											p = ((te))-1;
 											begin
-												emit(:FALSE, ts, te, meta) 
+												emit(:FALSE, ts, te, meta, "false") 
 											end
 											
 										end
@@ -770,7 +770,7 @@ def self.run_lexer(query_string)
 										begin
 											p = ((te))-1;
 											begin
-												emit(:NULL, ts, te, meta) 
+												emit(:NULL, ts, te, meta, "null") 
 											end
 											
 										end
@@ -778,7 +778,7 @@ def self.run_lexer(query_string)
 										begin
 											p = ((te))-1;
 											begin
-												emit(:QUERY, ts, te, meta) 
+												emit(:QUERY, ts, te, meta, "query") 
 											end
 											
 										end
@@ -786,7 +786,7 @@ def self.run_lexer(query_string)
 										begin
 											p = ((te))-1;
 											begin
-												emit(:MUTATION, ts, te, meta) 
+												emit(:MUTATION, ts, te, meta, "mutation") 
 											end
 											
 										end
@@ -794,7 +794,7 @@ def self.run_lexer(query_string)
 										begin
 											p = ((te))-1;
 											begin
-												emit(:SUBSCRIPTION, ts, te, meta) 
+												emit(:SUBSCRIPTION, ts, te, meta, "subscription") 
 											end
 											
 										end
@@ -1371,11 +1371,11 @@ end
 
 def self.record_comment(ts, te, meta)
 token = GraphQL::Language::Token.new(
-name: :COMMENT,
-value: meta[:data][ts, te - ts].pack(PACK_DIRECTIVE).force_encoding(UTF_8_ENCODING),
-line: meta[:line],
-col: meta[:col],
-prev_token: meta[:previous_token],
+:COMMENT,
+meta[:data][ts, te - ts].pack(PACK_DIRECTIVE).force_encoding(UTF_8_ENCODING),
+meta[:line],
+meta[:col],
+meta[:previous_token],
 )
 
 meta[:previous_token] = token
@@ -1383,13 +1383,14 @@ meta[:previous_token] = token
 meta[:col] += te - ts
 end
 
-def self.emit(token_name, ts, te, meta)
+def self.emit(token_name, ts, te, meta, token_value = nil)
+token_value ||= meta[:data][ts, te - ts].pack(PACK_DIRECTIVE).force_encoding(UTF_8_ENCODING)
 meta[:tokens] << token = GraphQL::Language::Token.new(
-name: token_name,
-value: meta[:data][ts, te - ts].pack(PACK_DIRECTIVE).force_encoding(UTF_8_ENCODING),
-line: meta[:line],
-col: meta[:col],
-prev_token: meta[:previous_token],
+token_name,
+token_value,
+meta[:line],
+meta[:col],
+meta[:previous_token],
 )
 meta[:previous_token] = token
 # Bump the column counter for the next token
@@ -1428,30 +1429,30 @@ end
 # (It's faster: https://bugs.ruby-lang.org/issues/8110)
 if !value.valid_encoding? || value !~ VALID_STRING
 meta[:tokens] << token = GraphQL::Language::Token.new(
-name: :BAD_UNICODE_ESCAPE,
-value: value,
-line: meta[:line],
-col: meta[:col],
-prev_token: meta[:previous_token],
+:BAD_UNICODE_ESCAPE,
+value,
+meta[:line],
+meta[:col],
+meta[:previous_token],
 )
 else
 replace_escaped_characters_in_place(value)
 
 if !value.valid_encoding?
 	meta[:tokens] << token = GraphQL::Language::Token.new(
-	name: :BAD_UNICODE_ESCAPE,
-	value: value,
-	line: meta[:line],
-	col: meta[:col],
-	prev_token: meta[:previous_token],
+	:BAD_UNICODE_ESCAPE,
+	value,
+	meta[:line],
+	meta[:col],
+	meta[:previous_token],
 	)
 	else
 	meta[:tokens] << token = GraphQL::Language::Token.new(
-	name: :STRING,
-	value: value,
-	line: meta[:line],
-	col: meta[:col],
-	prev_token: meta[:previous_token],
+	:STRING,
+	value,
+	meta[:line],
+	meta[:col],
+	meta[:previous_token],
 	)
 	end
 end

--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -28,7 +28,8 @@ module GraphQL
         def initialize(options={})
           if options.key?(:position_source)
             position_source = options.delete(:position_source)
-            @line, @col = position_source.line_and_column
+            @line = position_source.line
+            @col = position_source.col
           end
 
           @filename = options.delete(:filename)
@@ -350,6 +351,8 @@ module GraphQL
 
       # A single selection in a GraphQL query.
       class Field < AbstractNode
+        NONE = [].freeze
+
         scalar_methods :name, :alias
         children_methods({
           arguments: GraphQL::Language::Nodes::Argument,
@@ -360,13 +363,13 @@ module GraphQL
         # @!attribute selections
         #   @return [Array<Nodes::Field>] Selections on this object (or empty array if this is a scalar field)
 
-        def initialize_node(name: nil, arguments: [], directives: [], selections: [], **kwargs)
-          @name = name
-          @arguments = arguments
-          @directives = directives
-          @selections = selections
+        def initialize_node(attributes)
+          @name = attributes[:name]
+          @arguments = attributes[:arguments] || NONE
+          @directives = attributes[:directives] || NONE
+          @selections = attributes[:selections] || NONE
           # oops, alias is a keyword:
-          @alias = kwargs.fetch(:alias, nil)
+          @alias = attributes[:alias]
         end
 
         # Override this because default is `:fields`

--- a/lib/graphql/language/parser.rb
+++ b/lib/graphql/language/parser.rb
@@ -21,6 +21,7 @@ def initialize(query_string, filename:, tracer: Tracing::NullTracer)
   @query_string = query_string
   @filename = filename
   @tracer = tracer
+  @reused_next_token = [nil, nil]
 end
 
 def parse_document
@@ -51,7 +52,9 @@ def next_token
   if lexer_token.nil?
     nil
   else
-    [lexer_token.name, lexer_token]
+    @reused_next_token[0] = lexer_token.name
+    @reused_next_token[1] = lexer_token
+    @reused_next_token
   end
 end
 

--- a/lib/graphql/language/parser.y
+++ b/lib/graphql/language/parser.y
@@ -440,6 +440,7 @@ def initialize(query_string, filename:, tracer: Tracing::NullTracer)
   @query_string = query_string
   @filename = filename
   @tracer = tracer
+  @reused_next_token = [nil, nil]
 end
 
 def parse_document
@@ -470,7 +471,9 @@ def next_token
   if lexer_token.nil?
     nil
   else
-    [lexer_token.name, lexer_token]
+    @reused_next_token[0] = lexer_token.name
+    @reused_next_token[1] = lexer_token
+    @reused_next_token
   end
 end
 

--- a/lib/graphql/language/token.rb
+++ b/lib/graphql/language/token.rb
@@ -14,7 +14,7 @@ module GraphQL
       attr_reader :value
       attr_reader :prev_token, :line, :col
 
-      def initialize(value:, name:, line:, col:, prev_token:)
+      def initialize(name, value, line, col, prev_token)
         @name = name
         @value = -value
         @line = line


### PR DESCRIPTION
I saw that @DmitryTsepelev  gave a really good talk about graphql-ruby's internals, and it included some detailed benchmarks. I decided to see if I could improve them 😈 

They're here: https://gist.github.com/DmitryTsepelev/36e290cf64b4ec0b18294d0a57fb26ff

Specifically, I looked at the parsing benchmark. I was able to reduce the memory by about half, but the time is about the same. 

#### Before 

```
~/code/graphql-ruby $ ruby benchmark.rb
                                   user     system      total        real
8 fields, 0 nested levels (   122 bytes):   0.000366   0.000017   0.000383 (  0.000382)
8 fields, 2 nested levels ( 10706 bytes):   0.022603   0.000751   0.023354 (  0.024115)
8 fields, 4 nested levels (853970 bytes):   0.948247   0.013408   0.961655 (  0.974112)
Total allocated: 77147304 bytes (664744 objects)
Total retained:  0 bytes (0 objects)

allocated memory by gem
-----------------------------------
  54076800  graphql-ruby/lib
  15392936  other
   7677568  racc
```

#### After 

```
~/code/graphql-ruby $ ruby benchmark.rb
                                   user     system      total        real
8 fields, 0 nested levels (   122 bytes):   0.000298   0.000012   0.000310 (  0.000305)
8 fields, 2 nested levels ( 10706 bytes):   0.013025   0.000106   0.013131 (  0.013165)
8 fields, 4 nested levels (853970 bytes):   0.887415   0.012889   0.900304 (  0.907571)

Total allocated: 32733272 bytes (393241 objects)
Total retained:  0 bytes (0 objects)

allocated memory by gem
-----------------------------------
  13520544  other
  11535160  graphql-ruby/lib
   7677568  racc
```

The optimizations were: 

- Use positional args instead of keyword args for `Token.new`, to avoid allocating a Hash (😢  I wish that wasn't necessary!)
- Hardcode token values for constant tokens (punctuation), then skip the allocate-then-pack for determining the token value 
- Don't allocate a hash in `Field#initialize_node` 
- Don't call `.line_and_column` which allocates a needless array (hilariously, this is a carryover from the very first parser, written in parslet. Great gem.)
- Instead of allocating a new `next_token`, use the same array over and over. This one seems kind of risky -- there's no guarantee that `racc` isn't mutating the array in its own way!