### PR TITLE
updates mutation_generator to use underscored field names

### DIFF
--- a/lib/generators/graphql/mutation_generator.rb
+++ b/lib/generators/graphql/mutation_generator.rb
@@ -45,7 +45,7 @@ module Graphql
       private
 
       def assign_names!(name)
-        @field_name = name.camelize(:lower)
+        @field_name = name.camelize.underscore
         @mutation_name = name.camelize(:upper)
         @file_name = name.camelize.underscore
       end

--- a/spec/integration/rails/generators/graphql/mutation_generator_spec.rb
+++ b/spec/integration/rails/generators/graphql/mutation_generator_spec.rb
@@ -39,7 +39,7 @@ RUBY
   EXPECTED_MUTATION_TYPE = <<-RUBY
 module Types
   class MutationType < Types::BaseObject
-    field :updateName, mutation: Mutations::UpdateName
+    field :update_name, mutation: Mutations::UpdateName
     # TODO: remove me
     field :test_field, String, null: false,
       description: "An example field added by the generator"


### PR DESCRIPTION
Currently the mutation generator are generating camel case field names.

I think since this https://github.com/rmosolgo/graphql-ruby/pull/1126
and the class based API were introduced, the standard seems to have changed to ruby underscore
syntax names. See https://github.com/rmosolgo/graphql-ruby/pull/1126/files#diff-161608206c9ba9bc29a59e613e2bdbfdR307  

Before

```
field :updateName, mutation: Mutations::UpdateName
```

After

```
field :update_name, mutation: Mutations::UpdateName
```

Let me know if this is the expected behaviour

cc @rmosolgo 