### PR TITLE
Handle base64 argument errors in the encoder

### DIFF
--- a/lib/graphql/relay/base_connection.rb
+++ b/lib/graphql/relay/base_connection.rb
@@ -74,8 +74,6 @@ module GraphQL
 
       def decode(data)
         @encoder.decode(data, nonce: true)
-      rescue ArgumentError
-        raise GraphQL::ExecutionError, "Invalid cursor: #{data.inspect}"
       end
 
       # The value passed as `first:`, if there was one. Negative numbers become `0`.

--- a/lib/graphql/schema/base_64_encoder.rb
+++ b/lib/graphql/schema/base_64_encoder.rb
@@ -14,7 +14,7 @@ module GraphQL
         # urlsafe_decode64 is for forward compatibility
         Base64Bp.urlsafe_decode64(encoded_text)
       rescue ArgumentError
-        raise GraphQL::ExecutionError, "Invalid cursor: #{encoded_text.inspect}"
+        raise GraphQL::ExecutionError, "Invalid input: #{encoded_text.inspect}"
       end
     end
   end

--- a/lib/graphql/schema/base_64_encoder.rb
+++ b/lib/graphql/schema/base_64_encoder.rb
@@ -13,6 +13,8 @@ module GraphQL
       def self.decode(encoded_text, nonce: false)
         # urlsafe_decode64 is for forward compatibility
         Base64Bp.urlsafe_decode64(encoded_text)
+      rescue ArgumentError
+        raise GraphQL::ExecutionError, "Invalid cursor: #{encoded_text.inspect}"
       end
     end
   end

--- a/spec/graphql/schema/base_64_encoder_spec.rb
+++ b/spec/graphql/schema/base_64_encoder_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::Schema::Base64Encoder do
+  describe ".decode" do
+    it "decodes base64 encoded strings" do
+      string = "12345"
+      encoded_string = GraphQL::Schema::Base64Encoder.encode(string)
+      decoded_string = GraphQL::Schema::Base64Encoder.decode(encoded_string)
+
+      assert_equal(string, decoded_string)
+    end
+
+    it "raises an execution error when an invalid cursor is given" do
+      assert_raises(GraphQL::ExecutionError) do
+        GraphQL::Schema::Base64Encoder.decode("12345")
+      end
+    end
+  end
+end


### PR DESCRIPTION
The new pagination system crashes when it's using the default cursor encoder and receives an invalid cursor. This was already fixed in #1855 for the relay connections. I just moved the error handling introduced there to the encoder. Now it can be used by both connection types.

I would say that it probably also makes more sense to be there because the encoder is configurable and different encoders can throw different errors. Handling all possible errors in the connections could become messy.