### PR TITLE
Implement `__type`/`__schema` introspection disabling

### DIFF
--- a/guides/schema/introspection.md
+++ b/guides/schema/introspection.md
@@ -197,3 +197,12 @@ class MySchema < GraphQL::Schema
   disable_introspection_entry_points if Rails.env.production?
 end
 ```
+
+Where `disable_introspection_entry_points` will disable both the `__schema` and `__type` introspection entry points, you can also individually disable the introspection entry points using the `disable_schema_introspection_entry_point` and `disable_type_introspection_entry_point` shorthand methods:
+
+```ruby
+class MySchema < GraphQL::Schema
+  disable_schema_introspection_entry_point
+  disable_type_introspection_entry_point
+end
+```

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -99,6 +99,8 @@ module GraphQL
       mutation: ->(schema, t) { schema.mutation = t.respond_to?(:graphql_definition) ? t.graphql_definition : t },
       subscription: ->(schema, t) { schema.subscription = t.respond_to?(:graphql_definition) ? t.graphql_definition : t },
       disable_introspection_entry_points: ->(schema) { schema.disable_introspection_entry_points = true },
+      disable_schema_introspection_entry_point: ->(schema) { schema.disable_schema_introspection_entry_point = true },
+      disable_type_introspection_entry_point: ->(schema) { schema.disable_type_introspection_entry_point = true },
       directives: ->(schema, directives) { schema.directives = directives.reduce({}) { |m, d| m[d.name] = d; m } },
       directive: ->(schema, directive) { schema.directives[directive.graphql_name] = directive },
       instrument: ->(schema, type, instrumenter, after_built_ins: false) {
@@ -154,6 +156,12 @@ module GraphQL
     # [Boolean] True if this object disables the introspection entry point fields
     attr_accessor :disable_introspection_entry_points
 
+    # [Boolean] True if this object disables the __schema introspection entry point field
+    attr_accessor :disable_schema_introspection_entry_point
+
+    # [Boolean] True if this object disables the __type introspection entry point field
+    attr_accessor :disable_type_introspection_entry_point
+
     class << self
       attr_writer :default_execution_strategy
     end
@@ -203,6 +211,8 @@ module GraphQL
       @interpreter = false
       @error_bubbling = false
       @disable_introspection_entry_points = false
+      @disable_schema_introspection_entry_point = false
+      @disable_type_introspection_entry_point = false
     end
 
     # @return [Boolean] True if using the new {GraphQL::Execution::Interpreter}
@@ -736,6 +746,8 @@ module GraphQL
         :get_field, :root_types, :references_to, :type_from_ast,
         :possible_types,
         :disable_introspection_entry_points=
+        :disable_schema_introspection_entry_point=
+        :disable_type_introspection_entry_point=
 
       def graphql_definition
         @graphql_definition ||= to_graphql
@@ -761,6 +773,8 @@ module GraphQL
         schema_defn.default_max_page_size = default_max_page_size
         schema_defn.orphan_types = orphan_types
         schema_defn.disable_introspection_entry_points = disable_introspection_entry_points?
+        schema_defn.disable_schema_introspection_entry_point = disable_schema_introspection_entry_point?
+        schema_defn.disable_type_introspection_entry_point = disable_type_introspection_entry_point?
 
         prepped_dirs = {}
         directives.each { |k, v| prepped_dirs[k] = v.graphql_definition}
@@ -916,11 +930,35 @@ module GraphQL
         @disable_introspection_entry_points = true
       end
 
+      def disable_schema_introspection_entry_point
+        @disable_schema_introspection_entry_point = true
+      end
+
+      def disable_type_introspection_entry_point
+        @disable_type_introspection_entry_point = true
+      end
+
       def disable_introspection_entry_points?
         if instance_variable_defined?(:@disable_introspection_entry_points)
           @disable_introspection_entry_points
         else
           find_inherited_value(:disable_introspection_entry_points?, false)
+        end
+      end
+
+      def disable_schema_introspection_entry_point?
+        if instance_variable_defined?(:@disable_schema_introspection_entry_point)
+          @disable_schema_introspection_entry_point
+        else
+          find_inherited_value(:disable_schema_introspection_entry_point?, false)
+        end
+      end
+
+      def disable_type_introspection_entry_point?
+        if instance_variable_defined?(:@disable_type_introspection_entry_point)
+          @disable_type_introspection_entry_point
+        else
+          find_inherited_value(:disable_type_introspection_entry_point?, false)
         end
       end
 

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -745,8 +745,8 @@ module GraphQL
         :union_memberships,
         :get_field, :root_types, :references_to, :type_from_ast,
         :possible_types,
-        :disable_introspection_entry_points=
-        :disable_schema_introspection_entry_point=
+        :disable_introspection_entry_points=,
+        :disable_schema_introspection_entry_point=,
         :disable_type_introspection_entry_point=
 
       def graphql_definition

--- a/lib/graphql/schema/introspection_system.rb
+++ b/lib/graphql/schema/introspection_system.rb
@@ -22,7 +22,10 @@ module GraphQL
           if schema.disable_introspection_entry_points
             {}
           else
-            get_fields_from_class(class_sym: :EntryPoints)
+            entry_point_fields = get_fields_from_class(class_sym: :EntryPoints)
+            entry_point_fields.delete('__schema') if schema.disable_schema_introspection_entry_point
+            entry_point_fields.delete('__type') if schema.disable_type_introspection_entry_point
+            entry_point_fields
           end
         @dynamic_fields = get_fields_from_class(class_sym: :DynamicFields)
       end

--- a/spec/graphql/schema/introspection_system_spec.rb
+++ b/spec/graphql/schema/introspection_system_spec.rb
@@ -65,7 +65,7 @@ describe GraphQL::Schema::IntrospectionSystem do
   describe "#disable_introspection_entry_points" do
     let(:schema) { Jazz::Schema }
 
-    it "allows entry point introspection by default" do
+    it "allows the __schema entry point introspection by default" do
       res = schema.execute("{ __schema { types { name } } }")
       assert res
 
@@ -73,8 +73,44 @@ describe GraphQL::Schema::IntrospectionSystem do
       refute_empty types
     end
 
+    it "allows the __type entry point introspection by default" do
+      res = schema.execute('{ __type(name: "Musician") { name } }')
+      assert res
+
+      types = res["data"]["__type"]["name"]
+      refute_empty types
+    end
+
     describe "when entry points introspection is disabled" do
       let(:schema) { Jazz::SchemaWithoutIntrospection }
+
+      it "returns error on __schema introspection" do
+        res = schema.execute("{ __schema { types { name } } }")
+        assert res
+
+        assert_nil res["data"]
+        assert_equal ["Field '__schema' doesn't exist on type 'Query'"], res["errors"].map { |e| e["message"] }
+      end
+
+      it "returns error on __type introspection" do
+        res = schema.execute('{ __type(name: "Musician") { name } }')
+        assert res
+
+        assert_nil res["data"]
+        assert_equal ["Field '__type' doesn't exist on type 'Query'"], res["errors"].map { |e| e["message"] }
+      end
+    end
+
+    describe "when the __schema entry point introspection is disabled" do
+      let(:schema) { Jazz::SchemaWithoutSchemaIntrospection }
+
+      it "allows the __type entry point introspection" do
+        res = schema.execute('{ __type(name: "Musician") { name } }')
+        assert res
+
+        types = res["data"]["__type"]["name"]
+        refute_empty types
+      end
 
       it "returns error" do
         res = schema.execute("{ __schema { types { name } } }")
@@ -82,6 +118,46 @@ describe GraphQL::Schema::IntrospectionSystem do
 
         assert_nil res["data"]
         assert_equal ["Field '__schema' doesn't exist on type 'Query'"], res["errors"].map { |e| e["message"] }
+      end
+    end
+
+    describe "when __type entry point introspection is disabled" do
+      let(:schema) { Jazz::SchemaWithoutTypeIntrospection }
+
+      it "allows the __schema entry point introspection by default" do
+        res = schema.execute("{ __schema { types { name } } }")
+        assert res
+
+        types = res["data"]["__schema"]["types"]
+        refute_empty types
+      end
+
+      it "returns error" do
+        res = schema.execute('{ __type(name: "Musician") { name } }')
+        assert res
+
+        assert_nil res["data"]
+        assert_equal ["Field '__type' doesn't exist on type 'Query'"], res["errors"].map { |e| e["message"] }
+      end
+    end
+
+    describe "when __type and __schema entry point introspection is disabled" do
+      let(:schema) { Jazz::SchemaWithoutSchemaOrTypeIntrospection }
+
+      it "returns error on __schema introspection" do
+        res = schema.execute("{ __schema { types { name } } }")
+        assert res
+
+        assert_nil res["data"]
+        assert_equal ["Field '__schema' doesn't exist on type 'Query'"], res["errors"].map { |e| e["message"] }
+      end
+
+      it "returns error on __type introspection" do
+        res = schema.execute('{ __type(name: "Musician") { name } }')
+        assert res
+
+        assert_nil res["data"]
+        assert_equal ["Field '__type' doesn't exist on type 'Query'"], res["errors"].map { |e| e["message"] }
       end
     end
   end

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -850,4 +850,23 @@ module Jazz
 
     disable_introspection_entry_points
   end
+
+  class SchemaWithoutSchemaIntrospection < GraphQL::Schema
+    query(Query)
+
+    disable_schema_introspection_entry_point
+  end
+
+  class SchemaWithoutTypeIntrospection < GraphQL::Schema
+    query(Query)
+
+    disable_type_introspection_entry_point
+  end
+
+  class SchemaWithoutSchemaOrTypeIntrospection < GraphQL::Schema
+    query(Query)
+
+    disable_schema_introspection_entry_point
+    disable_type_introspection_entry_point
+  end
 end


### PR DESCRIPTION
A question was asked in issue GH-2546 asking whether it was possible to
disable a single introspection entry point considering that #2327 had
implemented then functionality to disable introspection as a whole using
`disable_introspection_entry_points`. In the issue, an option was laid
out to implement the functionality for individual
`disable_schema_introspection_entry_point` and
`disable_type_introspection_entry_point` options. This commit implements
these methods.

These new methods are used in an identical manner to
`disable_introspection_entry_points`:

 # Disabling `__type` introspection

```ruby
class MySchema < GraphQL::Schema
  disable_type_introspection_entry_point
end
```

With the above, attempting to execute a query with `__type`
introspection will return the following error message:

```
Field '__type' doesn't exist on type 'Query'
```

 # Disabling `__schema` introspection
```ruby
class MySchema < GraphQL::Schema
  disable_schema_introspection_entry_point
end
```

With the above, attempting to execute a query with `__schema`
introspection will return the following error message:

```
Field '__schema' doesn't exist on type 'Query'
```

Note, having both `disable_type_introspection_entry_point` and
`disable_schema_introspection_entry_point` is identical to having just
`disable_introspection_entry_points`. Having
`disable_introspection_entry_points` and
`disable_type_introspection_entry_point` or
`disable_schema_introspection_entry_point` is no different to just
having `disable_introspection_entry_points`.