### PR TITLE
Revert "Authorize arguments of input objects, too"

### DIFF
--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -94,17 +94,7 @@ module GraphQL
       end
 
       def authorized?(obj, ctx)
-        arg_type = type.unwrap
-        if arg_type.kind.input_object? && arg_type != @owner
-          arg_type.arguments.each do |_name, input_obj_arg|
-            if !input_obj_arg.authorized?(obj, ctx)
-              return false
-            end
-          end
-          true
-        else
-          true
-        end
+        true
       end
 
       def to_graphql

--- a/spec/graphql/authorization_spec.rb
+++ b/spec/graphql/authorization_spec.rb
@@ -24,16 +24,6 @@ describe GraphQL::Authorization do
       end
     end
 
-    class BaseInputObjectArgument < BaseArgument
-      def authorized?(parent_object, context)
-        super && parent_object != :hide3
-      end
-    end
-
-    class BaseInputObject < GraphQL::Schema::InputObject
-      argument_class BaseInputObjectArgument
-    end
-
     class BaseField < GraphQL::Schema::Field
       def initialize(*args, edge_class: nil, **kwargs, &block)
         @edge_class = edge_class
@@ -261,11 +251,6 @@ describe GraphQL::Authorization do
       value "TAR_PIT", role: :hidden
     end
 
-    class AddInput < BaseInputObject
-      argument :left, Integer, required: true
-      argument :right, Integer, required: true
-    end
-
     class Query < BaseObject
       def self.authorized?(obj, ctx)
         !ctx[:query_unauthorized]
@@ -369,14 +354,6 @@ describe GraphQL::Authorization do
       field :replaced_object, ReplacedObject, null: false
       def replaced_object
         Replaceable.new
-      end
-
-      field :add_inputs, Integer, null: true do
-        argument :input, AddInput, required: true
-      end
-
-      def add_inputs(input:)
-        input[:left] + input[:right]
       end
     end
 
@@ -768,21 +745,6 @@ describe GraphQL::Authorization do
       assert_nil hidden_response["data"].fetch("int2")
       visible_response = auth_execute(query)
       assert_equal 5, visible_response["data"]["int2"]
-    end
-
-    it "halts on unauthorized input object arguments, using the parent object" do
-      query = "{ addInputs(input: { left: 3, right: 2 }) }"
-      hidden_field_argument_response = auth_execute(query, root_value: :hide2)
-      assert_nil hidden_field_argument_response["data"].fetch("addInputs")
-      assert_equal ["Unauthorized Query: :hide2"], hidden_field_argument_response["errors"].map { |e| e["message"] }
-
-      hidden_input_obj_argument_response = auth_execute(query, root_value: :hide3)
-      assert_nil hidden_input_obj_argument_response["data"].fetch("addInputs")
-      assert_equal ["Unauthorized Query: :hide3"], hidden_input_obj_argument_response["errors"].map { |e| e["message"] }
-
-      visible_response = auth_execute(query)
-      assert_equal 5, visible_response["data"]["addInputs"]
-      refute visible_response.key?("errors")
     end
 
     it "works with edges and connections" do


### PR DESCRIPTION
Reverts rmosolgo/graphql-ruby#2519

It caused cyclical loops. 1.10-dev has a better behavior here.

Fixes #2554 
