### PR TITLE
Fix multiplex max depth

### DIFF
--- a/guides/queries/ast_analysis.md
+++ b/guides/queries/ast_analysis.md
@@ -124,3 +124,11 @@ end
 ```
 
 **Make sure you pass the class and not an instance of your analyzer. The new analysis engine will take care of instantiating your analyzers with the query**.
+
+## Analyzing Multiplexes
+
+Analyzers are initialized with the _unit of analysis_, available as `subject`.
+
+When analyzers are hooked up to multiplexes, `query` is `nil`, but `multiplex` returns the subject of analysis. You can use `visitor.query` inside visit methods to reference the query that owns the current AST node.
+
+Note that some built-in analyzers (eg `AST::MaxQueryDepth`) support multiplexes even though `Query` is in their name.

--- a/lib/graphql/analysis/ast.rb
+++ b/lib/graphql/analysis/ast.rb
@@ -23,7 +23,7 @@ module GraphQL
       #
       # @param multiplex [GraphQL::Execution::Multiplex]
       # @param analyzers [Array<GraphQL::Analysis::AST::Analyzer>]
-      # @return [void]
+      # @return [Array<Any>] Results from multiplex analyzers
       def analyze_multiplex(multiplex, analyzers)
         multiplex_analyzers = analyzers.map { |analyzer| analyzer.new(multiplex) }
 
@@ -46,8 +46,8 @@ module GraphQL
           multiplex.queries.each_with_index do |query, idx|
             query.analysis_errors = multiplex_errors + analysis_errors(query_results[idx])
           end
+          multiplex_results
         end
-        nil
       end
 
       # @param query [GraphQL::Query]

--- a/lib/graphql/analysis/ast/analyzer.rb
+++ b/lib/graphql/analysis/ast/analyzer.rb
@@ -5,10 +5,21 @@ module GraphQL
       # Query analyzer for query ASTs. Query analyzers respond to visitor style methods
       # but are prefixed by `enter` and `leave`.
       #
-      # @param [GraphQL::Query] The query to analyze
+      # When an analyzer is initialized with a Multiplex, you can always get the current query from
+      # `visitor.query` in the visit methods.
+      #
+      # @param [GraphQL::Query, GraphQL::Execution::Multiplex] The query or multiplex to analyze
       class Analyzer
-        def initialize(query)
-          @query = query
+        def initialize(subject)
+          @subject = subject
+
+          if subject.is_a?(GraphQL::Query)
+            @query = subject
+            @multiplex = nil
+          else
+            @multiplex = subject
+            @query = nil
+          end
         end
 
         # Analyzer hook to decide at analysis time whether a query should
@@ -58,7 +69,15 @@ module GraphQL
 
         protected
 
+        # @return [GraphQL::Query, GraphQL::Execution::Multiplex] Whatever this analyzer is analyzing
+        attr_reader :subject
+
+        # @return [GraphQL::Query, nil] `nil` if this analyzer is visiting a multiplex
+        #  (When this is `nil`, use `visitor.query` inside visit methods to get the current query)
         attr_reader :query
+
+        # @return [GraphQL::Execution::Multiplex, nil] `nil` if this analyzer is visiting a query
+        attr_reader :multiplex
       end
     end
   end

--- a/lib/graphql/analysis/ast/max_query_complexity.rb
+++ b/lib/graphql/analysis/ast/max_query_complexity.rb
@@ -7,12 +7,12 @@ module GraphQL
       # see {Schema#max_complexity} and {Query#max_complexity}
       class MaxQueryComplexity < QueryComplexity
         def result
-          return if query.max_complexity.nil?
+          return if subject.max_complexity.nil?
 
           total_complexity = max_possible_complexity
 
-          if total_complexity > query.max_complexity
-            GraphQL::AnalysisError.new("Query has complexity of #{total_complexity}, which exceeds max complexity of #{query.max_complexity}")
+          if total_complexity > subject.max_complexity
+            GraphQL::AnalysisError.new("Query has complexity of #{total_complexity}, which exceeds max complexity of #{subject.max_complexity}")
           else
             nil
           end

--- a/lib/graphql/analysis/ast/max_query_depth.rb
+++ b/lib/graphql/analysis/ast/max_query_depth.rb
@@ -4,10 +4,10 @@ module GraphQL
     module AST
       class MaxQueryDepth < QueryDepth
         def result
-          configured_max_depth = if query.is_a?(GraphQL::Execution::Multiplex)
-            query.schema.max_depth
-          else
+          configured_max_depth = if query
             query.max_depth
+          else
+            multiplex.schema.max_depth
           end
 
           if configured_max_depth && @max_depth > configured_max_depth

--- a/lib/graphql/analysis/ast/max_query_depth.rb
+++ b/lib/graphql/analysis/ast/max_query_depth.rb
@@ -4,10 +4,14 @@ module GraphQL
     module AST
       class MaxQueryDepth < QueryDepth
         def result
-          return unless query.max_depth
+          configured_max_depth = if query.is_a?(GraphQL::Execution::Multiplex)
+            query.schema.max_depth
+          else
+            query.max_depth
+          end
 
-          if @max_depth > query.max_depth
-            GraphQL::AnalysisError.new("Query has depth of #{@max_depth}, which exceeds max depth of #{query.max_depth}")
+          if configured_max_depth && @max_depth > configured_max_depth
+            GraphQL::AnalysisError.new("Query has depth of #{@max_depth}, which exceeds max depth of #{configured_max_depth}")
           else
             nil
           end

--- a/lib/graphql/analysis/ast/query_complexity.rb
+++ b/lib/graphql/analysis/ast/query_complexity.rb
@@ -42,7 +42,7 @@ module GraphQL
           if @complexities_on_type.last.is_a?(AbstractTypeComplexity)
             key = selection_key(visitor.response_path, visitor.query)
             parent_type = visitor.parent_type_definition
-            query.possible_types(parent_type).each do |type|
+            visitor.query.possible_types(parent_type).each do |type|
               @complexities_on_type.last.merge(type, key, own_complexity)
             end
           else
@@ -74,7 +74,7 @@ module GraphQL
 
           case defined_complexity
           when Proc
-            defined_complexity.call(query.context, arguments, child_complexity)
+            defined_complexity.call(visitor.query.context, arguments, child_complexity)
           when Numeric
             defined_complexity + (child_complexity || 0)
           else

--- a/spec/graphql/analysis/ast/max_query_depth_spec.rb
+++ b/spec/graphql/analysis/ast/max_query_depth_spec.rb
@@ -2,7 +2,11 @@
 require "spec_helper"
 
 describe GraphQL::Analysis::AST::MaxQueryDepth do
-  let(:schema) { Class.new(Dummy::Schema) }
+  let(:schema) {
+    schema = Class.new(Dummy::Schema)
+    schema.analysis_engine = GraphQL::Analysis::AST
+    schema
+  }
   let(:query_string) { "
     {
       cheese(id: 1) {
@@ -20,64 +24,61 @@ describe GraphQL::Analysis::AST::MaxQueryDepth do
       }
     }
   "}
-  let(:query) { GraphQL::Query.new(schema, query_string) }
+  let(:max_depth) { nil }
+  let(:query) {
+    # Don't override `schema.max_depth` with `nil`
+    options = max_depth ? { max_depth: max_depth } : {}
+    GraphQL::Query.new(
+      schema.graphql_definition,
+      query_string,
+      variables: {},
+      **options
+    )
+  }
   let(:result) {
     GraphQL::Analysis::AST.analyze_query(query, [GraphQL::Analysis::AST::MaxQueryDepth]).first
   }
+  let(:multiplex) {
+    GraphQL::Execution::Multiplex.new(
+      schema: schema,
+      queries: [query.dup, query.dup],
+      context: {},
+      max_complexity: nil
+    )
+  }
+  let(:multiplex_result) {
+    GraphQL::Analysis::AST.analyze_multiplex(multiplex, [GraphQL::Analysis::AST::MaxQueryDepth]).first
+  }
 
   describe "when the query is deeper than max depth" do
+    let(:max_depth) { 5 }
+
     it "adds an error message for a too-deep query" do
       assert_equal "Query has depth of 7, which exceeds max depth of 5", result.message
     end
   end
 
+  describe "when a multiplex queries is deeper than max depth" do
+    before do
+      schema.max_depth = 5
+    end
+
+    it "adds an error message for a too-deep query on from multiplex analyzer" do
+      assert_equal "Query has depth of 7, which exceeds max depth of 5", multiplex_result.message
+    end
+  end
+
   describe "when the query specifies a different max_depth" do
-    let(:query) { GraphQL::Query.new(schema, query_string, max_depth: 100) }
+    let(:max_depth) { 100 }
 
     it "obeys that max_depth" do
       assert_nil result
-    end
-  end
-
-  describe "when the query disables max_depth" do
-    let(:query) { GraphQL::Query.new(schema, query_string, max_depth: nil) }
-
-    it "obeys that max_depth" do
-      assert_nil result
-    end
-  end
-
-  describe "When the query includes introspective fields" do
-    let(:query_string) { "
-    query allSchemaTypes {
-      __schema {
-         types {
-            fields {
-              type {
-                fields {
-                  type {
-                    fields {
-                      type {
-                        name
-                      }
-                    }
-                  }
-                }
-              }
-            }
-         }
-      }
-    }
-  "}
-
-    it "adds an error message for a too-deep query" do
-      assert_equal "Query has depth of 9, which exceeds max depth of 5", result.message
     end
   end
 
   describe "When the query is not deeper than max_depth" do
     before do
-      schema.max_depth(100)
+      schema.max_depth = 100
     end
 
     it "doesn't add an error" do
@@ -87,8 +88,7 @@ describe GraphQL::Analysis::AST::MaxQueryDepth do
 
   describe "when the max depth isn't set" do
     before do
-      # Yuck - Can't override GraphQL::Schema.max_depth to return nil if it has already been set
-      schema.define_singleton_method(:max_depth) { |*| nil }
+      schema.max_depth = nil
     end
 
     it "doesn't add an error message" do
@@ -98,7 +98,7 @@ describe GraphQL::Analysis::AST::MaxQueryDepth do
 
   describe "when a fragment exceeds max depth" do
     before do
-      schema.max_depth(4)
+      schema.max_depth = 4
     end
 
     let(:query_string) { "


### PR DESCRIPTION
Fixes #2388 

Alternative to #2394 

We were already using "query" analyzers to analyze multiplexes, but in some cases it didn't actually work. 

I want to update it to, yknow, _actually_ work, and also: 

- Update the analyzer API to clarify what kind of thing it's analyzing (while maintaining a use-agnostic access to `subject`) 
- Reflect this dual usage in the docs 

Thanks especially to @patvice who wrote up this issue in detail, provided the appropriate tests, and explored an alternative solution. 