### PR TITLE
New connections fixes

### DIFF
--- a/lib/graphql/pagination/array_connection.rb
+++ b/lib/graphql/pagination/array_connection.rb
@@ -21,7 +21,7 @@ module GraphQL
 
       def cursor_for(item)
         idx = items.find_index(item) + 1
-        context.schema.cursor_encoder.encode(idx.to_s)
+        encode(idx.to_s)
       end
 
       private

--- a/lib/graphql/pagination/connection.rb
+++ b/lib/graphql/pagination/connection.rb
@@ -29,14 +29,22 @@ module GraphQL
       # Raw access to client-provided values. (`max_page_size` not applied to first or last.)
       attr_accessor :before_value, :after_value, :first_value, :last_value
 
-      # @return [String, nil] the client-provided cursor
+      # @return [String, nil] the client-provided cursor. `""` is treated as `nil`.
       def before
-        @before_value
+        if defined?(@before)
+          @before
+        else
+          @before = @before_value == "" ? nil : @before_value
+        end
       end
 
-      # @return [String, nil] the client-provided cursor
+      # @return [String, nil] the client-provided cursor. `""` is treated as `nil`.
       def after
-        @after_value
+        if defined?(@after)
+          @after
+        else
+          @after = @after_value == "" ? nil : @after_value
+        end
       end
 
       # @param items [Object] some unpaginated collection item, like an `Array` or `ActiveRecord::Relation`
@@ -147,7 +155,11 @@ module GraphQL
       end
 
       def decode(cursor)
-        context.schema.cursor_encoder.decode(cursor)
+        context.schema.cursor_encoder.decode(cursor, nonce: true)
+      end
+
+      def encode(cursor)
+        context.schema.cursor_encoder.encode(cursor, nonce: true)
       end
 
       # A wrapper around paginated items. It includes a {cursor} for pagination

--- a/lib/graphql/pagination/relation_connection.rb
+++ b/lib/graphql/pagination/relation_connection.rb
@@ -44,7 +44,7 @@ module GraphQL
         load_nodes
         # index in nodes + existing offset + 1 (because it's offset, not index)
         offset = nodes.index(item) + 1 + (@paged_nodes_offset || 0) + (relation_offset(items) || 0)
-        context.schema.cursor_encoder.encode(offset.to_s)
+        encode(offset.to_s)
       end
 
       private

--- a/spec/support/connection_assertions.rb
+++ b/spec/support/connection_assertions.rb
@@ -22,14 +22,14 @@ module ConnectionAssertions
   class NonceEnabledEncoder
     class << self
       def encode(value, nonce: false)
-        "#{JSON.dump(value)}#{nonce ? "+nonce" : ""}"
+        "#{JSON.dump([value])}#{nonce ? "+nonce" : ""}"
       end
 
       def decode(value, nonce: false)
         if nonce
           value = value.sub(/\+nonce$/, "")
         end
-        JSON.parse(value)
+        JSON.parse(value).first
       end
     end
   end


### PR DESCRIPTION
- Ignore cursors given as `""`
- Use `nonce: true` when generating cursors 

Fixes #2819 