### PR TITLE
Allow return raw values from resolvers

### DIFF
--- a/lib/graphql/execution/interpreter.rb
+++ b/lib/graphql/execution/interpreter.rb
@@ -3,6 +3,7 @@ require "graphql/execution/interpreter/execution_errors"
 require "graphql/execution/interpreter/hash_response"
 require "graphql/execution/interpreter/runtime"
 require "graphql/execution/interpreter/resolve"
+require "graphql/execution/interpreter/handles_raw_value"
 
 module GraphQL
   module Execution
@@ -22,6 +23,8 @@ module GraphQL
         schema_class.query_execution_strategy(GraphQL::Execution::Interpreter)
         schema_class.mutation_execution_strategy(GraphQL::Execution::Interpreter)
         schema_class.subscription_execution_strategy(GraphQL::Execution::Interpreter)
+
+        GraphQL::Schema::Object.include(HandlesRawValue)
       end
 
       def self.begin_multiplex(multiplex)

--- a/lib/graphql/execution/interpreter/handles_raw_value.rb
+++ b/lib/graphql/execution/interpreter/handles_raw_value.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module Execution
+    class Interpreter
+      # Wrapper for raw values
+      class RawValue
+        attr_reader :object
+
+        def initialize(obj = nil)
+          @object = obj
+        end
+
+        alias_method :resolve, :object
+      end
+
+      # Allows to return "raw" value from the resolver
+      module HandlesRawValue
+        def raw_value(obj = nil)
+          RawValue.new(obj)
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/execution/interpreter/handles_raw_value.rb
+++ b/lib/graphql/execution/interpreter/handles_raw_value.rb
@@ -5,13 +5,13 @@ module GraphQL
     class Interpreter
       # Wrapper for raw values
       class RawValue
-        attr_reader :object
-
         def initialize(obj = nil)
           @object = obj
         end
 
-        alias_method :resolve, :object
+        def resolve
+          @object
+        end
       end
 
       # Allows to return "raw" value from the resolver

--- a/lib/graphql/execution/interpreter/handles_raw_value.rb
+++ b/lib/graphql/execution/interpreter/handles_raw_value.rb
@@ -16,7 +16,7 @@ module GraphQL
 
       # Allows to return "raw" value from the resolver
       module HandlesRawValue
-        def raw_value(obj = nil)
+        def raw_value(obj)
           RawValue.new(obj)
         end
       end

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -223,7 +223,7 @@ module GraphQL
                 continue_value = continue_value(next_path, inner_result, field_defn, return_type.non_null?, ast_node)
                 if RawValue === continue_value
                   # Write raw value directly to the response without resolving nested objects
-                  write_in_response(next_path, continue_value.object)
+                  write_in_response(next_path, continue_value.resolve)
                 elsif HALT != continue_value
                   continue_field(next_path, continue_value, field_defn, return_type, ast_node, next_selections, false, object, kwarg_arguments)
                 end

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -223,7 +223,7 @@ module GraphQL
                 continue_value = continue_value(next_path, inner_result, field_defn, return_type.non_null?, ast_node)
                 if RawValue === continue_value
                   # Write raw value directly to the response without resolving nested objects
-                  write_in_response(next_path, continue_value.resolve)
+                  write_in_response(next_path, continue_value.object)
                   continue_value.object
                 elsif HALT != continue_value
                   continue_field(next_path, continue_value, field_defn, return_type, ast_node, next_selections, false, object, kwarg_arguments)

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -146,7 +146,6 @@ module GraphQL
                 raise "Invariant: no field for #{owner_type}.#{field_name}"
               end
             end
-
             return_type = field_defn.type
 
             next_path = path.dup
@@ -222,7 +221,11 @@ module GraphQL
               end
               after_lazy(app_result, owner: owner_type, field: field_defn, path: next_path, scoped_context: context.scoped_context, owner_object: object, arguments: kwarg_arguments) do |inner_result|
                 continue_value = continue_value(next_path, inner_result, field_defn, return_type.non_null?, ast_node)
-                if HALT != continue_value
+                if RawValue === continue_value
+                  # Write raw value directly to the response without resolving nested objects
+                  write_in_response(next_path, continue_value.resolve)
+                  continue_value.object
+                elsif HALT != continue_value
                   continue_field(next_path, continue_value, field_defn, return_type, ast_node, next_selections, false, object, kwarg_arguments)
                 end
               end

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -224,7 +224,6 @@ module GraphQL
                 if RawValue === continue_value
                   # Write raw value directly to the response without resolving nested objects
                   write_in_response(next_path, continue_value.object)
-                  continue_value.object
                 elsif HALT != continue_value
                   continue_field(next_path, continue_value, field_defn, return_type, ast_node, next_selections, false, object, kwarg_arguments)
                 end

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -44,6 +44,11 @@ describe GraphQL::Execution::Interpreter do
       def null_union_field_test
         1
       end
+
+      field :always_cached_value, Integer, null: false
+      def always_cached_value
+        raise "should never be called"
+      end
     end
 
     class Card < GraphQL::Schema::Object
@@ -129,6 +134,12 @@ describe GraphQL::Execution::Interpreter do
 
       def expansion(sym:)
         EXPANSIONS.find { |e| e.sym == sym }
+      end
+
+      field :expansion_raw, Expansion, null: false
+
+      def expansion_raw
+        raw_value(sym: "RAW", name: "Raw expansion", always_cached_value: 42)
       end
 
       field :expansions, [Expansion], null: false
@@ -478,6 +489,23 @@ describe GraphQL::Execution::Interpreter do
 
       res = InterpreterTest::Schema.execute('{ nodes(ids: ["abc", "xyz"]) { id } }')
       assert_equal ["abc", "xyz"], res["data"]["nodes"].map { |n| n["id"] }
+    end
+  end
+
+  describe "returning raw values" do
+    it "returns raw value" do
+      query_str = <<-GRAPHQL
+      {
+        expansionRaw {
+          name
+          sym
+          alwaysCachedValue
+        }
+      }
+      GRAPHQL
+
+      res = InterpreterTest::Schema.execute(query_str)
+      assert_equal({ sym: "RAW", name: "Raw expansion", always_cached_value: 42 }, res["data"]["expansionRaw"])
     end
   end
 end


### PR DESCRIPTION
This PR allows to return _raw values_ from resolvers. When Interpreter gets such a value, it should write it directly to the response, instead of visiting all the child nodes. This is how it could look like:

```ruby
class Query < GraphQL::Schema::Object
  field :expansion_raw, Expansion, null: false
  
  def expansion_raw
    raw_value(sym: "RAW", name: "Raw expansion")
  end
end
```

This change is a first step of implementing partial response caching (current solutions are very limited and skip various built-in checks). Here is an example [gist](https://gist.github.com/palkan/faad9f6ff1db16fcdb1c071ec50e4190) by @palkan, which contains the same change (using metaprogramming) as well as caching implementation.

What do you think? Do you have suggestions on the API design?