### PR TITLE
Add Query#fingerprint for grouping queries in logs

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -3,6 +3,7 @@ require "graphql/query/arguments"
 require "graphql/query/arguments_cache"
 require "graphql/query/context"
 require "graphql/query/executor"
+require "graphql/query/fingerprint"
 require "graphql/query/literal_input"
 require "graphql/query/null_context"
 require "graphql/query/result"
@@ -263,6 +264,21 @@ module GraphQL
       with_prepared_ast {
         GraphQL::Language::SanitizedPrinter.new(self).sanitized_query_string
       }
+    end
+
+    # @return [String] An opaque hash identifying this query-variables combination
+    def fingerprint
+      @fingerprint ||= "#{query_fingerprint}/#{variables_fingerprint}"
+    end
+
+    # @return [String] An opaque hash for identifying this query's given query string
+    def query_fingerprint
+      @query_hash ||= Fingerprint.generate(query_string)
+    end
+
+    # @return [String] An opaque hash for identifying this query's given a variable values (not including defaults)
+    def variables_fingerprint
+      @variables_hash ||= Fingerprint.generate(provided_variables.to_json)
     end
 
     def validation_pipeline

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -107,7 +107,7 @@ module GraphQL
       if variables.is_a?(String)
         raise ArgumentError, "Query variables should be a Hash, not a String. Try JSON.parse to prepare variables."
       else
-        @provided_variables = variables
+        @provided_variables = variables || {}
       end
 
       @query_string = query_string || query
@@ -266,19 +266,30 @@ module GraphQL
       }
     end
 
-    # @return [String] An opaque hash identifying this query-variables combination
+    # This contains a few components:
+    #
+    # - The selected operation name (or `anonymous`)
+    # - The fingerprint of the query string
+    # - The number of given variables (for readability)
+    # - The fingerprint of the given variables
+    #
+    # This fingerprint can be used to track runs of the same operation-variables combination over time.
+    #
+    # @see operation_fingerprint
+    # @see variables_fingerprint
+    # @return [String] An opaque hash identifying this operation-variables combination
     def fingerprint
-      @fingerprint ||= "#{query_fingerprint}/#{variables_fingerprint}"
+      @fingerprint ||= "#{operation_fingerprint}/#{variables_fingerprint}"
     end
 
-    # @return [String] An opaque hash for identifying this query's given query string
-    def query_fingerprint
-      @query_hash ||= Fingerprint.generate(query_string)
+    # @return [String] An opaque hash for identifying this query's given query string and selected operation
+    def operation_fingerprint
+      @operation_fingerprint ||= "#{selected_operation_name || "anonymous"}/#{Fingerprint.generate(query_string)}"
     end
 
     # @return [String] An opaque hash for identifying this query's given a variable values (not including defaults)
     def variables_fingerprint
-      @variables_hash ||= Fingerprint.generate(provided_variables.to_json)
+      @variables_fingerprint ||= "#{provided_variables.size}/#{Fingerprint.generate(provided_variables.to_json)}"
     end
 
     def validation_pipeline

--- a/lib/graphql/query/fingerprint.rb
+++ b/lib/graphql/query/fingerprint.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module GraphQL
+  class Query
+    # @api private
+    # @see Query#query_fingerprint
+    # @see Query#variables_fingerprint
+    # @see Query#fingerprint
+    module Fingerprint
+      # Make an obfuscated hash of the given string (either a query string or variables JSON)
+      # @param string [String]
+      # @return [String] A normalized, opaque hash
+      def self.generate(input_str)
+        # Implemented to be:
+        # - Short (and uniform) length
+        # - Stable
+        # - Irreversibly Opaque (don't want to leak variable values)
+        # - URL-friendly
+        bytes = Digest::SHA256.digest(input_str)
+        Base64.urlsafe_encode64(bytes)
+      end
+    end
+  end
+end

--- a/spec/graphql/query/fingerprint_spec.rb
+++ b/spec/graphql/query/fingerprint_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::Query::Fingerprint do
+  def build_query(str, var)
+    GraphQL::Query.new(Dummy::Schema, str, variables: var)
+  end
+
+  it "makes stable variable fingerprints" do
+    var1a = { "a" => 1, "b" => 2 }
+    var1b = { "a" => 1, "b" => 2 }
+    # These keys are in a different order -- they'll be hashed differently.
+    var2  = { "b" => 2, "a" => 1 }
+
+    str = "{ __typename }"
+    expected_fingerprint = "QyWM_3g_5wNtikMDP4MK38YOwDc4JHNUisdCuIgpJ3c="
+    assert_equal expected_fingerprint, build_query(str, var1a).variables_fingerprint
+    assert_equal expected_fingerprint, build_query(str, var1b).variables_fingerprint
+    other_expected_fingerprint = "P7dUUyJccyp2t4meoglt2hRVGJyJgXI5cyGC9z_loJ8="
+    assert_equal other_expected_fingerprint, build_query(str, var2).variables_fingerprint
+  end
+
+  it "makes stable query fingerprints" do
+    str1a = "{ __typename }"
+    str1b = "{ __typename }"
+    # Different whitespace is a different query
+    str2  = "{\n  __typename\n}\n"
+    expected_fingerprint = "f1bmfdIas_MNH_i3vtCIk_Cg24ZEmDYYmzYd0eVt20s="
+    assert_equal expected_fingerprint, build_query(str1a, {}).query_fingerprint
+    assert_equal expected_fingerprint, build_query(str1b, {}).query_fingerprint
+    other_expected_fingerprint = "jY9zZenob6jjMT_K8hMbgB6v6VSd4iNzCJzydRGFizk="
+    assert_equal other_expected_fingerprint, build_query(str2, {}).query_fingerprint
+  end
+
+  it "makes combined fingerprints" do
+    str1a = "{ __typename }"
+    str1b = "{ __typename }"
+    str1_fingerprint = "f1bmfdIas_MNH_i3vtCIk_Cg24ZEmDYYmzYd0eVt20s="
+
+    # Different whitespace is a different query
+    str2  = "{\n  __typename\n}\n"
+    str2_fingerprint = "jY9zZenob6jjMT_K8hMbgB6v6VSd4iNzCJzydRGFizk="
+
+    var1a = { "a" => 1, "b" => 2 }
+    var1b = { "a" => 1, "b" => 2 }
+    var1_fingerprint = "QyWM_3g_5wNtikMDP4MK38YOwDc4JHNUisdCuIgpJ3c="
+
+    # These keys are in a different order -- they'll be hashed differently.
+    var2  = { "b" => 2, "a" => 1 }
+    var2_fingerprint = "P7dUUyJccyp2t4meoglt2hRVGJyJgXI5cyGC9z_loJ8="
+
+    assert_equal "#{str1_fingerprint}/#{var1_fingerprint}", build_query(str1a, var1a).fingerprint
+    assert_equal "#{str1_fingerprint}/#{var1_fingerprint}", build_query(str1b, var1b).fingerprint
+    assert_equal "#{str2_fingerprint}/#{var2_fingerprint}", build_query(str2, var2).fingerprint
+    assert_equal "#{str1_fingerprint}/#{var2_fingerprint}", build_query(str1a, var2).fingerprint
+    assert_equal "#{str2_fingerprint}/#{var1_fingerprint}", build_query(str2, var1b).fingerprint
+  end
+end

--- a/spec/graphql/query/fingerprint_spec.rb
+++ b/spec/graphql/query/fingerprint_spec.rb
@@ -13,23 +13,31 @@ describe GraphQL::Query::Fingerprint do
     var2  = { "b" => 2, "a" => 1 }
 
     str = "{ __typename }"
-    expected_fingerprint = "QyWM_3g_5wNtikMDP4MK38YOwDc4JHNUisdCuIgpJ3c="
+    expected_fingerprint = "2/QyWM_3g_5wNtikMDP4MK38YOwDc4JHNUisdCuIgpJ3c="
     assert_equal expected_fingerprint, build_query(str, var1a).variables_fingerprint
     assert_equal expected_fingerprint, build_query(str, var1b).variables_fingerprint
-    other_expected_fingerprint = "P7dUUyJccyp2t4meoglt2hRVGJyJgXI5cyGC9z_loJ8="
+    other_expected_fingerprint = "2/P7dUUyJccyp2t4meoglt2hRVGJyJgXI5cyGC9z_loJ8="
     assert_equal other_expected_fingerprint, build_query(str, var2).variables_fingerprint
+
+    # `nil` is treated like {}
+    empty_fingerprint = "0/RBNvo1WzZ4oRRq0W9-hknpT7T8If536DEMBg9hyq_4o="
+    assert_equal empty_fingerprint, build_query(str, nil).variables_fingerprint
+    assert_equal empty_fingerprint, build_query(str, {}).variables_fingerprint
   end
 
   it "makes stable query fingerprints" do
     str1a = "{ __typename }"
     str1b = "{ __typename }"
     # Different whitespace is a different query
-    str2  = "{\n  __typename\n}\n"
-    expected_fingerprint = "f1bmfdIas_MNH_i3vtCIk_Cg24ZEmDYYmzYd0eVt20s="
-    assert_equal expected_fingerprint, build_query(str1a, {}).query_fingerprint
-    assert_equal expected_fingerprint, build_query(str1b, {}).query_fingerprint
-    other_expected_fingerprint = "jY9zZenob6jjMT_K8hMbgB6v6VSd4iNzCJzydRGFizk="
-    assert_equal other_expected_fingerprint, build_query(str2, {}).query_fingerprint
+    str2 = "{\n  __typename\n}\n"
+    str3 = "query GetTypename { __typename }"
+    expected_fingerprint = "anonymous/f1bmfdIas_MNH_i3vtCIk_Cg24ZEmDYYmzYd0eVt20s="
+    assert_equal expected_fingerprint, build_query(str1a, {}).operation_fingerprint
+    assert_equal expected_fingerprint, build_query(str1b, {}).operation_fingerprint
+    other_expected_fingerprint = "anonymous/jY9zZenob6jjMT_K8hMbgB6v6VSd4iNzCJzydRGFizk="
+    assert_equal other_expected_fingerprint, build_query(str2, {}).operation_fingerprint
+    op_name_expected_fingerprint = "GetTypename/eKSJYYymUg0JV-FrtUF5idy4Ydt1IE4lZoHzxtzWog0="
+    assert_equal op_name_expected_fingerprint, build_query(str3, {}).operation_fingerprint
   end
 
   it "makes combined fingerprints" do
@@ -37,9 +45,8 @@ describe GraphQL::Query::Fingerprint do
     str1b = "{ __typename }"
     str1_fingerprint = "f1bmfdIas_MNH_i3vtCIk_Cg24ZEmDYYmzYd0eVt20s="
 
-    # Different whitespace is a different query
-    str2  = "{\n  __typename\n}\n"
-    str2_fingerprint = "jY9zZenob6jjMT_K8hMbgB6v6VSd4iNzCJzydRGFizk="
+    str2 = "query getTypename {\n  __typename\n}\n"
+    str2_fingerprint = "PZ4sJYI9Dkw_SxWdh_VdxKEuktK_nIoSvev_0QrEHL8="
 
     var1a = { "a" => 1, "b" => 2 }
     var1b = { "a" => 1, "b" => 2 }
@@ -49,10 +56,15 @@ describe GraphQL::Query::Fingerprint do
     var2  = { "b" => 2, "a" => 1 }
     var2_fingerprint = "P7dUUyJccyp2t4meoglt2hRVGJyJgXI5cyGC9z_loJ8="
 
-    assert_equal "#{str1_fingerprint}/#{var1_fingerprint}", build_query(str1a, var1a).fingerprint
-    assert_equal "#{str1_fingerprint}/#{var1_fingerprint}", build_query(str1b, var1b).fingerprint
-    assert_equal "#{str2_fingerprint}/#{var2_fingerprint}", build_query(str2, var2).fingerprint
-    assert_equal "#{str1_fingerprint}/#{var2_fingerprint}", build_query(str1a, var2).fingerprint
-    assert_equal "#{str2_fingerprint}/#{var1_fingerprint}", build_query(str2, var1b).fingerprint
+    nil_var_fingerprint = "RBNvo1WzZ4oRRq0W9-hknpT7T8If536DEMBg9hyq_4o="
+
+    assert_equal "anonymous/#{str1_fingerprint}/2/#{var1_fingerprint}", build_query(str1a, var1a).fingerprint
+    assert_equal "anonymous/#{str1_fingerprint}/2/#{var1_fingerprint}", build_query(str1b, var1b).fingerprint
+    assert_equal "getTypename/#{str2_fingerprint}/0/#{nil_var_fingerprint}", build_query(str2, nil).fingerprint
+    assert_equal "anonymous/#{str1_fingerprint}/2/#{var2_fingerprint}", build_query(str1a, var2).fingerprint
+    assert_equal "getTypename/#{str2_fingerprint}/2/#{var1_fingerprint}", build_query(str2, var1b).fingerprint
+
+    example_query = build_query(str2, var1b)
+    assert_equal example_query.fingerprint, "#{example_query.operation_fingerprint}/#{example_query.variables_fingerprint}"
   end
 end


### PR DESCRIPTION
We use something like this at GitHub to connect query runs over time. You can use these identifiers to trace query performance over the long run.

__TODO:__

- Make the string a bit more human-friendly:
  - [x] Add selected operation name and/or number of root selections to query hash 
  - [x] Add number of variables to var hash 

cc @swalkinshaw I'd love to know, do y'all at shopify have something like this? (Any advice in this area?)