### PR TITLE
Fix TypeError in BigInt for nil input

### DIFF
--- a/lib/graphql/types/big_int.rb
+++ b/lib/graphql/types/big_int.rb
@@ -6,7 +6,7 @@ module GraphQL
       description "Represents non-fractional signed whole numeric values. Since the value may exceed the size of a 32-bit integer, it's encoded as a string."
 
       def self.coerce_input(value, _ctx)
-        Integer(value)
+        value && Integer(value)
       rescue ArgumentError
         nil
       end

--- a/spec/graphql/types/big_int_spec.rb
+++ b/spec/graphql/types/big_int_spec.rb
@@ -21,4 +21,8 @@ describe GraphQL::Types::BigInt do
     assert_equal nil, GraphQL::Types::BigInt.coerce_input("xyz", nil)
     assert_equal nil, GraphQL::Types::BigInt.coerce_input("2.2", nil)
   end
+
+  it 'returns `nil` for nil' do
+    assert_equal nil, GraphQL::Types::BigInt.coerce_input(nil, nil)
+  end
 end


### PR DESCRIPTION
`Integer(nil)` raises TypeError which is not handled by the BigInt class.

This will return `nil` for `nil` input.