### PR TITLE
Fix loads: on nested input objects

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -175,6 +175,11 @@ module GraphQL
             end
 
             after_lazy(kwarg_arguments, owner: owner_type, field: field_defn, path: next_path, scoped_context: context.scoped_context, owner_object: object, arguments: kwarg_arguments) do |kwarg_arguments|
+              if kwarg_arguments.is_a? GraphQL::ExecutionError
+                continue_value(next_path, kwarg_arguments, field_defn, return_type.non_null?, ast_node)
+                next
+              end
+
               # It might turn out that making arguments for every field is slow.
               # If we have to cache them, we'll need a more subtle approach here.
               field_defn.extras.each do |extra|
@@ -432,7 +437,7 @@ module GraphQL
                   end
                 end
                 rescue GraphQL::ExecutionError, GraphQL::UnauthorizedError => err
-                  yield(err)
+                  err
               end
               after_lazy(inner_obj, owner: owner, field: field, path: path, scoped_context: context.scoped_context, owner_object: owner_object, arguments: arguments, eager: eager) do |really_inner_obj|
                 yield(really_inner_obj)

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -210,8 +210,10 @@ module GraphQL
 
           input_values = coerce_arguments(nil, value, ctx)
 
-          input_obj_instance = self.new(ruby_kwargs: input_values, context: ctx, defaults_used: nil)
-          input_obj_instance.prepare
+          ctx.schema.after_lazy(input_values) do |resolved_input_values|
+            input_obj_instance = self.new(ruby_kwargs: resolved_input_values, context: ctx, defaults_used: nil)
+            input_obj_instance.prepare
+          end
         end
 
         # It's funny to think of a _result_ of an input object.

--- a/lib/graphql/schema/member/has_arguments.rb
+++ b/lib/graphql/schema/member/has_arguments.rb
@@ -97,16 +97,16 @@ module GraphQL
                 end
               end
 
-              context.schema.after_lazy(loaded_value) do |loaded_value|
-                coerced_value = nil
+              coerced_value = if loaded_value
+                loaded_value
+              else
+                context.schema.error_handler.with_error_handling(context) do
+                  arg_defn.type.coerce_input(value, context)
+                end
+              end
+
+              context.schema.after_lazy(coerced_value) do |coerced_value|
                 prepared_value = context.schema.error_handler.with_error_handling(context) do
-
-                  coerced_value = if loaded_value
-                    loaded_value
-                  else
-                    arg_defn.type.coerce_input(value, context)
-                  end
-
                   arg_defn.prepare_value(parent_object, coerced_value, context: context)
                 end
 

--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -138,13 +138,14 @@ describe GraphQL::Schema::InputObject do
       class Schema < GraphQL::Schema
         query(Query)
         mutation(Mutation)
+        lazy_resolve(Proc, :call)
         if TESTING_INTERPRETER
           use GraphQL::Execution::Interpreter
           use GraphQL::Analysis::AST
         end
 
         def self.object_from_id(id, ctx)
-          Jazz::GloballyIdentifiableType.find(id)
+          -> { Jazz::GloballyIdentifiableType.find(id) }
         end
 
         def self.resolve_type(type, obj, ctx)


### PR DESCRIPTION
Fixes https://github.com/rmosolgo/graphql-ruby/issues/2671 (?)

Example adapted from the app I'm working on:

```rb
class MySchema < GraphQL::Schema
  def object_from_id(id)
    BatchLoader::GraphQL.for(id).batch { ... }
  end
end

class UpdateThingInput < BaseInputObject
  argument :id, ID, required: true, loads: Types::Thing, as: :thing

  ...
end

class UpdateThing < BaseMutation # < RelayClassicMutation
  input_type UpdateThingInput

  def resolve(thing:, **args)
    ...
  end
end
```

Without the fix from this PR, attempting to use that mutation results in:

```
NoMethodError:
  undefined method `key?' for #<GraphQL::Execution::Lazy:0x0000565081e580f8>
# /bundle/bundler/gems/graphql-ruby-8010c6243b95/lib/graphql/schema/input_object.rb:29:in `block in initialize'
# /bundle/bundler/gems/graphql-ruby-8010c6243b95/lib/graphql/schema/input_object.rb:25:in `each'
# /bundle/bundler/gems/graphql-ruby-8010c6243b95/lib/graphql/schema/input_object.rb:25:in `initialize'
# /bundle/bundler/gems/graphql-ruby-8010c6243b95/lib/graphql/schema/input_object.rb:213:in `new'
# /bundle/bundler/gems/graphql-ruby-8010c6243b95/lib/graphql/schema/input_object.rb:213:in `coerce_input'
# /bundle/bundler/gems/graphql-ruby-8010c6243b95/lib/graphql/schema/non_null.rb:54:in `coerce_input'
# /bundle/bundler/gems/graphql-ruby-8010c6243b95/lib/graphql/schema/member/has_arguments.rb:107:in `block (3 levels) in coerce_arguments'
...
```