### PR TITLE
Support new connection system on old runtime

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -934,6 +934,11 @@ module GraphQL
         if !schema_defn.interpreter?
           schema_defn.instrumenters[:query] << GraphQL::Schema::Member::Instrumentation
         end
+
+        if new_connections?
+          schema_defn.connections = self.connections
+        end
+
         schema_defn.send(:rebuild_artifacts)
 
         schema_defn

--- a/spec/support/connection_assertions.rb
+++ b/spec/support/connection_assertions.rb
@@ -62,7 +62,12 @@ module ConnectionAssertions
         end
 
         def items(max_page_size_override: nil)
-          context.schema.connection_class.new(get_items, max_page_size: max_page_size_override)
+          if max_page_size_override
+            context.schema.connection_class.new(get_items, max_page_size: max_page_size_override)
+          else
+            # don't manually apply the wrapper when it's not required -- check automatic wrapping.
+            get_items
+          end
         end
 
         field :custom_items, custom_item_connection, null: false


### PR DESCRIPTION
Oops, if a class was configured with the new connection system, it wasn't properly passed to that class's instance, which was used by the old runtime. Pass it along as needed.

Fixes #2793 