### PR TITLE
Pass request errors to observer in Ably handler

### DIFF
--- a/javascript_client/src/subscriptions/__tests__/createAblyHandlerTest.ts
+++ b/javascript_client/src/subscriptions/__tests__/createAblyHandlerTest.ts
@@ -153,4 +153,35 @@ describe("createAblyHandler", () => {
     expect(errorInvokedWith).toBeUndefined()
     expect(nextInvokedWith).toBeUndefined()
   })
+
+  it("dispatches caught errors", async () => {
+    let errorInvokedWith = undefined
+    let nextInvokedWith = undefined
+
+    const error = new Error("blam")
+
+    const producer = createAblyHandler({
+      fetchOperation: () => new Promise((_resolve, reject) => reject(error)),
+      ably: createDummyConsumer()
+    })
+
+    producer(
+      dummyOperation,
+      {},
+      {},
+      {
+        onError: (errors: any) => {
+          errorInvokedWith = errors
+        },
+        onNext: (response: any) => {
+          nextInvokedWith = response
+        },
+        onCompleted: () => {}
+      }
+    )
+
+    await nextTick()
+    expect(errorInvokedWith).toBe(error)
+    expect(nextInvokedWith).toBeUndefined()
+  })
 })


### PR DESCRIPTION
Hi Robert, here is another one where any errors in the original request (such as a 500) weren't being passed on to the subscription error handler.
