### PR TITLE
Block Strings: Fix bug calling empty? on nil

### DIFF
--- a/lib/graphql/language/block_string.rb
+++ b/lib/graphql/language/block_string.rb
@@ -32,10 +32,10 @@ module GraphQL
         end
 
         # Remove leading & trailing blank lines
-        while lines.first.empty?
+        while lines.size > 0 && lines[0].empty?
           lines.shift
         end
-        while lines.last.empty?
+        while lines.size > 0 && lines[-1].empty?
           lines.pop
         end
 

--- a/spec/graphql/language/block_string_spec.rb
+++ b/spec/graphql/language/block_string_spec.rb
@@ -59,6 +59,11 @@ describe GraphQL::Language::BlockString do
           "Hello,     \n  World!   \n\nYours,     \n  GraphQL.  ",
 
         ],
+        [
+          # Doesn't crash when the string is only a newline
+          "\n",
+          ""
+        ]
       ]
 
       examples.each_with_index do |(before, after), idx|


### PR DESCRIPTION
This fixes a bug when a block string contains only newlines.