### PR TITLE
Remove ruby2_keywords method

### DIFF
--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -7,14 +7,6 @@ require "forwardable"
 require_relative "./graphql/railtie" if defined? Rails::Railtie
 
 module GraphQL
-  # forwards-compat for argument handling
-  module Ruby2Keywords
-    if RUBY_VERSION < "2.7"
-      def ruby2_keywords(*)
-      end
-    end
-  end
-
   class Error < StandardError
   end
 

--- a/lib/graphql/define/defined_object_proxy.rb
+++ b/lib/graphql/define/defined_object_proxy.rb
@@ -6,7 +6,6 @@ module GraphQL
     # {@target} is passed to the specified function, along with any arguments and block.
     # This allows a method-based DSL without adding methods to the defined class.
     class DefinedObjectProxy
-      extend GraphQL::Ruby2Keywords
       # The object which will be defined by definition functions
       attr_reader :target
 
@@ -43,7 +42,6 @@ module GraphQL
           raise NoDefinitionError, msg, caller
         end
       end
-      ruby2_keywords :method_missing
 
       def respond_to_missing?(name, include_private = false)
         @dictionary[name] || super

--- a/lib/graphql/define/instance_definable.rb
+++ b/lib/graphql/define/instance_definable.rb
@@ -191,19 +191,13 @@ module GraphQL
       end
 
       class AssignAttribute
-        extend GraphQL::Ruby2Keywords
-
         def initialize(attr_name)
           @attr_assign_method = :"#{attr_name}="
         end
 
-        # Even though we're just using the first value here,
-        # We have to add a splat here to use `ruby2_keywords`,
-        # so that it will accept a `[{}]` input from the caller.
         def call(defn, *value)
           defn.public_send(@attr_assign_method, value.first)
         end
-        ruby2_keywords :call
       end
     end
   end


### PR DESCRIPTION
This method is specifically undefined in Ruby 2.7, causing a `NoMethodError`.

The method is also called on a symbol and does nothing but return `nil`.