### PR TITLE
Deprecate GraphQL::Tracing::SkylightTracing

### DIFF
--- a/lib/graphql/tracing/skylight_tracing.rb
+++ b/lib/graphql/tracing/skylight_tracing.rb
@@ -18,7 +18,7 @@ module GraphQL
       #   This is not advised if you run more than one query per HTTP request, for example, with `graphql-client` or multiplexing.
       #   It can also be specified per-query with `context[:set_skylight_endpoint_name]`.
       def initialize(options = {})
-        warn("GraphQL::Tracing::SkylightTracing is deprecated, enable Skylight's GraphQL probe instead.")
+        warn("GraphQL::Tracing::SkylightTracing is deprecated, please enable Skylight's GraphQL probe instead: https://www.skylight.io/support/getting-more-from-skylight#graphql.")
         @set_endpoint_name = options.fetch(:set_endpoint_name, false)
         super
       end

--- a/lib/graphql/tracing/skylight_tracing.rb
+++ b/lib/graphql/tracing/skylight_tracing.rb
@@ -18,6 +18,7 @@ module GraphQL
       #   This is not advised if you run more than one query per HTTP request, for example, with `graphql-client` or multiplexing.
       #   It can also be specified per-query with `context[:set_skylight_endpoint_name]`.
       def initialize(options = {})
+        warn("GraphQL::Tracing::SkylightTracing is deprecated, enable Skylight's GraphQL probe instead.")
         @set_endpoint_name = options.fetch(:set_endpoint_name, false)
         super
       end


### PR DESCRIPTION
This is a follow-up to #2583.

Ensures that we warn whenever the `GraphQL::Tracing::SkylightTracing` class is initialized*, and suggest enabling Skylight's GraphQL probe instead.

*I guessed that warning in the `initialize` made the most sense, but definitely let me know if this warning should live somewhere else! :)