### PR TITLE
TimeoutMiddleware: switch to monotonic time

### DIFF
--- a/lib/graphql/schema/timeout_middleware.rb
+++ b/lib/graphql/schema/timeout_middleware.rb
@@ -35,9 +35,10 @@ module GraphQL
 
       def call(parent_type, parent_object, field_definition, field_args, query_context)
         ns = query_context.namespace(self.class)
-        timeout_at = ns[:timeout_at] ||= Time.now + @max_seconds
+        now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        timeout_at = ns[:timeout_at] ||= now + @max_seconds
 
-        if timeout_at < Time.now
+        if timeout_at < now
           on_timeout(parent_type, parent_object, field_definition, field_args, query_context)
         else
           yield


### PR DESCRIPTION
The call to `Time.now` can be affected by changes to system time such as
NTP updating the OS' time. This can be avoided by using a monotonically
increasing time source.

For more information see:
https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way/