### PR TITLE
Fix `default_max_page_size` in documentation

### DIFF
--- a/guides/pagination/using_connections.md
+++ b/guides/pagination/using_connections.md
@@ -79,7 +79,7 @@ You can apply `max_page_size` to limit the number of items returned, regardless 
 
   ```ruby
   class MyAppSchema < GraphQL::Schema
-    max_page_size 50
+    default_max_page_size 50
   end
   ```
 


### PR DESCRIPTION
For the "whole schema" it seems the method is `default_max_page_size` and not `max_page_size` which is what is specified in the documentation

Trying to use `max_page_size` will throw an unknown method error
```
undefined method `max_page_size' for MySchema:Class
```