### PR TITLE
Improve the readability of add_type recursive method

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -1838,17 +1838,13 @@ module GraphQL
           um << owner
         end
 
-        if (prev_type = own_types[type.graphql_name])
-          if prev_type != type
-            raise DuplicateTypeNamesError.new(
-              type_name: type.graphql_name,
-              first_definition: prev_type,
-              second_definition: type,
-              path: path,
-            )
-          else
-            # This type was already added
-          end
+        if (prev_type = own_types[type.graphql_name]) != type
+          raise DuplicateTypeNamesError.new(
+            type_name: type.graphql_name,
+            first_definition: prev_type,
+            second_definition: type,
+            path: path,
+          )
         elsif type.is_a?(Class) && type < GraphQL::Schema::Directive
           type.arguments.each do |name, arg|
             arg_type = arg.type.unwrap


### PR DESCRIPTION
Improve duplicate type names checking a bit, this code block is quite long and many branches with if..else, it makes me to feel really hard
to read. Especially duplicate type name case, we didn't return and exit
in `else` branch of it, so I have to ready all remaining conditional to
understand, so I refactor it a bit by removing else branch and merge if
with check nil of prev_type. This kills two birds with one stone in
that:

1. We remove 1 if..else block
2. We improve the readability of flow a bit and don't need to question
what happen if the flow jump in `else` branch like me did.