### PR TITLE
Fixes for new pagination 

### DIFF
--- a/lib/graphql/pagination/array_connection.rb
+++ b/lib/graphql/pagination/array_connection.rb
@@ -68,7 +68,6 @@ module GraphQL
 
           limited_nodes = limited_nodes.first(first) if first
           limited_nodes = limited_nodes.last(last) if last
-          limited_nodes = limited_nodes.first(max_page_size) if max_page_size && !first && !last
 
           limited_nodes
         end

--- a/lib/graphql/pagination/connections.rb
+++ b/lib/graphql/pagination/connections.rb
@@ -29,7 +29,14 @@ module GraphQL
       end
 
       def self.use(schema_defn)
-        schema_defn.connections = self.new
+        if schema_defn.is_a?(Class)
+          schema_defn.connections = self.new
+        else
+          # Unwrap a `.define` object
+          schema_defn = schema_defn.target
+          schema_defn.connections = self.new
+          schema_defn.class.connections = schema_defn.connections
+        end
       end
 
       def initialize

--- a/lib/graphql/pagination/relation_connection.rb
+++ b/lib/graphql/pagination/relation_connection.rb
@@ -131,13 +131,6 @@ module GraphQL
             end
           end
 
-          # Apply max page size if nothing else was applied
-          if max_page_size && !first && !last
-            if relation_limit(paginated_nodes).nil? || relation_limit(paginated_nodes) > max_page_size
-              paginated_nodes = set_limit(paginated_nodes, max_page_size)
-            end
-          end
-
           @has_next_page = !!(
             (before_offset && before_offset > 0) ||
             (first && sliced_nodes_count > first)

--- a/lib/graphql/pagination/relation_connection.rb
+++ b/lib/graphql/pagination/relation_connection.rb
@@ -53,6 +53,7 @@ module GraphQL
         raise "#{self.class}#null_relation(relation) must return an empty relation for a #{relation.class} (#{relation.inspect})"
       end
 
+      # @return [Integer]
       def offset_from_cursor(cursor)
         decode(cursor).to_i
       end

--- a/lib/graphql/schema/field/connection_extension.rb
+++ b/lib/graphql/schema/field/connection_extension.rb
@@ -31,10 +31,10 @@ module GraphQL
           elsif value.is_a?(GraphQL::Pagination::Connection)
             # update the connection with some things that may not have been provided
             value.context ||= context
-            value.first ||= arguments[:first]
-            value.after ||= arguments[:after]
-            value.last ||= arguments[:last]
-            value.before ||= arguments[:before]
+            value.first_value ||= arguments[:first]
+            value.after_value ||= arguments[:after]
+            value.last_value ||= arguments[:last]
+            value.before_value ||= arguments[:before]
             value.max_page_size ||= field.max_page_size
             value
           elsif context.schema.new_connections?

--- a/spec/support/connection_assertions.rb
+++ b/spec/support/connection_assertions.rb
@@ -191,14 +191,20 @@ module ConnectionAssertions
           res = exec_query(query_str, {})
           # Even though neither first nor last was provided, max_page_size was applied.
           assert_names(["Avocado", "Beet", "Cucumber", "Dill", "Eggplant", "Fennel"], res)
+          assert_equal true, get_page_info(res, "hasNextPage")
+          assert_equal false, get_page_info(res, "hasPreviousPage")
 
           # max_page_size overrides first
           res = exec_query(query_str, first: 10)
           assert_names(["Avocado", "Beet", "Cucumber", "Dill", "Eggplant", "Fennel"], res)
+          assert_equal true, get_page_info(res, "hasNextPage")
+          assert_equal false, get_page_info(res, "hasPreviousPage")
 
           # max_page_size overrides last
           res = exec_query(query_str, last: 10)
           assert_names(["Eggplant", "Fennel", "Ginger", "Horseradish", "I Can't Believe It's Not Butter", "Jicama"], res)
+          assert_equal false, get_page_info(res, "hasNextPage")
+          assert_equal true, get_page_info(res, "hasPreviousPage")
         end
       end
 


### PR DESCRIPTION
Improve capping by max_page_size, now subclasses can "just" use `first` and `last`. Max_page_size will be applied as `first` if no `first` or `last` is given. 

The advantage there is we get `has_next_page`/`has_previous_page` correctly implemented for free, and it's harder to forget to use max_page_size. Fixes #1109 