### PR TITLE
fix(website) new mongo install instructions

### DIFF
--- a/guides/development.md
+++ b/guides/development.md
@@ -25,7 +25,7 @@ Get your own copy of graphql-ruby by forking [`rmosolgo/graphql-ruby` on GitHub]
 
 Then, install the dependencies:
 
-- Install SQLite3 and MongoDB (eg, `brew install sqlite && brew install mongodb`)
+- Install SQLite3 and MongoDB (eg, `brew install sqlite && brew tap mongodb/brew && brew install mongodb-community`)
 - `bundle install`
 - Optional: [Ragel](https://www.colm.net/open-source/ragel/) is required to build the lexer
 


### PR DESCRIPTION
:wave: Noticed this while running through the setup. Mongo has its own tap now -- see https://github.com/Homebrew/homebrew-core/pull/43770.