### PR TITLE
[Docs] Fixing small mistake in table for "List" docs

### DIFF
--- a/guides/type_definitions/lists.md
+++ b/guides/type_definitions/lists.md
@@ -109,7 +109,7 @@ Valid | Invalid
 ------|------
 `[]`  | `null`
 `[1, 2, ...]`| `[null]`
- | `[1, null, 2, ...]`
+| | `[1, null, 2, ...]`
 
 ### Non-null lists with nullable items
 


### PR DESCRIPTION
There was a small issue with the valid/invalid table for "Non-null lists with nullable items". 
An example that should have been _invalid_ was showing up as _valid_.


<img width="911" alt="Screen Shot 2019-11-11 at 12 48 35 PM" src="https://user-images.githubusercontent.com/6835779/68608830-de97bd00-0481-11ea-8339-775547eabbbe.png">