### PR TITLE
Unify input coercion

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -440,7 +440,11 @@ module GraphQL
         def prepare_args_hash(ast_arg_or_hash_or_value)
           case ast_arg_or_hash_or_value
           when Hash
-            ast_arg_or_hash_or_value
+            args_hash = {}
+            ast_arg_or_hash_or_value.each do |k, v|
+              args_hash[k] = prepare_args_hash(v)
+            end
+            args_hash
           when Array
             ast_arg_or_hash_or_value.map { |v| prepare_args_hash(v) }
           when GraphQL::Language::Nodes::Field, GraphQL::Language::Nodes::InputObject, GraphQL::Language::Nodes::Directive
@@ -459,13 +463,19 @@ module GraphQL
             else
               NO_VALUE_GIVEN
             end
+          when GraphQL::Language::Nodes::Enum
+            ast_arg_or_hash_or_value.name
+          when GraphQL::Language::Nodes::NullValue
+            nil
           else
             ast_arg_or_hash_or_value
           end
         end
 
         def arguments(graphql_object, arg_owner, ast_node_or_hash)
+          # First, normalize all AST or Ruby values to a plain Ruby hash
           args_hash = prepare_args_hash(ast_node_or_hash)
+          # Then call into the schema to coerce those incoming values
           arg_owner.coerce_arguments(graphql_object, args_hash, context)
         end
 

--- a/lib/graphql/query/null_context.rb
+++ b/lib/graphql/query/null_context.rb
@@ -23,6 +23,10 @@ module GraphQL
 
       def [](key); end
 
+      def interpreter?
+        false
+      end
+
       class << self
         extend Forwardable
 
@@ -32,7 +36,7 @@ module GraphQL
           @instance = self.new
         end
 
-        def_delegators :instance, :query, :schema, :warden
+        def_delegators :instance, :query, :schema, :warden, :interpreter?
       end
     end
   end

--- a/lib/graphql/query/variables.rb
+++ b/lib/graphql/query/variables.rb
@@ -32,9 +32,9 @@ module GraphQL
             begin
               validation_result = variable_type.validate_input(provided_value, ctx)
               if validation_result.valid?
-                memo[variable_name] = if value_was_provided
+                if value_was_provided
                   # Add the variable if a value was provided
-                  if ctx.query.interpreter?
+                  memo[variable_name] = if ctx.query.interpreter?
                     provided_value
                   elsif provided_value.nil?
                     nil
@@ -44,7 +44,7 @@ module GraphQL
                     end
                   end
                 elsif default_value != nil
-                  if ctx.query.interpreter?
+                  memo[variable_name] = if ctx.query.interpreter?
                     default_value
                   else
                     # Add the variable if it wasn't provided but it has a default value (including `null`)

--- a/lib/graphql/query/variables.rb
+++ b/lib/graphql/query/variables.rb
@@ -34,7 +34,7 @@ module GraphQL
               if validation_result.valid?
                 if value_was_provided
                   # Add the variable if a value was provided
-                  memo[variable_name] = if ctx.query.interpreter?
+                  memo[variable_name] = if ctx.interpreter?
                     provided_value
                   elsif provided_value.nil?
                     nil
@@ -44,7 +44,7 @@ module GraphQL
                     end
                   end
                 elsif default_value != nil
-                  memo[variable_name] = if ctx.query.interpreter?
+                  memo[variable_name] = if ctx.interpreter?
                     default_value
                   else
                     # Add the variable if it wasn't provided but it has a default value (including `null`)

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -34,7 +34,9 @@ module GraphQL
             end
           end
 
-          if @ruby_style_hash.key?(ruby_kwargs_key) && arg_defn.prepare
+          # Weirdly, procs are applied during coercion, but not methods.
+          # Probably because these methods require a `self`.
+          if @ruby_style_hash.key?(ruby_kwargs_key) && arg_defn.prepare.is_a?(Symbol)
             @ruby_style_hash[ruby_kwargs_key] = arg_defn.prepare_value(self, @ruby_style_hash[ruby_kwargs_key])
           end
         end

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -36,7 +36,7 @@ module GraphQL
 
           # Weirdly, procs are applied during coercion, but not methods.
           # Probably because these methods require a `self`.
-          if @ruby_style_hash.key?(ruby_kwargs_key) && arg_defn.prepare.is_a?(Symbol)
+          if @ruby_style_hash.key?(ruby_kwargs_key) && (arg_defn.prepare.is_a?(Symbol) || context.nil?  || !context.interpreter?)
             @ruby_style_hash[ruby_kwargs_key] = arg_defn.prepare_value(self, @ruby_style_hash[ruby_kwargs_key])
           end
         end
@@ -190,32 +190,8 @@ module GraphQL
           if value.nil?
             return nil
           end
-          input_values = {}
 
-          arguments.each do |name, argument_defn|
-            arg_key = argument_defn.keyword
-            has_value = false
-
-            # Accept either string or symbol
-            field_value = if value.key?(name)
-              has_value = true
-              value[name]
-            elsif value.key?(arg_key)
-              has_value = true
-              value[arg_key]
-            elsif argument_defn.default_value?
-              has_value = true
-              argument_defn.default_value
-            else
-              nil
-            end
-            # Only continue if some value was found for this argument
-            if has_value
-              coerced_value = argument_defn.type.coerce_input(field_value, ctx)
-              prepared_value = argument_defn.prepare_value(nil, coerced_value, context: ctx)
-              input_values[arg_key] = prepared_value
-            end
-          end
+          input_values = coerce_arguments(nil, value, ctx)
 
           input_obj_instance = self.new(ruby_kwargs: input_values, context: ctx, defaults_used: nil)
           input_obj_instance.prepare

--- a/lib/graphql/schema/member/has_arguments.rb
+++ b/lib/graphql/schema/member/has_arguments.rb
@@ -72,10 +72,14 @@ module GraphQL
           arg_defns = self.arguments
 
           arg_defns.each do |arg_name, arg_defn|
+            arg_key = arg_defn.keyword
             has_value = false
             if values.key?(arg_name)
               has_value = true
               value = values[arg_name]
+            elsif values.key?(arg_key)
+              has_value = true
+              value = values[arg_key]
             elsif arg_defn.default_value?
               has_value = true
               value = arg_defn.default_value
@@ -85,7 +89,7 @@ module GraphQL
               coerced_value = nil
               prepared_value = context.schema.error_handler.with_error_handling(context) do
                 coerced_value = arg_defn.type.coerce_input(value, context)
-                arg_defn.prepare_value(parent_object, coerced_value)
+                arg_defn.prepare_value(parent_object, coerced_value, context: context)
               end
               kwarg_arguments[arg_defn.keyword] = prepared_value
             end

--- a/lib/graphql/schema/member/has_arguments.rb
+++ b/lib/graphql/schema/member/has_arguments.rb
@@ -82,8 +82,11 @@ module GraphQL
             end
 
             if has_value
-              coerced_value = arg_defn.type.coerce_input(value, context)
-              prepared_value = arg_defn.prepare_value(parent_object, coerced_value)
+              coerced_value = nil
+              prepared_value = context.schema.error_handler.with_error_handling(context) do
+                coerced_value = arg_defn.type.coerce_input(value, context)
+                arg_defn.prepare_value(parent_object, coerced_value)
+              end
               kwarg_arguments[arg_defn.keyword] = prepared_value
             end
           end

--- a/spec/graphql/execution/errors_spec.rb
+++ b/spec/graphql/execution/errors_spec.rb
@@ -182,8 +182,8 @@ describe "GraphQL::Execution::Errors" do
           variables: { values: { "value" => 2 } },
           context: context,
         )
-        # The message appears in extensions here:
-        assert_equal ["ErrorD on nil at boot"], res["errors"].map { |e| e["extensions"]["problems"][0]["explanation"] }
+
+        assert_equal ["ErrorD on nil at Query.inputField()"], res["errors"].map { |e| e["message"] }
       end
     end
   end

--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -149,8 +149,16 @@ describe GraphQL::Schema::InputObject do
       res = InputObjectPrepareTest::Schema.execute(query_str, context: { multiply_by: 3 },
                                                    variables: { input: input})
       assert_nil(res["data"])
-      assert_equal("boom!", res["errors"][0]["message"])
-      assert_equal([{ "line" => 1, "column" => 33 }], res["errors"][0]["locations"])
+
+      if TESTING_INTERPRETER
+        assert_equal("boom!", res["errors"][0]["message"])
+        assert_equal([{ "line" => 1, "column" => 33 }], res["errors"][0]["locations"])
+      else
+        assert_equal("Variable $input of type InputObj! was provided invalid value", res["errors"][0]["message"])
+        assert_equal([{ "line" => 1, "column" => 13 }], res["errors"][0]["locations"])
+        assert_equal("boom!", res["errors"][0]["extensions"]["problems"][0]["explanation"])
+        assert_equal(input, res["errors"][0]["extensions"]["value"])
+      end
     end
 
     it "loads input object arguments" do

--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -149,10 +149,8 @@ describe GraphQL::Schema::InputObject do
       res = InputObjectPrepareTest::Schema.execute(query_str, context: { multiply_by: 3 },
                                                    variables: { input: input})
       assert_nil(res["data"])
-      assert_equal("Variable $input of type InputObj! was provided invalid value", res["errors"][0]["message"])
-      assert_equal([{ "line" => 1, "column" => 13 }], res["errors"][0]["locations"])
-      assert_equal("boom!", res["errors"][0]["extensions"]["problems"][0]["explanation"])
-      assert_equal(input, res["errors"][0]["extensions"]["value"])
+      assert_equal("boom!", res["errors"][0]["message"])
+      assert_equal([{ "line" => 1, "column" => 33 }], res["errors"][0]["locations"])
     end
 
     it "loads input object arguments" do


### PR DESCRIPTION
I've added all the coercion behavior to type classes, but `runtime.rb` was still doing a lot of it itself. I've refactored it to use the type classes, instead.