### PR TITLE
align error json format in development with production's

### DIFF
--- a/lib/generators/graphql/templates/graphql_controller.erb
+++ b/lib/generators/graphql/templates/graphql_controller.erb
@@ -43,6 +43,6 @@ class GraphqlController < ApplicationController
     logger.error e.message
     logger.error e.backtrace.join("\n")
 
-    render json: { error: { message: e.message, backtrace: e.backtrace }, data: {} }, status: 500
+    render json: { errors: [{ message: e.message, backtrace: e.backtrace }], data: {} }, status: 500
   end
 end

--- a/spec/integration/rails/generators/graphql/install_generator_spec.rb
+++ b/spec/integration/rails/generators/graphql/install_generator_spec.rb
@@ -235,7 +235,7 @@ class GraphqlController < ApplicationController
     logger.error e.message
     logger.error e.backtrace.join("\n")
 
-    render json: { error: { message: e.message, backtrace: e.backtrace }, data: {} }, status: 500
+    render json: { errors: [{ message: e.message, backtrace: e.backtrace }], data: {} }, status: 500
   end
 end
 RUBY


### PR DESCRIPTION
Hi, thanks really really a lot for your labor to maintain this awesome gem!

We just encountered a strange situation where the error message in graphql-ruby is delivered in wired manner in development environment.

After digging it a while, I noticed that the development error handler, which was auto-generated by this gem's template, uses slightly different key compared with [the error handling system in graphql-ruby](https://github.com/rmosolgo/graphql-ruby/blob/564b9219435950a764afbff30a4327ee4ee842ab/guides/errors/execution_errors.md).

```ruby
  def handle_error_in_development(e)
    logger.error e.message
    logger.error e.backtrace.join("\n")

    render json: { error: { message: e.message, backtrace: e.backtrace }, data: {} }, status: 500
    #              ^^^^^^
  end
```

This PR is a little chore to fix this template. Hope that makes sense :)

#### small note
I firstly thought of this a 'breaking change', but realized that it would only impacts on those who newly generates GraphqlController using the generator. While this won't bother the current users of this gem (unless anyone try to re-generate the controller). It will only minimize the confusion for the new users who is about to adopting graphql.

If there's anything I overlooked, or I need to work on, I'm happy to know!