### PR TITLE
Include directive argument types as reachable

### DIFF
--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -230,6 +230,16 @@ module GraphQL
           unvisited_types << root_type if root_type
         end
         unvisited_types.concat(@schema.introspection_system.types.values)
+
+        directives.each do |dir_class|
+          dir_class.arguments.values.each do |arg_defn|
+            arg_t = arg_defn.type.unwrap
+            if get_type(arg_t.graphql_name)
+              unvisited_types << arg_t
+            end
+          end
+        end
+
         @schema.orphan_types.each do |orphan_type|
           if get_type(orphan_type.graphql_name)
             unvisited_types << orphan_type

--- a/spec/graphql/language/document_from_schema_definition_spec.rb
+++ b/spec/graphql/language/document_from_schema_definition_spec.rb
@@ -58,6 +58,44 @@ describe GraphQL::Language::DocumentFromSchemaDefinition do
 
     let(:expected_document) { GraphQL.parse(expected_idl) }
 
+    describe "when schemas have enums" do
+      let(:schema_idl) { <<-GRAPHQL.chomp
+directive @locale(lang: LangEnum!) on FIELD
+
+enum LangEnum {
+  en
+  ru
+}
+
+type Query {
+  i: Int
+}
+      GRAPHQL
+      }
+
+      class DirectiveSchema < GraphQL::Schema
+        class Query < GraphQL::Schema::Object
+          field :i, Int, null: true
+        end
+
+        class Locale < GraphQL::Schema::Directive
+          class LangEnum < GraphQL::Schema::Enum
+            value "en"
+            value "ru"
+          end
+          locations GraphQL::Schema::Directive::FIELD
+
+          argument :lang, LangEnum, required: true
+        end
+
+        query(Query)
+        directive(Locale)
+      end
+      focus
+      it "dumps them into the string" do
+        assert_equal schema_idl, DirectiveSchema.to_definition
+      end
+    end
     describe "when printing and schema respects root name conventions" do
       let(:schema_idl) { <<-GRAPHQL
         type Query {


### PR DESCRIPTION
Types referenced from directive arguments were previously excluded by the warden because they weren't in `reachable_types`. Fixes #2677 