### PR TITLE
Reprint all directives when schema is built from IDL

### DIFF
--- a/lib/graphql/schema/printer.rb
+++ b/lib/graphql/schema/printer.rb
@@ -94,20 +94,6 @@ module GraphQL
         print(node)
       end
 
-      def print_directive(directive)
-        if directive.name == "deprecated"
-          reason = directive.arguments.find { |arg| arg.name == "reason" }
-
-          if reason.value == GraphQL::Schema::Directive::DEFAULT_DEPRECATION_REASON
-            "@deprecated"
-          else
-            "@deprecated(reason: #{reason.value.to_s.inspect})"
-          end
-        else
-          super
-        end
-      end
-
       class IntrospectionPrinter < GraphQL::Language::Printer
         def print_schema_definition(schema)
           "schema {\n  query: Root\n}"

--- a/spec/graphql/schema/printer_spec.rb
+++ b/spec/graphql/schema/printer_spec.rb
@@ -853,4 +853,25 @@ SCHEMA
     str = GraphQL::Schema::Printer.print_schema TestPrintSchema
     assert_equal "schema {\n  query: OddlyNamedQuery\n}\n\ntype OddlyNamedQuery {\n  int: Int!\n}", str
   end
+
+  it "prints directives parsed from IDL" do
+    input = <<-GRAPHQL
+input I {
+  i1: Int @intDir(a: 1)
+}
+
+type Query @someDirective {
+  e(i: I): Thing
+  i: Int! @customDirective
+}
+
+enum Thing {
+  A @a(a: A)
+  B @b(b: {b: B})
+}
+    GRAPHQL
+
+    schema = GraphQL::Schema.from_definition(input)
+    assert_equal input.chomp, GraphQL::Schema::Printer.print_schema(schema)
+  end
 end


### PR DESCRIPTION
Now, any directive in an IDL-based schema is printed verbatim. 

This makes parse-then-dump work as expected, eg: 

```ruby 
GraphQL::Schema.from_definition(idl_string).to_definition
```