### PR TITLE
Only rescue NoMethodErrors relating to the .each call

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -347,9 +347,14 @@ module GraphQL
                   end
                 end
               end
-            rescue NoMethodError
-              # This happens when the GraphQL schema doesn't match the implementation. Help the dev debug.
-              raise ListResultFailedError.new(value: value, field: field, path: path)
+            rescue NoMethodError => err
+              if err.name == :each && err.receiver == value
+                # This happens when the GraphQL schema doesn't match the implementation. Help the dev debug.
+                raise ListResultFailedError.new(value: value, field: field, path: path)
+              else
+                # This was some other NoMethodError -- let it bubble to reveal the real error.
+                raise
+              end
             end
 
             response_list

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -348,7 +348,8 @@ module GraphQL
                 end
               end
             rescue NoMethodError => err
-              if err.name == :each && err.receiver == value
+              # Ruby 2.2 doesn't have NoMethodError#receiver, can't check that one in this case. (It's been EOL since 2017.)
+              if err.name == :each && (err.respond_to?(:receiver) ? err.receiver == value : true)
                 # This happens when the GraphQL schema doesn't match the implementation. Help the dev debug.
                 raise ListResultFailedError.new(value: value, field: field, path: path)
               else


### PR DESCRIPTION
This `rescue` was catching _other_ NoMethodErrors, derp! 

Fixes https://github.com/rmosolgo/graphql-ruby/pull/2854#discussion_r409771169

cc @dewski -- thanks for reporting it!