### PR TITLE
Fix argument deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@
 
 ### Bug fixes
 
+## 1.9.15 (22 Dec 2019)
+
+## Bug fixes
+
+- Fix argument underscoring #2611
+
+### Breaking changes
+
+- Arguments with integers were being incorrectly deserialized #2611
+
 ## 1.9.14 (14 Oct 2019)
 
 ## New features

--- a/lib/graphql/schema/member/build_type.rb
+++ b/lib/graphql/schema/member/build_type.rb
@@ -161,6 +161,8 @@ module GraphQL
           string
             .gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2') # URLDecoder -> URL_Decoder
             .gsub(/([a-z\d])([A-Z])/,'\1_\2')     # someThing -> some_Thing
+            .gsub(/([A-Za-z]+)([0-9]+)/,'\1_\2')  # some1 -> some_1
+            .gsub(/([0-9]+)([A-Za-z]+)/,'\1_\2')  # 1thing -> 1_thing
             .downcase
         end
       end

--- a/lib/graphql/version.rb
+++ b/lib/graphql/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module GraphQL
-  VERSION = "1.9.14"
+  VERSION = "1.9.15"
 end

--- a/spec/graphql/authorization_spec.rb
+++ b/spec/graphql/authorization_spec.rb
@@ -273,14 +273,14 @@ describe GraphQL::Authorization do
 
       field :hidden, Integer, null: false
       field :unauthorized, Integer, null: true, method: :itself
-      field :int2, Integer, null: true do
+      field :int_2, Integer, null: true do
         argument :int, Integer, required: false
         argument :hidden, Integer, required: false
         argument :inaccessible, Integer, required: false
         argument :unauthorized, Integer, required: false
       end
 
-      def int2(**args)
+      def int_2(**args)
         args[:unauthorized] || 1
       end
 
@@ -600,8 +600,8 @@ describe GraphQL::Authorization do
       GRAPHQL
       query_field_names = res["data"]["query"]["fields"].map { |f| f["name"] }
       refute_includes query_field_names, "int"
-      int2_arg_names = res["data"]["query"]["fields"].find { |f| f["name"] == "int2" }["args"].map { |a| a["name"] }
-      assert_equal ["int", "inaccessible", "unauthorized"], int2_arg_names
+      int_2_arg_names = res["data"]["query"]["fields"].find { |f| f["name"] == "int2" }["args"].map { |a| a["name"] }
+      assert_equal ["int", "inaccessible", "unauthorized"], int_2_arg_names
 
       assert_nil res["data"]["hiddenObject"]
       assert_nil res["data"]["hiddenInterface"]

--- a/spec/graphql/execution/errors_spec.rb
+++ b/spec/graphql/execution/errors_spec.rb
@@ -33,37 +33,37 @@ describe "GraphQL::Execution::Errors" do
     end
 
     class Query < GraphQL::Schema::Object
-      field :f1, Int, null: true do
-        argument :a1, Int, required: false
+      field :f_1, Int, null: true do
+        argument :a_1, Int, required: false
       end
 
-      def f1(a1: nil)
-        raise ErrorA, "f1 broke"
+      def f_1(a_1: nil)
+        raise ErrorA, "f_1 broke"
       end
 
-      field :f2, Int, null: true
-      def f2
-        -> { raise ErrorA, "f2 broke" }
+      field :f_2, Int, null: true
+      def f_2
+        -> { raise ErrorA, "f_2 broke" }
       end
 
-      field :f3, Int, null: true
+      field :f_3, Int, null: true
 
-      def f3
+      def f_3
         raise ErrorB
       end
 
-      field :f4, Int, null: false
-      def f4
+      field :f_4, Int, null: false
+      def f_4
         raise ErrorC.new(value: 20)
       end
 
-      field :f5, Int, null: true
-      def f5
+      field :f_5, Int, null: true
+      def f_5
         raise ErrorASubclass, "raised subclass"
       end
 
-      field :f6, Int, null: true
-      def f6
+      field :f_6, Int, null: true
+      def f_6
         -> { raise ErrorB }
       end
     end
@@ -77,14 +77,14 @@ describe "GraphQL::Execution::Errors" do
       ctx = { errors: [] }
       res = ErrorsTestSchema.execute "{ f1(a1: 1) }", context: ctx, root_value: :abc
       assert_equal({ "data" => { "f1" => nil } }, res)
-      assert_equal ["f1 broke (ErrorsTestSchema::Query.f1, :abc, {:a1=>1})"], ctx[:errors]
+      assert_equal ["f_1 broke (ErrorsTestSchema::Query.f1, :abc, {:a_1=>1})"], ctx[:errors]
     end
 
     it "rescues errors from lazy code" do
       ctx = { errors: [] }
       res = ErrorsTestSchema.execute("{ f2 }", context: ctx)
       assert_equal({ "data" => { "f2" => nil } }, res)
-      assert_equal ["f2 broke (ErrorsTestSchema::Query.f2, nil, {})"], ctx[:errors]
+      assert_equal ["f_2 broke (ErrorsTestSchema::Query.f2, nil, {})"], ctx[:errors]
     end
 
     it "rescues errors from lazy code with handlers that re-raise" do

--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -133,7 +133,7 @@ describe GraphQL::Schema::InputObject do
       GRAPHQL
 
       res = InputObjectPrepareTest::Schema.execute(query_str, context: { multiply_by: 3 })
-      expected_obj = [{ a: 1, b2: 2, c: 9, d2: 12, e2: 30, instrument: Jazz::Models::Instrument.new("Drum Kit", "PERCUSSION") }.inspect, "Drum Kit"]
+      expected_obj = [{ a: 1, b_2: 2, c: 9, d_2: 4, e_2: 5, instrument: Jazz::Models::Instrument.new("Drum Kit", "PERCUSSION") }.inspect, "Drum Kit"]
       assert_equal expected_obj, res["data"]["inputs"]
     end
 

--- a/spec/graphql/schema/member/build_type_spec.rb
+++ b/spec/graphql/schema/member/build_type_spec.rb
@@ -60,4 +60,16 @@ describe GraphQL::Schema::Member::BuildType do
       assert_equal "T", GraphQL::Schema::Member::BuildType.to_type_name(list_req_t)
     end
   end
+
+  describe ".underscore" do
+    it "converts things" do
+      assert_equal "url_decoder", GraphQL::Schema::Member::BuildType.underscore("URLDecoder")
+      assert_equal "some_thing", GraphQL::Schema::Member::BuildType.underscore("someThing")
+      assert_equal "some_thing_after", GraphQL::Schema::Member::BuildType.underscore("someThingAfter")
+      assert_equal "some_thing_1", GraphQL::Schema::Member::BuildType.underscore("someThing1")
+      assert_equal "some_thing_123", GraphQL::Schema::Member::BuildType.underscore("someThing123")
+      assert_equal "123_some_thing", GraphQL::Schema::Member::BuildType.underscore("123SomeThing")
+      assert_equal "some_thing_123_after", GraphQL::Schema::Member::BuildType.underscore("someThing123After")
+    end
+  end
 end

--- a/spec/graphql/schema/resolver_spec.rb
+++ b/spec/graphql/schema/resolver_spec.rb
@@ -255,52 +255,52 @@ describe GraphQL::Schema::Resolver do
     end
 
     class PrepResolver10 < BaseResolver
-      argument :int1, Integer, required: true
-      argument :int2, Integer, required: true, as: :integer_2
+      argument :int_1, Integer, required: true
+      argument :int_2, Integer, required: true, as: :integer_2
       type Integer, null: true
-      def authorized?(int1:, integer_2:)
-        if int1 + integer_2 > context[:max_int]
+      def authorized?(int_1:, integer_2:)
+        if int_1 + integer_2 > context[:max_int]
           raise GraphQL::ExecutionError, "Inputs too big"
-        elsif context[:min_int] && (int1 + integer_2 < context[:min_int])
+        elsif context[:min_int] && (int_1 + integer_2 < context[:min_int])
           false
         else
           true
         end
       end
 
-      def resolve(int1:, integer_2:)
-        int1 + integer_2
+      def resolve(int_1:, integer_2:)
+        int_1 + integer_2
       end
     end
 
     class PrepResolver11 < PrepResolver10
-      def authorized?(int1:, integer_2:)
-        LazyBlock.new { super(int1: int1 * 2, integer_2: integer_2) }
+      def authorized?(int_1:, integer_2:)
+        LazyBlock.new { super(int_1: int_1 * 2, integer_2: integer_2) }
       end
     end
 
     class PrepResolver12 < GraphQL::Schema::Mutation
-      argument :int1, Integer, required: true
-      argument :int2, Integer, required: true
+      argument :int_1, Integer, required: true
+      argument :int_2, Integer, required: true
       field :error_messages, [String], null: true
       field :value, Integer, null: true
-      def authorized?(int1:, int2:)
-        if int1 + int2 > context[:max_int]
-          return false, { error_messages: ["Inputs must be less than #{context[:max_int]} (but you provided #{int1 + int2})"] }
+      def authorized?(int_1:, int_2:)
+        if int_1 + int_2 > context[:max_int]
+          return false, { error_messages: ["Inputs must be less than #{context[:max_int]} (but you provided #{int_1 + int_2})"] }
         else
           true
         end
       end
 
-      def resolve(int1:, int2:)
-        { value: int1 + int2 }
+      def resolve(int_1:, int_2:)
+        { value: int_1 + int_2 }
       end
     end
 
     class PrepResolver13 < PrepResolver12
-      def authorized?(int1:, int2:)
+      def authorized?(int_1:, int_2:)
         # Increment the numbers so we can be sure they're passing through here
-        LazyBlock.new { super(int1: int1 + 1, int2: int2 + 1) }
+        LazyBlock.new { super(int_1: int_1 + 1, int_2: int_2 + 1) }
       end
     end
 


### PR DESCRIPTION
As outlined in https://github.com/rmosolgo/graphql-ruby/issues/2611
there appears to be a bug in argument deserialization if the argument
contains a number. This bug was confirmed by @rmosolgo [here](https://github.com/rmosolgo/graphql-ruby/issues/2611#issuecomment-558790828)

This commit contains a patch for the bug. The culprit was
`GraphQL::Schema::Member::BuildType#underscore`. Upon investigation,
this method used `gsub` to include underscores but just split the string
based on letters. This was confirmed by adding a test for the
`#underscore` method in `spec/graphql/schema/member/build_type_spec.rb`
which was not initially present.

After identifying the issue, the following two `gsub` calls were chained
to the `underscore` method:

```ruby
.gsub(/([A-Za-z]+)([0-9]+)/,'\1_\2')  # some1 -> some_1
.gsub(/([0-9]+)([A-Za-z]+)/,'\1_\2')  # 1thing -> 1_thing
```

Having added the tests that confirm the bug has been fixed, a number of
other tests failed due to the test code using the incorrectly
deserialized values. This commit also patches these tests.