### PR TITLE
Prune unreachable types when parsing schema from IDL

### DIFF
--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -140,6 +140,9 @@ module GraphQL
                 use(plugin)
               end
             end
+
+            # Empty `orphan_types` -- this will make unreachable types ... unreachable.
+            own_orphan_types.clear
           end
         end
 

--- a/spec/graphql/language/document_from_schema_definition_spec.rb
+++ b/spec/graphql/language/document_from_schema_definition_spec.rb
@@ -8,6 +8,7 @@ describe GraphQL::Language::DocumentFromSchemaDefinition do
     let(:schema_idl) { <<-GRAPHQL
       type QueryType {
         foo: Foo
+        u: Union
       }
 
       type Foo implements Bar {
@@ -101,6 +102,7 @@ type Query {
       let(:schema_idl) { <<-GRAPHQL
         type Query {
           foo: Foo
+          u: Union
         }
 
         type Foo implements Bar {
@@ -150,6 +152,7 @@ type Query {
       let(:expected_idl) { <<-GRAPHQL
         type QueryType {
           foo: Foo
+          u: Union
         }
 
         type Foo implements Bar {
@@ -206,6 +209,7 @@ type Query {
       let(:expected_idl) { <<-GRAPHQL
         type QueryType {
           foo: Foo
+          u: Union
         }
 
         type Foo implements Bar {
@@ -267,6 +271,7 @@ type Query {
       let(:expected_idl) { <<-GRAPHQL
         type QueryType {
           foo: Foo
+          u: Union
         }
 
         type Foo implements Bar {
@@ -320,6 +325,7 @@ type Query {
       let(:expected_idl) { <<-GRAPHQL
         type QueryType {
           foo: Foo
+          u: Union
         }
 
         type Foo implements Bar {
@@ -370,6 +376,7 @@ type Query {
       let(:expected_idl) { <<-GRAPHQL
         type QueryType {
           foo: Foo
+          u: Union
         }
 
         type Foo implements Bar {

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -99,6 +99,7 @@ type Hello implements I {
   And a field to boot
   """
   str(i: Input): String
+  u: U
 }
 
 """
@@ -157,17 +158,17 @@ union U = Hello
       assert_equal 34, field.ast_node.line
       assert_equal 37, field.ast_node.definition_line
 
-      assert_equal 40, built_schema.types["I"].ast_node.line
-      assert_equal 43, built_schema.types["I"].ast_node.definition_line
+      assert_equal 41, built_schema.types["I"].ast_node.line
+      assert_equal 44, built_schema.types["I"].ast_node.definition_line
 
-      assert_equal 47, built_schema.types["Input"].ast_node.line
-      assert_equal 50, built_schema.types["Input"].ast_node.definition_line
+      assert_equal 48, built_schema.types["Input"].ast_node.line
+      assert_equal 51, built_schema.types["Input"].ast_node.definition_line
 
-      assert_equal 54, built_schema.types["S"].ast_node.line
-      assert_equal 57, built_schema.types["S"].ast_node.definition_line
+      assert_equal 55, built_schema.types["S"].ast_node.line
+      assert_equal 58, built_schema.types["S"].ast_node.definition_line
 
-      assert_equal 59, built_schema.types["U"].ast_node.line
-      assert_equal 62, built_schema.types["U"].ast_node.definition_line
+      assert_equal 60, built_schema.types["U"].ast_node.line
+      assert_equal 63, built_schema.types["U"].ast_node.definition_line
     end
 
     it 'maintains built-in directives' do
@@ -1306,7 +1307,6 @@ type ThingEdge {
   end
 
   describe "orphan types" do
-    focus
     it "only puts unreachable types in orphan types" do
       schema = GraphQL::Schema.from_definition <<-GRAPHQL
       type Query {

--- a/spec/graphql/schema/warden_spec.rb
+++ b/spec/graphql/schema/warden_spec.rb
@@ -488,6 +488,7 @@ describe GraphQL::Schema::Warden do
       sdl = "
         type Query {
           node: Node
+          a: A
         }
 
         type A implements Node {
@@ -518,7 +519,7 @@ describe GraphQL::Schema::Warden do
 
       res = schema.execute(query_string)
       assert res["data"]["Node"]
-      assert_equal ["node"], res["data"]["Query"]["fields"].map { |f| f["name"] }
+      assert_equal ["a", "node"], res["data"]["Query"]["fields"].map { |f| f["name"] }
 
       # When the possible types are all hidden, hide the interface and fields pointing to it
       res = schema.execute(query_string, except: ->(m, _) { ["A", "B", "C"].include?(m.graphql_name) })
@@ -529,7 +530,7 @@ describe GraphQL::Schema::Warden do
       # still show the interface since it allows code reuse
       res = schema.execute(query_string, except: ->(m, _) { m.graphql_name == "node" })
       assert_equal "Node", res["data"]["Node"]["name"]
-      assert_equal [], res["data"]["Query"]["fields"]
+      assert_equal [{"name" => "a"}], res["data"]["Query"]["fields"]
     end
 
     it "can't be a fragment condition" do


### PR DESCRIPTION
Putting _every type_ in orphan types means you can't really use `warden.reachable_types` when a schema is parsed from IDL. 

Instead, let's empty that array _out_ after the schema is loaded. 

The downside is, somehow, something might possibly break, because truly-orphaned types are lost completely. 

However, I don't think those types would have ever been valid in queries, so I don't expect this to break query behavior.