### PR TITLE
Consider fields not selected in lookahead if skipped by a directive

### DIFF
--- a/lib/graphql/execution/lookahead.rb
+++ b/lib/graphql/execution/lookahead.rb
@@ -51,7 +51,7 @@ module GraphQL
 
       # @return [Hash<Symbol, Object>]
       def arguments
-        @arguments ||= @field && ArgumentHelpers.arguments(@query, nil, @field, ast_nodes.first)
+        @arguments ||= @field && ArgumentHelpers.arguments(@query, @field, ast_nodes.first)
       end
 
       # True if this node has a selection on `field_name`.
@@ -263,7 +263,7 @@ module GraphQL
       end
 
       def arguments_match?(arguments, field_defn, field_node)
-        query_kwargs = ArgumentHelpers.arguments(@query, nil, field_defn, field_node)
+        query_kwargs = ArgumentHelpers.arguments(@query, field_defn, field_node)
         arguments.all? do |arg_name, arg_value|
           arg_name = normalize_keyword(arg_name)
           # Make sure the constraint is present with a matching value
@@ -275,20 +275,15 @@ module GraphQL
       module ArgumentHelpers
         module_function
 
-        def arguments(query, graphql_object, arg_owner, ast_node)
+        def arguments(query, arg_owner, ast_node)
           kwarg_arguments = {}
           arg_defns = arg_owner.arguments
           ast_node.arguments.each do |arg|
             arg_defn = arg_defns[arg.name] || raise("Invariant: missing argument definition for #{arg.name.inspect} in #{arg_defns.keys} from #{arg_owner}")
             # Need to distinguish between client-provided `nil`
             # and nothing-at-all
-            is_present, value = arg_to_value(query, graphql_object, arg_defn.type, arg.value)
+            is_present, value = arg_to_value(query, arg_defn.type, arg.value)
             if is_present
-              # This doesn't apply to directives, which are legacy
-              # Can remove this when Skip and Include use classes or something.
-              if graphql_object
-                value = arg_defn.prepare_value(graphql_object, value)
-              end
               kwarg_arguments[arg_defn.keyword] = value
             end
           end
@@ -305,7 +300,7 @@ module GraphQL
         # @param arg_type [Class, GraphQL::Schema::NonNull, GraphQL::Schema::List]
         # @param ast_value [GraphQL::Language::Nodes::VariableIdentifier, String, Integer, Float, Boolean]
         # @return [Array(is_present, value)]
-        def arg_to_value(query, graphql_object, arg_type, ast_value)
+        def arg_to_value(query, arg_type, ast_value)
           if ast_value.is_a?(GraphQL::Language::Nodes::VariableIdentifier)
             # If it's not here, it will get added later
             if query.variables.key?(ast_value.name)
@@ -316,13 +311,13 @@ module GraphQL
           elsif ast_value.is_a?(GraphQL::Language::Nodes::NullValue)
             return true, nil
           elsif arg_type.is_a?(GraphQL::Schema::NonNull)
-            arg_to_value(query, graphql_object, arg_type.of_type, ast_value)
+            arg_to_value(query, arg_type.of_type, ast_value)
           elsif arg_type.is_a?(GraphQL::Schema::List)
             # Treat a single value like a list
             arg_value = Array(ast_value)
             list = []
             arg_value.map do |inner_v|
-              _present, value = arg_to_value(query, graphql_object, arg_type.of_type, inner_v)
+              _present, value = arg_to_value(query, arg_type.of_type, inner_v)
               list << value
             end
             return true, list

--- a/lib/graphql/schema/directive.rb
+++ b/lib/graphql/schema/directive.rb
@@ -60,7 +60,12 @@ module GraphQL
         end
 
         # If false, this part of the query won't be evaluated
-        def include?(_object, _arguments, _context)
+        def include?(_object, arguments, context)
+          static_include?(arguments, context)
+        end
+
+        # Determines whether {Execution::Lookahead} considers the field to be selected
+        def static_include?(_arguments, _context)
           true
         end
 

--- a/lib/graphql/schema/directive/include.rb
+++ b/lib/graphql/schema/directive/include.rb
@@ -16,7 +16,7 @@ module GraphQL
 
         default_directive true
 
-        def self.include?(obj, args, ctx)
+        def self.static_include?(args, ctx)
           !!args[:if]
         end
       end

--- a/lib/graphql/schema/directive/skip.rb
+++ b/lib/graphql/schema/directive/skip.rb
@@ -16,7 +16,7 @@ module GraphQL
 
         default_directive true
 
-        def self.include?(obj, args, ctx)
+        def self.static_include?(args, ctx)
           !args[:if]
         end
       end

--- a/spec/graphql/execution/lookahead_spec.rb
+++ b/spec/graphql/execution/lookahead_spec.rb
@@ -387,5 +387,28 @@ describe GraphQL::Execution::Lookahead do
       assert_instance_of GraphQL::Execution::Lookahead::NullLookahead, null_lookahead
       assert_equal [], null_lookahead.selections
     end
+
+    it "excludes fields skipped by directives" do
+      document = GraphQL.parse <<-GRAPHQL
+        query($skipName: Boolean!, $includeGenus: Boolean!){
+          findBirdSpecies(byName: "Cardinal") {
+            id
+            name @skip(if: $skipName)
+            genus @include(if: $includeGenus)
+          }
+        }
+      GRAPHQL
+      query = GraphQL::Query.new(LookaheadTest::Schema, document: document,
+        variables: { skipName: false, includeGenus: true })
+      lookahead = query.lookahead.selection("findBirdSpecies")
+      assert_equal [:id, :name, :genus], lookahead.selections.map(&:name)
+      assert_equal true, lookahead.selects?(:name)
+
+      query = GraphQL::Query.new(LookaheadTest::Schema, document: document,
+        variables: { skipName: true, includeGenus: false })
+      lookahead = query.lookahead.selection("findBirdSpecies")
+      assert_equal [:id], lookahead.selections.map(&:name)
+      assert_equal false, lookahead.selects?(:name)
+    end
   end
 end


### PR DESCRIPTION
## Problem

GraphQL::Execution::Lookahead is primarily for determining what fields will need to be loaded for the query, so that they can be used to optimize database access.  However, it doesn't take into consideration whether or not fields are excluded by `@skip` or `@include` directives.

## Solution

I wasn't able to use `GraphQL::Schema::Directive.include?` directly, because it is given the parent object, which we won't know when looking ahead more than one level deep.  As a result, I added a `GraphQL::Schema::Directive.static_include?` method that directive classes can override so that `GraphQL::Execution::Lookahead` will use it to determine if the field will be included.

While looking at the code in lib/graphql/execution/lookahead.rb, I noticed that there was a reference to directives in a comment that precedes a conditional that is never taken.  `nil` is always passed in `ArgumentHelpers.arguments` for the `graphql_object` parameters.  I removed this unused parameters and cleaned up the dead code to avoid confusion.