### PR TITLE
Use Interface.orphan_types in schema construction

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -1817,6 +1817,11 @@ module GraphQL
               add_type(t, owner: type, late_types: late_types)
             end
           end
+          if type.kind.interface?
+            type.orphan_types.each do |t|
+              add_type(t, owner: type, late_types: late_types)
+            end
+          end
           if type.kind.object?
             own_possible_types[type.graphql_name] = [type]
             type.interfaces.each do |i|

--- a/spec/graphql/interface_type_spec.rb
+++ b/spec/graphql/interface_type_spec.rb
@@ -6,7 +6,7 @@ describe GraphQL::InterfaceType do
   let(:dummy_query_context) { OpenStruct.new(schema: Dummy::Schema) }
 
   it "has possible types" do
-    expected_defns = [Dummy::Cheese, Dummy::Milk, Dummy::Honey]
+    expected_defns = [Dummy::Cheese, Dummy::Milk, Dummy::Honey, Dummy::Aspartame]
     assert_equal(expected_defns, Dummy::Schema.possible_types(interface))
   end
 

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -165,9 +165,13 @@ module Dummy
     possible_types Milk
   end
 
+  class Aspartame < BaseObject; end
+
   module Sweetener
     include BaseInterface
     field :sweetness, Integer, null: true
+
+    orphan_types Aspartame
   end
 
   # No actual data; This type is an "orphan", only accessible through Interfaces
@@ -176,6 +180,14 @@ module Dummy
     field :flower_type, String, "What flower this honey came from", null: true
     implements Edible
     implements AnimalProduct
+    implements Sweetener
+  end
+
+  # No actual data; Same as "Honey", but only accessible through an interface's orphans
+  class Aspartame < BaseObject
+    description "Sugar substitute with an off-flavor aftertaste"
+    field :manufacturer, String, "What manufacturer this aspartame came from", null: true
+    implements Edible
     implements Sweetener
   end
 


### PR DESCRIPTION
Fixes #2694 

(cc @liang3404814 -- I saw this commit on your repo and I'm getting ready to cut 1.10.1, so I grabbed it!)