### PR TITLE
feat: Date scalars accept Date, DateTime, and well-formatted Strings

### DIFF
--- a/lib/graphql/types/iso_8601_date.rb
+++ b/lib/graphql/types/iso_8601_date.rb
@@ -15,10 +15,10 @@ module GraphQL
     class ISO8601Date < GraphQL::Schema::Scalar
       description "An ISO 8601-encoded date"
 
-      # @param value [Date]
+      # @param value [Date,DateTime,String]
       # @return [String]
       def self.coerce_result(value, _ctx)
-        value.iso8601
+        Date.parse(value.to_s).iso8601
       end
 
       # @param str_value [String]

--- a/lib/graphql/types/iso_8601_date_time.rb
+++ b/lib/graphql/types/iso_8601_date_time.rb
@@ -34,7 +34,7 @@ module GraphQL
       def self.coerce_result(value, _ctx)
         value = value.iso8601(time_precision) if value.class == DateTime
         DateTime.parse(value.to_s).iso8601(time_precision)
-      rescue ArgumentError => e
+      rescue ArgumentError
         raise GraphQL::Error, "An incompatible object (#{value.class}) was given to #{self}. Make sure that only Dates, DateTimes, and well-formatted Strings are used with this type."
       end
 

--- a/lib/graphql/types/iso_8601_date_time.rb
+++ b/lib/graphql/types/iso_8601_date_time.rb
@@ -35,7 +35,7 @@ module GraphQL
         value = value.iso8601(time_precision) if value.class == DateTime
         DateTime.parse(value.to_s).iso8601(time_precision)
       rescue ArgumentError => e
-        raise GraphQL::Error, "An incompatible object (#{value.class}) was given to #{self}. Make sure that only DateTimes are used with this type."
+        raise GraphQL::Error, "An incompatible object (#{value.class}) was given to #{self}. Make sure that only Dates, DateTimes, and well-formatted Strings are used with this type."
       end
 
       # @param str_value [String]

--- a/lib/graphql/types/iso_8601_date_time.rb
+++ b/lib/graphql/types/iso_8601_date_time.rb
@@ -31,11 +31,20 @@ module GraphQL
 
       # @param value [Date,DateTime,String]
       # @return [String]
-      def self.coerce_result(value, _ctx)
-        value = value.iso8601(time_precision) if value.class == DateTime
-        DateTime.parse(value.to_s).iso8601(time_precision)
-      rescue ArgumentError
-        raise GraphQL::Error, "An incompatible object (#{value.class}) was given to #{self}. Make sure that only Dates, DateTimes, and well-formatted Strings are used with this type."
+      def self.coerce_result(value, _ctx)\
+        case value
+        when DateTime
+          return value.iso8601(time_precision)
+        when Date
+          return DateTime.parse(value.to_s).iso8601(time_precision)
+        when ::String
+          return DateTime.parse(value).iso8601(time_precision)
+        else
+          # In case some other API-compliant thing is given: 
+          return value.iso8601(time_precision)
+        end 
+      rescue StandardError => error
+        raise GraphQL::Error, "An incompatible object (#{value.class}) was given to #{self}. Make sure that only Dates, DateTimes, and well-formatted Strings are used with this type. (#{error.message})"
       end
 
       # @param str_value [String]

--- a/lib/graphql/types/iso_8601_date_time.rb
+++ b/lib/graphql/types/iso_8601_date_time.rb
@@ -29,11 +29,12 @@ module GraphQL
         @time_precision = value
       end
 
-      # @param value [DateTime]
+      # @param value [Date,DateTime,String]
       # @return [String]
       def self.coerce_result(value, _ctx)
-        value.iso8601(time_precision)
-      rescue ArgumentError
+        value = value.iso8601(time_precision) if value.class == DateTime
+        DateTime.parse(value.to_s).iso8601(time_precision)
+      rescue ArgumentError => e
         raise GraphQL::Error, "An incompatible object (#{value.class}) was given to #{self}. Make sure that only DateTimes are used with this type."
       end
 

--- a/spec/graphql/types/iso_8601_date_spec.rb
+++ b/spec/graphql/types/iso_8601_date_spec.rb
@@ -15,9 +15,36 @@ describe GraphQL::Types::ISO8601Date do
         argument :date, GraphQL::Types::ISO8601Date, required: true
       end
 
+      field :parse_date_time, DateObject, null: true do
+        argument :date, GraphQL::Types::ISO8601Date, required: true
+      end
+
+      field :parse_date_string, DateObject, null: true do
+        argument :date, GraphQL::Types::ISO8601Date, required: true
+      end
+
+      field :parse_date_time_string, DateObject, null: true do
+        argument :date, GraphQL::Types::ISO8601Date, required: true
+      end
+
       def parse_date(date:)
-        # Date is parsed by the scalar, so it's already a DateTime
-        date
+        # Resolve a Date object
+        Date.parse(date.iso8601)
+      end
+
+      def parse_date_time(date:)
+        # Resolve a DateTime object
+        DateTime.parse(date.iso8601)
+      end
+
+      def parse_date_string(date:)
+        # Resolve a Date string
+        Date.parse(date.iso8601).iso8601
+      end
+
+      def parse_date_time_string(date:)
+        # Resolve a DateTime string
+        DateTime.parse(date.iso8601).iso8601
       end
     end
 
@@ -68,18 +95,41 @@ describe GraphQL::Types::ISO8601Date do
   end
 
   describe "as an output" do
-    it "returns a string" do
-      query_str = <<-GRAPHQL
+    let(:date_str) { "2010-02-02" }
+    let(:query_str) do
+      <<-GRAPHQL
       query($date: ISO8601Date!){
         parseDate(date: $date) {
           iso8601
         }
+        parseDateTime(date: $date) {
+          iso8601
+        }
+        parseDateString(date: $date) {
+          iso8601
+        }
+        parseDateTimeString(date: $date) {
+          iso8601
+        }
       }
       GRAPHQL
-
-      date_str = "2010-02-02"
-      full_res = DateTest::Schema.execute(query_str, variables: { date: date_str })
+    end
+    let(:full_res) { DateTest::Schema.execute(query_str, variables: { date: date_str }) }
+    
+    it 'serializes a Date object as an ISO8601 Date string' do
       assert_equal date_str, full_res["data"]["parseDate"]["iso8601"]
+    end
+
+    it 'serializes a DateTime object as an ISO8601 Date string' do
+      assert_equal date_str, full_res["data"]["parseDateTime"]["iso8601"]
+    end
+
+    it 'serializes a Date string as an ISO8601 Date string' do
+      assert_equal date_str, full_res["data"]["parseDateString"]["iso8601"]
+    end
+
+    it 'serializes a DateTime string as an ISO8601 Date string' do
+      assert_equal date_str, full_res["data"]["parseDateTimeString"]["iso8601"]
     end
   end
 

--- a/spec/graphql/types/iso_8601_date_time_spec.rb
+++ b/spec/graphql/types/iso_8601_date_time_spec.rb
@@ -189,7 +189,7 @@ describe GraphQL::Types::ISO8601DateTime do
         err = assert_raises(GraphQL::Error) do
           DateTimeTest::Schema.execute(query_str)
         end
-        assert_equal err.message, "An incompatible object (String) was given to GraphQL::Types::ISO8601DateTime. Make sure that only Dates, DateTimes, and well-formatted Strings are used with this type."
+        assert_equal err.message, "An incompatible object (String) was given to GraphQL::Types::ISO8601DateTime. Make sure that only Dates, DateTimes, and well-formatted Strings are used with this type. (invalid date)"
       end
     end
   end

--- a/spec/graphql/types/iso_8601_date_time_spec.rb
+++ b/spec/graphql/types/iso_8601_date_time_spec.rb
@@ -189,7 +189,7 @@ describe GraphQL::Types::ISO8601DateTime do
         err = assert_raises(GraphQL::Error) do
           DateTimeTest::Schema.execute(query_str)
         end
-        assert_equal err.message, "An incompatible object (String) was given to GraphQL::Types::ISO8601DateTime. Make sure that only DateTimes are used with this type."
+        assert_equal err.message, "An incompatible object (String) was given to GraphQL::Types::ISO8601DateTime. Make sure that only Dates, DateTimes, and well-formatted Strings are used with this type."
       end
     end
   end


### PR DESCRIPTION
## Motivation
It can be easy to unintentionally resolve a Date object for a DateTime scalar field and vice versa. The intent of this PR is to make `ISO8601Date` and `ISO8601DateTime` more flexible, by allowing them to be resolved with either a `Date` object, a `DateTime` object, or a well-formatted string.

## Changes
- Updates `ISO8601Date.coerce_result` to parse the resolved value and coerce to a `Date` object
- Updates `ISO8601DateTime.coerce_result` to parse the resolved value and coerce to a `DateTime` object while retaining precision if the resolved value is already a `DateTime` object
- Updates the exception text for `ISO8601DateTime` to reflect the extended input options
- Adds test cases for all combinations of scalars + resolve options

## Alternative approach
- Each `coerce_result` could perform explicit logic for each potential type of resolved value, but this would lead to more verbose code (i.e. if `Date`, if `DateTime`, if `String`)