### PR TITLE
Inherit superclass interfaces to children in to_graphql

### DIFF
--- a/lib/graphql/schema/object.rb
+++ b/lib/graphql/schema/object.rb
@@ -162,7 +162,7 @@ module GraphQL
           obj_type = GraphQL::ObjectType.new
           obj_type.name = graphql_name
           obj_type.description = description
-          obj_type.structural_interface_type_memberships = own_interface_type_memberships
+          obj_type.structural_interface_type_memberships = interface_type_memberships
           obj_type.introspection = introspection
           obj_type.mutation = mutation
           obj_type.ast_node = ast_node

--- a/spec/graphql/schema/object_spec.rb
+++ b/spec/graphql/schema/object_spec.rb
@@ -265,6 +265,12 @@ describe GraphQL::Schema::Object do
       res = Jazz::Schema.execute(query_str)
       assert_equal ["BELA FLECK AND THE FLECKTONES", "ROBERT GLASPER EXPERIMENT"], res["data"]["ensembles"].map { |e| e["upcaseName"] }
     end
+
+    it "passes on type memberships from superclases" do
+      obj_type = Jazz::StylishMusician.to_graphql
+      parent_obj_type = Jazz::Musician.to_graphql
+      assert_equal parent_obj_type.interfaces, obj_type.interfaces
+    end
   end
 
 

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -306,6 +306,14 @@ module Jazz
     end
   end
 
+  class StylishMusician < Musician
+    field :sunglasses_type, String, null: false
+
+    def sunglasses_type
+      "cool"
+    end
+  end
+
   # Since this is not a legacy input type, this test can be removed
   class LegacyInputType < GraphQL::Schema::InputObject
     argument :int_value, Int, required: true

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -310,7 +310,7 @@ module Jazz
     field :sunglasses_type, String, null: false
 
     def sunglasses_type
-      "cool"
+      "cool 😎"
     end
   end
 


### PR DESCRIPTION
In the situation of:

```
module MyInterface
end

class MyClass
  include MyInterface
end

class MySubClass < MyClass
end
```

`MySubClass.to_graphql` was not correctly passing down its superclass interfaces. This because of a small bug in a recent PR in which the wrong method was used to pass down these interfaces:

https://github.com/rmosolgo/graphql-ruby/pull/2791/files#diff-bb60261811b3e1117b450eedea63f7fcR165

We used `own_interface_type_memberships` but previously we were using `interfaces` which also read from the superclass's interfaces.

cc @otereshin-shopify who found the bug

----- 

Fixes #2873 