### PR TITLE
Explicitly list RUBY_KEYWORDS in GraphQL::Schema::Member::HasFields

### DIFF
--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'irb/ruby-token'
 
 module GraphQL
   class Schema
@@ -43,9 +42,7 @@ module GraphQL
         # A list of Ruby keywords.
         #
         # @api private
-        RUBY_KEYWORDS = RubyToken::TokenDefinitions.select { |definition| definition[1] == RubyToken::TkId }
-                                                   .map { |definition| definition[2] }
-                                                   .compact
+        RUBY_KEYWORDS = [:class, :module, :def, :undef, :begin, :rescue, :ensure, :end, :if, :unless, :then, :elsif, :else, :case, :when, :while, :until, :for, :break, :next, :redo, :retry, :in, :do, :return, :yield, :super, :self, :nil, :true, :false, :and, :or, :not, :alias, :defined?, :BEGIN, :END, :__LINE__, :__FILE__]
 
         # A list of GraphQL-Ruby keywords.
         #


### PR DESCRIPTION
Some time ago I've [added](https://github.com/rmosolgo/graphql-ruby/pull/2559) a check to make sure user not defines a field with a name that matches one of Ruby keywords. In order to do that I've used a `RubyToken` module, which was [removed](https://github.com/ruby/ruby/commit/45bb6f28db04a1f267f5b8d79392cb35087510d8) from Ruby a couple of weeks ago, so that hack doesn't work with ruby 2.7.0-preview3 (thanks @ahlucas for pointing that out!).

After a short research I found out that `irb/ruby-token` was not used for a long time (so removing it was a matter of time). Also, I could not find a new way to list all the Ruby keywords in the runtime (I guess because neither ruby nor [parser](https://github.com/whitequark/parser) need to check _if_ a token is a keyword, they need to know _the name_ of the keyword).

Taking into the consideration the fact that keywords are not added to often, we could switch back to listing them explicitly. What do you think?

By the way, what do you think of adding RUBY HEAD to the test matrix? 