### PR TITLE
Reduce stack depths of deeply nested blocks

### DIFF
--- a/lib/graphql/compatibility/execution_specification/specification_schema.rb
+++ b/lib/graphql/compatibility/execution_specification/specification_schema.rb
@@ -43,8 +43,8 @@ module GraphQL
             @storage = storage
           end
 
-          def each
-            @storage.each { |i| yield(i) }
+          def each(&block)
+            @storage.each(&block)
           end
         end
 

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -412,7 +412,7 @@ module GraphQL
         # @param eager [Boolean] Set to `true` for mutation root fields only
         # @param trace [Boolean] If `false`, don't wrap this with field tracing
         # @return [GraphQL::Execution::Lazy, Object] If loading `object` will be deferred, it's a wrapper over it.
-        def after_lazy(lazy_obj, owner:, field:, path:, scoped_context:, owner_object:, arguments:, eager: false, trace: true)
+        def after_lazy(lazy_obj, owner:, field:, path:, scoped_context:, owner_object:, arguments:, eager: false, trace: true, &block)
           @interpreter_context[:current_object] = owner_object
           @interpreter_context[:current_arguments] = arguments
           @interpreter_context[:current_path] = path
@@ -439,9 +439,7 @@ module GraphQL
                 rescue GraphQL::ExecutionError, GraphQL::UnauthorizedError => err
                   err
               end
-              after_lazy(inner_obj, owner: owner, field: field, path: path, scoped_context: context.scoped_context, owner_object: owner_object, arguments: arguments, eager: eager, trace: trace) do |really_inner_obj|
-                yield(really_inner_obj)
-              end
+              after_lazy(inner_obj, owner: owner, field: field, path: path, scoped_context: context.scoped_context, owner_object: owner_object, arguments: arguments, eager: eager, trace: trace, &block)
             end
 
             if eager

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -439,7 +439,7 @@ module GraphQL
                 rescue GraphQL::ExecutionError, GraphQL::UnauthorizedError => err
                   err
               end
-              after_lazy(inner_obj, owner: owner, field: field, path: path, scoped_context: context.scoped_context, owner_object: owner_object, arguments: arguments, eager: eager) do |really_inner_obj|
+              after_lazy(inner_obj, owner: owner, field: field, path: path, scoped_context: context.scoped_context, owner_object: owner_object, arguments: arguments, eager: eager, trace: trace) do |really_inner_obj|
                 yield(really_inner_obj)
               end
             end

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -374,11 +374,12 @@ module GraphQL
           end
         end
 
-        def resolve_with_directives(object, ast_node)
-          run_directive(object, ast_node, 0) { yield }
+        def resolve_with_directives(object, ast_node, &block)
+          return yield if ast_node.directives.empty?
+          run_directive(object, ast_node, 0, &block)
         end
 
-        def run_directive(object, ast_node, idx)
+        def run_directive(object, ast_node, idx, &block)
           dir_node = ast_node.directives[idx]
           if !dir_node
             yield
@@ -389,7 +390,7 @@ module GraphQL
             end
             dir_args = arguments(nil, dir_defn, dir_node)
             dir_defn.resolve(object, dir_args, context) do
-              run_directive(object, ast_node, idx + 1) { yield }
+              run_directive(object, ast_node, idx + 1, &block)
             end
           end
         end

--- a/lib/graphql/internal_representation/scope.rb
+++ b/lib/graphql/internal_representation/scope.rb
@@ -66,11 +66,11 @@ module GraphQL
       # Call the block for each type in `self`.
       # This uses the simplest possible expression of `self`,
       # so if this scope is defined by an abstract type, it gets yielded.
-      def each
+      def each(&block)
         if @abstract_type
           yield(@type)
         else
-          @types.each { |t| yield(t) }
+          @types.each(&block)
         end
       end
 

--- a/lib/graphql/internal_representation/visit.rb
+++ b/lib/graphql/internal_representation/visit.rb
@@ -23,11 +23,11 @@ module GraphQL
 
       # Traverse a node in a rewritten query tree,
       # visiting the node itself and each of its typed children.
-      def each_node(node)
+      def each_node(node, &block)
         yield(node)
         node.typed_children.each do |obj_type, children|
           children.each do |name, node|
-            each_node(node) { |n| yield(n) }
+            each_node(node, &block)
           end
         end
       end

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -101,14 +101,12 @@ module GraphQL
       # - Right away, if `value` is not registered with `lazy_resolve`
       # - After resolving `value`, if it's registered with `lazy_resolve` (eg, `Promise`)
       # @api private
-      def after_lazy(value)
+      def after_lazy(value, &block)
         if lazy?(value)
           GraphQL::Execution::Lazy.new do
             result = sync_lazy(value)
             # The returned result might also be lazy, so check it, too
-            after_lazy(result) do |final_result|
-              yield(final_result) if block_given?
-            end
+            after_lazy(result, &block)
           end
         else
           yield(value) if block_given?

--- a/lib/graphql/schema/object.rb
+++ b/lib/graphql/schema/object.rb
@@ -79,14 +79,14 @@ module GraphQL
                 raise "#{int} cannot be implemented since it's not a GraphQL Interface. Use `include` for plain Ruby modules."
               end
 
-              new_memberships << int.type_membership_class.new(int, self, options)
+              new_memberships << int.type_membership_class.new(int, self, **options)
 
               # Include the methods here,
               # `.fields` will use the inheritance chain
               # to find inherited fields
               include(int)
             elsif int.is_a?(GraphQL::InterfaceType)
-              new_memberships << int.type_membership_class.new(int, self, options)
+              new_memberships << int.type_membership_class.new(int, self, **options)
             elsif int.is_a?(String) || int.is_a?(GraphQL::Schema::LateBoundType)
               if options.any?
                 raise ArgumentError, "`implements(...)` doesn't support options with late-loaded types yet. Remove #{options} and open an issue to request this feature."

--- a/lib/graphql/tracing.rb
+++ b/lib/graphql/tracing.rb
@@ -63,8 +63,9 @@ module GraphQL
       # @param key [String] The name of the event in GraphQL internals
       # @param metadata [Hash] Event-related metadata (can be anything)
       # @return [Object] Must return the value of the block
-      def trace(key, metadata)
-        call_tracers(0, key, metadata) { yield }
+      def trace(key, metadata, &block)
+        return yield if @tracers.empty?
+        call_tracers(0, key, metadata, &block)
       end
 
       private
@@ -76,11 +77,11 @@ module GraphQL
       # @param key [String] The current event name
       # @param metadata [Object] The current event object
       # @return Whatever the block returns
-      def call_tracers(idx, key, metadata)
+      def call_tracers(idx, key, metadata, &block)
         if idx == @tracers.length
           yield
         else
-          @tracers[idx].trace(key, metadata) { call_tracers(idx + 1, key, metadata) { yield } }
+          @tracers[idx].trace(key, metadata) { call_tracers(idx + 1, key, metadata, &block) }
         end
       end
     end


### PR DESCRIPTION
graphql-ruby tends to end up with very large stacks of things happening recursively. This PR attempts to, wherever possible, avoid pushing extra stack frames from blocks.

Move of these changes follow the pattern of instead doing:
``` ruby
def each
  @array.each { |i| yield(i) }
```

We capture the block and pass it through.

``` ruby
def each(&block)
  @array.each(&block)
end
```

Which avoids re-visiting our `each` in the stack.