### PR TITLE
Introspection shouldn't return types that are unreachable due to visibility checks

### DIFF
--- a/lib/graphql/introspection/entry_points.rb
+++ b/lib/graphql/introspection/entry_points.rb
@@ -15,8 +15,9 @@ module GraphQL
       end
 
       def __type(name:)
-        type = context.warden.get_type(name)
+        return unless context.warden.reachable_type?(name)
 
+        type = context.warden.get_type(name)
         if type && context.interpreter?
           type = type.metadata[:type_class] || raise("Invariant: interpreter requires class-based type for #{name}")
         end

--- a/lib/graphql/introspection/schema_type.rb
+++ b/lib/graphql/introspection/schema_type.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'set'
-
 module GraphQL
   module Introspection
     class SchemaType < Introspection::BaseObject
@@ -17,7 +15,7 @@ module GraphQL
       field :directives, [GraphQL::Schema::LateBoundType.new("__Directive")], "A list of all directives supported by this server.", null: false
 
       def types
-        types = reachable_types
+        types = @context.warden.reachable_types.sort_by(&:graphql_name)
         if context.interpreter?
           types.map { |t| t.metadata[:type_class] || raise("Invariant: can't introspect non-class-based type: #{t}") }
         else
@@ -26,15 +24,15 @@ module GraphQL
       end
 
       def query_type
-        @query_type ||= permitted_root_type("query")
+        permitted_root_type("query")
       end
 
       def mutation_type
-        @mutation_type ||= permitted_root_type("mutation")
+        permitted_root_type("mutation")
       end
 
       def subscription_type
-        @subscription_type ||= permitted_root_type("subscription")
+        permitted_root_type("subscription")
       end
 
       def directives
@@ -44,63 +42,7 @@ module GraphQL
       private
 
       def permitted_root_type(op_type)
-        context.warden.root_type_for_operation(op_type)
-      end
-
-      def reachable_types
-        reachable_types = Set.new
-
-        unvisited_types = []
-        unvisited_types << query_type if query_type
-        unvisited_types << mutation_type if mutation_type
-        unvisited_types << subscription_type if subscription_type
-        unvisited_types.concat(context.schema.introspection_system.object_types)
-        context.schema.orphan_types.each do |orphan_type|
-          unvisited_types << orphan_type.graphql_definition if context.warden.get_type(orphan_type.graphql_name)
-        end
-
-        until unvisited_types.empty?
-          type = unvisited_types.pop
-          if reachable_types.add?(type)
-            if type.is_a?(GraphQL::InputObjectType) || type.is_a?(GraphQL::Directive)
-              # recurse into visible arguments
-              context.warden.arguments(type).each do |argument|
-                argument_type = argument.type.unwrap
-                unvisited_types << argument_type
-              end
-            elsif type.is_a?(GraphQL::UnionType)
-              # recurse into visible possible types
-              context.warden.possible_types(type).each do |possible_type|
-                unvisited_types << possible_type
-              end
-            else
-              if type.is_a?(GraphQL::InterfaceType)
-                # recurse into visible orphan types
-                type.orphan_types.each do |orphan_type|
-                  unvisited_types << orphan_type.graphql_definition if context.warden.get_type(orphan_type.graphql_name)
-                end
-              elsif type.is_a?(GraphQL::ObjectType)
-                # recurse into visible implemented interfaces
-                context.warden.interfaces(type).each do |interface|
-                  unvisited_types << interface
-                end
-              end
-
-              # recurse into visible fields
-              context.warden.fields(type).each do |field|
-                field_type = field.type.unwrap
-                unvisited_types << field_type
-                # recurse into visible arguments
-                context.warden.arguments(field).each do |argument|
-                  argument_type = argument.type.unwrap
-                  unvisited_types << argument_type
-                end
-              end
-            end
-          end
-        end
-
-        reachable_types.sort_by(&:graphql_name)
+        @context.warden.root_type_for_operation(op_type)
       end
     end
   end

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+require 'set'
+
 module GraphQL
   class Schema
     # Restrict access to a {GraphQL::Schema} with a user-defined filter.
@@ -60,6 +63,17 @@ module GraphQL
         end
 
         @visible_types[type_name]
+      end
+
+      # @return [Array<GraphQL::BaseType>] Visible and reachable types in the schema
+      def reachable_types
+        @reachable_types ||= reachable_type_set.to_a
+      end
+
+      # @return Boolean True if the type is visible and reachable in the schema
+      def reachable_type?(type_name)
+        type = get_type(type_name)
+        type && reachable_type_set.include?(type)
       end
 
       # @return [GraphQL::Field, nil] The field named `field_name` on `parent_type`, if it exists
@@ -179,6 +193,65 @@ module GraphQL
 
       def read_through
         Hash.new { |h, k| h[k] = yield(k) }
+      end
+
+      def reachable_type_set
+        return @reachable_type_set if defined?(@reachable_type_set)
+
+        @reachable_type_set = Set.new
+
+        unvisited_types = []
+        ['query', 'mutation', 'subscription'].each do |op_name|
+          root_type = root_type_for_operation(op_name)
+          unvisited_types << root_type if root_type
+        end
+        unvisited_types.concat(@schema.introspection_system.object_types)
+        @schema.orphan_types.each do |orphan_type|
+          unvisited_types << orphan_type.graphql_definition if get_type(orphan_type.graphql_name)
+        end
+
+        until unvisited_types.empty?
+          type = unvisited_types.pop
+          if @reachable_type_set.add?(type)
+            if type.kind.input_object?
+              # recurse into visible arguments
+              arguments(type).each do |argument|
+                argument_type = argument.type.unwrap
+                unvisited_types << argument_type
+              end
+            elsif type.kind.union?
+              # recurse into visible possible types
+              possible_types(type).each do |possible_type|
+                unvisited_types << possible_type
+              end
+            elsif type.kind.fields?
+              if type.kind.interface?
+                # recurse into visible possible types
+                possible_types(type).each do |possible_type|
+                  unvisited_types << possible_type
+                end
+              elsif type.kind.object?
+                # recurse into visible implemented interfaces
+                interfaces(type).each do |interface|
+                  unvisited_types << interface
+                end
+              end
+
+              # recurse into visible fields
+              fields(type).each do |field|
+                field_type = field.type.unwrap
+                unvisited_types << field_type
+                # recurse into visible arguments
+                arguments(field).each do |argument|
+                  argument_type = argument.type.unwrap
+                  unvisited_types << argument_type
+                end
+              end
+            end
+          end
+        end
+
+        @reachable_type_set
       end
     end
   end

--- a/spec/graphql/introspection/entry_points_spec.rb
+++ b/spec/graphql/introspection/entry_points_spec.rb
@@ -46,13 +46,13 @@ describe GraphQL::Introspection::EntryPoints do
 
     it "returns reachable types" do
       result = schema.execute(query_string, variables: { name: 'Visible' })
-      type_name = result.dig('data', '__type', 'name')
+      type_name = result['data']['__type']['name']
       assert_equal('Visible', type_name)
     end
 
     it "returns nil for unreachable types" do
       result = schema.execute(query_string, variables: { name: 'NestedInvisible' })
-      type_name = result.dig('data', '__type', 'name')
+      type_name = result['data']['__type']
       assert_nil(type_name)
     end
   end

--- a/spec/graphql/introspection/entry_points_spec.rb
+++ b/spec/graphql/introspection/entry_points_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::Introspection::EntryPoints do
+  describe "#__type" do
+    let(:schema) do
+      nested_invisible_type = Class.new(GraphQL::Schema::Object) do
+        graphql_name 'NestedInvisible'
+        field :foo, String, null: false
+      end
+
+      invisible_type = Class.new(GraphQL::Schema::Object) do
+        graphql_name 'Invisible'
+        field :foo, String, null: false
+        field :nested_invisible, nested_invisible_type, null: false
+
+        def self.visible?(context)
+          false
+        end
+      end
+
+      visible_type = Class.new(GraphQL::Schema::Object) do
+        graphql_name 'Visible'
+        field :foo, String, null: false
+      end
+
+      query_type = Class.new(GraphQL::Schema::Object) do
+        graphql_name 'Query'
+        field :foo, String, null: false
+        field :invisible, invisible_type, null: false
+        field :visible, visible_type, null: false
+      end
+
+      Class.new(GraphQL::Schema) do
+        query query_type
+      end
+    end
+
+    let(:query_string) {%|
+      query getType($name: String!) {
+        __type(name: $name) {
+          name
+        }
+      }
+    |}
+
+    it "returns reachable types" do
+      result = schema.execute(query_string, variables: { name: 'Visible' })
+      type_name = result.dig('data', '__type', 'name')
+      assert_equal('Visible', type_name)
+    end
+
+    it "returns nil for unreachable types" do
+      result = schema.execute(query_string, variables: { name: 'NestedInvisible' })
+      type_name = result.dig('data', '__type', 'name')
+      assert_nil(type_name)
+    end
+  end
+end

--- a/spec/graphql/introspection/schema_type_spec.rb
+++ b/spec/graphql/introspection/schema_type_spec.rb
@@ -12,7 +12,7 @@ describe GraphQL::Introspection::SchemaType do
       }
     }
   |}
-  let(:result) {schema.execute(query_string) }
+  let(:result) { schema.execute(query_string) }
 
   it "exposes the schema" do
     expected = { "data" => {

--- a/spec/graphql/introspection/schema_type_spec.rb
+++ b/spec/graphql/introspection/schema_type_spec.rb
@@ -142,7 +142,7 @@ describe GraphQL::Introspection::SchemaType do
         '__Type',
         '__TypeKind'
       ]
-      types = result.dig('data', '__schema', 'types').map { |type| type.fetch('name') }
+      types = result['data']['__schema']['types'].map { |type| type.fetch('name') }
       assert_equal(expected_types, types)
     end
   end

--- a/spec/graphql/schema/warden_spec.rb
+++ b/spec/graphql/schema/warden_spec.rb
@@ -147,6 +147,8 @@ module MaskHelpers
       description "Find an emic unit by its name"
       argument :name, String, required: true
     end
+
+    field :manners, [MannerType], null: false
   end
 
   class MutationType < BaseObject


### PR DESCRIPTION
This PR takes a crack at fixing the heart of issue #1333 by hiding any types in introspection queries that become unreachable due to visibility checks. The algorithm does a depth first traversal of the schema's "graph" starting at the roots and only recursing into nodes that pass visibility checks. It punts on pushing this logic into Warden since that's a much trickier problem to solve and doesn't appear to provide much value.

I ran the introspection query benchmark and it doesn't seem to add any noticeable performance impact although this could be different for large schemas:

Branch:
```
Warming up --------------------------------------
               query     2.000  i/100ms
Calculating -------------------------------------
               query     23.533  (± 4.2%) i/s -    118.000  in   5.020621s
```

Master:
```
Warming up --------------------------------------
               query     2.000  i/100ms
Calculating -------------------------------------
               query     23.128  (± 4.3%) i/s -    116.000  in   5.019993s
```
