### PR TITLE
Fix argument default_value: {} on Ruby 2.7

### DIFF
--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -7,6 +7,14 @@ require "forwardable"
 require_relative "./graphql/railtie" if defined? Rails::Railtie
 
 module GraphQL
+  # forwards-compat for argument handling
+  module Ruby2Keywords
+    if RUBY_VERSION < "2.7"
+      def ruby2_keywords(*)
+      end
+    end
+  end
+
   class Error < StandardError
   end
 

--- a/lib/graphql/define/defined_object_proxy.rb
+++ b/lib/graphql/define/defined_object_proxy.rb
@@ -34,7 +34,8 @@ module GraphQL
       end
 
       # Lookup a function from the dictionary and call it if it's found.
-      ruby2_keywords def method_missing(name, *args, &block)
+      ruby2_keywords
+      def method_missing(name, *args, &block)
         definition = @dictionary[name]
         if definition
           definition.call(@target, *args, &block)

--- a/lib/graphql/define/defined_object_proxy.rb
+++ b/lib/graphql/define/defined_object_proxy.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
+
 module GraphQL
   module Define
     # This object delegates most methods to a dictionary of functions, {@dictionary}.
     # {@target} is passed to the specified function, along with any arguments and block.
     # This allows a method-based DSL without adding methods to the defined class.
     class DefinedObjectProxy
+      extend GraphQL::Ruby2Keywords
       # The object which will be defined by definition functions
       attr_reader :target
 
@@ -32,16 +34,10 @@ module GraphQL
       end
 
       # Lookup a function from the dictionary and call it if it's found.
-      def method_missing(name, *args, **kwargs, &block)
+      ruby2_keywords def method_missing(name, *args, &block)
         definition = @dictionary[name]
         if definition
-          # Avoid passing `kwargs` when it's not used.
-          # Ruby 2.7 does fine here, but older Rubies receive too many arguments.
-          if kwargs.any?
-            definition.call(@target, *args, **kwargs, &block)
-          else
-            definition.call(@target, *args, &block)
-          end
+          definition.call(@target, *args, &block)
         else
           msg = "#{@target.class.name} can't define '#{name}'"
           raise NoDefinitionError, msg, caller

--- a/lib/graphql/define/instance_definable.rb
+++ b/lib/graphql/define/instance_definable.rb
@@ -200,7 +200,8 @@ module GraphQL
         # Even though we're just using the first value here,
         # We have to add a splat here to use `ruby2_keywords`,
         # so that it will accept a `[{}]` input from the caller.
-        ruby2_keywords def call(defn, *value)
+        ruby2_keywords
+        def call(defn, *value)
           defn.public_send(@attr_assign_method, value.first)
         end
       end

--- a/lib/graphql/define/instance_definable.rb
+++ b/lib/graphql/define/instance_definable.rb
@@ -191,12 +191,17 @@ module GraphQL
       end
 
       class AssignAttribute
+        extend GraphQL::Ruby2Keywords
+
         def initialize(attr_name)
           @attr_assign_method = :"#{attr_name}="
         end
 
-        def call(defn, value)
-          defn.public_send(@attr_assign_method, value)
+        # Even though we're just using the first value here,
+        # We have to add a splat here to use `ruby2_keywords`,
+        # so that it will accept a `[{}]` input from the caller.
+        ruby2_keywords def call(defn, *value)
+          defn.public_send(@attr_assign_method, value.first)
         end
       end
     end

--- a/spec/graphql/input_object_type_spec.rb
+++ b/spec/graphql/input_object_type_spec.rb
@@ -21,5 +21,31 @@ describe GraphQL::InputObjectType do
         assert_equal default_test_input_value[:foo], 'a'
       end
     end
+
+    describe "when it's an empty object" do
+      it "is passed in" do
+        input_obj = GraphQL::InputObjectType.define do
+          name "InputObj"
+          argument :s, types.String
+        end
+
+        query = GraphQL::ObjectType.define do
+          name "Query"
+          field(:f, types.String) do
+            argument(:arg, input_obj, default_value: {})
+            resolve ->(obj, args, ctx) {
+              args[:arg].to_h.inspect
+            }
+          end
+        end
+
+        schema = GraphQL::Schema.define do
+          query(query)
+        end
+
+        res = schema.execute("{ f } ")
+        assert_equal "{}", res["data"]["f"]
+      end
+    end
   end
 end

--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -391,6 +391,11 @@ describe GraphQL::Schema::InputObject do
       assert_equal "Jazz::InspectableInput -> {:string_value=>\"S\"}", res["data"]["defaultValueTest"]
     end
 
+    it "works with empty objects" do
+      res = Jazz::Schema.execute("{ defaultValueTest2 }")
+      assert_equal "Jazz::InspectableInput -> {}", res["data"]["defaultValueTest2"]
+    end
+
     it "introspects in GraphQL language with enums" do
       class InputDefaultSchema < GraphQL::Schema
         class Letter < GraphQL::Schema::Enum

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -491,6 +491,10 @@ module Jazz
       "#{arg_with_default.class.name} -> #{arg_with_default.to_h}"
     end
 
+    field :default_value_test_2, String, null: false, resolver_method: :default_value_test do
+      argument :arg_with_default, InspectableInput, required: false, default_value: {}
+    end
+
     field :complex_hash_key, String, null: false, hash_key: :'foo bar/fizz-buzz'
   end
 


### PR DESCRIPTION
Oops, passing `.call(arg, :default_value, [{}])` was causing the empty hash to be dropped. I think the built-in compat method will help here, and GraphQL-Ruby 2.0 will eventually drop this code anyways.

I will backport to 1.9.x

Fixes #2691 