### PR TITLE
Fix directive graphql_name

### DIFF
--- a/lib/graphql/schema/directive.rb
+++ b/lib/graphql/schema/directive.rb
@@ -9,8 +9,14 @@ module GraphQL
     class Directive < GraphQL::Schema::Member
       extend GraphQL::Schema::Member::HasArguments
       class << self
+        # Return a name based on the class name,
+        # but downcase the first letter.
         def default_graphql_name
-          super.downcase
+          @default_graphql_name ||= begin
+            camelized_name = super
+            camelized_name[0] = camelized_name[0].downcase
+            camelized_name
+          end
         end
 
         def locations(*new_locations)

--- a/spec/graphql/schema/directive_spec.rb
+++ b/spec/graphql/schema/directive_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::Schema::Directive do
+  class MultiWord < GraphQL::Schema::Directive
+  end
+
+  it "uses a downcased class name" do
+    assert_equal "multiWord", MultiWord.graphql_name
+  end
+end


### PR DESCRIPTION
Oops, it was downcasing the whole name. This broke when I tried to migrate to `Schema::Directive`, so now I'm upstreaming the fix.