### PR TITLE
Improve error message for failed list result

### DIFF
--- a/lib/graphql/execution/interpreter.rb
+++ b/lib/graphql/execution/interpreter.rb
@@ -92,6 +92,19 @@ module GraphQL
           Interpreter::Resolve.resolve_all(final_values)
         end
       end
+
+      class ListResultFailedError < GraphQL::Error
+        def initialize(value:, path:, field:)
+          message = "Failed to build a GraphQL list result for field `#{field.path}` at path `#{path.join(".")}`.\n".dup
+
+          message << "Expected `#{value.inspect}` to implement `.each` to satisfy the GraphQL return type `#{field.type.to_type_signature}`.\n"
+
+          if field.connection?
+            message << "\nThis field was treated as a Relay-style connection; add `connection: false` to the `field(...)` to disable this behavior."
+          end
+          super(message)
+        end
+      end
     end
   end
 end

--- a/spec/graphql/pagination/array_connection_spec.rb
+++ b/spec/graphql/pagination/array_connection_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 
 describe GraphQL::Pagination::ArrayConnection do
-  ITEMS = ConnectionAssertions::NAMES.map { |n| { name: n } }
+  ARRAY_ITEMS = ConnectionAssertions::NAMES.map { |n| { name: n } }
 
   class ArrayConnectionWithTotalCount < GraphQL::Pagination::ArrayConnection
     def total_count
@@ -14,7 +14,7 @@ describe GraphQL::Pagination::ArrayConnection do
     ConnectionAssertions.build_schema(
       connection_class: GraphQL::Pagination::ArrayConnection,
       total_count_connection_class: ArrayConnectionWithTotalCount,
-      get_items: -> { ITEMS }
+      get_items: -> { ARRAY_ITEMS }
     )
   }
 

--- a/spec/graphql/pagination/connections_spec.rb
+++ b/spec/graphql/pagination/connections_spec.rb
@@ -54,4 +54,36 @@ describe GraphQL::Pagination::Connections do
       schema.connections.wrap(field_defn, Set.new([1,2,3]), {}, nil, wrappers: {})
     end
   end
+
+  # Simulate a schema with a `*Connection` type that _isn't_
+  # supposed to be a connection. Help debug, see https://github.com/rmosolgo/graphql-ruby/issues/2588
+  class ConnectionErrorTestSchema < GraphQL::Schema
+    use GraphQL::Execution::Interpreter
+    use GraphQL::Analysis::AST
+    use GraphQL::Pagination::Connections
+
+    class ThingConnection < GraphQL::Schema::Object
+      field :name, String, null: false
+    end
+
+    class Query < GraphQL::Schema::Object
+      field :things, [ThingConnection], null: false
+
+      def things
+        [{name: "thing1"}, {name: "thing2"}]
+      end
+    end
+
+    query(Query)
+  end
+
+  it "raises a helpful error when it fails to implement a connection" do
+    err = assert_raises GraphQL::Execution::Interpreter::ListResultFailedError do
+      pp ConnectionErrorTestSchema.execute("{ things { name } }")
+    end
+
+    assert_includes err.message, "Failed to build a GraphQL list result for field `Query.things` at path `things`."
+    assert_includes err.message, "to implement `.each` to satisfy the GraphQL return type `[ThingConnection!]!`"
+    assert_includes err.message, "This field was treated as a Relay-style connection; add `connection: false` to the `field(...)` to disable this behavior."
+  end
 end


### PR DESCRIPTION
Improve the error message when the returned value doesn't satisfy GraphQL's expectation. 

Fixes #2588 

new message:

```
Failed to build a GraphQL list result for field `Query.things` at path `things`.
Expected `#<GraphQL::Pagination::ArrayConnection:0x00007fe77f3d2020 @items=[{:name=>"thing1"}, {:name=>"thing2"}], @context=#<Query::Context ...>, @first_value=nil, @after_value=nil, @last_value=nil, @before_value=nil, @has_max_page_size_override=true, @max_page_size=nil>` to implement `.each` to satisfy the GraphQL return type `[ThingConnection!]!`.

This field was treated as a Relay-style connection; add `connection: false` to the `field(...)` to disable this behavior.
```