### PR TITLE
Fix wrong number of args for ArgumentHelpers#arguments

### DIFF
--- a/lib/graphql/execution/lookahead.rb
+++ b/lib/graphql/execution/lookahead.rb
@@ -340,7 +340,7 @@ module GraphQL
             # For these, `prepare` is applied during `#initialize`.
             # Pass `nil` so it will be skipped in `#arguments`.
             # What a mess.
-            args = arguments(query, nil, arg_type, ast_value)
+            args = arguments(query, arg_type, ast_value)
             # We're not tracking defaults_used, but for our purposes
             # we compare the value to the default value.
             return true, arg_type.new(ruby_kwargs: args, context: query.context, defaults_used: nil)


### PR DESCRIPTION
Fixes
```
wrong number of arguments (given 4, expected 3)
/var/lib/gems/2.6.0/gems/graphql-1.10.4/lib/graphql/execution/lookahead.rb:293:in `arguments'
/var/lib/gems/2.6.0/gems/graphql-1.10.4/lib/graphql/execution/lookahead.rb:343:in `arg_to_value'
/var/lib/gems/2.6.0/gems/graphql-1.10.4/lib/graphql/execution/lookahead.rb:300:in `block in arguments'
...
```

Looks like this place was missed during this refactor in this PR:
https://github.com/rmosolgo/graphql-ruby/commit/ecb55bdf1aff056e82c2d5723a1db730d19c5f1f#diff-5e9f88f9bfd250959abb6c9a6155b20eL278-R278