### PR TITLE
fix: Use schema context class for SDL generation

### DIFF
--- a/lib/graphql/language/document_from_schema_definition.rb
+++ b/lib/graphql/language/document_from_schema_definition.rb
@@ -28,7 +28,7 @@ module GraphQL
           filter = filter.merge(only: @schema.method(:visible?))
         end
 
-        schema_context = GraphQL::Query::Context.new(query: nil, object: nil, schema: schema, values: context)
+        schema_context = schema.context_class.new(query: nil, object: nil, schema: schema, values: context)
         @warden = GraphQL::Schema::Warden.new(
           filter,
           schema: @schema,


### PR DESCRIPTION
This change ensures that visibility checks during SDL generation receive an instance of the context class set on the schema.  Related change: https://github.com/rmosolgo/graphql-ruby/pull/2637