### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,84 @@
+---
+name: Bug report
+about: Create a report to help us improve graphql-ruby
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+
+A clear and concise description of what the bug is.
+
+**Versions**
+
+`graphql` version:
+`rails` (or other framework):
+other applicable versions (`graphql-batch`, etc)
+
+**GraphQL schema**
+
+Include relevant types and fields (in Ruby is best, in GraphQL IDL is ok).
+Are you using [interpreter](https://graphql-ruby.org/queries/interpreter.html)? Any custom instrumentation, etc?
+
+```ruby
+class Product < GraphQL::Schema::Object
+  field :id, ID, null: false, hash_key: :id
+  # …
+end
+
+class ApplicationSchema < GraphQL::Schema
+  query QueryType
+  # …
+end
+```
+
+**GraphQL query**
+
+Example GraphQL query and response (if query execution is involved)
+
+```graphql
+query {
+  products { id title }
+}
+```
+
+```json
+{
+  "data": {
+    "products": […]
+  }
+}
+```
+
+**Steps to reproduce**
+
+Steps to reproduce the behavior
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen.
+
+**Actual behavior**
+
+What specifically went wrong?
+
+Place full backtrace here (if a Ruby exception is involved):
+
+<details>
+<summary>Click to view exception backtrace</summary>
+
+```
+Something went wrong
+2.6.0/gems/graphql-1.9.17/lib/graphql/subscriptions/instrumentation.rb:34:in `after_query'
+… don't hesitate to include all the rows here: they will be collapsed
+```
+
+</details>
+
+**Additional context**
+
+Add any other context about the problem here.
+
+With these details, we can efficiently hunt down the bug!

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
As I learned when I was creating my issues here, writing good issues for graphql-ruby is hard. Because so many details (query, schema, versions) are crucial for issue to be complete.
So I propose to add issue templates to ease it for others.

Two templates are included in this pull request:
 1. Bug report is customized with stuff from your [contributing guide](https://github.com/rmosolgo/graphql-ruby/blob/8b517c43e79fa1fdbfcc1280dbf2ce87d55e6c38/.github/contributing.md) but even more descriptive with placeholders for code examples and so on. I hope that it will allow people to create descriptive and actionable issues. 
 2. Feature request is left as it is suggested by GitHub web UI (no idea what to place here).

Related GitHub docs:
 1. [About issue and pull request templates](https://help.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates),
 2. [Configuring issue templates for your repository](https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository)