### PR TITLE
Add clarification to Multiplex about ordering of responses

### DIFF
--- a/guides/queries/multiplex.md
+++ b/guides/queries/multiplex.md
@@ -47,7 +47,7 @@ Then, pass them to `Schema#multiplex`:
 results = MySchema.multiplex(queries)
 ```
 
-`results` will contain the result for each query in `queries`.
+`results` will contain the result for each query in `queries`. __NOTE:__ The results will always be in the same order that their respective requests were sent in.
 
 ## Apollo Query Batching
 

--- a/spec/graphql/execution/multiplex_spec.rb
+++ b/spec/graphql/execution/multiplex_spec.rb
@@ -52,6 +52,32 @@ describe GraphQL::Execution::Multiplex do
       res = multiplex(queries)
       assert_equal expected_data, res
     end
+
+    it "returns responses in the same order as their respective requests" do
+      queries = 2000.times.map do |index|
+        case index % 3
+        when 0
+          {query: q1}
+        when 1
+          {query: q2}
+        when 2
+          {query: q3}
+        end
+      end
+
+      responses = multiplex(queries)
+
+      responses.each.with_index do |response, index|
+        case index % 3
+        when 0
+          assert_equal "Q1", response.query.operation_name
+        when 1
+          assert_equal "Q2", response.query.operation_name
+        when 2
+          assert_equal "Q3", response.query.operation_name
+        end
+      end
+    end
   end
 
   describe "when some have validation errors or runtime errors" do


### PR DESCRIPTION
@rmosolgo 
We were worried that since `Multiplex` processes requests concurrently, that it wouldn't be able to maintain order in our responses. 

This PR is to confirm to users that results will always be kept in the same order that their respective requests were sent in. 

This way users can do something like the following without worrying about whether or not the order of the responses was maintained:
```
payload = [
  ComponentA.required_graphql_query,
  ComponentB.required_graphql_query
]

responses = GraphQLClient.batch_request(payload: payload)

ComponentA.handle_response(responses[0])
ComponentB.handle_response(response[1])
```

I could optionally remove the test case I made, but the doc change should be made so people don't get confused in the future