### PR TITLE
Use Module#module_parent_name instead of Module#parent_name

### DIFF
--- a/lib/generators/graphql/core.rb
+++ b/lib/generators/graphql/core.rb
@@ -48,9 +48,17 @@ module Graphql
           if options[:schema]
             options[:schema]
           else
-            require File.expand_path("config/application", destination_root)
-            "#{Rails.application.class.parent_name}Schema"
+            "#{parent_name}Schema"
           end
+        end
+      end
+
+      def parent_name
+        require File.expand_path("config/application", destination_root)
+        if Rails.application.class.respond_to?(:module_parent_name)
+          Rails.application.class.module_parent_name
+        else
+          Rails.application.class.parent_name
         end
       end
     end


### PR DESCRIPTION
Hi,

Module#parent_name is deprecated in Rails 6.0 and will be removed in Rails 6.1.
Ref: https://github.com/rails/rails/pull/34051

To suppress a deprecation warning, use Module#module_parent_name instead.