### PR TITLE
Fix query.arguments_for with Interpreter and variables

### DIFF
--- a/lib/graphql/execution/interpreter.rb
+++ b/lib/graphql/execution/interpreter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "graphql/execution/interpreter/arguments_cache"
 require "graphql/execution/interpreter/execution_errors"
 require "graphql/execution/interpreter/hash_response"
 require "graphql/execution/interpreter/runtime"

--- a/lib/graphql/execution/interpreter/arguments_cache.rb
+++ b/lib/graphql/execution/interpreter/arguments_cache.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module Execution
+    class Interpreter
+      class ArgumentsCache
+        def initialize(query)
+          @query = query
+          @storage = Hash.new do |h, ast_node|
+            h[ast_node] = Hash.new do |h2, arg_owner|
+              h2[arg_owner] = Hash.new do |h3, parent_object|
+                # First, normalize all AST or Ruby values to a plain Ruby hash
+                args_hash = prepare_args_hash(ast_node)
+                # Then call into the schema to coerce those incoming values
+                arg_owner.coerce_arguments(parent_object, args_hash, query.context)
+              end
+            end
+          end
+        end
+
+        def fetch(ast_node, argument_owner, parent_object)
+          @storage[ast_node][argument_owner][parent_object]
+        end
+
+        private
+
+        NO_VALUE_GIVEN = Object.new
+
+        def prepare_args_hash(ast_arg_or_hash_or_value)
+          case ast_arg_or_hash_or_value
+          when Hash
+            args_hash = {}
+            ast_arg_or_hash_or_value.each do |k, v|
+              args_hash[k] = prepare_args_hash(v)
+            end
+            args_hash
+          when Array
+            ast_arg_or_hash_or_value.map { |v| prepare_args_hash(v) }
+          when GraphQL::Language::Nodes::Field, GraphQL::Language::Nodes::InputObject, GraphQL::Language::Nodes::Directive
+            args_hash = {}
+            ast_arg_or_hash_or_value.arguments.each do |arg|
+              v = prepare_args_hash(arg.value)
+              if v != NO_VALUE_GIVEN
+                args_hash[arg.name] = v
+              end
+            end
+            args_hash
+          when GraphQL::Language::Nodes::VariableIdentifier
+            if @query.variables.key?(ast_arg_or_hash_or_value.name)
+              variable_value = @query.variables[ast_arg_or_hash_or_value.name]
+              prepare_args_hash(variable_value)
+            else
+              NO_VALUE_GIVEN
+            end
+          when GraphQL::Language::Nodes::Enum
+            ast_arg_or_hash_or_value.name
+          when GraphQL::Language::Nodes::NullValue
+            nil
+          else
+            ast_arg_or_hash_or_value
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -436,48 +436,8 @@ module GraphQL
           end
         end
 
-        NO_VALUE_GIVEN = Object.new
-
-        def prepare_args_hash(ast_arg_or_hash_or_value)
-          case ast_arg_or_hash_or_value
-          when Hash
-            args_hash = {}
-            ast_arg_or_hash_or_value.each do |k, v|
-              args_hash[k] = prepare_args_hash(v)
-            end
-            args_hash
-          when Array
-            ast_arg_or_hash_or_value.map { |v| prepare_args_hash(v) }
-          when GraphQL::Language::Nodes::Field, GraphQL::Language::Nodes::InputObject, GraphQL::Language::Nodes::Directive
-            args_hash = {}
-            ast_arg_or_hash_or_value.arguments.each do |arg|
-              v = prepare_args_hash(arg.value)
-              if v != NO_VALUE_GIVEN
-                args_hash[arg.name] = v
-              end
-            end
-            args_hash
-          when GraphQL::Language::Nodes::VariableIdentifier
-            if query.variables.key?(ast_arg_or_hash_or_value.name)
-              variable_value = query.variables[ast_arg_or_hash_or_value.name]
-              prepare_args_hash(variable_value)
-            else
-              NO_VALUE_GIVEN
-            end
-          when GraphQL::Language::Nodes::Enum
-            ast_arg_or_hash_or_value.name
-          when GraphQL::Language::Nodes::NullValue
-            nil
-          else
-            ast_arg_or_hash_or_value
-          end
-        end
-
-        def arguments(graphql_object, arg_owner, ast_node_or_hash)
-          # First, normalize all AST or Ruby values to a plain Ruby hash
-          args_hash = prepare_args_hash(ast_node_or_hash)
-          # Then call into the schema to coerce those incoming values
-          arg_owner.coerce_arguments(graphql_object, args_hash, context)
+        def arguments(graphql_object, arg_owner, ast_node)
+          query.arguments_for(ast_node, arg_owner, parent_object: graphql_object)
         end
 
         def write_invalid_null_in_response(path, invalid_null_error)

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -124,8 +124,6 @@ module GraphQL
         end
       end
 
-      @arguments_cache = ArgumentsCache.build(self)
-
       # Trying to execute a document
       # with no operations returns an empty hash
       @ast_variables = []
@@ -243,10 +241,18 @@ module GraphQL
     end
 
     # Node-level cache for calculating arguments. Used during execution and query analysis.
-    # @api private
-    # @return [GraphQL::Query::Arguments] Arguments for this node, merging default values, literal values and query variables
-    def arguments_for(irep_or_ast_node, definition)
-      @arguments_cache[irep_or_ast_node][definition]
+    # @param ast_node [GraphQL::Language::Nodes::AbstractNode]
+    # @param definition [GraphQL::Schema::Field]
+    # @param parent_object [GraphQL::Schema::Object]
+    # @return Hash{Symbol => Object}
+    def arguments_for(ast_node, definition, parent_object: nil)
+      if interpreter?
+        @arguments_cache ||= Execution::Interpreter::ArgumentsCache.new(self)
+        @arguments_cache.fetch(ast_node, definition, parent_object)
+      else
+        @arguments_cache ||= ArgumentsCache.build(self)
+        @arguments_cache[ast_node][definition]
+      end
     end
 
     def validation_pipeline


### PR DESCRIPTION
Fixes #2778 

Also, this moves the interpreter's runtime code to use `query.arguments_for`, which makes me pretty confident of the test coverage 🍻 