### PR TITLE
New interpreter not reporting certain type of errors

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -339,8 +339,7 @@ module GraphQL
               set_type_at_path(next_path, inner_type)
               # This will update `response_list` with the lazy
               after_lazy(inner_value, owner: inner_type, path: next_path, scoped_context: scoped_context, field: field, owner_object: owner_object, arguments: arguments) do |inner_inner_value|
-                # reset `is_non_null` here and below, because the inner type will have its own nullability constraint
-                continue_value = continue_value(next_path, inner_inner_value, field, false, ast_node)
+                continue_value = continue_value(next_path, inner_inner_value, field, inner_type.non_null?, ast_node)
                 if HALT != continue_value
                   continue_field(next_path, continue_value, field, inner_type, ast_node, next_selections, false, owner_object, arguments)
                 end

--- a/spec/graphql/execution/errors_spec.rb
+++ b/spec/graphql/execution/errors_spec.rb
@@ -105,10 +105,26 @@ describe "GraphQL::Execution::Errors" do
       field :input_field, Int, null: true do
         argument :values, ValuesInput, required: true, method_access: false
       end
+
+      field :non_nullable_array, [String], null: false
+      def non_nullable_array
+        [nil]
+      end
     end
 
     query(Query)
     lazy_resolve(Proc, :call)
+  end
+
+  class ErrorsTestSchemaWithoutInterpreter < GraphQL::Schema
+    class Query < GraphQL::Schema::Object
+      field :non_nullable_array, [String], null: false
+      def non_nullable_array
+        [nil]
+      end
+    end
+
+    query(Query)
   end
 
   describe "rescue_from handling" do
@@ -184,6 +200,24 @@ describe "GraphQL::Execution::Errors" do
         )
         # The message appears in extensions here:
         assert_equal ["ErrorD on nil at boot"], res["errors"].map { |e| e["extensions"]["problems"][0]["explanation"] }
+      end
+    end
+
+    describe "errors raised in non_nullable_array loads" do
+      it "outputs the appropriate error message when using non-interpreter schema" do
+        res = ErrorsTestSchemaWithoutInterpreter.execute("{ nonNullableArray }")
+        expected_error = {
+          "message" => "Cannot return null for non-nullable field Query.nonNullableArray"
+        }
+        assert_equal({ "data" => nil, "errors" => [expected_error] }, res)
+      end
+
+      it "outputs the appropriate error message when using interpreter schema" do
+        res = ErrorsTestSchema.execute("{ nonNullableArray }")
+        expected_error = {
+          "message" => "Cannot return null for non-nullable field Query.nonNullableArray"
+        }
+        assert_equal({ "data" => nil, "errors" => [expected_error] }, res)
       end
     end
   end


### PR DESCRIPTION
This PR illustrates an issue we encountered with `GraphQL::Execution::Interpreter` where it did not return the error when it saw a non-nullable array field returning nulls. The expected behavior is shown with a simple schema that does not use `GraphQL::Execution::Interpreter`.

I'd be happy to work on a fix if I knew where to look.