### PR TITLE
Generate a base mutation class referencing the base type classes

### DIFF
--- a/guides/mutations/mutation_classes.md
+++ b/guides/mutations/mutation_classes.md
@@ -36,7 +36,7 @@ An additional `null` helper method is provided on classes inheriting from `Graph
 
 ## Example mutation class
 
-You should add a base class to your application, for example:
+If you used the {% internal_link "install generator", "/schema/generators#graphqlinstall" %}, a base mutation class will already have been generated for you. If that's not the case, you should add a base class to your application, for example:
 
 ```ruby
 class Mutations::BaseMutation < GraphQL::Schema::RelayClassicMutation

--- a/guides/schema/generators.md
+++ b/guides/schema/generators.md
@@ -29,6 +29,7 @@ This will:
 - Add schema definition
 - Add base type classes
 - Add a `Query` type definition
+- Add a `Mutation` type definition with a base mutation class
 - Add a route and controller for executing queries
 - Install [`graphiql-rails`](https://github.com/rmosolgo/graphiql-rails)
 

--- a/lib/generators/graphql/core.rb
+++ b/lib/generators/graphql/core.rb
@@ -25,6 +25,7 @@ module Graphql
 
       def create_mutation_root_type
         create_dir("#{options[:directory]}/mutations")
+        template("base_mutation.erb", "#{options[:directory]}/mutations/base_mutation.rb", { skip: true })
         template("mutation_type.erb", "#{options[:directory]}/types/mutation_type.rb", { skip: true })
         insert_root_type('mutation', 'MutationType')
       end

--- a/lib/generators/graphql/install_generator.rb
+++ b/lib/generators/graphql/install_generator.rb
@@ -24,6 +24,7 @@ module Graphql
     #       - query_type.rb
     #     - loaders/
     #     - mutations/
+    #       - base_mutation.rb
     #     - {app_name}_schema.rb
     # ```
     #

--- a/lib/generators/graphql/templates/base_mutation.erb
+++ b/lib/generators/graphql/templates/base_mutation.erb
@@ -1,0 +1,8 @@
+module Mutations
+  class BaseMutation < GraphQL::Schema::RelayClassicMutation
+    argument_class Types::BaseArgument
+    field_class Types::BaseField
+    input_object_class Types::BaseInputObject
+    object_class Types::BaseObject
+  end
+end

--- a/lib/generators/graphql/templates/mutation.erb
+++ b/lib/generators/graphql/templates/mutation.erb
@@ -1,5 +1,5 @@
 module Mutations
-  class <%= mutation_name %> < GraphQL::Schema::RelayClassicMutation
+  class <%= mutation_name %> < BaseMutation
     # TODO: define return fields
     # field :post, Types::PostType, null: false
 

--- a/spec/integration/rails/generators/graphql/install_generator_spec.rb
+++ b/spec/integration/rails/generators/graphql/install_generator_spec.rb
@@ -19,6 +19,7 @@ class GraphQLGeneratorsInstallGeneratorTest < Rails::Generators::TestCase
 
     assert_file "app/graphql/types/.keep"
     assert_file "app/graphql/mutations/.keep"
+    assert_file "app/graphql/mutations/base_mutation.rb"
     ["base_input_object", "base_enum", "base_scalar", "base_union"].each do |base_type|
       assert_file "app/graphql/types/#{base_type}.rb"
     end
@@ -47,6 +48,17 @@ end
 RUBY
     assert_file "app/graphql/dummy_schema.rb", expected_schema
 
+    expected_base_mutation = <<-RUBY
+module Mutations
+  class BaseMutation < GraphQL::Schema::RelayClassicMutation
+    argument_class Types::BaseArgument
+    field_class Types::BaseField
+    input_object_class Types::BaseInputObject
+    object_class Types::BaseObject
+  end
+end
+RUBY
+    assert_file "app/graphql/mutations/base_mutation.rb", expected_base_mutation
 
     expected_query_type = <<-RUBY
 module Types

--- a/spec/integration/rails/generators/graphql/mutation_generator_spec.rb
+++ b/spec/integration/rails/generators/graphql/mutation_generator_spec.rb
@@ -21,7 +21,7 @@ class GraphQLGeneratorsMutationGeneratorTest < BaseGeneratorTest
 
   UPDATE_NAME_MUTATION = <<-RUBY
 module Mutations
-  class UpdateName < GraphQL::Schema::RelayClassicMutation
+  class UpdateName < BaseMutation
     # TODO: define return fields
     # field :post, Types::PostType, null: false
 


### PR DESCRIPTION
I noticed that a few places in the guides reference a `BaseMutation`, including the [Mutation Classes guide](https://graphql-ruby.org/mutations/mutation_classes.html#example-mutation-class). I though it would be a good idea to have the generator create that BaseMutation, referencing the type classes that are generated.

Let me know what you think! Happy to tweak things if this is an appropriate addition to the project.