### PR TITLE
Fix field extensions after change default value to [] from nil

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -689,7 +689,7 @@ module GraphQL
       # Written iteratively to avoid big stack traces.
       # @return [Object] Whatever the
       def with_extensions(obj, args, ctx)
-        if @extensions.nil?
+        if @extensions.empty?
           yield(obj, args)
         else
           # Save these so that the originals can be re-given to `after_resolve` handlers.


### PR DESCRIPTION
In commit https://github.com/rmosolgo/graphql-ruby/commit/2eb84f0c8bdf41912517f96fb71e89a63f0c04b2#diff-19915f765769f8f600fa85498d1ea515 was changed @extensions default value to [], one condition was not changed.