### PR TITLE
loads: with plain field arguments

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -648,6 +648,17 @@ module GraphQL
           # Apply any `prepare` methods. Not great code organization, can this go somewhere better?
           arguments.each do |name, arg_defn|
             ruby_kwargs_key = arg_defn.keyword
+
+            loads = arg_defn.loads
+            if ruby_kwargs.key?(ruby_kwargs_key) && loads && !arg_defn.from_resolver?
+              value = ruby_kwargs[ruby_kwargs_key]
+              ruby_kwargs[ruby_kwargs_key] = if arg_defn.type.list?
+                value.map { |val| load_application_object(arg_defn, loads, val, field_ctx.query.context) }
+              else
+                load_application_object(arg_defn, loads, value, field_ctx.query.context)
+              end
+            end
+
             if ruby_kwargs.key?(ruby_kwargs_key) && arg_defn.prepare
               ruby_kwargs[ruby_kwargs_key] = arg_defn.prepare_value(obj, ruby_kwargs[ruby_kwargs_key])
             end

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -5,6 +5,7 @@ module GraphQL
       extend GraphQL::Schema::Member::AcceptsDefinition
       extend Forwardable
       extend GraphQL::Schema::Member::HasArguments
+      extend GraphQL::Schema::Member::HasArguments::ArgumentObjectLoader
       extend GraphQL::Schema::Member::ValidatesInput
 
       include GraphQL::Dig
@@ -25,12 +26,12 @@ module GraphQL
           ruby_kwargs_key = arg_defn.keyword
           loads = arg_defn.loads
 
-          if @ruby_style_hash.key?(ruby_kwargs_key) && loads && !arg_defn.from_resolver?
+          if @ruby_style_hash.key?(ruby_kwargs_key) && loads && !arg_defn.from_resolver? && !context.interpreter?
             value = @ruby_style_hash[ruby_kwargs_key]
             @ruby_style_hash[ruby_kwargs_key] = if arg_defn.type.list?
-              value.map { |val| load_application_object(arg_defn, loads, val) }
+              value.map { |val| load_application_object(arg_defn, loads, val, context) }
             else
-              load_application_object(arg_defn, loads, value)
+              load_application_object(arg_defn, loads, value, context)
             end
           end
 

--- a/lib/graphql/schema/member/has_arguments.rb
+++ b/lib/graphql/schema/member/has_arguments.rb
@@ -86,9 +86,24 @@ module GraphQL
             end
 
             if has_value
-              coerced_value = nil
+              loads = arg_defn.loads
+              loaded_value = nil
+              if loads && !arg_defn.from_resolver?
+                loaded_value = if arg_defn.type.list?
+                  value.map { |val| load_application_object(arg_defn, loads, val, context) }
+                else
+                  load_application_object(arg_defn, loads, value, context)
+                end
+              end
+
               prepared_value = context.schema.error_handler.with_error_handling(context) do
-                coerced_value = arg_defn.type.coerce_input(value, context)
+
+                coerced_value = if loaded_value
+                  loaded_value
+                else
+                  arg_defn.type.coerce_input(value, context)
+                end
+
                 arg_defn.prepare_value(parent_object, coerced_value, context: context)
               end
               kwarg_arguments[arg_defn.keyword] = prepared_value
@@ -119,7 +134,7 @@ module GraphQL
             context.schema.object_from_id(id, context)
           end
 
-          def load_application_object(argument, lookup_as_type, id)
+          def load_application_object(argument, lookup_as_type, id, context)
             # See if any object can be found for this ID
             loaded_application_object = object_from_id(lookup_as_type, id, context)
             context.schema.after_lazy(loaded_application_object) do |application_object|

--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -285,7 +285,7 @@ module GraphQL
               argument = @arguments_by_keyword[:#{arg_defn.keyword}]
               lookup_as_type = @arguments_loads_as_type[:#{arg_defn.keyword}]
               context.schema.after_lazy(values) do |values2|
-                GraphQL::Execution::Lazy.all(values2.map { |value| load_application_object(argument, lookup_as_type, value) })
+                GraphQL::Execution::Lazy.all(values2.map { |value| load_application_object(argument, lookup_as_type, value, context) })
               end
             end
             RUBY
@@ -294,7 +294,7 @@ module GraphQL
             def load_#{arg_defn.keyword}(value)
               argument = @arguments_by_keyword[:#{arg_defn.keyword}]
               lookup_as_type = @arguments_loads_as_type[:#{arg_defn.keyword}]
-              load_application_object(argument, lookup_as_type, value)
+              load_application_object(argument, lookup_as_type, value, context)
             end
             RUBY
           else

--- a/spec/graphql/execution/errors_spec.rb
+++ b/spec/graphql/execution/errors_spec.rb
@@ -3,14 +3,6 @@ require "spec_helper"
 
 describe "GraphQL::Execution::Errors" do
   class ErrorsTestSchema < GraphQL::Schema
-    def self.object_from_id(id, ctx)
-      if id == 1
-        :thing
-      else
-        raise ErrorD
-      end
-    end
-
     class ErrorA < RuntimeError; end
     class ErrorB < RuntimeError; end
     class ErrorC < RuntimeError
@@ -61,7 +53,7 @@ describe "GraphQL::Execution::Errors" do
     class ValuesInput < GraphQL::Schema::InputObject
       argument :value, Int, required: true, loads: Thing
 
-      def object_from_id(type, value, ctx)
+      def self.object_from_id(type, value, ctx)
         if value == 1
           :thing
         else

--- a/spec/graphql/execution/errors_spec.rb
+++ b/spec/graphql/execution/errors_spec.rb
@@ -3,6 +3,14 @@ require "spec_helper"
 
 describe "GraphQL::Execution::Errors" do
   class ErrorsTestSchema < GraphQL::Schema
+    def self.object_from_id(id, ctx)
+      if id == 1
+        :thing
+      else
+        raise ErrorD
+      end
+    end
+
     class ErrorA < RuntimeError; end
     class ErrorB < RuntimeError; end
     class ErrorC < RuntimeError

--- a/spec/graphql/schema/argument_spec.rb
+++ b/spec/graphql/schema/argument_spec.rb
@@ -19,6 +19,7 @@ describe GraphQL::Schema::Argument do
         end
 
         argument :keys, [String], required: false, method_access: false
+        argument :instrument_id, ID, required: false, loads: Jazz::InstrumentType
 
         class Multiply
           def call(val, context)
@@ -48,12 +49,18 @@ describe GraphQL::Schema::Argument do
         use GraphQL::Execution::Interpreter
         use GraphQL::Analysis::AST
       end
+
+      def self.object_from_id(id, ctx)
+        Jazz::GloballyIdentifiableType.find(id)
+      end
+
+      orphan_types [Jazz::InstrumentType]
     end
   end
 
   describe "#keys" do
     it "is not overwritten by the 'keys' argument" do
-      expected_keys = ["aliasedArg", "arg", "argWithBlock", "explodingPreparedArg", "keys", "preparedArg", "preparedByCallableArg", "preparedByProcArg", "requiredWithDefaultArg"]
+      expected_keys = ["aliasedArg", "arg", "argWithBlock", "explodingPreparedArg", "instrumentId", "keys", "preparedArg", "preparedByCallableArg", "preparedByProcArg", "requiredWithDefaultArg"]
       assert_equal expected_keys, SchemaArgumentTest::Query.fields["field"].arguments.keys.sort
     end
   end
@@ -182,6 +189,16 @@ describe GraphQL::Schema::Argument do
       res = SchemaArgumentTest::Schema.execute(query_str)
       assert_equal "Argument 'requiredWithDefaultArg' on Field 'field' has an invalid value (null). Expected type 'Int!'.", res['errors'][0]['message']
     end
+  end
 
+  describe 'loads' do
+    it "loads input object arguments" do
+      query_str = <<-GRAPHQL
+      query { field(instrumentId: "Instrument/Drum Kit") }
+      GRAPHQL
+
+      res = SchemaArgumentTest::Schema.execute(query_str)
+      assert_equal "{:instrument=>#{Jazz::Models::Instrument.new("Drum Kit", "PERCUSSION").inspect}, :required_with_default_arg=>1}", res["data"]["field"]
+    end
   end
 end


### PR DESCRIPTION
Hi! Thank you for the great gem.
`loads:` with plain field arguments does not work now.
ref #2544

I think it is more convenient to add this.

I may have made the wrong fix or have some missing tests. If so please point.
best regards.