### PR TITLE
Don't allow mixing legacy and class-based types in the same Schema

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -1818,7 +1818,6 @@ module GraphQL
           um << owner
         end
 
-        prev_type = own_types[type.graphql_name]
         if (prev_type = own_types[type.graphql_name])
           if prev_type != orig_type
             raise DuplicateTypeNamesError.new(

--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -354,43 +354,22 @@ module StarWars
       [OpenStruct.new(id: nil)]
     end
 
-    if TESTING_INTERPRETER
-      add_field(GraphQL::Types::Relay::NodeField)
-    else
-      field :node, field: GraphQL::Relay::Node.field
+    add_field(GraphQL::Types::Relay::NodeField)
+
+    field :node_with_custom_resolver, GraphQL::Types::Relay::Node, null: true do
+      argument :id, ID, required: true
+    end
+    def node_with_custom_resolver(id:)
+      StarWars::DATA["Faction"]["1"]
     end
 
-    if TESTING_INTERPRETER
-      field :node_with_custom_resolver, GraphQL::Types::Relay::Node, null: true do
-        argument :id, ID, required: true
-      end
-      def node_with_custom_resolver(id:)
-        StarWars::DATA["Faction"]["1"]
-      end
-    else
-      custom_node_field = GraphQL::Relay::Node.field do
-        resolve ->(_, _, _) { StarWars::DATA["Faction"]["1"] }
-      end
-      field :nodeWithCustomResolver, field: custom_node_field
-    end
+    add_field(GraphQL::Types::Relay::NodesField)
 
-    if TESTING_INTERPRETER
-      add_field(GraphQL::Types::Relay::NodesField)
-    else
-      field :nodes, field: GraphQL::Relay::Node.plural_field
+    field :nodes_with_custom_resolver, [GraphQL::Types::Relay::Node, null: true], null: true do
+      argument :ids, [ID], required: true
     end
-
-    if TESTING_INTERPRETER
-      field :nodes_with_custom_resolver, [GraphQL::Types::Relay::Node, null: true], null: true do
-        argument :ids, [ID], required: true
-      end
-      def nodes_with_custom_resolver(ids:)
-        [StarWars::DATA["Faction"]["1"], StarWars::DATA["Faction"]["2"]]
-      end
-    else
-      field :nodesWithCustomResolver, field: GraphQL::Relay::Node.plural_field(
-        resolve: ->(_, _, _) { [StarWars::DATA["Faction"]["1"], StarWars::DATA["Faction"]["2"]] }
-      )
+    def nodes_with_custom_resolver(ids:)
+      [StarWars::DATA["Faction"]["1"], StarWars::DATA["Faction"]["2"]]
     end
 
     field :batchedBase, BaseType, null: true do


### PR DESCRIPTION
It's interestingly possible to have _both_ `T` and `T.graphql_definition` in your schema, and this happens with built-in types like `Node` and `Int`. 

We can detect this at schema build time and prevent it. 

This might break some schemas, because a schema with this inconsistency _would_ work -- but the recommended fix is not too hard. 

Fixes #2724 
Fixes #2784