### PR TITLE
Adds scoped context for propagating values specific to a field and its children

### DIFF
--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -215,6 +215,11 @@ module GraphQL
         @scoped_context = @scoped_context.merge(hash)
       end
 
+      def scoped_set!(key, value)
+        scoped_merge!(key => value)
+        nil
+      end
+
       class FieldResolutionContext
         include SharedMethods
         include Tracing::Traceable

--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -167,15 +167,27 @@ module GraphQL
       # @api private
       attr_accessor :scoped_context
 
-      def_delegators :@provided_values, :[], :[]=, :to_h, :to_hash, :key?, :fetch, :dig
+      def_delegators :@provided_values, :[]=
+      def_delegators :to_h, :fetch, :dig
       def_delegators :@query, :trace, :interpreter?
-
-      # @!method [](key)
-      #   Lookup `key` from the hash passed to {Schema#execute} as `context:`
 
       # @!method []=(key, value)
       #   Reassign `key` to the hash passed to {Schema#execute} as `context:`
 
+      # Lookup `key` from the hash passed to {Schema#execute} as `context:`
+      def [](key)
+        return @scoped_context[key] if @scoped_context.key?(key)
+        @provided_values[key]
+      end
+
+      def to_h
+        @provided_values.merge(@scoped_context)
+      end
+      alias :to_hash :to_h
+
+      def key?(key)
+        @scoped_context.key?(key) || @provided_values.key?(key)
+      end
 
       # @return [GraphQL::Schema::Warden]
       def warden
@@ -201,10 +213,6 @@ module GraphQL
 
       def scoped_merge!(hash)
         @scoped_context = @scoped_context.merge(hash)
-      end
-
-      def scoped_get(key)
-        @scoped_context[key]
       end
 
       class FieldResolutionContext

--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -155,6 +155,7 @@ module GraphQL
         @path = []
         @value = nil
         @context = self # for SharedMethods
+        @scoped_context = {}
       end
 
       # @api private
@@ -162,6 +163,9 @@ module GraphQL
 
       # @api private
       attr_writer :value
+
+      # @api private
+      attr_accessor :scoped_context
 
       def_delegators :@provided_values, :[], :[]=, :to_h, :to_hash, :key?, :fetch, :dig
       def_delegators :@query, :trace, :interpreter?
@@ -193,6 +197,14 @@ module GraphQL
       def received_null_child
         @invalid_null = true
         @value = nil
+      end
+
+      def scoped_merge!(hash)
+        @scoped_context = @scoped_context.merge(hash)
+      end
+
+      def scoped_get(key)
+        @scoped_context[key]
       end
 
       class FieldResolutionContext

--- a/spec/graphql/query/context_spec.rb
+++ b/spec/graphql/query/context_spec.rb
@@ -506,5 +506,16 @@ TABLE
       assert_equal(expected_value, context.fetch(expected_key))
       assert_equal(expected_value, context.dig(expected_key)) if RUBY_VERSION >= '2.3.0'
     end
+
+    it "sets a value using #scoped_set!" do
+      expected_key = :a
+      expected_value = :test
+
+      context = GraphQL::Query::Context.new(query: OpenStruct.new(schema: schema), values: nil, object: nil)
+      assert_nil(context[expected_key])
+
+      context.scoped_set!(expected_key, expected_value)
+      assert_equal(expected_value, context[expected_key])
+    end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/rmosolgo/graphql-ruby/issues/2602.

This PR adds a "scoped context" to the existing context. This is useful for propagating values which are specific to a field and its children, as opposed to for the entirety of the query.

This is achieved with very little overhead on the interpreter runtime by simply reinitializing the scoped context at various points where new resolvers would run within a possibly new context as the query is being executed.