### PR TITLE
Dispatch initial response in Ably handler

### DIFF
--- a/javascript_client/package.json
+++ b/javascript_client/package.json
@@ -30,5 +30,8 @@
     "graphql": "^14.3.1",
     "minimist": "^1.2.0",
     "typescript": "^3.7.5"
+  },
+  "prettier": {
+    "semi": false
   }
 }

--- a/javascript_client/src/subscriptions/__tests__/createAblyHandlerTest.ts
+++ b/javascript_client/src/subscriptions/__tests__/createAblyHandlerTest.ts
@@ -1,0 +1,156 @@
+import { createAblyHandler } from "../createAblyHandler"
+import { Realtime } from "ably"
+
+const dummyOperation = { text: "", name: "" }
+
+const channelTemplate = {
+  presence: {
+    enter() {},
+    enterClient() {},
+    leave() {}
+  },
+  subscribe: () => {},
+  unsubscribe: () => {}
+}
+
+const createDummyConsumer = (channel: any = channelTemplate): Realtime =>
+  (({
+    auth: { clientId: "foo" },
+    channels: {
+      get: () => channel
+    }
+  } as unknown) as Realtime)
+
+const nextTick = () => new Promise(resolve => setTimeout(resolve, 0))
+
+describe("createAblyHandler", () => {
+  it("returns a function producing a disposable subscription", async () => {
+    var wasDisposed = false
+
+    const producer = createAblyHandler({
+      fetchOperation: () =>
+        new Promise(resolve =>
+          resolve({ headers: new Map(), body: { data: { foo: "bar" } } })
+        ),
+      ably: createDummyConsumer({
+        ...channelTemplate,
+        unsubscribe: () => {
+          wasDisposed = true
+        }
+      })
+    })
+
+    const subscription = producer(
+      dummyOperation,
+      {},
+      {},
+      { onError: () => {}, onNext: () => {}, onCompleted: () => {} }
+    )
+
+    await nextTick()
+    subscription.dispose()
+    expect(wasDisposed).toEqual(true)
+  })
+
+  it("dispatches the immediate response in case of success", async () => {
+    let errorInvokedWith = undefined
+    let nextInvokedWith = undefined
+
+    const producer = createAblyHandler({
+      fetchOperation: () =>
+        new Promise(resolve =>
+          resolve({ headers: new Map(), body: { data: { foo: "bar" } } })
+        ),
+      ably: createDummyConsumer()
+    })
+
+    producer(
+      dummyOperation,
+      {},
+      {},
+      {
+        onError: (errors: any) => {
+          errorInvokedWith = errors
+        },
+        onNext: (response: any) => {
+          nextInvokedWith = response
+        },
+        onCompleted: () => {}
+      }
+    )
+
+    await nextTick()
+    expect(errorInvokedWith).toBeUndefined()
+    expect(nextInvokedWith).toEqual({ data: { foo: "bar" } })
+  })
+
+  it("dispatches the immediate response in case of error", async () => {
+    let errorInvokedWith = undefined
+    let nextInvokedWith = undefined
+
+    const dummyErrors = [{ message: "baz" }]
+
+    const producer = createAblyHandler({
+      fetchOperation: () =>
+        new Promise(resolve =>
+          resolve({
+            headers: new Map(),
+            body: { errors: dummyErrors }
+          })
+        ),
+      ably: createDummyConsumer()
+    })
+
+    producer(
+      dummyOperation,
+      {},
+      {},
+      {
+        onError: (errors: any) => {
+          errorInvokedWith = errors
+        },
+        onNext: () => {},
+        onCompleted: () => {}
+      }
+    )
+
+    await nextTick()
+    expect(errorInvokedWith).toEqual(dummyErrors)
+    expect(nextInvokedWith).toBeUndefined()
+  })
+
+  it("doesn't dispatch anything for an empty response", async () => {
+    let errorInvokedWith = undefined
+    let nextInvokedWith = undefined
+
+    const producer = createAblyHandler({
+      fetchOperation: () =>
+        new Promise(resolve =>
+          resolve({
+            headers: new Map(),
+            body: {}
+          })
+        ),
+      ably: createDummyConsumer()
+    })
+
+    producer(
+      dummyOperation,
+      {},
+      {},
+      {
+        onError: (errors: any) => {
+          errorInvokedWith = errors
+        },
+        onNext: (response: any) => {
+          nextInvokedWith = response
+        },
+        onCompleted: () => {}
+      }
+    )
+
+    await nextTick()
+    expect(errorInvokedWith).toBeUndefined()
+    expect(nextInvokedWith).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Hi Robert, as far as I can tell this is necessary for making the [initial response](https://github.com/rmosolgo/graphql-ruby/blob/master/guides/subscriptions/subscription_classes.md#adding-an-initial-response) work, or am I missing something?

This should probably also be done for ActionCable etc., but I'll leave that up to you.

There is a slight semantic change here in that a message with an empty (or otherwise malformed) payload would previously have triggered a call to `onNext({ data: undefined })` and now doesn't trigger one at all. This seems the most consistent and straightforward to me. Could do this a few different ways as well -- feel free to change.

Prettier made some formatting changes, and I've added a small bit of config to match your style. Feel free to undo/remove.

