### PR TITLE
Fix some Ruby 2.7 deprecation warnings.

### DIFF
--- a/lib/graphql/argument.rb
+++ b/lib/graphql/argument.rb
@@ -134,9 +134,9 @@ module GraphQL
       end
 
       if type_or_argument.is_a?(GraphQL::Argument)
-        type_or_argument.redefine(kwargs, &block)
+        type_or_argument.redefine(**kwargs, &block)
       else
-        GraphQL::Argument.define(kwargs, &block)
+        GraphQL::Argument.define(**kwargs, &block)
       end
     end
 

--- a/lib/graphql/define/assign_object_field.rb
+++ b/lib/graphql/define/assign_object_field.rb
@@ -28,9 +28,9 @@ module GraphQL
         end
 
         obj_field = if base_field
-          base_field.redefine(kwargs, &block)
+          base_field.redefine(**kwargs, &block)
         else
-          GraphQL::Field.define(kwargs, &block)
+          GraphQL::Field.define(**kwargs, &block)
         end
 
 

--- a/lib/graphql/execution/execute.rb
+++ b/lib/graphql/execution/execute.rb
@@ -20,7 +20,7 @@ module GraphQL
 
       def execute(ast_operation, root_type, query)
         result = resolve_root_selection(query)
-        lazy_resolve_root_selection(result, {query: query})
+        lazy_resolve_root_selection(result, **{query: query})
         GraphQL::Execution::Flatten.call(query.context)
       end
 

--- a/lib/graphql/execution/multiplex.rb
+++ b/lib/graphql/execution/multiplex.rb
@@ -44,9 +44,9 @@ module GraphQL
       end
 
       class << self
-        def run_all(schema, query_options, *args)
-          queries = query_options.map { |opts| GraphQL::Query.new(schema, nil, opts) }
-          run_queries(schema, queries, *args)
+        def run_all(schema, query_options, **kwargs)
+          queries = query_options.map { |opts| GraphQL::Query.new(schema, nil, **opts) }
+          run_queries(schema, queries, **kwargs)
         end
 
         # @param schema [GraphQL::Schema]

--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -25,7 +25,7 @@ module GraphQL
         # Initialize a node by extracting its position,
         # then calling the class's `initialize_node` method.
         # @param options [Hash] Initial attributes for this node
-        def initialize(options={})
+        def initialize(options = {})
           if options.key?(:position_source)
             position_source = options.delete(:position_source)
             @line = position_source.line
@@ -34,7 +34,7 @@ module GraphQL
 
           @filename = options.delete(:filename)
 
-          initialize_node(options)
+          initialize_node(**options)
         end
 
         # Value equality

--- a/lib/graphql/relay/node.rb
+++ b/lib/graphql/relay/node.rb
@@ -11,7 +11,7 @@ module GraphQL
         field = GraphQL::Types::Relay::NodeField.graphql_definition
 
         if kwargs.any? || block
-          field = field.redefine(kwargs, &block)
+          field = field.redefine(**kwargs, &block)
         end
 
         field
@@ -21,7 +21,7 @@ module GraphQL
         field = GraphQL::Types::Relay::NodesField.graphql_definition
 
         if kwargs.any? || block
-          field = field.redefine(kwargs, &block)
+          field = field.redefine(**kwargs, &block)
         end
 
         field

--- a/lib/graphql/schema/mutation.rb
+++ b/lib/graphql/schema/mutation.rb
@@ -64,7 +64,7 @@ module GraphQL
 
       class << self
         # Override this method to handle legacy-style usages of `MyMutation.field`
-        def field(*args, &block)
+        def field(*args, **kwargs, &block)
           if args.empty?
             raise ArgumentError, "#{name}.field is used for adding fields to this mutation. Use `mutation: #{name}` to attach this mutation instead."
           else

--- a/lib/graphql/schema/relay_classic_mutation.rb
+++ b/lib/graphql/schema/relay_classic_mutation.rb
@@ -61,7 +61,7 @@ module GraphQL
         end
 
         return_value = if input_kwargs.any?
-          super(input_kwargs)
+          super(**input_kwargs)
         else
           super()
         end

--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -76,7 +76,7 @@ module GraphQL
             context.schema.after_lazy(load_arguments_val) do |loaded_args|
               # Then call `authorized?`, which may raise or may return a lazy object
               authorized_val = if loaded_args.any?
-                authorized?(loaded_args)
+                authorized?(**loaded_args)
               else
                 authorized?
               end

--- a/lib/graphql/schema/type_membership.rb
+++ b/lib/graphql/schema/type_membership.rb
@@ -19,7 +19,7 @@ module GraphQL
       # @param abstract_type [Class<GraphQL::Schema::Union>, Module<GraphQL::Schema::Interface>]
       # @param object_type [Class<GraphQL::Schema::Object>]
       # @param options [Hash] Any options passed to `.possible_types` or `.implements`
-      def initialize(abstract_type, object_type, options)
+      def initialize(abstract_type, object_type, **options)
         @abstract_type = abstract_type
         @object_type = object_type
         @options = options

--- a/lib/graphql/schema/union.rb
+++ b/lib/graphql/schema/union.rb
@@ -8,7 +8,7 @@ module GraphQL
         def possible_types(*types, context: GraphQL::Query::NullContext, **options)
           if types.any?
             types.each do |t|
-              type_memberships << type_membership_class.new(self, t, options)
+              type_memberships << type_membership_class.new(self, t, **options)
             end
           else
             visible_types = []

--- a/lib/graphql/subscriptions.rb
+++ b/lib/graphql/subscriptions.rb
@@ -90,7 +90,7 @@ module GraphQL
       operation_name = query_data.fetch(:operation_name)
       # Re-evaluate the saved query
       result = @schema.execute(
-        {
+        **{
           query: query_string,
           context: context,
           subscription_topic: event.topic,

--- a/lib/graphql/union_type.rb
+++ b/lib/graphql/union_type.rb
@@ -25,7 +25,7 @@ module GraphQL
   #
   class UnionType < GraphQL::BaseType
     accepts_definitions :resolve_type, :type_membership_class,
-      possible_types: ->(target, possible_types, options = {}) { target.add_possible_types(possible_types, options) }
+      possible_types: ->(target, possible_types, options = {}) { target.add_possible_types(possible_types, **options) }
     ensure_defined :possible_types, :resolve_type, :resolve_type_proc, :type_membership_class
 
     attr_accessor :resolve_type_proc
@@ -72,13 +72,13 @@ module GraphQL
       # This is a re-assignment, so clear the previous values
       @type_memberships = []
       @cached_possible_types = nil
-      add_possible_types(types, {})
+      add_possible_types(types, **{})
     end
 
-    def add_possible_types(types, options)
+    def add_possible_types(types, **options)
       @type_memberships ||= []
       Array(types).each { |t|
-        @type_memberships << self.type_membership_class.new(self, t, options)
+        @type_memberships << self.type_membership_class.new(self, t, **options)
       }
       nil
     end

--- a/spec/graphql/query/context_spec.rb
+++ b/spec/graphql/query/context_spec.rb
@@ -292,8 +292,8 @@ TABLE
 
   describe "scoped context" do
     class LazyBlock
-      def initialize
-        @get_value = Proc.new
+      def initialize(&block)
+        @get_value = block
       end
 
       def value

--- a/spec/graphql/schema/resolver_spec.rb
+++ b/spec/graphql/schema/resolver_spec.rb
@@ -4,8 +4,8 @@ require "spec_helper"
 describe GraphQL::Schema::Resolver do
   module ResolverTest
     class LazyBlock
-      def initialize
-        @get_value = Proc.new
+      def initialize(&block)
+        @get_value = block
       end
 
       def value


### PR DESCRIPTION
Fixes part of #2650. This fixes all the deprecations that I had when running graphql-ruby with my Rails app, and removes almost 1000 deprecation warnings from my test suite. Looking at the travis logs for ruby-head there are some deprecation warnings my changes don't seem to fix. A lot of the deprecations from ruby-head in travis are external libraries that can be fixed by just updating them, e.g. rake, rails, and rubocop.