### PR TITLE
Fix actioncable unsubscribe

### DIFF
--- a/javascript_client/src/subscriptions/ActionCableLink.ts
+++ b/javascript_client/src/subscriptions/ActionCableLink.ts
@@ -53,7 +53,7 @@ class ActionCableLink extends ApolloLink {
       })
 
       // Make the ActionCable subscription behave like an Apollo subscription
-      return { ...subscription, closed: false, unsubscribe: subscription.unsubscribe }
+      return Object.assign(subscription, {closed: false})
     })
   }
 }

--- a/javascript_client/src/subscriptions/ActionCableLink.ts
+++ b/javascript_client/src/subscriptions/ActionCableLink.ts
@@ -47,14 +47,13 @@ class ActionCableLink extends ApolloLink {
           }
 
           if (!payload.more) {
-            this.unsubscribe()
             observer.complete()
           }
         }
       })
 
       // Make the ActionCable subscription behave like an Apollo subscription
-      return { ...subscription, closed: false }
+      return { ...subscription, closed: false, unsubscribe: subscription.unsubscribe }
     })
   }
 }


### PR DESCRIPTION
fixes #2838 

A few notes:
- I refactored the ActionCableLinkTest tests mainly to have the cable mock object more accurately reflect what actioncable returns. I'm also getting reference to the underlying subscription through the Observable subscriptions `_cleanup` object. Setting the reference within the mock (old line 13) doesn't give you the object after ActionCableLink has transformed it.
- I removed `this.unsubscribe()` on line 50 because I discovered that `observer.complete()` also calls unsubscribe, and the call is redundant.
- The actual fix involves using `Object.assign` instead of the spread operator for two reasons:
  - The spread operator doesn't carry over prototype methods
  - Creating a clone of the object breaks an equality check in actioncable when removing/unsubscribing a subscription
