### PR TITLE
Test new connections system with existing tests for previous system

### DIFF
--- a/lib/graphql/pagination/active_record_relation_connection.rb
+++ b/lib/graphql/pagination/active_record_relation_connection.rb
@@ -6,11 +6,17 @@ module GraphQL
     # Customizes `RelationConnection` to work with `ActiveRecord::Relation`s.
     class ActiveRecordRelationConnection < Pagination::RelationConnection
       def relation_count(relation)
-        if relation.respond_to?(:unscope)
+        int_or_hash = if relation.respond_to?(:unscope)
           relation.unscope(:order).count(:all)
         else
           # Rails 3
           relation.count
+        end
+        if int_or_hash.is_a?(Integer)
+          int_or_hash
+        else
+          # Grouped relations return count-by-group hashes
+          int_or_hash.length
         end
       end
 

--- a/lib/graphql/pagination/array_connection.rb
+++ b/lib/graphql/pagination/array_connection.rb
@@ -59,7 +59,7 @@ module GraphQL
             sliced_nodes.count > first
           elsif before
             # The original array is longer than the `before` index
-            index_from_cursor(before) < items.length
+            index_from_cursor(before) < items.length + 1
           else
             false
           end

--- a/lib/graphql/pagination/relation_connection.rb
+++ b/lib/graphql/pagination/relation_connection.rb
@@ -137,8 +137,9 @@ module GraphQL
       def limited_nodes
         @limited_nodes ||= begin
           paginated_nodes = sliced_nodes
+          previous_limit = relation_limit(paginated_nodes)
 
-          if first && (relation_limit(paginated_nodes).nil? || relation_limit(paginated_nodes) > first) && last.nil?
+          if first && (previous_limit.nil? || previous_limit > first)
             # `first` would create a stricter limit that the one already applied, so add it
             paginated_nodes = set_limit(paginated_nodes, first)
           end

--- a/spec/integration/rails/graphql/relay/array_connection_spec.rb
+++ b/spec/integration/rails/graphql/relay/array_connection_spec.rb
@@ -260,49 +260,78 @@ describe GraphQL::Relay::ArrayConnection do
     end
 
     describe "bidirectional pagination" do
-      it "provides bidirectional_pagination" do
-        result = star_wars_query(query_string, { "first" => 1 })
-        last_cursor = get_last_cursor(result)
+      if TESTING_INTERPRETER
+        it "provides bidirectional_pagination by default" do
+          result = star_wars_query(query_string, { "first" => 1 })
+          last_cursor = get_last_cursor(result)
 
-        # When going forwards, bi-directional pagination
-        # returns `true` even for `hasPreviousPage`
-        result = star_wars_query(query_string, { "first" => 1, "after" => last_cursor })
-        assert_equal(true, get_page_info(result, "ships")["hasNextPage"])
-        assert_equal(false, get_page_info(result, "ships")["hasPreviousPage"])
+          result = star_wars_query(query_string, { "first" => 3, "after" => last_cursor })
+          assert_equal(true, get_page_info(result, "ships")["hasNextPage"])
+          assert_equal(true, get_page_info(result, "ships")["hasPreviousPage"])
 
-        result = with_bidirectional_pagination {
-          star_wars_query(query_string, { "first" => 3, "after" => last_cursor })
-        }
-        assert_equal(true, get_page_info(result, "ships")["hasNextPage"])
-        assert_equal(true, get_page_info(result, "ships")["hasPreviousPage"])
+          # When going backwards, bi-directional pagination
+          # returns true for `hasNextPage`
+          last_cursor = get_last_cursor(result)
+          result = star_wars_query(query_string, { "last" => 2, "before" => last_cursor })
+          assert_equal(true, get_page_info(result, "ships")["hasNextPage"])
+          assert_equal(true, get_page_info(result, "ships")["hasPreviousPage"])
+        end
 
-        # When going backwards, bi-directional pagination
-        # returns true for `hasNextPage`
-        last_cursor = get_last_cursor(result)
-        result = star_wars_query(query_string, { "last" => 1, "before" => last_cursor })
-        assert_equal(false, get_page_info(result, "ships")["hasNextPage"])
-        assert_equal(true, get_page_info(result, "ships")["hasPreviousPage"])
+        it "returns correct page info when the before cursor belongs to the last element in the array" do
+          result = star_wars_query(query_string, { "last" => 1 })
 
-        result = with_bidirectional_pagination {
-          star_wars_query(query_string, { "last" => 2, "before" => last_cursor })
-        }
-        assert_equal(true, get_page_info(result, "ships")["hasNextPage"])
-        assert_equal(true, get_page_info(result, "ships")["hasPreviousPage"])
-      end
+          last_cursor = get_last_cursor(result)
 
-      it "returns correct page info when the before cursor belongs to the last element in the array" do
-        result = with_bidirectional_pagination{
-          star_wars_query(query_string, { "last" => 1 })
-        }
+          result = star_wars_query(query_string, { "before" => last_cursor, "last" => 1 })
 
-        last_cursor = get_last_cursor(result)
+          assert_equal(true, get_page_info(result, "ships")["hasNextPage"])
+          assert_equal(true, get_page_info(result, "ships")["hasPreviousPage"])
+        end
+      else
+        it "provides bidirectional_pagination" do
+            result = star_wars_query(query_string, { "first" => 1 })
+            last_cursor = get_last_cursor(result)
 
-        result = with_bidirectional_pagination{
-          star_wars_query(query_string, { "before" => last_cursor, "last" => 1 })
-        }
+            # When going forwards, bi-directional pagination
+            # returns `true` even for `hasPreviousPage`
+            result = star_wars_query(query_string, { "first" => 1, "after" => last_cursor })
+            assert_equal(true, get_page_info(result, "ships")["hasNextPage"])
+            assert_equal(false, get_page_info(result, "ships")["hasPreviousPage"])
 
-        assert_equal(true, get_page_info(result, "ships")["hasNextPage"])
-        assert_equal(true, get_page_info(result, "ships")["hasPreviousPage"])
+            result = with_bidirectional_pagination {
+              star_wars_query(query_string, { "first" => 3, "after" => last_cursor })
+            }
+            assert_equal(true, get_page_info(result, "ships")["hasNextPage"])
+            assert_equal(true, get_page_info(result, "ships")["hasPreviousPage"])
+
+            # When going backwards, bi-directional pagination
+            # returns true for `hasNextPage`
+            last_cursor = get_last_cursor(result)
+            result = star_wars_query(query_string, { "last" => 1, "before" => last_cursor })
+            assert_equal(false, get_page_info(result, "ships")["hasNextPage"])
+            assert_equal(true, get_page_info(result, "ships")["hasPreviousPage"])
+
+            result = with_bidirectional_pagination {
+              star_wars_query(query_string, { "last" => 2, "before" => last_cursor })
+            }
+            assert_equal(true, get_page_info(result, "ships")["hasNextPage"])
+            assert_equal(true, get_page_info(result, "ships")["hasPreviousPage"])
+        end
+
+        it "returns correct page info when the before cursor belongs to the last element in the array" do
+          result = with_bidirectional_pagination{
+            star_wars_query(query_string, { "last" => 1 })
+          }
+
+          last_cursor = get_last_cursor(result)
+
+          result = with_bidirectional_pagination{
+            star_wars_query(query_string, { "before" => last_cursor, "last" => 1 })
+          }
+
+          assert_equal(true, get_page_info(result, "ships")["hasNextPage"])
+          assert_equal(true, get_page_info(result, "ships")["hasPreviousPage"])
+        end
       end
     end
   end

--- a/spec/integration/rails/graphql/relay/array_connection_spec.rb
+++ b/spec/integration/rails/graphql/relay/array_connection_spec.rb
@@ -289,33 +289,33 @@ describe GraphQL::Relay::ArrayConnection do
         end
       else
         it "provides bidirectional_pagination" do
-            result = star_wars_query(query_string, { "first" => 1 })
-            last_cursor = get_last_cursor(result)
+          result = star_wars_query(query_string, { "first" => 1 })
+          last_cursor = get_last_cursor(result)
 
-            # When going forwards, bi-directional pagination
-            # returns `true` even for `hasPreviousPage`
-            result = star_wars_query(query_string, { "first" => 1, "after" => last_cursor })
-            assert_equal(true, get_page_info(result, "ships")["hasNextPage"])
-            assert_equal(false, get_page_info(result, "ships")["hasPreviousPage"])
+          # When going forwards, bi-directional pagination
+          # returns `true` even for `hasPreviousPage`
+          result = star_wars_query(query_string, { "first" => 1, "after" => last_cursor })
+          assert_equal(true, get_page_info(result, "ships")["hasNextPage"])
+          assert_equal(false, get_page_info(result, "ships")["hasPreviousPage"])
 
-            result = with_bidirectional_pagination {
-              star_wars_query(query_string, { "first" => 3, "after" => last_cursor })
-            }
-            assert_equal(true, get_page_info(result, "ships")["hasNextPage"])
-            assert_equal(true, get_page_info(result, "ships")["hasPreviousPage"])
+          result = with_bidirectional_pagination {
+            star_wars_query(query_string, { "first" => 3, "after" => last_cursor })
+          }
+          assert_equal(true, get_page_info(result, "ships")["hasNextPage"])
+          assert_equal(true, get_page_info(result, "ships")["hasPreviousPage"])
 
-            # When going backwards, bi-directional pagination
-            # returns true for `hasNextPage`
-            last_cursor = get_last_cursor(result)
-            result = star_wars_query(query_string, { "last" => 1, "before" => last_cursor })
-            assert_equal(false, get_page_info(result, "ships")["hasNextPage"])
-            assert_equal(true, get_page_info(result, "ships")["hasPreviousPage"])
+          # When going backwards, bi-directional pagination
+          # returns true for `hasNextPage`
+          last_cursor = get_last_cursor(result)
+          result = star_wars_query(query_string, { "last" => 1, "before" => last_cursor })
+          assert_equal(false, get_page_info(result, "ships")["hasNextPage"])
+          assert_equal(true, get_page_info(result, "ships")["hasPreviousPage"])
 
-            result = with_bidirectional_pagination {
-              star_wars_query(query_string, { "last" => 2, "before" => last_cursor })
-            }
-            assert_equal(true, get_page_info(result, "ships")["hasNextPage"])
-            assert_equal(true, get_page_info(result, "ships")["hasPreviousPage"])
+          result = with_bidirectional_pagination {
+            star_wars_query(query_string, { "last" => 2, "before" => last_cursor })
+          }
+          assert_equal(true, get_page_info(result, "ships")["hasNextPage"])
+          assert_equal(true, get_page_info(result, "ships")["hasPreviousPage"])
         end
 
         it "returns correct page info when the before cursor belongs to the last element in the array" do

--- a/spec/integration/rails/graphql/relay/connection_type_spec.rb
+++ b/spec/integration/rails/graphql/relay/connection_type_spec.rb
@@ -5,14 +5,14 @@ describe GraphQL::Relay::ConnectionType do
   describe ".create_type" do
     describe "connections with custom Edge classes / EdgeTypes" do
       let(:query_string) {%|
-        {
+        query($testNames: Boolean!) {
           rebels {
             basesWithCustomEdge {
               totalCountTimes100
-              fieldName
+              fieldName @include(if: $testNames)
               edges {
-                upcasedName
-                upcasedParentName
+                upcasedName @include(if: $testNames)
+                upcasedParentName @include(if: $testNames)
                 edgeClassName
                 node {
                   name
@@ -25,15 +25,17 @@ describe GraphQL::Relay::ConnectionType do
       |}
 
       it "uses the custom edge and custom connection" do
-        result = star_wars_query(query_string)
+        result = star_wars_query(query_string, { "testNames" => !TESTING_INTERPRETER })
         bases = result["data"]["rebels"]["basesWithCustomEdge"]
         assert_equal 300, bases["totalCountTimes100"]
-        assert_equal 'basesWithCustomEdge', bases["fieldName"]
-        assert_equal ["YAVIN", "ECHO BASE", "SECRET HIDEOUT"] , bases["edges"].map { |e| e["upcasedName"] }
+        if !TESTING_INTERPRETER
+          assert_equal 'basesWithCustomEdge', bases["fieldName"]
+          assert_equal ["YAVIN", "ECHO BASE", "SECRET HIDEOUT"] , bases["edges"].map { |e| e["upcasedName"] }
+          assert_equal [upcased_rebels_name] , bases["edges"].map { |e| e["upcasedParentName"] }.uniq
+        end
         assert_equal ["Yavin", "Echo Base", "Secret Hideout"] , bases["edges"].map { |e| e["node"]["name"] }
         assert_equal ["StarWars::CustomBaseEdge"] , bases["edges"].map { |e| e["edgeClassName"] }.uniq
         upcased_rebels_name = "ALLIANCE TO RESTORE THE REPUBLIC"
-        assert_equal [upcased_rebels_name] , bases["edges"].map { |e| e["upcasedParentName"] }.uniq
       end
     end
 

--- a/spec/integration/rails/graphql/relay/connection_type_spec.rb
+++ b/spec/integration/rails/graphql/relay/connection_type_spec.rb
@@ -31,11 +31,11 @@ describe GraphQL::Relay::ConnectionType do
         if !TESTING_INTERPRETER
           assert_equal 'basesWithCustomEdge', bases["fieldName"]
           assert_equal ["YAVIN", "ECHO BASE", "SECRET HIDEOUT"] , bases["edges"].map { |e| e["upcasedName"] }
+          upcased_rebels_name = "ALLIANCE TO RESTORE THE REPUBLIC"
           assert_equal [upcased_rebels_name] , bases["edges"].map { |e| e["upcasedParentName"] }.uniq
         end
         assert_equal ["Yavin", "Echo Base", "Secret Hideout"] , bases["edges"].map { |e| e["node"]["name"] }
         assert_equal ["StarWars::CustomBaseEdge"] , bases["edges"].map { |e| e["edgeClassName"] }.uniq
-        upcased_rebels_name = "ALLIANCE TO RESTORE THE REPUBLIC"
       end
     end
 

--- a/spec/integration/rails/graphql/relay/page_info_spec.rb
+++ b/spec/integration/rails/graphql/relay/page_info_spec.rb
@@ -51,21 +51,23 @@ describe GraphQL::Relay::PageInfo do
 
       last_cursor = get_last_cursor(result)
       result = star_wars_query(query_string, { "first" => 100, "after" => last_cursor })
+      backwards_pagination = TESTING_INTERPRETER ? true : false
       assert_equal(false, get_page_info(result)["hasNextPage"])
-      assert_equal(false, get_page_info(result)["hasPreviousPage"])
+      assert_equal(backwards_pagination, get_page_info(result)["hasPreviousPage"])
       assert_equal("Mw", get_page_info(result)["startCursor"])
       assert_equal("Mw", get_page_info(result)["endCursor"])
     end
 
     it "hasPreviousPage if there are more items" do
       result = star_wars_query(query_string, { "last" => 100, "before" => cursor_of_last_base })
-      assert_equal(false, get_page_info(result)["hasNextPage"])
+      backwards_pagination = TESTING_INTERPRETER ? true : false
+      assert_equal(backwards_pagination, get_page_info(result)["hasNextPage"])
       assert_equal(false, get_page_info(result)["hasPreviousPage"])
       assert_equal("MQ", get_page_info(result)["startCursor"])
       assert_equal("Mg", get_page_info(result)["endCursor"])
 
       result = star_wars_query(query_string, { "last" => 1, "before" => cursor_of_last_base })
-      assert_equal(false, get_page_info(result)["hasNextPage"])
+      assert_equal(backwards_pagination, get_page_info(result)["hasNextPage"])
       assert_equal(true, get_page_info(result)["hasPreviousPage"])
       assert_equal("Mg", get_page_info(result)["startCursor"])
       assert_equal("Mg", get_page_info(result)["endCursor"])
@@ -73,8 +75,13 @@ describe GraphQL::Relay::PageInfo do
 
     it "has both if first and last are present" do
       result = star_wars_query(query_string, { "last" => 1, "first" => 1, "before" => cursor_of_last_base })
+      # I think this was actually a bug in the previous implementation.
+      # This query returns the first node in the list:
+      #     Base64.decode64("MQ") # => "1"
+      # So, there is _not_ a previous page.
+      prev_page = TESTING_INTERPRETER ? false : true
       assert_equal(true, get_page_info(result)["hasNextPage"])
-      assert_equal(true, get_page_info(result)["hasPreviousPage"])
+      assert_equal(prev_page, get_page_info(result)["hasPreviousPage"])
       assert_equal("MQ", get_page_info(result)["startCursor"])
       assert_equal("MQ", get_page_info(result)["endCursor"])
     end
@@ -89,15 +96,16 @@ describe GraphQL::Relay::PageInfo do
       assert_equal("Mg", get_last_cursor(result))
 
       result = star_wars_query(query_string, { "first" => 1, "after" => get_page_info(result)["endCursor"] })
+      backwards_pagination = TESTING_INTERPRETER ? true : false
       assert_equal(false, get_page_info(result)["hasNextPage"])
-      assert_equal(false, get_page_info(result)["hasPreviousPage"])
+      assert_equal(backwards_pagination, get_page_info(result)["hasPreviousPage"])
       assert_equal("Mw", get_page_info(result)["startCursor"])
       assert_equal("Mw", get_page_info(result)["endCursor"])
       assert_equal("Mw", get_first_cursor(result))
       assert_equal("Mw", get_last_cursor(result))
 
       result = star_wars_query(query_string, { "last" => 1, "before" => get_page_info(result)["endCursor"] })
-      assert_equal(false, get_page_info(result)["hasNextPage"])
+      assert_equal(backwards_pagination, get_page_info(result)["hasNextPage"])
       assert_equal(true, get_page_info(result)["hasPreviousPage"])
       assert_equal("Mg", get_page_info(result)["startCursor"])
       assert_equal("Mg", get_page_info(result)["endCursor"])

--- a/spec/integration/rails/graphql/relay/relation_connection_spec.rb
+++ b/spec/integration/rails/graphql/relay/relation_connection_spec.rb
@@ -132,39 +132,55 @@ describe GraphQL::Relay::RelationConnection do
       assert_equal 2, result["data"]["empire"]["bases"]["edges"].size
     end
 
-    it "provides bidirectional_pagination" do
-      result = star_wars_query(query_string, { "first" => 1 })
-      last_cursor = get_last_cursor(result)
+    if TESTING_INTERPRETER
+      it "does bidirectional pagination by default" do
+        result = star_wars_query(query_string, { "first" => 1 })
+        last_cursor = get_last_cursor(result)
+        result = star_wars_query(query_string, { "first" => 1, "after" => last_cursor })
+        assert_equal true, get_page_info(result)["hasNextPage"]
+        assert_equal true, get_page_info(result)["hasPreviousPage"]
 
-      result = star_wars_query(query_string, { "first" => 1, "after" => last_cursor })
-      assert_equal true, get_page_info(result)["hasNextPage"]
-      assert_equal false, get_page_info(result)["hasPreviousPage"]
+        result = star_wars_query(query_string, { "first" => 100 })
+        last_cursor = get_last_cursor(result)
+        result = star_wars_query(query_string, { "last" => 1, "before" => last_cursor })
+        assert_equal true, get_page_info(result)["hasNextPage"]
+        assert_equal true, get_page_info(result)["hasPreviousPage"]
+      end
+    else
+      it "provides bidirectional_pagination" do
+        result = star_wars_query(query_string, { "first" => 1 })
+        last_cursor = get_last_cursor(result)
 
-      result = with_bidirectional_pagination {
-        star_wars_query(query_string, { "first" => 1, "after" => last_cursor })
-      }
-      assert_equal true, get_page_info(result)["hasNextPage"]
-      assert_equal true, get_page_info(result)["hasPreviousPage"]
+        result = star_wars_query(query_string, { "first" => 1, "after" => last_cursor })
+        assert_equal true, get_page_info(result)["hasNextPage"]
+        assert_equal false, get_page_info(result)["hasPreviousPage"]
 
-      last_cursor = get_last_cursor(result)
-      result = with_bidirectional_pagination {
-        star_wars_query(query_string, { "last" => 1, "before" => last_cursor })
-      }
-      assert_equal true, get_page_info(result)["hasNextPage"]
-      assert_equal false, get_page_info(result)["hasPreviousPage"]
+        result = with_bidirectional_pagination {
+          star_wars_query(query_string, { "first" => 1, "after" => last_cursor })
+        }
+        assert_equal true, get_page_info(result)["hasNextPage"]
+        assert_equal true, get_page_info(result)["hasPreviousPage"]
 
-      result = star_wars_query(query_string, { "first" => 100 })
-      last_cursor = get_last_cursor(result)
+        last_cursor = get_last_cursor(result)
+        result = with_bidirectional_pagination {
+          star_wars_query(query_string, { "last" => 1, "before" => last_cursor })
+        }
+        assert_equal true, get_page_info(result)["hasNextPage"]
+        assert_equal false, get_page_info(result)["hasPreviousPage"]
 
-      result = star_wars_query(query_string, { "last" => 1, "before" => last_cursor })
-      assert_equal false, get_page_info(result)["hasNextPage"]
-      assert_equal true, get_page_info(result)["hasPreviousPage"]
+        result = star_wars_query(query_string, { "first" => 100 })
+        last_cursor = get_last_cursor(result)
 
-      result = with_bidirectional_pagination {
-        star_wars_query(query_string, { "last" => 1, "before" => last_cursor })
-      }
-      assert_equal true, get_page_info(result)["hasNextPage"]
-      assert_equal true, get_page_info(result)["hasPreviousPage"]
+        result = star_wars_query(query_string, { "last" => 1, "before" => last_cursor })
+        assert_equal false, get_page_info(result)["hasNextPage"]
+        assert_equal true, get_page_info(result)["hasPreviousPage"]
+
+        result = with_bidirectional_pagination {
+          star_wars_query(query_string, { "last" => 1, "before" => last_cursor })
+        }
+        assert_equal true, get_page_info(result)["hasNextPage"]
+        assert_equal true, get_page_info(result)["hasPreviousPage"]
+      end
     end
 
     it 'slices the result' do

--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -48,7 +48,11 @@ module StarWars
     field :total_count, Integer, null: true
 
     def total_count
-      object.nodes.count
+      if TESTING_INTERPRETER
+        object.items.count
+      else
+        object.nodes.count
+      end
     end
   end
 
@@ -431,6 +435,8 @@ module StarWars
     if TESTING_INTERPRETER
       use GraphQL::Execution::Interpreter
       use GraphQL::Analysis::AST
+      use GraphQL::Pagination::Connections
+      connections.add(LazyNodesWrapper, LazyNodesRelationConnection)
     end
 
     def self.resolve_type(type, object, ctx)


### PR DESCRIPTION
#2805 Mentioned a previously-fixed bug that showed up in the new connection system. This adds a build that runs _new_ connections with the _old_ tests. There are some differences, which are now explicitly called out in the suite. 

Along the way, I fixed #2349 _again_. But this didn't fix the bug reported in #2805.