### PR TITLE
adds lookahead arg to mutations resolve method on RelayClassicMutatio…

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -525,7 +525,7 @@ module GraphQL
                 else
                   extended_obj
                 end
-                @resolver_class.new(object: resolver_obj, context: ctx)
+                @resolver_class.new(object: resolver_obj, context: ctx, field: self)
               else
                 extended_obj
               end
@@ -642,7 +642,7 @@ module GraphQL
             if extended_obj.is_a?(GraphQL::Schema::Object)
               extended_obj = extended_obj.object
             end
-            extended_obj = @resolver_class.new(object: extended_obj, context: query_ctx)
+            extended_obj = @resolver_class.new(object: extended_obj, context: query_ctx, field: self)
           end
 
           if extended_obj.respond_to?(@resolver_method)

--- a/lib/graphql/schema/relay_classic_mutation.rb
+++ b/lib/graphql/schema/relay_classic_mutation.rb
@@ -33,6 +33,8 @@ module GraphQL
         # But when using the interpreter, no instrumenters are applied.
         if context.interpreter?
           input = inputs[:input].to_kwargs
+          input[:lookahead] = inputs[:lookahead] if inputs[:lookahead]
+
           # Transfer these from the top-level hash to the
           # shortcutted `input:` object
           self.class.extras.each do |ext|

--- a/lib/graphql/schema/relay_classic_mutation.rb
+++ b/lib/graphql/schema/relay_classic_mutation.rb
@@ -34,11 +34,12 @@ module GraphQL
         if context.interpreter?
           input = inputs[:input].to_kwargs
 
-          new_extras = field.extras if field
+          new_extras = field ? field.extras : []
+          all_extras = self.class.extras + new_extras
 
           # Transfer these from the top-level hash to the
           # shortcutted `input:` object
-          self.class.extras(new_extras).each do |ext|
+          all_extras.each do |ext|
             # It's possible that the `extra` was not passed along by this point,
             # don't re-add it if it wasn't given here.
             if inputs.key?(ext)

--- a/lib/graphql/schema/relay_classic_mutation.rb
+++ b/lib/graphql/schema/relay_classic_mutation.rb
@@ -33,11 +33,10 @@ module GraphQL
         # But when using the interpreter, no instrumenters are applied.
         if context.interpreter?
           input = inputs[:input].to_kwargs
-          input[:lookahead] = inputs[:lookahead] if inputs[:lookahead]
 
           # Transfer these from the top-level hash to the
           # shortcutted `input:` object
-          self.class.extras.each do |ext|
+          self.class.extras(field&.extras).each do |ext|
             # It's possible that the `extra` was not passed along by this point,
             # don't re-add it if it wasn't given here.
             if inputs.key?(ext)

--- a/lib/graphql/schema/relay_classic_mutation.rb
+++ b/lib/graphql/schema/relay_classic_mutation.rb
@@ -34,9 +34,11 @@ module GraphQL
         if context.interpreter?
           input = inputs[:input].to_kwargs
 
+          new_extras = field.extras if field
+
           # Transfer these from the top-level hash to the
           # shortcutted `input:` object
-          self.class.extras(field&.extras).each do |ext|
+          self.class.extras(new_extras).each do |ext|
             # It's possible that the `extra` was not passed along by this point,
             # don't re-add it if it wasn't given here.
             if inputs.key?(ext)

--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -29,9 +29,11 @@ module GraphQL
 
       # @param object [Object] the initialize object, pass to {Query.initialize} as `root_value`
       # @param context [GraphQL::Query::Context]
-      def initialize(object:, context:)
+      # @param field [GraphQL::Schema::Field]
+      def initialize(object:, context:, field: nil)
         @object = object
         @context = context
+        @field = field
         # Since this hash is constantly rebuilt, cache it for this call
         @arguments_by_keyword = {}
         self.class.arguments.each do |name, arg|
@@ -45,6 +47,9 @@ module GraphQL
 
       # @return [GraphQL::Query::Context]
       attr_reader :context
+
+      # @return [GraphQL::Schema::Field]
+      attr_reader :field
 
       # This method is _actually_ called by the runtime,
       # it does some preparation and then eventually calls

--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -30,7 +30,7 @@ module GraphQL
       # @param object [Object] the initialize object, pass to {Query.initialize} as `root_value`
       # @param context [GraphQL::Query::Context]
       # @param field [GraphQL::Schema::Field]
-      def initialize(object:, context:, field: nil)
+      def initialize(object:, context:, field:)
         @object = object
         @context = context
         @field = field

--- a/lib/graphql/schema/subscription.rb
+++ b/lib/graphql/schema/subscription.rb
@@ -29,7 +29,7 @@ module GraphQL
       # propagate null.
       null false
 
-      def initialize(object:, context:, field: nil)
+      def initialize(object:, context:, field:)
         super
         # Figure out whether this is an update or an initial subscription
         @mode = context.query.subscription_update? ? :update : :subscribe

--- a/lib/graphql/schema/subscription.rb
+++ b/lib/graphql/schema/subscription.rb
@@ -29,7 +29,7 @@ module GraphQL
       # propagate null.
       null false
 
-      def initialize(object:, context:)
+      def initialize(object:, context:, field: nil)
         super
         # Figure out whether this is an update or an initial subscription
         @mode = context.query.subscription_update? ? :update : :subscribe

--- a/spec/graphql/schema/relay_classic_mutation_spec.rb
+++ b/spec/graphql/schema/relay_classic_mutation_spec.rb
@@ -95,6 +95,32 @@ describe GraphQL::Schema::RelayClassicMutation do
       assert_equal 5, res["data"]["hasExtras"]["int"]
     end
 
+    it "supports field extras" do
+      res = Jazz::Schema.execute <<-GRAPHQL
+      mutation {
+        hasFieldExtras(input: {}) {
+          lookaheadClass
+          int
+        }
+      }
+      GRAPHQL
+
+      assert_equal "GraphQL::Execution::Lookahead", res["data"]["hasFieldExtras"]["lookaheadClass"]
+      assert_nil res["data"]["hasFieldExtras"]["int"]
+
+      # Also test with given args
+      res = Jazz::Schema.execute <<-GRAPHQL
+      mutation {
+        hasFieldExtras(input: {int: 5}) {
+          lookaheadClass
+          int
+        }
+      }
+      GRAPHQL
+      assert_equal "GraphQL::Execution::Lookahead", res["data"]["hasFieldExtras"]["lookaheadClass"]
+      assert_equal 5, res["data"]["hasFieldExtras"]["int"]
+    end
+
     it "can strip out extras" do
       ctx = {}
       res = Jazz::Schema.execute <<-GRAPHQL, context: ctx

--- a/spec/graphql/schema/resolver_spec.rb
+++ b/spec/graphql/schema/resolver_spec.rb
@@ -20,7 +20,7 @@ describe GraphQL::Schema::Resolver do
       argument :value, Integer, required: false
       type [Integer, null: true], null: false
 
-      def initialize(object:, context:)
+      def initialize(object:, context:, field:)
         super
         if defined?(@value)
           raise "The instance should start fresh"
@@ -447,7 +447,7 @@ describe GraphQL::Schema::Resolver do
     end
 
     it "works on instances" do
-      r = ResolverTest::Resolver1.new(object: nil, context: nil)
+      r = ResolverTest::Resolver1.new(object: nil, context: nil, field: nil)
       assert_equal "Resolver1", r.path
     end
   end

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -534,6 +534,23 @@ module Jazz
     end
   end
 
+  class HasFieldExtras < GraphQL::Schema::RelayClassicMutation
+    null true
+    description "Test field with extras in RelayClassicMutation"
+
+    argument :int, Integer, required: false
+
+    field :lookahead_class, String, null: false
+    field :int, Integer, null: true
+
+    def resolve(int: nil, lookahead:)
+      {
+        int: int,
+        lookahead_class: lookahead.class.name,
+      }
+    end
+  end
+
   class StripsExtras < GraphQL::Schema::RelayClassicMutation
     extras [:lookahead]
     def resolve_with_support(lookahead: , **rest)
@@ -686,6 +703,7 @@ module Jazz
     field :returns_multiple_errors, mutation: ReturnsMultipleErrors, null: false
     field :has_extras, mutation: HasExtras
     field :has_extras_stripped, mutation: HasExtrasStripped
+    field :has_field_extras, mutation: HasFieldExtras, extras: [:lookahead]
 
     def add_ensemble(input:)
       ens = Models::Ensemble.new(input.name)


### PR DESCRIPTION
Related to issue https://github.com/rmosolgo/graphql-ruby/issues/2606

This PR tries to make `lookahead` work on mutations by injecting `lookahead` argument value into mutations `resolver` methods. 

The script used to reproduce this is on the issue description https://github.com/rmosolgo/graphql-ruby/issues/2606

**Before**

```ruby
#=> resolve: missing keyword: lookahead (ArgumentError)
```

**After**

```ruby
#<GraphQL::Query::Result @query=... @to_h={"data"=>{"updateName"=>{"output"=>"New name: John Doe - lookahead: GraphQL::Execution::Lookahead"}}}>
```

NOTE: I'm not sure this is the best or preferred way to do it, but it fixes the issue I was having as you can see/reproduce it with the testing script on the issue https://github.com/rmosolgo/graphql-ruby/issues/2606.

cc @rmosolgo 