### PR TITLE
Don't add half-way connection handling to schemas from definition

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -715,14 +715,20 @@ module GraphQL
     # @param using [Hash] Plugins to attach to the created schema with `use(key, value)`
     # @param interpreter [Boolean] If false, the legacy {Execution::Execute} runtime will be used
     # @return [Class] the schema described by `document`
-    def self.from_definition(definition_or_path, default_resolve: BuildFromDefinition::DefaultResolve, interpreter: true, parser: BuildFromDefinition::DefaultParser, using: {})
+    def self.from_definition(definition_or_path, default_resolve: nil, interpreter: true, parser: BuildFromDefinition::DefaultParser, using: {})
       # If the file ends in `.graphql`, treat it like a filepath
       definition = if definition_or_path.end_with?(".graphql")
         File.read(definition_or_path)
       else
         definition_or_path
       end
-      GraphQL::Schema::BuildFromDefinition.from_definition(definition, default_resolve: default_resolve, parser: parser, using: using, interpreter: interpreter)
+      GraphQL::Schema::BuildFromDefinition.from_definition(
+        definition,
+        default_resolve: default_resolve,
+        parser: parser,
+        using: using,
+        interpreter: interpreter,
+      )
     end
 
     # Error that is raised when [#Schema#from_definition] is passed an invalid schema definition string.

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -5,9 +5,11 @@ module GraphQL
   class Schema
     module BuildFromDefinition
       class << self
-        def from_definition(definition_string, default_resolve:, using: {}, interpreter: true, parser: DefaultParser)
+        # @see {Schema.from_definition}
+        def from_definition(definition_string, default_resolve:, using: {}, relay: false, interpreter: true, parser: DefaultParser)
           document = parser.parse(definition_string)
-          Builder.build(document, default_resolve: default_resolve, using: using, interpreter: interpreter)
+          default_resolve ||= {}
+          Builder.build(document, default_resolve: default_resolve, relay: relay, using: using, interpreter: interpreter)
         end
       end
 
@@ -15,21 +17,10 @@ module GraphQL
       DefaultParser = GraphQL::Language::Parser
 
       # @api private
-      module DefaultResolve
-        def self.call(type, field, obj, args, ctx)
-          if field.arguments.any?
-            obj.public_send(field.name, args, ctx)
-          else
-            obj.public_send(field.name)
-          end
-        end
-      end
-
-      # @api private
       module Builder
         extend self
 
-        def build(document, default_resolve: DefaultResolve, using: {}, interpreter: true)
+        def build(document, default_resolve:, using: {}, interpreter: true, relay:)
           raise InvalidDocumentError.new('Must provide a document ast.') if !document || !document.is_a?(GraphQL::Language::Nodes::Document)
 
           if default_resolve.is_a?(Hash)
@@ -316,6 +307,7 @@ module GraphQL
               type: type_resolver.call(field_definition.type),
               null: true,
               connection: type_name.end_with?("Connection"),
+              connection_extension: nil,
               deprecation_reason: build_deprecation_reason(field_definition.directives),
               ast_node: field_definition,
               method_conflict_warning: false,

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -172,6 +172,7 @@ module GraphQL
       # @param hash_key [String, Symbol] The hash key to lookup on the underlying object (if its a Hash) to resolve this field (defaults to `name` or `name.to_s`)
       # @param resolver_method [Symbol] The method on the type to call to resolve this field (defaults to `name`)
       # @param connection [Boolean] `true` if this field should get automagic connection behavior; default is to infer by `*Connection` in the return type name
+      # @param connection_extension [Class] The extension to add, to implement connections. If `nil`, no extension is added.
       # @param max_page_size [Integer] For connections, the maximum number of items to return from this field
       # @param introspection [Boolean] If true, this field will be marked as `#introspection?` and the name may begin with `__`
       # @param resolve [<#call(obj, args, ctx)>] **deprecated** for compatibility with <1.8.0
@@ -187,7 +188,7 @@ module GraphQL
       # @param trace [Boolean] If true, a {GraphQL::Tracing} tracer will measure this scalar field
       # @param ast_node [Language::Nodes::FieldDefinition, nil] If this schema was parsed from definition, this AST node defined the field
       # @param method_conflict_warning [Boolean] If false, skip the warning if this field's method conflicts with a built-in method
-      def initialize(type: nil, name: nil, owner: nil, null: nil, field: nil, function: nil, description: nil, deprecation_reason: nil, method: nil, hash_key: nil, resolver_method: nil, resolve: nil, connection: nil, max_page_size: nil, scope: nil, introspection: false, camelize: true, trace: nil, complexity: 1, ast_node: nil, extras: [], extensions: EMPTY_ARRAY, resolver_class: nil, subscription_scope: nil, relay_node_field: false, relay_nodes_field: false, method_conflict_warning: true, arguments: EMPTY_HASH, &definition_block)
+      def initialize(type: nil, name: nil, owner: nil, null: nil, field: nil, function: nil, description: nil, deprecation_reason: nil, method: nil, hash_key: nil, resolver_method: nil, resolve: nil, connection: nil, max_page_size: nil, scope: nil, introspection: false, camelize: true, trace: nil, complexity: 1, ast_node: nil, extras: [], extensions: EMPTY_ARRAY, connection_extension: self.class.connection_extension, resolver_class: nil, subscription_scope: nil, relay_node_field: false, relay_nodes_field: false, method_conflict_warning: true, arguments: EMPTY_HASH, &definition_block)
         if name.nil?
           raise ArgumentError, "missing first `name` argument or keyword `name:`"
         end
@@ -275,8 +276,8 @@ module GraphQL
         end
         # The problem with putting this after the definition_block
         # is that it would override arguments
-        if connection?
-          self.extension(self.class.connection_extension)
+        if connection? && connection_extension
+          self.extension(connection_extension)
         end
 
         if definition_block

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -1220,27 +1220,28 @@ SCHEMA
 
     describe "relay behaviors" do
       let(:schema_defn) { <<-GRAPHQL
-      type Query {
-        node(id: ID!): Node
-      }
+interface Node {
+  id: ID!
+}
 
-      interface Node {
-        id: ID!
-      }
+type Query {
+  node(id: ID!): Node
+}
 
-      type Thing implements Node {
-        name: String!
-        otherThings(first: Int, after: String, last: Int, before: String): ThingConnection!
-      }
+type Thing implements Node {
+  id: ID!
+  name: String!
+  otherThings(after: String, first: Int): ThingConnection!
+}
 
-      type ThingConnection {
-        edges: [ThingEdge!]!
-      }
+type ThingConnection {
+  edges: [ThingEdge!]!
+}
 
-      type ThingEdge {
-        node: Thing!
-        cursor: String!
-      }
+type ThingEdge {
+  cursor: String!
+  node: Thing!
+}
       GRAPHQL
       }
       let(:query_string) {'
@@ -1295,6 +1296,11 @@ SCHEMA
           }
         }
         assert_equal expected_data, result["data"]
+      end
+
+      it "doesn't add arguments that aren't in the IDL" do
+        schema = GraphQL::Schema.from_definition(schema_defn)
+        assert_equal schema_defn.chomp, schema.to_definition
       end
     end
   end


### PR DESCRIPTION
There are a handful of issues about whether or not this library will provide Relay-like behaviors to schemas built from IDL. 

I think the best answer is no -- it will be complicated to implement, and in `.from_definition`, you're already providing the implementation, so better to put the schema's behavior there. 

Fixes #2731 
Fixes #1043
Fixes #1077

If you were previously _depending_ on the halfway support, I recommend taking inspiration from the ConnectionExtension, and adding the relevant wrapping code to your resolver implementation. 

Here's the generalized code for applying wrappers: 

https://github.com/rmosolgo/graphql-ruby/blob/4cae8b41479cc4348a8627c65f1399269b441aa0/lib/graphql/schema/field/connection_extension.rb#L40-L56

But, if you're writing resolvers by hand, you can probably apply wrappers directly, for example: 

```ruby 
relation = MyModel.where(...)
GraphQL::Pagination::ActiveRecordRelationConnection.new(
  relation,
  context: context,
  max_page_size: context.schema.default_max_page_size,
  first: arguments[:first],
  after: arguments[:after],
  last: arguments[:last],
  before: arguments[:before],
)
```

The equivalent code in the gem is here: 

https://github.com/rmosolgo/graphql-ruby/blob/4cae8b41479cc4348a8627c65f1399269b441aa0/lib/graphql/pagination/connections.rb#L80-L89

 


