### PR TITLE
Enable to work AST Analyzer

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -908,6 +908,7 @@ module GraphQL
         schema_defn.cursor_encoder = cursor_encoder
         schema_defn.tracers.concat(tracers)
         schema_defn.query_analyzers.concat(query_analyzers)
+        schema_defn.analysis_engine = analysis_engine
 
         schema_defn.middleware.concat(all_middleware)
         schema_defn.multiplex_analyzers.concat(multiplex_analyzers)

--- a/spec/graphql/analysis/analyze_query_spec.rb
+++ b/spec/graphql/analysis/analyze_query_spec.rb
@@ -218,7 +218,10 @@ describe GraphQL::Analysis do
       }
     |}
     let(:schema) do
-      schema = Class.new(Dummy::Schema)
+      schema = Class.new(Dummy::Schema) do
+        self.analysis_engine = GraphQL::Analysis
+      end
+
       schema.query_analyzer(id_catcher)
       schema.query_analyzer(flavor_catcher)
       schema.graphql_definition

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -291,6 +291,30 @@ describe GraphQL::Schema do
         assert_equal true, query.context[:no_op_analyzer_ran_on_leave_field]
         assert_equal true, query.context[:no_op_analyzer_ran_result]
       end
+
+      describe "when called on schema instance" do
+        let(:schema) do
+          Class.new(GraphQL::Schema) do
+            query query_type
+            use GraphQL::Analysis::AST
+            use PluginWithInstrumentationTracingAndAnalyzer
+          end.to_graphql
+        end
+
+        let(:query) { GraphQL::Query.new(schema, "query { foobar }") }
+
+        it "attaches plugins correctly, runs all of their callbacks" do
+          res = query.result
+          assert res.key?("data")
+
+          assert_equal true, query.context[:no_op_instrumentation_ran_before_query]
+          assert_equal true, query.context[:no_op_instrumentation_ran_after_query]
+          assert_equal true, query.context[:no_op_tracer_ran]
+          assert_equal true, query.context[:no_op_analyzer_ran_initialize]
+          assert_equal true, query.context[:no_op_analyzer_ran_on_leave_field]
+          assert_equal true, query.context[:no_op_analyzer_ran_result]
+        end
+      end
     end
 
     describe "when called on schema subclasses" do


### PR DESCRIPTION
Fix #2717 

I've confirmed this patch solves the problem described in the issue, but I got an error with an existence test.



```bash
Error:
GraphQL::Analysis::.visit_analyzers#test_0001_groups all errors together:
NoMethodError: undefined method `new' for #<IdCatcher:0x0000563352e005c0>
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/analysis/ast.rb:58:in `block (2 levels) in analyze_query'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/analysis/ast.rb:58:in `map'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/analysis/ast.rb:58:in `block in analyze_query'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:67:in `block in trace'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:81:in `call_tracers'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:67:in `trace'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/analysis/ast.rb:56:in `analyze_query'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/analysis/ast.rb:32:in `block (2 levels) in analyze_multiplex'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/analysis/ast.rb:30:in `map'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/analysis/ast.rb:30:in `block in analyze_multiplex'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:67:in `block in trace'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:81:in `call_tracers'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:67:in `trace'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/analysis/ast.rb:29:in `analyze_multiplex'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/multiplex.rb:195:in `block in instrument_and_analyze'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/instrumentation.rb:29:in `block (2 levels) in apply_instrumenters'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/instrumentation.rb:46:in `block (2 levels) in each_query_call_hooks'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/instrumentation.rb:41:in `each_query_call_hooks'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/instrumentation.rb:45:in `block in each_query_call_hooks'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/instrumentation.rb:72:in `call_hooks'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/instrumentation.rb:44:in `each_query_call_hooks'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/instrumentation.rb:27:in `block in apply_instrumenters'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/instrumentation.rb:72:in `call_hooks'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/instrumentation.rb:26:in `apply_instrumenters'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/multiplex.rb:175:in `instrument_and_analyze'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/multiplex.rb:61:in `block in run_queries'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:67:in `block in trace'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:81:in `call_tracers'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:67:in `trace'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/multiplex.rb:59:in `run_queries'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/multiplex.rb:49:in `run_all'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/schema.rb:435:in `block in multiplex'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/schema.rb:1947:in `with_definition_error_check'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/schema.rb:434:in `multiplex'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/schema.rb:411:in `execute'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/spec/graphql/analysis/analyze_query_spec.rb:226:in `block (3 levels) in <top (required)>'
```


I'm not sure how to fix it. Could you give me advice? 


----

And I tried to add a test case for this fix with the following patch, but it failed.

```diff
diff --git a/spec/graphql/schema_spec.rb b/spec/graphql/schema_spec.rb
index aed267f7f..8c7bff4ce 100644
--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -293,6 +293,31 @@ describe GraphQL::Schema do
       end
     end
 
+    describe "when called on schema instance" do
+      let(:schema) do
+        Class.new(GraphQL::Schema) do
+          query query_type
+          use GraphQL::Analysis::AST
+          use GraphQL::Execution::Interpreter
+          use PluginWithInstrumentationTracingAndAnalyzer
+        end.to_graphql
+      end
+
+      let(:query) { GraphQL::Query.new(schema, "query { foobar }") }
+
+      it "attaches plugins correctly, runs all of their callbacks" do
+        res = query.result
+        assert res.key?("data")
+
+        assert_equal true, query.context[:no_op_instrumentation_ran_before_query]
+        assert_equal true, query.context[:no_op_instrumentation_ran_after_query]
+        assert_equal true, query.context[:no_op_tracer_ran]
+        assert_equal true, query.context[:no_op_analyzer_ran_initialize]
+        assert_equal true, query.context[:no_op_analyzer_ran_on_leave_field]
+        assert_equal true, query.context[:no_op_analyzer_ran_result]
+      end
+    end
+
     describe "when called on schema subclasses" do
       let(:schema) do
         schema = Class.new(GraphQL::Schema) do
```

It just copied "when called on class definitions" test case and add `to_graphql` method call.

I got the following error message.


```
NoMethodError: undefined method `authorized_new' for Query:GraphQL::ObjectType
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:585:in `block in authorized_new'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:66:in `block in trace'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:82:in `block (2 levels) in call_tracers'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:80:in `call_tracers'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:82:in `block in call_tracers'
    spec/graphql/schema_spec.rb:228:in `trace'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:82:in `call_tracers'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:66:in `trace'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:584:in `authorized_new'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:53:in `run_eager'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/interpreter.rb:70:in `block in evaluate'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:66:in `block in trace'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:82:in `block (2 levels) in call_tracers'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:80:in `call_tracers'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:82:in `block in call_tracers'
    spec/graphql/schema_spec.rb:228:in `trace'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:82:in `call_tracers'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:66:in `trace'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/interpreter.rb:69:in `evaluate'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/interpreter.rb:42:in `begin_query'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/multiplex.rb:113:in `begin_query'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/multiplex.rb:84:in `block in run_as_multiplex'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/multiplex.rb:83:in `map'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/multiplex.rb:83:in `run_as_multiplex'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/multiplex.rb:62:in `block (2 levels) in run_queries'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/multiplex.rb:196:in `block in instrument_and_analyze'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/instrumentation.rb:29:in `block (2 levels) in apply_instrumenters'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/instrumentation.rb:46:in `block (2 levels) in each_query_call_hooks'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/instrumentation.rb:41:in `each_query_call_hooks'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/instrumentation.rb:45:in `block in each_query_call_hooks'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/instrumentation.rb:72:in `call_hooks'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/instrumentation.rb:44:in `each_query_call_hooks'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/instrumentation.rb:27:in `block in apply_instrumenters'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/instrumentation.rb:72:in `call_hooks'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/instrumentation.rb:26:in `apply_instrumenters'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/multiplex.rb:175:in `instrument_and_analyze'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/multiplex.rb:61:in `block in run_queries'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:66:in `block in trace'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:82:in `block (2 levels) in call_tracers'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:80:in `call_tracers'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:82:in `block in call_tracers'
    spec/graphql/schema_spec.rb:228:in `trace'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:82:in `call_tracers'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/tracing.rb:66:in `trace'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/execution/multiplex.rb:59:in `run_queries'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/query.rb:196:in `block in result'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/query.rb:396:in `with_prepared_ast'
    /home/pocke/ghq/github.com/rmosolgo/graphql-ruby/lib/graphql/query.rb:195:in `result'
    spec/graphql/schema_spec.rb:309:in `block (4 levels) in <main>'
```


If I should add a test case, could you also give me any advice to add the test? 


