### PR TITLE
Add tracing events for authorized and resolve_type calls

### DIFF
--- a/lib/generators/graphql/templates/schema.erb
+++ b/lib/generators/graphql/templates/schema.erb
@@ -1,7 +1,5 @@
 class <%= schema_name %> < GraphQL::Schema
-  # Root types
   query(Types::QueryType)
-  # mutation(Types::MutationType)
 
   # Opt in to the new runtime (default in future graphql-ruby versions)
   use GraphQL::Execution::Interpreter

--- a/lib/graphql/directive.rb
+++ b/lib/graphql/directive.rb
@@ -95,6 +95,10 @@ module GraphQL
     def inspect
       "#<GraphQL::Directive #{name}>"
     end
+
+    def type_class
+      metadata[:type_class]
+    end
   end
 end
 

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -1295,11 +1295,11 @@ module GraphQL
       end
 
       def visible?(member, ctx)
-        member.visible?(ctx)
+        member.type_class.visible?(ctx)
       end
 
       def accessible?(member, ctx)
-        member.accessible?(ctx)
+        member.type_class.accessible?(ctx)
       end
 
       # This hook is called when a client tries to access one or more

--- a/lib/graphql/schema/enum_value.rb
+++ b/lib/graphql/schema/enum_value.rb
@@ -26,6 +26,7 @@ module GraphQL
     #     enum_value_class CustomEnumValue
     #   end
     class EnumValue < GraphQL::Schema::Member
+      include GraphQL::Schema::Member::CachedGraphQLDefinition
       include GraphQL::Schema::Member::AcceptsDefinition
       include GraphQL::Schema::Member::HasPath
       include GraphQL::Schema::Member::HasAstNode

--- a/lib/graphql/schema/object.rb
+++ b/lib/graphql/schema/object.rb
@@ -35,15 +35,28 @@ module GraphQL
         # @return [GraphQL::Schema::Object, GraphQL::Execution::Lazy]
         # @raise [GraphQL::UnauthorizedError] if the user-provided hook returns `false`
         def authorized_new(object, context)
+          trace_payload = { context: context, object: object, type: self }
           auth_val = context.query.with_error_handling do
             begin
-              authorized?(object, context)
+              context.query.trace("authorized", trace_payload) do
+                authorized?(object, context)
+              end
             rescue GraphQL::UnauthorizedError => err
               context.schema.unauthorized_object(err)
             end
           end
 
-          context.schema.after_lazy(auth_val) do |is_authorized|
+          auth_lazy = if context.schema.lazy?(auth_val)
+            GraphQL::Execution::Lazy.new do
+              context.query.trace("authorized_lazy", trace_payload) do
+                context.schema.sync_lazy(auth_val)
+              end
+            end
+          else
+            auth_val
+          end
+
+          context.schema.after_lazy(auth_lazy) do |is_authorized|
             if is_authorized
               self.new(object, context)
             else
@@ -57,13 +70,9 @@ module GraphQL
                 else
                   nil
                 end
-              # rescue GraphQL::ExecutionError => err
-              #   err
               end
             end
           end
-        # rescue GraphQL::ExecutionError => err
-        #   err
         end
       end
 

--- a/lib/graphql/tracing.rb
+++ b/lib/graphql/tracing.rb
@@ -44,6 +44,10 @@ module GraphQL
   # execute_query_lazy | `{ query: GraphQL::Query?, multiplex: GraphQL::Execution::Multiplex? }`
   # execute_field | `{ context: GraphQL::Query::Context::FieldResolutionContext?, owner: Class?, field: GraphQL::Schema::Field?, query: GraphQL::Query?, path: Array<String, Integer>?}`
   # execute_field_lazy | `{ context: GraphQL::Query::Context::FieldResolutionContext?, owner: Class?, field: GraphQL::Schema::Field?, query: GraphqL::Query?, path: Array<String, Integer>?}`
+  # authorized | `{ context: GrpahQL::Query::Context, type: Class, object: Object }`
+  # authorized_lazy | `{ context: GrpahQL::Query::Context, type: Class, object: Object }`
+  # resolve_type | `{ context: GrpahQL::Query::Context, type: Class, object: Object }`
+  # resolve_type_lazy | `{ context: GrpahQL::Query::Context, type: Class, object: Object }`
   #
   # Note that `execute_field` and `execute_field_lazy` receive different data in different settings:
   #

--- a/lib/graphql/tracing.rb
+++ b/lib/graphql/tracing.rb
@@ -43,11 +43,11 @@ module GraphQL
   # execute_query | `{ query: GraphQL::Query }`
   # execute_query_lazy | `{ query: GraphQL::Query?, multiplex: GraphQL::Execution::Multiplex? }`
   # execute_field | `{ context: GraphQL::Query::Context::FieldResolutionContext?, owner: Class?, field: GraphQL::Schema::Field?, query: GraphQL::Query?, path: Array<String, Integer>?}`
-  # execute_field_lazy | `{ context: GraphQL::Query::Context::FieldResolutionContext?, owner: Class?, field: GraphQL::Schema::Field?, query: GraphqL::Query?, path: Array<String, Integer>?}`
-  # authorized | `{ context: GrpahQL::Query::Context, type: Class, object: Object }`
-  # authorized_lazy | `{ context: GrpahQL::Query::Context, type: Class, object: Object }`
-  # resolve_type | `{ context: GrpahQL::Query::Context, type: Class, object: Object }`
-  # resolve_type_lazy | `{ context: GrpahQL::Query::Context, type: Class, object: Object }`
+  # execute_field_lazy | `{ context: GraphQL::Query::Context::FieldResolutionContext?, owner: Class?, field: GraphQL::Schema::Field?, query: GraphQL::Query?, path: Array<String, Integer>?}`
+  # authorized | `{ context: GraphQL::Query::Context, type: Class, object: Object, path: Array<String, Integer> }`
+  # authorized_lazy | `{ context: GraphQL::Query::Context, type: Class, object: Object, path: Array<String, Integer> }`
+  # resolve_type | `{ context: GraphQL::Query::Context, type: Class, object: Object, path: Array<String, Integer> }`
+  # resolve_type_lazy | `{ context: GraphQL::Query::Context, type: Class, object: Object, path: Array<String, Integer> }`
   #
   # Note that `execute_field` and `execute_field_lazy` receive different data in different settings:
   #

--- a/lib/graphql/tracing/active_support_notifications_tracing.rb
+++ b/lib/graphql/tracing/active_support_notifications_tracing.rb
@@ -17,6 +17,10 @@ module GraphQL
         "execute_query_lazy" => "execute_query_lazy.graphql",
         "execute_field" => "execute_field.graphql",
         "execute_field_lazy" => "execute_field_lazy.graphql",
+        "authorized" => "authorized.graphql",
+        "authorized_lazy" => "authorized_lazy.graphql",
+        "resolve_type" => "resolve_type.graphql",
+        "resolve_type_lazy" => "resolve_type.graphql",
       }
 
       def self.trace(key, metadata)

--- a/lib/graphql/tracing/appsignal_tracing.rb
+++ b/lib/graphql/tracing/appsignal_tracing.rb
@@ -27,6 +27,10 @@ module GraphQL
       def platform_authorized_key(type)
         "#{type.graphql_name}.authorized.graphql"
       end
+
+      def platform_resolve_type_key(type)
+        "#{type.graphql_name}.resolve_type.graphql"
+      end
     end
   end
 end

--- a/lib/graphql/tracing/appsignal_tracing.rb
+++ b/lib/graphql/tracing/appsignal_tracing.rb
@@ -23,6 +23,10 @@ module GraphQL
       def platform_field_key(type, field)
         "#{type.graphql_name}.#{field.graphql_name}.graphql"
       end
+
+      def platform_authorized_key(type)
+        "#{type.graphql_name}.authorized.graphql"
+      end
     end
   end
 end

--- a/lib/graphql/tracing/data_dog_tracing.rb
+++ b/lib/graphql/tracing/data_dog_tracing.rb
@@ -63,6 +63,10 @@ module GraphQL
       def platform_field_key(type, field)
         "#{type.graphql_name}.#{field.graphql_name}"
       end
+
+      def platform_authorized_key(type)
+        "#{type.graphql_name}.authorized"
+      end
     end
   end
 end

--- a/lib/graphql/tracing/data_dog_tracing.rb
+++ b/lib/graphql/tracing/data_dog_tracing.rb
@@ -67,6 +67,10 @@ module GraphQL
       def platform_authorized_key(type)
         "#{type.graphql_name}.authorized"
       end
+
+      def platform_resolve_type_key(type)
+        "#{type.graphql_name}.resolve_type"
+      end
     end
   end
 end

--- a/lib/graphql/tracing/new_relic_tracing.rb
+++ b/lib/graphql/tracing/new_relic_tracing.rb
@@ -53,6 +53,10 @@ module GraphQL
       def platform_authorized_key(type)
         "GraphQL/Authorize/#{type.graphql_name}"
       end
+
+      def platform_resolve_type_key(type)
+        "GraphQL/ResolveType/#{type.graphql_name}"
+      end
     end
   end
 end

--- a/lib/graphql/tracing/new_relic_tracing.rb
+++ b/lib/graphql/tracing/new_relic_tracing.rb
@@ -49,6 +49,10 @@ module GraphQL
       def platform_field_key(type, field)
         "GraphQL/#{type.graphql_name}/#{field.graphql_name}"
       end
+
+      def platform_authorized_key(type)
+        "GraphQL/Authorize/#{type.graphql_name}"
+      end
     end
   end
 end

--- a/lib/graphql/tracing/platform_tracing.rb
+++ b/lib/graphql/tracing/platform_tracing.rb
@@ -61,6 +61,15 @@ module GraphQL
           platform_trace(platform_key, key, data) do
             yield
           end
+        when "resolve_type", "resolve_type_lazy"
+          cache = platform_key_cache(data.fetch(:context))
+          type = data.fetch(:type)
+          platform_key = cache.fetch(type) do
+            cache[type] = platform_resolve_type_key(type)
+          end
+          platform_trace(platform_key, key, data) do
+            yield
+          end
         else
           # it's a custom key
           yield

--- a/lib/graphql/tracing/prometheus_tracing.rb
+++ b/lib/graphql/tracing/prometheus_tracing.rb
@@ -36,6 +36,10 @@ module GraphQL
         "#{type.graphql_name}.#{field.graphql_name}"
       end
 
+      def platform_authorized_key(type)
+        "#{type.graphql_name}.authorized"
+      end
+
       private
 
       def instrument_execution(platform_key, key, data, &block)

--- a/lib/graphql/tracing/prometheus_tracing.rb
+++ b/lib/graphql/tracing/prometheus_tracing.rb
@@ -40,6 +40,10 @@ module GraphQL
         "#{type.graphql_name}.authorized"
       end
 
+      def platform_resolve_type_key(type)
+        "#{type.graphql_name}.resolve_type"
+      end
+
       private
 
       def instrument_execution(platform_key, key, data, &block)

--- a/lib/graphql/tracing/scout_tracing.rb
+++ b/lib/graphql/tracing/scout_tracing.rb
@@ -34,6 +34,10 @@ module GraphQL
       def platform_authorized_key(type)
         "#{type.graphql_name}.authorized"
       end
+
+      def platform_resolve_type_key(type)
+        "#{type.graphql_name}.resolve_type"
+      end
     end
   end
 end

--- a/lib/graphql/tracing/scout_tracing.rb
+++ b/lib/graphql/tracing/scout_tracing.rb
@@ -30,6 +30,10 @@ module GraphQL
       def platform_field_key(type, field)
         "#{type.graphql_name}.#{field.graphql_name}"
       end
+
+      def platform_authorized_key(type)
+        "#{type.graphql_name}.authorized"
+      end
     end
   end
 end

--- a/lib/graphql/tracing/skylight_tracing.rb
+++ b/lib/graphql/tracing/skylight_tracing.rb
@@ -57,6 +57,10 @@ module GraphQL
       def platform_field_key(type, field)
         "graphql.#{type.graphql_name}.#{field.graphql_name}"
       end
+
+      def platform_authorized_key(type)
+        "graphql.authorized.#{type.graphql_name}"
+      end
     end
   end
 end

--- a/lib/graphql/tracing/skylight_tracing.rb
+++ b/lib/graphql/tracing/skylight_tracing.rb
@@ -61,6 +61,10 @@ module GraphQL
       def platform_authorized_key(type)
         "graphql.authorized.#{type.graphql_name}"
       end
+
+      def platform_resolve_type_key(type)
+        "graphql.resolve_type.#{type.graphql_name}"
+      end
     end
   end
 end

--- a/spec/graphql/execution/execute_spec.rb
+++ b/spec/graphql/execution/execute_spec.rb
@@ -276,11 +276,11 @@ describe GraphQL::Execution::Execute do
         assert_equal expected_traces, exec_traces.map { |t| t[:key] }
 
         if TESTING_INTERPRETER
-          authorized_1, field_1_eager, field_2_eager,
+          _authorized_1, field_1_eager, field_2_eager,
             query_eager, lazy_loader,
             # field 3 is eager-resolved _during_ field 1's lazy resolve
-            field_1_lazy, authorized_2, field_3_eager,
-            field_2_lazy, authorized_3, field_4_eager,
+            field_1_lazy, _authorized_2, field_3_eager,
+            field_2_lazy, _authorized_3, field_4_eager,
             # field 3 didn't finish above, it's resolved in the next round
             field_3_lazy, field_4_lazy,
             query_lazy, multiplex = exec_traces

--- a/spec/graphql/execution/execute_spec.rb
+++ b/spec/graphql/execution/execute_spec.rb
@@ -256,30 +256,44 @@ describe GraphQL::Execution::Execute do
 
         exec_traces = traces[5..-1]
         expected_traces = [
+          (TESTING_INTERPRETER ? "authorized" : nil),
           "execute_field",
           "execute_field",
           "execute_query",
           "lazy_loader",
           "execute_field_lazy",
+          (TESTING_INTERPRETER ? "authorized" : nil),
           "execute_field",
           "execute_field_lazy",
+          (TESTING_INTERPRETER ? "authorized" : nil),
           "execute_field",
           "execute_field_lazy",
           "execute_field_lazy",
           "execute_query_lazy",
           "execute_multiplex",
-        ]
+        ].compact
+
         assert_equal expected_traces, exec_traces.map { |t| t[:key] }
 
-        field_1_eager, field_2_eager,
-          query_eager, lazy_loader,
-          # field 3 is eager-resolved _during_ field 1's lazy resolve
-          field_1_lazy, field_3_eager,
-          field_2_lazy, field_4_eager,
-          # field 3 didn't finish above, it's resolved in the next round
-          field_3_lazy, field_4_lazy,
-          query_lazy, multiplex = exec_traces
-
+        if TESTING_INTERPRETER
+          authorized_1, field_1_eager, field_2_eager,
+            query_eager, lazy_loader,
+            # field 3 is eager-resolved _during_ field 1's lazy resolve
+            field_1_lazy, authorized_2, field_3_eager,
+            field_2_lazy, authorized_3, field_4_eager,
+            # field 3 didn't finish above, it's resolved in the next round
+            field_3_lazy, field_4_lazy,
+            query_lazy, multiplex = exec_traces
+        else
+          field_1_eager, field_2_eager,
+            query_eager, lazy_loader,
+            # field 3 is eager-resolved _during_ field 1's lazy resolve
+            field_1_lazy, field_3_eager,
+            field_2_lazy, field_4_eager,
+            # field 3 didn't finish above, it's resolved in the next round
+            field_3_lazy, field_4_lazy,
+            query_lazy, multiplex = exec_traces
+        end
         assert_equal ["b1"], field_1_eager[:path]
         assert_equal ["b2"], field_2_eager[:path]
         assert_instance_of GraphQL::Query, query_eager[:query]

--- a/spec/graphql/execution_error_spec.rb
+++ b/spec/graphql/execution_error_spec.rb
@@ -96,6 +96,26 @@ describe GraphQL::ExecutionError do
           },
           "errors"=>[
             {
+              "message"=>"missing dairy",
+              "locations"=>[{"line"=>25, "column"=>5}],
+              "path"=>["dairyErrors", 1]
+            },
+            {
+              "message"=>"There was an execution error",
+              "locations"=>[{"line"=>31, "column"=>9}],
+              "path"=>["dairy", "milks", 0, "executionError"]
+            },
+            {
+              "message"=>"There was an execution error",
+              "locations"=>[{"line"=>41, "column"=>5}],
+              "path"=>["executionError"]
+            },
+            {
+              "message"=>"Could not fetch latest value",
+              "locations"=>[{"line"=>42, "column"=>5}],
+              "path"=>["valueWithExecutionError"]
+            },
+            {
               "message"=>"No cheeses are made from Yak milk!",
               "locations"=>[{"line"=>5, "column"=>7}],
               "path"=>["cheese", "error1"]
@@ -111,29 +131,9 @@ describe GraphQL::ExecutionError do
               "path"=>["allDairy", 3, "executionError"]
             },
             {
-              "message"=>"missing dairy",
-              "locations"=>[{"line"=>25, "column"=>5}],
-              "path"=>["dairyErrors", 1]
-            },
-            {
-              "message"=>"There was an execution error",
-              "locations"=>[{"line"=>31, "column"=>9}],
-              "path"=>["dairy", "milks", 0, "executionError"]
-            },
-            {
               "message"=>"There was an execution error",
               "locations"=>[{"line"=>36, "column"=>13}],
               "path"=>["dairy", "milks", 0, "allDairy", 3, "executionError"]
-            },
-            {
-              "message"=>"There was an execution error",
-              "locations"=>[{"line"=>41, "column"=>5}],
-              "path"=>["executionError"]
-            },
-            {
-              "message"=>"Could not fetch latest value",
-              "locations"=>[{"line"=>42, "column"=>5}],
-              "path"=>["valueWithExecutionError"]
             },
           ]
         }

--- a/spec/graphql/tracing/platform_tracing_spec.rb
+++ b/spec/graphql/tracing/platform_tracing_spec.rb
@@ -24,6 +24,10 @@ describe GraphQL::Tracing::PlatformTracing do
       "#{type.graphql_name}.authorized"
     end
 
+    def platform_resolve_type_key(type)
+      "#{type.graphql_name}.resolve_type"
+    end
+
     def platform_trace(platform_key, key, data)
       TRACE << platform_key
       yield
@@ -58,6 +62,28 @@ describe GraphQL::Tracing::PlatformTracing do
           "Cheese.authorized",
           "eql",
           "Cheese.authorized", # This is the lazy part, calling the proc
+        ]
+
+      assert_equal expected_trace, CustomPlatformTracer::TRACE
+    end
+
+    it "traces resolve_type calls" do
+      schema.execute(" { favoriteEdible { __typename } }")
+      expected_trace = [
+          "em",
+          "am",
+          "l",
+          "p",
+          "v",
+          "aq",
+          "eq",
+          "Query.authorized",
+          "Q.f",
+          "Edible.resolve_type",
+          "eql",
+          "Edible.resolve_type",
+          "Milk.authorized",
+          "DynamicFields.authorized",
         ]
 
       assert_equal expected_trace, CustomPlatformTracer::TRACE

--- a/spec/graphql/tracing/platform_tracing_spec.rb
+++ b/spec/graphql/tracing/platform_tracing_spec.rb
@@ -20,6 +20,10 @@ describe GraphQL::Tracing::PlatformTracing do
       "#{type.graphql_name[0]}.#{field.graphql_name[0]}"
     end
 
+    def platform_authorized_key(type)
+      "#{type.graphql_name}.authorized"
+    end
+
     def platform_trace(platform_key, key, data)
       TRACE << platform_key
       yield
@@ -49,8 +53,11 @@ describe GraphQL::Tracing::PlatformTracing do
           "v",
           "aq",
           "eq",
+          "Query.authorized",
           "Q.c", # notice that the flavor is skipped
+          "Cheese.authorized",
           "eql",
+          "Cheese.authorized", # This is the lazy part, calling the proc
         ]
 
       assert_equal expected_trace, CustomPlatformTracer::TRACE
@@ -78,7 +85,9 @@ describe GraphQL::Tracing::PlatformTracing do
           "v",
           "aq",
           "eq",
+          "Query.authorized",
           "Q.t",
+          "TracingScalar.authorized",
           "T.t",
           "eql",
         ]
@@ -107,7 +116,9 @@ describe GraphQL::Tracing::PlatformTracing do
           "v",
           "aq",
           "eq",
+          "Query.authorized",
           "Q.t",
+          "TracingScalar.authorized",
           "T.t",
           "T.t",
           "eql",

--- a/spec/integration/rails/generators/graphql/install_generator_spec.rb
+++ b/spec/integration/rails/generators/graphql/install_generator_spec.rb
@@ -44,6 +44,12 @@ class GraphQLGeneratorsInstallGeneratorTest < Rails::Generators::TestCase
 class DummySchema < GraphQL::Schema
   mutation(Types::MutationType)
   query(Types::QueryType)
+
+  # Opt in to the new runtime (default in future graphql-ruby versions)
+  use GraphQL::Execution::Interpreter
+
+  # Add built-in connections for pagination
+  use GraphQL::Pagination::Connections
 end
 RUBY
     assert_file "app/graphql/dummy_schema.rb", expected_schema
@@ -235,9 +241,15 @@ RUBY
 
   EXPECTED_RELAY_BATCH_SCHEMA = <<-RUBY
 class DummySchema < GraphQL::Schema
-
   mutation(Types::MutationType)
   query(Types::QueryType)
+
+  # Opt in to the new runtime (default in future graphql-ruby versions)
+  use GraphQL::Execution::Interpreter
+
+  # Add built-in connections for pagination
+  use GraphQL::Pagination::Connections
+
   # Relay Object Identification:
 
   # Return a string UUID for `object`

--- a/spec/integration/rails/graphql/tracing/active_support_notifications_tracing_spec.rb
+++ b/spec/integration/rails/graphql/tracing/active_support_notifications_tracing_spec.rb
@@ -12,12 +12,18 @@ describe GraphQL::Tracing::ActiveSupportNotificationsTracing do
     traces = []
 
     callback = ->(name, started, finished, id, data) {
-      path_str = if data.key?(:field)
-        " (#{data[:field].path})"
-      elsif data.key?(:context)
-        " (#{data[:context].irep_node.owner_type}.#{data[:context].field.name})"
+      path_str = if TESTING_INTERPRETER
+        if data.key?(:field)
+          " (#{data[:field].path})"
+        else
+          ""
+        end
       else
-        ""
+        if data.key?(:context)
+          " (#{data[:context].irep_node.owner_type}.#{data[:context].field.name})"
+        else
+          ""
+        end
       end
       traces << "#{name}#{path_str}"
     }
@@ -44,19 +50,22 @@ describe GraphQL::Tracing::ActiveSupportNotificationsTracing do
       "validate.graphql",
       "analyze_query.graphql",
       "analyze_multiplex.graphql",
+      (TESTING_INTERPRETER ? "authorized.graphql" : nil),
       "execute_field.graphql (Query.batchedBase)",
       "execute_field.graphql (Query.batchedBase)",
       "execute_query.graphql",
       "lazy_loader.graphql",
       "execute_field_lazy.graphql (Query.batchedBase)",
+      (TESTING_INTERPRETER ? "authorized.graphql" : nil),
       "execute_field.graphql (Base.name)",
       "execute_field_lazy.graphql (Query.batchedBase)",
+      (TESTING_INTERPRETER ? "authorized.graphql" : nil),
       "execute_field.graphql (Base.name)",
       "execute_field_lazy.graphql (Base.name)",
       "execute_field_lazy.graphql (Base.name)",
       "execute_query_lazy.graphql",
       "execute_multiplex.graphql",
-    ]
+    ].compact
     assert_equal expected_traces, traces
   end
 end

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -88,6 +88,10 @@ module Dummy
     implements AnimalProduct
     implements LocalProduct
 
+    def self.authorized?(obj, ctx)
+      -> { true }
+    end
+
     field :id, Int, "Unique identifier", null: false
     field :flavor, String, "Kind of Cheese", null: false
     field :origin, String, "Place the cheese comes from", null: false
@@ -510,6 +514,7 @@ module Dummy
     use GraphQL::Execution::Interpreter
     use GraphQL::Analysis::AST
     use GraphQL::Execution::Errors
+    lazy_resolve(Proc, :call)
   end
 
   class AdminSchema < GraphQL::Schema

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -497,7 +497,7 @@ module Dummy
     rescue_from(NoSuchDairyError) { |err| raise GraphQL::ExecutionError, err.message  }
 
     def self.resolve_type(type, obj, ctx)
-      Schema.types[obj.class.name.split("::").last]
+      -> { Schema.types[obj.class.name.split("::").last] }
     end
 
     # This is used to confirm that the hook is called:


### PR DESCRIPTION
We noticed some unaccounted-for time in our internal perf tools, and I think it's because these aren't covered. 

Before the interpreter, `authorized_new` was included with the field that returned the value. But the interpreter ran it without any tracing. 

Also, wrapping `resolve_type` is brand new. 