### PR TITLE
Add Query#sanitized_query_string

### DIFF
--- a/lib/graphql/language.rb
+++ b/lib/graphql/language.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "graphql/language/block_string"
 require "graphql/language/printer"
+require "graphql/language/sanitized_printer"
 require "graphql/language/document_from_schema_definition"
 require "graphql/language/generation"
 require "graphql/language/lexer"

--- a/lib/graphql/language/printer.rb
+++ b/lib/graphql/language/printer.rb
@@ -93,7 +93,7 @@ module GraphQL
       end
 
       def print_input_object(input_object)
-        "{#{input_object.arguments.map { |a| "#{a.name}: #{print(a.value)}" }.join(", ")}}"
+        "{#{input_object.arguments.map { |a| print_argument(a) }.join(", ")}}"
       end
 
       def print_list_type(list_type)

--- a/lib/graphql/language/sanitized_printer.rb
+++ b/lib/graphql/language/sanitized_printer.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+module GraphQL
+  module Language
+    # A custom printer used to print sanitized queries. It inlines provided variables
+    # within the query for facilitate logging and analysis of queries.
+    #
+    # The printer returns `nil` if the query is invalid.
+    #
+    # Since the GraphQL Ruby AST for a GraphQL query doesnt contain any reference
+    # on the type of fields or arguments, we have to track the current object, field
+    # and input type while printing the query.
+    #
+    # @example Printing a scrubbed string
+    #   printer = QueryPrinter.new(query)
+    #   puts printer.sanitized_query_string
+    #
+    # @see {Query#sanitized_query_string}
+    class SanitizedPrinter < GraphQL::Language::Printer
+
+      REDACTED = "\"<REDACTED>\""
+
+      def initialize(query)
+        @query = query
+        @current_type = nil
+        @current_field = nil
+        @current_input_type = nil
+      end
+
+      # @return [String, nil] A scrubbed query string, if the query was valid.
+      def sanitized_query_string
+        if query.valid?
+          print(query.document)
+        else
+          nil
+        end
+      end
+
+      def print_node(node, indent: "")
+        if node.is_a?(String)
+          type = @current_input_type.unwrap
+          # Replace any strings that aren't IDs or Enum values with REDACTED
+          if type.kind.enum? || type.graphql_name == "ID"
+            super
+          else
+            REDACTED
+          end
+        elsif node.is_a?(Array)
+          old_input_type = @current_input_type
+          if @current_input_type && @current_input_type.list?
+            @current_input_type = @current_input_type.of_type
+            @current_input_type = @current_input_type.of_type if @current_input_type.non_null?
+          end
+
+          res = super
+          @current_input_type = old_input_type
+          res
+        else
+          super
+        end
+      end
+
+      def print_argument(argument)
+        arg_owner = @current_input_type || @current_directive || @current_field
+        arg_def = arg_owner.arguments[argument.name]
+
+        old_input_type = @current_input_type
+        @current_input_type = arg_def.type.non_null? ? arg_def.type.of_type : arg_def.type
+        res = super
+        @current_input_type = old_input_type
+        res
+      end
+
+      def print_list_type(list_type)
+        old_input_type = @current_input_type
+        @current_input_type = old_input_type.of_type
+        res = super
+        @current_input_type = old_input_type
+        res
+      end
+
+      def print_variable_identifier(variable_id)
+        variable_value = query.variables[variable_id.name]
+        print_node(value_to_ast(variable_value, @current_input_type))
+      end
+
+      def print_field(field, indent: "")
+        @current_field = query.schema.get_field(@current_type, field.name)
+        old_type = @current_type
+        @current_type = @current_field.type.unwrap
+        res = super
+        @current_type = old_type
+        res
+      end
+
+      def print_inline_fragment(inline_fragment, indent: "")
+        old_type = @current_type
+
+        if inline_fragment.type
+          @current_type = query.schema.types[inline_fragment.type.name]
+        end
+
+        res = super
+
+        @current_type = old_type
+
+        res
+      end
+
+      def print_fragment_definition(fragment_def, indent: "")
+        old_type = @current_type
+        @current_type = query.schema.types[fragment_def.type.name]
+
+        res = super
+
+        @current_type = old_type
+
+        res
+      end
+
+      def print_directive(directive)
+        @current_directive = query.schema.directives[directive.name]
+
+        res = super
+
+        @current_directive = nil
+        res
+      end
+
+      # Print the operation definition but do not include the variable
+      # definitions since we will inline them within the query
+      def print_operation_definition(operation_definition, indent: "")
+        old_type = @current_type
+        @current_type = query.schema.public_send(operation_definition.operation_type)
+
+        out = "#{indent}#{operation_definition.operation_type}".dup
+        out << " #{operation_definition.name}" if operation_definition.name
+        out << print_directives(operation_definition.directives)
+        out << print_selections(operation_definition.selections, indent: indent)
+
+        @current_type = old_type
+        out
+      end
+
+      private
+
+      def value_to_ast(value, type)
+        type = type.of_type if type.non_null?
+
+        if value.nil?
+          return GraphQL::Language::Nodes::NullValue.new(name: "null")
+        end
+
+        case type.kind.name
+        when "INPUT_OBJECT"
+          value = if value.respond_to?(:to_unsafe_h)
+            # for ActionController::Parameters
+            value.to_unsafe_h
+          else
+            value.to_h
+          end
+
+          arguments = value.map do |key, val|
+            sub_type = type.arguments[key.to_s].type
+
+            GraphQL::Language::Nodes::Argument.new(
+              name: key.to_s,
+              value: value_to_ast(val, sub_type)
+            )
+          end
+          GraphQL::Language::Nodes::InputObject.new(
+            arguments: arguments
+          )
+        when "LIST"
+          if value.respond_to?(:each)
+            value.each { |v| value_to_ast(v, type.of_type) }
+          else
+            [value].each { |v| value_to_ast(v, type.of_type) }
+          end
+        when "ENUM"
+          GraphQL::Language::Nodes::Enum.new(name: value)
+        else
+          value
+        end
+      end
+
+      attr_reader :query
+    end
+  end
+end

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -255,6 +255,15 @@ module GraphQL
       end
     end
 
+    # A version of the given query string, with:
+    # - Variables inlined to the query
+    # - Strings replaced with `<REDACTED>`
+    def sanitized_query_string
+      with_prepared_ast {
+        GraphQL::Language::SanitizedPrinter.new(self).sanitized_query_string
+      }
+    end
+
     def validation_pipeline
       with_prepared_ast { @validation_pipeline }
     end

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -258,6 +258,7 @@ module GraphQL
     # A version of the given query string, with:
     # - Variables inlined to the query
     # - Strings replaced with `<REDACTED>`
+    # @return [String, nil] Returns nil if the query is invalid.
     def sanitized_query_string
       with_prepared_ast {
         GraphQL::Language::SanitizedPrinter.new(self).sanitized_query_string

--- a/spec/graphql/language/sanitized_printer_spec.rb
+++ b/spec/graphql/language/sanitized_printer_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::Language::SanitizedPrinter do
+  module SanitizeTest
+    class Color < GraphQL::Schema::Enum
+      value "RED"
+      value "BLUE"
+    end
+
+    class Url < GraphQL::Schema::Scalar
+    end
+
+    class ExampleInput < GraphQL::Schema::InputObject
+      argument :string, String, required: true
+      argument :id, ID, required: true
+      argument :int, Int, required: true
+      argument :float, Float, required: true
+      argument :enum, Color, required: true
+      argument :input_object, ExampleInput, required: false
+      argument :url, Url, required: true
+    end
+
+    class Query < GraphQL::Schema::Object
+      field :inputs, String, null: false do
+        argument :string, String, required: true
+        argument :id, ID, required: true
+        argument :int, Int, required: true
+        argument :float, Float, required: true
+        argument :enum, Color, required: true
+        argument :input_object, ExampleInput, required: true
+        argument :url, Url, required: true
+      end
+
+      field :strings, String, null: false do
+        argument :strings, [String], required: true
+      end
+    end
+
+    class Schema < GraphQL::Schema
+      query(Query)
+      use GraphQL::Execution::Interpreter
+      use GraphQL::Analysis::AST
+    end
+  end
+
+  def sanitize_string(query_string, **options)
+    query = GraphQL::Query.new(
+      SanitizeTest::Schema,
+      query_string,
+      **options
+    )
+    query.sanitized_query_string
+  end
+
+  it "replaces strings with redacted" do
+    query_str = '
+    {
+      inputs(
+        string: "string",
+        id: "id",
+        int: 1,
+        float: 2.0,
+        url: "http://graphqliscool.com",
+        enum: RED
+        inputObject: {
+          string: "string"
+          id: "id"
+          int: 1
+          float: 2.0
+          url: "http://graphqliscool.com"
+          enum: RED
+        }
+      )
+    }
+    '
+
+    expected_query_string = 'query {
+  inputs(string: "<REDACTED>", id: "id", int: 1, float: 2.0, url: "<REDACTED>", enum: RED, inputObject: {string: "<REDACTED>", id: "id", int: 1, float: 2.0, url: "<REDACTED>", enum: RED})
+}'
+    assert_equal expected_query_string, sanitize_string(query_str)
+  end
+
+  it "inlines variables AND redacts their values" do
+    query_str = '
+    query($string1: String!, $string2: String = "str2", $inputObject: ExampleInput!) {
+      inputs(
+        string: $string1,
+        id: "id1",
+        int: 1,
+        float: 1.0,
+        url: "http://graphqliscool.com",
+        enum: RED
+        inputObject: {
+          string: $string2
+          id: "id2"
+          int: 2
+          float: 2.0
+          url: "http://graphqliscool.com"
+          enum: RED
+          inputObject: $inputObject
+        }
+      )
+    }
+    '
+
+    variables = {
+      "string1" => "str1",
+      "inputObject" => {
+        "string" => "str3",
+        "id" => "id3",
+        "int" => 3,
+        "float" => 3.3,
+        "url" => "three.com",
+        "enum" => "BLUE"
+      }
+    }
+
+    expected_query_string = 'query {
+  inputs(' +
+    'string: "<REDACTED>", id: "id1", int: 1, float: 1.0, url: "<REDACTED>", enum: RED, inputObject: {' +
+    'string: "<REDACTED>", id: "id2", int: 2, float: 2.0, url: "<REDACTED>", enum: RED, inputObject: {' +
+    'string: "<REDACTED>", id: "id3", int: 3, float: 3.3, url: "<REDACTED>", enum: BLUE}})
+}'
+    assert_equal expected_query_string, sanitize_string(query_str, variables: variables)
+  end
+
+  it "redacts from lists" do
+    query_str_1 = '{ strings(strings: ["s1", "s2"]) }'
+    query_str_2 = 'query($strings: [String!]!) { strings(strings: $strings) }'
+    expected_query_string = 'query {
+  strings(strings: ["<REDACTED>", "<REDACTED>"])
+}'
+
+    assert_equal expected_query_string, sanitize_string(query_str_1)
+    assert_equal expected_query_string, sanitize_string(query_str_2, variables: { "strings" => ["s1", "s2"]})
+  end
+
+  it "returns nil on invalid queries" do
+    assert_nil sanitize_string "{ __typename "
+  end
+end
+


### PR DESCRIPTION
The goal here is to add something that's safe for logging. All strings, except for IDs, are replaced with `"<REDACTED>"`. 

Variables are inlined and redacted the same way.


- Fixes #2334 
- Fixes #1106  
- Fixes #2333 