### PR TITLE
Include new analysis in default schema

### DIFF
--- a/lib/generators/graphql/templates/schema.erb
+++ b/lib/generators/graphql/templates/schema.erb
@@ -3,6 +3,7 @@ class <%= schema_name %> < GraphQL::Schema
 
   # Opt in to the new runtime (default in future graphql-ruby versions)
   use GraphQL::Execution::Interpreter
+  use GraphQL::Analysis::AST
 
   # Add built-in connections for pagination
   use GraphQL::Pagination::Connections

--- a/spec/integration/rails/generators/graphql/install_generator_spec.rb
+++ b/spec/integration/rails/generators/graphql/install_generator_spec.rb
@@ -47,6 +47,7 @@ class DummySchema < GraphQL::Schema
 
   # Opt in to the new runtime (default in future graphql-ruby versions)
   use GraphQL::Execution::Interpreter
+  use GraphQL::Analysis::AST
 
   # Add built-in connections for pagination
   use GraphQL::Pagination::Connections
@@ -246,6 +247,7 @@ class DummySchema < GraphQL::Schema
 
   # Opt in to the new runtime (default in future graphql-ruby versions)
   use GraphQL::Execution::Interpreter
+  use GraphQL::Analysis::AST
 
   # Add built-in connections for pagination
   use GraphQL::Pagination::Connections


### PR DESCRIPTION
Oops, the default schema used interpreter, but not the also-required Analysis::AST plugin. 

Fix #2718 