### PR TITLE
Fix lazy loads: with list args

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -146,10 +146,10 @@ module GraphQL
       def after_any_lazies(maybe_lazies)
         if maybe_lazies.any? { |l| lazy?(l) }
           GraphQL::Execution::Lazy.all(maybe_lazies).then do |result|
-            yield
+            yield result
           end
         else
-          yield
+          yield maybe_lazies
         end
       end
     end

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -663,7 +663,7 @@ module GraphQL
               loaded_value = if loads && !arg_defn.from_resolver?
                 if arg_defn.type.list?
                   loaded_values = value.map { |val| load_application_object(arg_defn, loads, val, field_ctx.query.context) }
-                  maybe_lazies.concat(loaded_values)
+                  field_ctx.schema.after_any_lazies(loaded_values) { |result| result }
                 else
                   load_application_object(arg_defn, loads, value, field_ctx.query.context)
                 end

--- a/lib/graphql/schema/member/has_arguments.rb
+++ b/lib/graphql/schema/member/has_arguments.rb
@@ -91,7 +91,8 @@ module GraphQL
               loaded_value = nil
               if loads && !arg_defn.from_resolver?
                 loaded_value = if arg_defn.type.list?
-                  value.map { |val| load_application_object(arg_defn, loads, val, context) }
+                  loaded_values = value.map { |val| load_application_object(arg_defn, loads, val, context) }
+                  context.schema.after_any_lazies(loaded_values) { |result| result }
                 else
                   load_application_object(arg_defn, loads, value, context)
                 end

--- a/spec/graphql/schema/argument_spec.rb
+++ b/spec/graphql/schema/argument_spec.rb
@@ -20,6 +20,7 @@ describe GraphQL::Schema::Argument do
 
         argument :keys, [String], required: false, method_access: false
         argument :instrument_id, ID, required: false, loads: Jazz::InstrumentType
+        argument :instrument_ids, [ID], required: false, loads: Jazz::InstrumentType
 
         class Multiply
           def call(val, context)
@@ -61,7 +62,7 @@ describe GraphQL::Schema::Argument do
 
   describe "#keys" do
     it "is not overwritten by the 'keys' argument" do
-      expected_keys = ["aliasedArg", "arg", "argWithBlock", "explodingPreparedArg", "instrumentId", "keys", "preparedArg", "preparedByCallableArg", "preparedByProcArg", "requiredWithDefaultArg"]
+      expected_keys = ["aliasedArg", "arg", "argWithBlock", "explodingPreparedArg", "instrumentId", "instrumentIds", "keys", "preparedArg", "preparedByCallableArg", "preparedByProcArg", "requiredWithDefaultArg"]
       assert_equal expected_keys, SchemaArgumentTest::Query.fields["field"].arguments.keys.sort
     end
   end
@@ -200,6 +201,13 @@ describe GraphQL::Schema::Argument do
 
       res = SchemaArgumentTest::Schema.execute(query_str)
       assert_equal "{:instrument=>#{Jazz::Models::Instrument.new("Drum Kit", "PERCUSSION").inspect}, :required_with_default_arg=>1}", res["data"]["field"]
+
+      query_str2 = <<-GRAPHQL
+      query { field(instrumentIds: ["Instrument/Organ"]) }
+      GRAPHQL
+
+      res = SchemaArgumentTest::Schema.execute(query_str2)
+      assert_equal "{:instruments=>[#{Jazz::Models::Instrument.new("Organ", "KEYS").inspect}], :required_with_default_arg=>1}", res["data"]["field"]
     end
 
     it "returns nil when no ID is given and `required: false`" do


### PR DESCRIPTION
If `object_from_id` returns a lazy value, and a field has an auto-loaded list argument, the resolved list values are `GraphQL::Execution::Lazy` objects rather than the underlying application objects.