### PR TITLE
Recommend the right thing up front for multiplex

### DIFF
--- a/guides/queries/multiplex.md
+++ b/guides/queries/multiplex.md
@@ -78,11 +78,9 @@ def execute
     )
   end
 
-  render json: result
+  render json: result, root: false
 end
 ```
-
-If Apollo Client has issues recognizing the result of `render json: result`, replace it with `render body: result.to_json, content_type: 'application/json'`.
 
 ## Validation and Error Handling
 


### PR DESCRIPTION
I'm pretty sure this is the right way to configure the JSON rendering to not include a
root node (which breaks the multiplex spec and confuses clients).

@rmosolgo I'm doing this a tad blind since I don't know the impetus behind the original multiple recommendations, but this works for us and AFAIK the pure `render json: result` should never work, so...

cc @rrangith