### PR TITLE
Use Argument names as configured (fix args with numbers)

### DIFF
--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -55,7 +55,7 @@ module GraphQL
         @owner = owner
         @as = as
         @loads = loads
-        @keyword = as || Schema::Member::BuildType.underscore(@name).to_sym
+        @keyword = as || (arg_name.is_a?(Symbol) ? arg_name : Schema::Member::BuildType.underscore(@name).to_sym)
         @prepare = prepare
         @ast_node = ast_node
         @from_resolver = from_resolver

--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -61,6 +61,27 @@ describe GraphQL::Schema::InputObject do
     end
   end
 
+  describe "camelizing with numbers" do
+    module InputObjectWithNumbers
+      class InputObject < GraphQL::Schema::InputObject
+        argument :number_arg1, Integer, required: false
+        argument :number_arg_2, Integer, required: false
+        argument :number_arg3, Integer, required: false, camelize: false
+        argument :number_arg_4, Integer, required: false, camelize: false
+      end
+    end
+
+    it "accepts leading underscores or _no_ underscores" do
+      input_obj = InputObjectWithNumbers::InputObject
+      assert_equal ["numberArg1", "numberArg2", "number_arg3", "number_arg_4"], input_obj.arguments.keys
+      assert_equal ["numberArg1", "numberArg2", "number_arg3", "number_arg_4"], input_obj.arguments.values.map(&:graphql_name)
+      assert_equal :number_arg1, input_obj.arguments["numberArg1"].keyword
+      assert_equal :number_arg_2, input_obj.arguments["numberArg2"].keyword
+      assert_equal :number_arg3, input_obj.arguments["number_arg3"].keyword
+      assert_equal :number_arg_4, input_obj.arguments["number_arg_4"].keyword
+    end
+  end
+
   describe "prepare: / loads: / as:" do
     module InputObjectPrepareTest
       class InputObj < GraphQL::Schema::InputObject

--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -68,17 +68,21 @@ describe GraphQL::Schema::InputObject do
         argument :number_arg_2, Integer, required: false
         argument :number_arg3, Integer, required: false, camelize: false
         argument :number_arg_4, Integer, required: false, camelize: false
+        argument :numberArg5, Integer, required: false
+        argument :numberArg6, Integer, required: false, camelize: false
       end
     end
 
     it "accepts leading underscores or _no_ underscores" do
       input_obj = InputObjectWithNumbers::InputObject
-      assert_equal ["numberArg1", "numberArg2", "number_arg3", "number_arg_4"], input_obj.arguments.keys
-      assert_equal ["numberArg1", "numberArg2", "number_arg3", "number_arg_4"], input_obj.arguments.values.map(&:graphql_name)
+      assert_equal ["numberArg1", "numberArg2", "number_arg3", "number_arg_4", "numberArg5", "numberArg6"], input_obj.arguments.keys
+      assert_equal ["numberArg1", "numberArg2", "number_arg3", "number_arg_4", "numberArg5", "numberArg6"], input_obj.arguments.values.map(&:graphql_name)
       assert_equal :number_arg1, input_obj.arguments["numberArg1"].keyword
       assert_equal :number_arg_2, input_obj.arguments["numberArg2"].keyword
       assert_equal :number_arg3, input_obj.arguments["number_arg3"].keyword
       assert_equal :number_arg_4, input_obj.arguments["number_arg_4"].keyword
+      assert_equal :numberArg5, input_obj.arguments["numberArg5"].keyword
+      assert_equal :numberArg6, input_obj.arguments["numberArg6"].keyword
     end
   end
 

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -104,7 +104,7 @@ module Dummy
       # metadata test
       joins [:cheeses, :milks]
       argument :source, [DairyAnimal], required: true
-      argument :nullableSource, [DairyAnimal], required: false, default_value: [1]
+      argument :nullable_source, [DairyAnimal], required: false, default_value: [1]
     end
 
     def similar_cheese(source:, nullable_source:)

--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -158,8 +158,8 @@ module StarWars
     field :shipsWithMaxPageSize, "Ships with max page size", max_page_size: 2, resolver: ShipsWithMaxPageSize
 
     field :bases, BasesConnectionWithTotalCountType, null: true, connection: true do
-      argument :nameIncludes, String, required: false
-      argument :complexOrder, Boolean, required: false
+      argument :name_includes, String, required: false
+      argument :complex_order, Boolean, required: false
     end
 
     def bases(name_includes: nil, complex_order: nil)
@@ -201,7 +201,7 @@ module StarWars
     field :basesWithoutNodes, BaseConnectionWithoutNodes, null: true, resolver_method: :all_bases_array
 
     field :basesAsSequelDataset, BasesConnectionWithTotalCountType, null: true, connection: true, max_page_size: 1000 do
-      argument :nameIncludes, String, required: false
+      argument :name_includes, String, required: false
     end
 
     def bases_as_sequel_dataset(name_includes: nil)


### PR DESCRIPTION
Currently, GraphQL-Ruby _doesn't_ use the provided symbol to build keyword arguments, which is confusing. 

So instead, if `argument(...)` is configured with a symbol, use the given symbol for the method's keyword arguments. 

This can break existing configurations if they configured arguments with camelized symbols, but expected underscored arguments in their methods (see the change in the test suite, for example).

Fixes #2611 
Fixes #2665 (this approach maintains current behavior)
Fixes #2706
Fixes #1839