### PR TITLE
Backport original Base64.urlsafe_encode64 performance improvement

### DIFF
--- a/lib/graphql/schema/base_64_bp.rb
+++ b/lib/graphql/schema/base_64_bp.rb
@@ -10,8 +10,9 @@ module Base64Bp
   module_function
 
   def urlsafe_encode64(bin, padding:)
-    str = strict_encode64(bin).tr("+/", "-_")
-    str = str.delete("=") unless padding
+    str = strict_encode64(bin)
+    str.tr!("+/", "-_")
+    str.delete!("=") unless padding
     str
   end
 


### PR DESCRIPTION
We backport Base64.urlsafe_encode64 method for old Rubies. And the method has been updated in Ruby master branch with a performance patch.
So this pull request applies the patch to graphql-ruby also.

ref
https://github.com/ruby/ruby/commit/1bdabaa6b13344c195698ca5b0ced323cb93e2e1
https://github.com/ruby/ruby/pull/1676


Thanks!