### PR TITLE
Fix deprecation on Schema.to_json parameters

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -870,8 +870,8 @@ module GraphQL
       # Returns the JSON response of {Introspection::INTROSPECTION_QUERY}.
       # @see {#as_json}
       # @return [String]
-      def to_json(*args)
-        JSON.pretty_generate(as_json(*args))
+      def to_json(**args)
+        JSON.pretty_generate(as_json(**args))
       end
 
       # Return the Hash response of {Introspection::INTROSPECTION_QUERY}.


### PR DESCRIPTION
In Ruby 2.7, `Schema.to_json` prints the following warning when called
with keyword arguments.

```
graphql-ruby/lib/graphql/schema.rb:874: warning: Using the last argument
as keyword parameters is deprecated; maybe ** should be added to the
call
```

I added `**` to args to fix the deprecation.