### PR TITLE
Subscriptions, prepare: and interpreter 

### DIFF
--- a/lib/graphql/subscriptions.rb
+++ b/lib/graphql/subscriptions.rb
@@ -228,7 +228,10 @@ module GraphQL
         # match query arguments.
         arg_owner.arguments.each do |name, arg_defn|
           if arg_defn.default_value? && !normalized_args.key?(arg_defn.name)
-            normalized_args[arg_defn.name] = arg_defn.default_value
+            default_value = arg_defn.default_value
+            # We don't have an underlying "object" here, so it can't call methods.
+            # This is broken.
+            normalized_args[arg_defn.name] = arg_defn.prepare_value(nil, default_value, context: GraphQL::Query::NullContext)
           end
         end
 

--- a/lib/graphql/subscriptions/subscription_root.rb
+++ b/lib/graphql/subscriptions/subscription_root.rb
@@ -38,12 +38,13 @@ module GraphQL
           elsif (events = context.namespace(:subscriptions)[:events])
             # This is the first execution, so gather an Event
             # for the backend to register:
-            events << Subscriptions::Event.new(
+            event = Subscriptions::Event.new(
               name: field.name,
               arguments: arguments,
               context: context,
               field: field,
             )
+            events << event
             value
           elsif context.query.subscription_topic == Subscriptions::Event.serialize(
               field.name,


### PR DESCRIPTION
I'm not sure if I can actually _fix_ this or not, but I want to keep an eye on this behavior 

Closes #2721 

TODO: 

- [x] Is calling `.prepare` in subscriptions the right thing, or should I have used a different `default_value`? 
  - Yes -- when I changed the default value, it :boom:ed because the prepared value wasn't a member of the Enum.