### PR TITLE
Properly wrap nested objects coming in variables

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -518,7 +518,7 @@ module GraphQL
               if ast_value.nil?
                 return false, nil
               else
-                args = ast_value
+                return true, ast_value
               end
             else
               # For these, `prepare` is applied during `#initialize`.

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -215,7 +215,8 @@ module GraphQL
             end
           end
 
-          input_values
+          input_obj_instance = self.new(ruby_kwargs: input_values, context: ctx, defaults_used: nil)
+          input_obj_instance.prepare
         end
 
         # It's funny to think of a _result_ of an input object.

--- a/spec/graphql/analysis/ast/query_complexity_spec.rb
+++ b/spec/graphql/analysis/ast/query_complexity_spec.rb
@@ -106,7 +106,7 @@ describe GraphQL::Analysis::AST::QueryComplexity do
               origin
             }
 
-            # 1 for honey
+            # 1 for honey, aspartame
             ... on Sweetener {
               sweetness
             }
@@ -164,7 +164,7 @@ describe GraphQL::Analysis::AST::QueryComplexity do
             # 1 for everybody
             ... on Edible { origin }
 
-            # 1 for honey
+            # 1 for honey, aspartame
             ... on Sweetener { sweetness }
           }
         }

--- a/spec/graphql/execution/errors_spec.rb
+++ b/spec/graphql/execution/errors_spec.rb
@@ -179,11 +179,11 @@ describe "GraphQL::Execution::Errors" do
         context = { authorized: false }
         res = ErrorsTestSchema.execute(
           "query($values: ValuesInput!) { inputField(values: $values) } ",
-          variables: { values: { value: 2 } },
+          variables: { values: { "value" => 2 } },
           context: context,
         )
         # The message appears in extensions here:
-        assert_equal ["ErrorD on nil at Query.inputField()"], res["errors"].map { |e| e["message"] }
+        assert_equal ["ErrorD on nil at boot"], res["errors"].map { |e| e["extensions"]["problems"][0]["explanation"] }
       end
     end
   end

--- a/spec/integration/rails/graphql/query/variables_spec.rb
+++ b/spec/integration/rails/graphql/query/variables_spec.rb
@@ -79,13 +79,13 @@ describe GraphQL::Query::Variables do
           fat_content: 0.99,
         }.merge(default_values)
 
-        assert_equal(expected_input_1.sort.to_h, variables["dairy_product_1"].sort.to_h)
+        assert_equal(expected_input_1.sort.to_h, variables["dairy_product_1"].to_h.sort.to_h)
 
         expected_input_2 = {
           source: :donkey,
           fat_content: 0.89,
         }.merge(default_values)
-        assert_equal(expected_input_2.sort.to_h, variables["dairy_product_2"].sort.to_h)
+        assert_equal(expected_input_2.sort.to_h, variables["dairy_product_2"].to_h.sort.to_h)
       end
     end
 


### PR DESCRIPTION
Oops, the interpreter was leaving these as Hashes instead of wrapping them in input object instances.