### PR TITLE
Fix default_value: {} on Ruby 2.7

### DIFF
--- a/lib/graphql/define/instance_definable.rb
+++ b/lib/graphql/define/instance_definable.rb
@@ -155,7 +155,7 @@ module GraphQL
             # Apply definition from `define(...)` kwargs
             defn.define_keywords.each do |keyword, value|
               # Don't splat string hashes, which blows up on Rubies before 2.7
-              if value.is_a?(Hash) && value.each_key.all? { |k| k.is_a?(Symbol) }
+              if value.is_a?(Hash) && !value.empty? && value.each_key.all? { |k| k.is_a?(Symbol) }
                 defn_proxy.public_send(keyword, **value)
               else
                 defn_proxy.public_send(keyword, value)


### PR DESCRIPTION
Follow up: https://github.com/rmosolgo/graphql-ruby/pull/2704

This is another subtle change in 2.7 handling of keyword arguments.

It wouldn't be a problem if the target method was set as `ruby2_keywords`, but in this case it isn't.

I wish I could produce a test case for this, but my understanding of the library is too limited. 

I figured that one out, because lots of our tests were failing, and all Argument with `default_value = {}` ended up with `default_value = nil`.
