### PR TITLE
Unsubscribe when read_subscription returns nil

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ rvm:
   - 2.3.8
 
 matrix:
+  allow_failures:
+    - rvm: ruby-head
+      gemfile: gemfiles/rails_master.gemfile
   include:
   - env:
       - DISPLAY=':99.0'
@@ -39,6 +42,8 @@ matrix:
       - TESTING_INTERPRETER=yes
     rvm: 2.4.3
     gemfile: gemfiles/rails_5.2.gemfile
+  - rvm: ruby-head
+    gemfile: gemfiles/rails_master.gemfile
   - rvm: 2.3.8
     gemfile: gemfiles/rails_3.2.gemfile
   - rvm: 2.3.8
@@ -84,8 +89,3 @@ matrix:
       - psql -c 'create database graphql_ruby_test;' -U postgres
   - rvm: 2.6.2
     gemfile: Gemfile
-
-jobs:
-  allow_failures:
-    - rvm: ruby-head
-      gemfile: gemfiles/rails_master.gemfile

--- a/lib/graphql/define/defined_object_proxy.rb
+++ b/lib/graphql/define/defined_object_proxy.rb
@@ -34,7 +34,6 @@ module GraphQL
       end
 
       # Lookup a function from the dictionary and call it if it's found.
-      ruby2_keywords
       def method_missing(name, *args, &block)
         definition = @dictionary[name]
         if definition
@@ -44,6 +43,7 @@ module GraphQL
           raise NoDefinitionError, msg, caller
         end
       end
+      ruby2_keywords :method_missing
 
       def respond_to_missing?(name, include_private = false)
         @dictionary[name] || super

--- a/lib/graphql/define/instance_definable.rb
+++ b/lib/graphql/define/instance_definable.rb
@@ -200,10 +200,10 @@ module GraphQL
         # Even though we're just using the first value here,
         # We have to add a splat here to use `ruby2_keywords`,
         # so that it will accept a `[{}]` input from the caller.
-        ruby2_keywords
         def call(defn, *value)
           defn.public_send(@attr_assign_method, value.first)
         end
+        ruby2_keywords :call
       end
     end
   end


### PR DESCRIPTION
It's possible for reads and writes to happen _between_ `each_subscription_id` and `read_subscription`, this allows `read_subscription` to signal to the caller that there's no such subscription anymore. The caller handles it by calling `delete_subscription`, which is an opportunity to clean up any dangling state. (There may not _be_ any state, since it wasn't found by `read_subscription` -- depends on the backend.)

Fixes #2061 