### PR TITLE
Change `eql?` to `==`

### DIFF
--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -39,11 +39,11 @@ module GraphQL
 
         # Value equality
         # @return [Boolean] True if `self` is equivalent to `other`
-        def eql?(other)
+        def ==(other)
           return true if equal?(other)
-          other.is_a?(self.class) &&
-            other.scalars.eql?(self.scalars) &&
-            other.children.eql?(self.children)
+          other.kind_of?(self.class) &&
+            other.scalars == self.scalars &&
+            other.children == self.children
         end
 
         NO_CHILDREN = [].freeze

--- a/spec/graphql/language/equality_spec.rb
+++ b/spec/graphql/language/equality_spec.rb
@@ -30,8 +30,8 @@ describe GraphQL::Language::Nodes::AbstractNode do
       let(:query_string2) { query_string1 }
 
       it "should be equal" do
-        assert document1.eql?(document2)
-        assert document2.eql?(document1)
+        assert document1 == document2
+        assert document2 == document1
       end
     end
 
@@ -40,8 +40,8 @@ describe GraphQL::Language::Nodes::AbstractNode do
       let(:query_string2) { "mutation { setField }" }
 
       it "should not be equal" do
-        refute document1.eql?(document2)
-        refute document2.eql?(document1)
+        refute document1 == document2
+        refute document2 == document1
       end
     end
 
@@ -50,8 +50,8 @@ describe GraphQL::Language::Nodes::AbstractNode do
       let(:query_string2) { "query { bar }" }
 
       it "should not be equal" do
-        refute document1.eql?(document2)
-        refute document2.eql?(document1)
+        refute document1 == document2
+        refute document2 == document1
       end
     end
 


### PR DESCRIPTION
`eql?` is the hash equality operator. Objects which implement `eql?` must also implement a matching `hash`, otherwise using these objects as hash keys or calling uniq with them will behave unpredictably.

The implementation was also not a good match for `eql`'s hash semantics. It checked that scalars and children were equal, but not filename, line, or col.  Additionally, subclasses like `Field` and `FragmentDefinition` also had additional attributes which were not tested (EDIT: maybe this is wrong).

This commit changes `eql?` to `==` so that we have an easy way to do tree comparison (as needed for comparing children) but we don't mess up hashing semantics.