### PR TITLE
Use count directly because mongoid was fixed

### DIFF
--- a/lib/graphql/relay/mongo_relation_connection.rb
+++ b/lib/graphql/relay/mongo_relation_connection.rb
@@ -16,8 +16,7 @@ module GraphQL
       end
 
       def relation_count(relation)
-        # Must perform query (hence #to_a) to count results https://jira.mongodb.org/browse/MONGOID-2325
-        relation.to_a.count
+        relation.count
       end
 
       def limit_nodes(sliced_nodes, limit)


### PR DESCRIPTION
We had this bit in there ever since this class was added (#1452), but it seems like it was fixed long ago. 

We test on mongoid 5, 6, and 7, so let's see if they're all in the clear. 

Fixes #2646 