### PR TITLE
Add `--playground` option to install generator

### DIFF
--- a/guides/schema/generators.md
+++ b/guides/schema/generators.md
@@ -43,6 +43,7 @@ After installing you can see your new schema by:
 
 - `--relay` will add [Relay](https://facebook.github.io/relay/)-specific code to your schema
 - `--batch` will add [GraphQL::Batch](https://github.com/Shopify/graphql-batch) to your gemfile and include the setup in your schema
+- `--playground` will include `graphql_playground-rails` in the setup (mounted at `/playground`)
 - `--no-graphiql` will exclude `graphiql-rails` from the setup
 - `--schema=MySchemaName` will be used for naming the schema (default is `#{app_name}Schema`)
 
@@ -55,7 +56,6 @@ Several generators will add GraphQL types to your project. Run them with `-h` to
 - `rails g graphql:union`
 - `rails g graphql:enum`
 - `rails g graphql:scalar`
-
 
 ## Scaffolding Mutations
 

--- a/lib/generators/graphql/install_generator.rb
+++ b/lib/generators/graphql/install_generator.rb
@@ -87,6 +87,11 @@ module Graphql
         default: false,
         desc: "Include GraphQL::Batch installation"
 
+      class_option :playground,
+        type: :boolean,
+        default: false,
+        desc: "Use GraphQL Playground over Graphiql as IDE"
+
       # These two options are taken from Rails' own generators'
       class_option :api,
         type: :boolean,
@@ -138,6 +143,20 @@ if Rails.env.development?
 RUBY
             end
           end
+        end
+
+        if options[:playground]
+          gem("graphql_playground-rails", group: :development)
+
+          log :route, 'graphql_playground-rails'
+          shell.mute do
+            route <<-RUBY
+if Rails.env.development?
+  mount GraphqlPlayground::Rails::Engine, at: "/playground", graphql_path: "/graphql"
+end
+RUBY
+          end
+
         end
 
         if gemfile_modified?

--- a/lib/generators/graphql/install_generator.rb
+++ b/lib/generators/graphql/install_generator.rb
@@ -150,11 +150,19 @@ RUBY
 
           log :route, 'graphql_playground-rails'
           shell.mute do
-            route <<-RUBY
+            if Rails::VERSION::STRING > "5.2"
+              route <<-RUBY
 if Rails.env.development?
   mount GraphqlPlayground::Rails::Engine, at: "/playground", graphql_path: "/graphql"
 end
 RUBY
+            else
+              route <<-RUBY
+if Rails.env.development?
+    mount GraphqlPlayground::Rails::Engine, at: "/playground", graphql_path: "/graphql"
+  end
+RUBY
+            end
           end
 
         end

--- a/spec/integration/rails/generators/graphql/install_generator_spec.rb
+++ b/spec/integration/rails/generators/graphql/install_generator_spec.rb
@@ -189,6 +189,24 @@ RUBY
     assert_file "app/controllers/graphql_controller.rb", /CustomSchema\.execute/
   end
 
+  test "it can add GraphQL Playground as an IDE through the --playground option" do
+    run_generator(["--playground"])
+
+    assert_file "Gemfile" do |contents|
+      assert_includes contents, "graphql_playground-rails"
+    end
+
+    expected_playground_route = %|
+  if Rails.env.development?
+    mount GraphqlPlayground::Rails::Engine, at: "/playground", graphql_path: "/graphql"
+  end
+|
+
+    assert_file "config/routes.rb" do |contents|
+      assert_includes contents, expected_playground_route
+    end
+  end
+
   EXPECTED_GRAPHQLS_CONTROLLER = <<-'RUBY'
 class GraphqlController < ApplicationController
   # If accessing from outside this domain, nullify the session


### PR DESCRIPTION
While `Graphiql` is great for testing GraphQL APIs, `GraphQL Playground` contains some features that `Graphiql` is missing such as http headers and is many developers preferred choice for testing their APIs. It can also be added to a rails project with the [`graphql_playground-rails`](https://rubygems.org/gems/graphql_playground-rails) gem. This PR adds an option to the install generator to set up `GraphQL Playground` upon installation in your project, by installing the gem and mounting it at the `/playground` route. Note that this does not prevent `Graphiql` from being installed as well (should it?) which can be done by including the `--skip-graphiql` option and also unlike `Graphiql` works for API only apps as well. Would love to hear thoughts and/or feedback on this addition!