### PR TITLE
Fix visitor replacement of variable definitions

### DIFF
--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -488,6 +488,8 @@ module GraphQL
 
         # @!attribute name
         #   @return [String] The identifier for this variable, _without_ `$`
+
+        self.children_method_name = :variables
       end
 
       # A query, mutation or subscription.

--- a/spec/graphql/language/visitor_spec.rb
+++ b/spec/graphql/language/visitor_spec.rb
@@ -237,6 +237,15 @@ describe GraphQL::Language::Visitor do
           super
         end
       end
+
+      def on_variable_definition(node, parent)
+        if node.type.name == 'A'
+          new_type = GraphQL::Language::Nodes::TypeName.new(name: 'RenamedA')
+          super(node.merge(type: new_type), parent)
+        else
+          super
+        end
+      end
     end
 
     def get_result(query_str)
@@ -248,7 +257,7 @@ describe GraphQL::Language::Visitor do
 
     it "returns a new AST with modifications applied" do
       query = <<-GRAPHQL.chop
-query {
+query($a: A, $b: B) {
   a(a1: 1) {
     b(b2: 2) {
       c(c3: 3)
@@ -260,7 +269,7 @@ query {
       document, new_document = get_result(query)
       refute_equal document, new_document
       expected_result = <<-GRAPHQL.chop
-query {
+query($a: RenamedA, $b: B) {
   a(a1: 1) {
     b(b2: 2) {
       renamedC(c3: 3)


### PR DESCRIPTION
Using `GraphQL::Language::Visitor` to replace a variable definition currently results in the following exception:
```
NoMethodError: undefined method `variable_definitions' for #<GraphQL::Language::Nodes::OperationDefinition:0x00007fa76b0c0c78>
    /Users/jturkel/salsify/jturkel-graphql-ruby/lib/graphql/language/nodes.rb:96:in `public_send'
    /Users/jturkel/salsify/jturkel-graphql-ruby/lib/graphql/language/nodes.rb:96:in `replace_child'
    /Users/jturkel/salsify/jturkel-graphql-ruby/lib/graphql/language/visitor.rb:180:in `on_node_with_modifications'
    /Users/jturkel/salsify/jturkel-graphql-ruby/lib/graphql/language/visitor.rb:102:in `block in on_abstract_node'
    /Users/jturkel/salsify/jturkel-graphql-ruby/lib/graphql/language/visitor.rb:101:in `each'
    /Users/jturkel/salsify/jturkel-graphql-ruby/lib/graphql/language/visitor.rb:101:in `on_abstract_node'
    /Users/jturkel/salsify/jturkel-graphql-ruby/lib/graphql/language/visitor.rb:123:in `on_operation_definition'
    /Users/jturkel/salsify/jturkel-graphql-ruby/lib/graphql/language/visitor.rb:79:in `public_send'
    /Users/jturkel/salsify/jturkel-graphql-ruby/lib/graphql/language/visitor.rb:79:in `visit_node'
    /Users/jturkel/salsify/jturkel-graphql-ruby/lib/graphql/language/visitor.rb:174:in `on_node_with_modifications'
    /Users/jturkel/salsify/jturkel-graphql-ruby/lib/graphql/language/visitor.rb:102:in `block in on_abstract_node'
    /Users/jturkel/salsify/jturkel-graphql-ruby/lib/graphql/language/visitor.rb:101:in `each'
    /Users/jturkel/salsify/jturkel-graphql-ruby/lib/graphql/language/visitor.rb:101:in `on_abstract_node'
    /Users/jturkel/salsify/jturkel-graphql-ruby/lib/graphql/language/visitor.rb:123:in `on_document'
    /Users/jturkel/salsify/jturkel-graphql-ruby/lib/graphql/language/visitor.rb:79:in `public_send'
    /Users/jturkel/salsify/jturkel-graphql-ruby/lib/graphql/language/visitor.rb:79:in `visit_node'
    /Users/jturkel/salsify/jturkel-graphql-ruby/lib/graphql/language/visitor.rb:174:in `on_node_with_modifications'
    /Users/jturkel/salsify/jturkel-graphql-ruby/lib/graphql/language/visitor.rb:68:in `visit'
```
Looks like the problem is `GraphQL::Language::Nodes::VariableDefinition` doesn't set the proper `children_method_name`.