### PR TITLE
rework Execution::Errors to manually wrap significant bits of code

### DIFF
--- a/lib/graphql/execution/errors.rb
+++ b/lib/graphql/execution/errors.rb
@@ -19,34 +19,36 @@ module GraphQL
     class Errors
       def self.use(schema)
         schema_class = schema.is_a?(Class) ? schema : schema.target.class
-        schema.tracer(self.new(schema_class))
+        schema_class.error_handler = self.new(schema_class)
       end
 
       def initialize(schema)
         @schema = schema
       end
 
-      def trace(event, data)
-        case event
-        when "execute_field", "execute_field_lazy"
-          with_error_handling(data) { yield }
-        else
+      class NullErrorHandler
+        def self.with_error_handling(query)
           yield
         end
       end
 
-      private
-
-      def with_error_handling(trace_data)
+      # Call the given block with the schema's configured error handlers.
+      #
+      # If the block returns a lazy value, it's not wrapped with error handling. That area will have to be wrapped itself.
+      #
+      # @param query [GraphQL::Query]
+      # @return [Object] Either the result of the given block, or some object to replace the result, in case of error handling.
+      def with_error_handling(query)
         yield
       rescue StandardError => err
         rescues = @schema.rescues
         _err_class, handler = rescues.find { |err_class, handler| err.is_a?(err_class) }
         if handler
-          obj = trace_data[:object]
-          args = trace_data[:arguments]
-          ctx = trace_data[:query].context
-          field = trace_data[:field]
+          ctx = query.context
+          runtime_info = ctx.namespace(:interpreter) || {}
+          obj = runtime_info[:current_object]
+          args = runtime_info[:current_arguments]
+          field = runtime_info[:current_field]
           if obj.is_a?(GraphQL::Schema::Object)
             obj = obj.object
           end

--- a/lib/graphql/execution/errors.rb
+++ b/lib/graphql/execution/errors.rb
@@ -2,7 +2,7 @@
 
 module GraphQL
   module Execution
-    # A tracer that wraps query execution with error handling.
+    # A plugin that wraps query execution with error handling.
     # Supports class-based schemas and the new {Interpreter} runtime only.
     #
     # @example Handling ActiveRecord::NotFound
@@ -27,7 +27,7 @@ module GraphQL
       end
 
       class NullErrorHandler
-        def self.with_error_handling(query)
+        def self.with_error_handling(_ctx)
           yield
         end
       end
@@ -36,15 +36,14 @@ module GraphQL
       #
       # If the block returns a lazy value, it's not wrapped with error handling. That area will have to be wrapped itself.
       #
-      # @param query [GraphQL::Query]
+      # @param ctx [GraphQL::Query::Context]
       # @return [Object] Either the result of the given block, or some object to replace the result, in case of error handling.
-      def with_error_handling(query)
+      def with_error_handling(ctx)
         yield
       rescue StandardError => err
         rescues = @schema.rescues
         _err_class, handler = rescues.find { |err_class, handler| err.is_a?(err_class) }
         if handler
-          ctx = query.context
           runtime_info = ctx.namespace(:interpreter) || {}
           obj = runtime_info[:current_object]
           args = runtime_info[:current_arguments]

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -300,6 +300,13 @@ module GraphQL
       with_prepared_ast { @subscription }
     end
 
+    # @api private
+    def with_error_handling
+      schema.error_handler.with_error_handling(self) do
+        yield
+      end
+    end
+
     private
 
     def find_operation(operations, operation_name)

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -302,7 +302,7 @@ module GraphQL
 
     # @api private
     def with_error_handling
-      schema.error_handler.with_error_handling(self) do
+      schema.error_handler.with_error_handling(context) do
         yield
       end
     end

--- a/lib/graphql/query/variables.rb
+++ b/lib/graphql/query/variables.rb
@@ -35,7 +35,9 @@ module GraphQL
               if validation_result.valid?
                 if value_was_provided
                   # Add the variable if a value was provided
-                  memo[variable_name] = variable_type.coerce_input(provided_value, ctx)
+                  memo[variable_name] = ctx.query.with_error_handling do
+                    variable_type.coerce_input(provided_value, ctx)
+                  end
                 elsif default_value != nil
                   # Add the variable if it wasn't provided but it has a default value (including `null`)
                   memo[variable_name] = GraphQL::Query::LiteralInput.coerce(variable_type, default_value, self)

--- a/lib/graphql/query/variables.rb
+++ b/lib/graphql/query/variables.rb
@@ -35,7 +35,7 @@ module GraphQL
               if validation_result.valid?
                 if value_was_provided
                   # Add the variable if a value was provided
-                  memo[variable_name] = ctx.query.with_error_handling do
+                  memo[variable_name] = schema.error_handler.with_error_handling(context) do
                     variable_type.coerce_input(provided_value, ctx)
                   end
                 elsif default_value != nil

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -597,6 +597,7 @@ module GraphQL
     alias :_schema_class :class
     def_delegators :_schema_class, :visible?, :accessible?, :authorized?, :unauthorized_object, :unauthorized_field, :inaccessible_fields
     def_delegators :_schema_class, :directive
+    def_delegators :_schema_class, :error_handler
 
     # A function to call when {#execute} receives an invalid query string
     #
@@ -1025,6 +1026,13 @@ module GraphQL
 
       def type_error(type_err, ctx)
         DefaultTypeError.call(type_err, ctx)
+      end
+
+      attr_writer :error_handler
+
+      # @return [GraphQL::Execution::Errors, Class<GraphQL::Execution::Errors::NullErrorHandler>]
+      def error_handler
+        @error_handler ||= GraphQL::Execution::Errors::NullErrorHandler
       end
 
       def lazy_resolve(lazy_class, value_method)

--- a/lib/graphql/schema/object.rb
+++ b/lib/graphql/schema/object.rb
@@ -35,10 +35,12 @@ module GraphQL
         # @return [GraphQL::Schema::Object, GraphQL::Execution::Lazy]
         # @raise [GraphQL::UnauthorizedError] if the user-provided hook returns `false`
         def authorized_new(object, context)
-          auth_val = begin
-            authorized?(object, context)
-          rescue GraphQL::UnauthorizedError => err
-            context.schema.unauthorized_object(err)
+          auth_val = context.query.with_error_handling do
+            begin
+              authorized?(object, context)
+            rescue GraphQL::UnauthorizedError => err
+              context.schema.unauthorized_object(err)
+            end
           end
 
           context.schema.after_lazy(auth_val) do |is_authorized|

--- a/spec/graphql/execution/errors_spec.rb
+++ b/spec/graphql/execution/errors_spec.rb
@@ -12,6 +12,7 @@ describe "GraphQL::Execution::Errors" do
         super
       end
     end
+    class ErrorD < RuntimeError; end
 
     class ErrorASubclass < ErrorA; end
 
@@ -30,6 +31,35 @@ describe "GraphQL::Execution::Errors" do
 
     rescue_from(ErrorC) do |err, *|
       err.value
+    end
+
+    rescue_from(ErrorD) do |err, obj, args, ctx, field|
+      raise GraphQL::ExecutionError, "ErrorD on #{obj.inspect} at #{field ? "#{field.path}(#{args})" : "boot"}"
+    end
+
+    class Thing < GraphQL::Schema::Object
+      def self.authorized?(obj, ctx)
+        if ctx[:authorized] == false
+          raise ErrorD
+        end
+      end
+
+      field :string, String, null: false
+      def string
+        "a string"
+      end
+    end
+
+    class ValuesInput < GraphQL::Schema::InputObject
+      argument :value, Int, required: true, loads: Thing
+
+      def object_from_id(type, value, ctx)
+        if value == 1
+          :thing
+        else
+          raise ErrorD
+        end
+      end
     end
 
     class Query < GraphQL::Schema::Object
@@ -65,6 +95,15 @@ describe "GraphQL::Execution::Errors" do
       field :f6, Int, null: true
       def f6
         -> { raise ErrorB }
+      end
+
+      field :thing, Thing, null: true
+      def thing
+        :thing
+      end
+
+      field :input_field, Int, null: true do
+        argument :values, ValuesInput, required: true, method_access: false
       end
     end
 
@@ -117,6 +156,35 @@ describe "GraphQL::Execution::Errors" do
       res = ErrorsTestSchema.execute("{ f5 }", context: context)
       assert_equal({ "data" => { "f5" => nil } }, res)
       assert_equal ["raised subclass (ErrorsTestSchema::Query.f5, nil, {})"], context[:errors]
+    end
+
+    describe "errors raised in authorized hooks" do
+      it "rescues them" do
+        context = { authorized: false }
+        res = ErrorsTestSchema.execute(" { thing { string } } ", context: context)
+        assert_equal ["ErrorD on nil at Query.thing({})"], res["errors"].map { |e| e["message"] }
+      end
+    end
+
+    describe "errors raised in input_object loads" do
+      it "rescues them from literal values" do
+        context = { authorized: false }
+        res = ErrorsTestSchema.execute(" { inputField(values: { value: 2 }) } ", root_value: :root, context: context)
+        # It would be better to have the arguments here, but since this error was raised during _creation_ of keywords,
+        # so the runtime arguments aren't available now.
+        assert_equal ["ErrorD on :root at Query.inputField()"], res["errors"].map { |e| e["message"] }
+      end
+
+      it "rescues them from variable values" do
+        context = { authorized: false }
+        res = ErrorsTestSchema.execute(
+          "query($values: ValuesInput!) { inputField(values: $values) } ",
+          variables: { values: { value: 2 } },
+          context: context,
+        )
+        # The message appears in extensions here:
+        assert_equal ["ErrorD on nil at boot"], res["errors"].map { |e| e["extensions"]["problems"][0]["explanation"] }
+      end
     end
   end
 end


### PR DESCRIPTION
Implementing as a tracer was ok, but there's some error-raising stuff that can happen _outside_ of those events, for example: 

- Loading objects from ID in query variables 
- `.authorized?` hooks (and initializing object instances)
 
There might be others; this will put us in a good place to "just" slap error handling on when needed.

Fixes #2629 
Fixes #2627 