### PR TITLE
Fix build_from_definition for built-in types

### DIFF
--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -42,7 +42,6 @@ module GraphQL
           end
           schema_definition = schema_defns.first
           types = {}
-          types.merge!(GraphQL::Schema::BUILT_IN_TYPES)
           directives = {}
           type_resolver = ->(type) { resolve_type(types, type)  }
 
@@ -66,6 +65,14 @@ module GraphQL
               types[definition.name] = build_input_object_type(definition, type_resolver)
             when GraphQL::Language::Nodes::DirectiveDefinition
               directives[definition.name] = build_directive(definition, type_resolver)
+            end
+          end
+
+          types = GraphQL::Schema::BUILT_IN_TYPES.merge(types) do |key, built_in_type, existing_type|
+            if existing_type.is_a?(GraphQL::Schema::LateBoundType)
+              built_in_type
+            else
+              existing_type
             end
           end
 

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -68,11 +68,18 @@ module GraphQL
             end
           end
 
-          types = GraphQL::Schema::BUILT_IN_TYPES.merge(types) do |key, built_in_type, existing_type|
+          # At this point, if types named by the built in types are _late-bound_ types,
+          # that means they were referenced in the schema but not defined in the schema.
+          # That's supported for built-in types. (Eg, you can use `String` without defining it.)
+          # In that case, insert the concrete type definition now.
+          #
+          # However, if the type in `types` is a _concrete_ type definition, that means that
+          # the document contained an explicit definition of the scalar type.
+          # Don't override it in this case.
+          GraphQL::Schema::BUILT_IN_TYPES.each do |scalar_name, built_in_scalar|
+            existing_type = types[scalar_name]
             if existing_type.is_a?(GraphQL::Schema::LateBoundType)
-              built_in_type
-            else
-              existing_type
+              types[scalar_name] = built_in_scalar
             end
           end
 

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -548,6 +548,24 @@ type WorldTwo {
       assert_schema_and_compare_output(schema.chop)
     end
 
+    it 'supports redefining built-in scalars' do
+      schema = <<-SCHEMA
+schema {
+  query: Root
+}
+
+scalar ID
+
+type Root {
+  builtInScalar: ID
+}
+      SCHEMA
+
+      built_schema = assert_schema_and_compare_output(schema.chop)
+      id_scalar = built_schema.types["ID"]
+      assert_equal true, id_scalar.valid_isolated_input?("123")
+    end
+
     it 'supports custom scalar' do
       schema = <<-SCHEMA
 schema {


### PR DESCRIPTION
If an SDL document contained a built-in type definition `build_from_definition` would raise an error due to type conflicts.

This defers merging in the `BUILT_IN_TYPES` and reverse merges them to keep any previously defined ones in the provided document.