### PR TITLE
Fix so Rake task loads environment by default

### DIFF
--- a/lib/graphql/rake_task.rb
+++ b/lib/graphql/rake_task.rb
@@ -76,7 +76,7 @@ module GraphQL
     # Set the parameters of this task by passing keyword arguments
     # or assigning attributes inside the block
     def initialize(options = {})
-      default_dependencies = if Rake::Task.task_defined?("environment")
+      default_dependencies = if Rake::Task.task_defined?(:environment)
         [:environment]
       else
         []


### PR DESCRIPTION
I am using this gem under rake 13.0.1 and rails 6.0.2.1. The graphql:schema:dump rake task doesn't work because it doesn't load the Rails environment so it can't find the schema to dump. To work around this I need to add `dependencies` parameter in graphql.rake:

```
require 'graphql/rake_task'
GraphQL::RakeTask.new(dependencies: :environment, schema_name: 'ApplicationSchema')
```

when it should instead be automatic. I suspect the amended line of code has stopped working and I propose this fix.