### PR TITLE
Update scalars.md

### DIFF
--- a/guides/type_definitions/scalars.md
+++ b/guides/type_definitions/scalars.md
@@ -31,7 +31,7 @@ field :top_score, Integer, null: false
 # Float field
 field :avg_points_per_game, Float, null: false
 # Boolean field
-field :is_top_ranked, Boolean, null: false
+field :is_top_ranked, GraphQL::Types::Boolean, null: false
 # ID field
 field :id, ID, null: false
 # ISO8601DateTime field


### PR DESCRIPTION
`Boolean` won't be found. Must be `GraphQL::Types::Boolean`. 

Another thing is: 

Defining a `GraphQL::Types::ISO8601Date` in a fields argument will raise `uninitialized constant GraphQL::Types::ISO8601Date::Date` same for `GraphQL::Types::ISO8601DateTime`.

Version `1.10.5`

Example:
```ruby
field :test, String, null: false do
  argument :foo, GraphQL::Types::ISO8601Date, required: true
end
```

Thanks and nice weekend :-)