### PR TITLE
Update conversion from ActiveRecord error

### DIFF
--- a/guides/mutations/mutation_errors.md
+++ b/guides/mutations/mutation_errors.md
@@ -74,7 +74,7 @@ def resolve(id:, attributes:)
     # Convert Rails model errors into GraphQL-ready error hashes
     user_errors = post.errors.map do |attribute, message|
       # This is the GraphQL argument which corresponds to the validation error:
-      path = ["attributes", attribute.camelize]
+      path = ["attributes", attribute.to_s.camelize(:lower)]
       {
         path: path,
         message: message,


### PR DESCRIPTION
ActiveRecord errors keys are symbols, so they would need to be converted to string first. The [`camelize`](https://api.rubyonrails.org/classes/String.html#method-i-camelize) method will also default to `PascalCase` unless the `:lower` argument is passed.

I though that it would help people implementing that pattern of errors.