### PR TITLE
Fix keyword parameters warning in Ruby 2.7

### DIFF
--- a/lib/graphql/object_type.rb
+++ b/lib/graphql/object_type.rb
@@ -88,7 +88,7 @@ module GraphQL
       interfaces.each do |iface|
         iface = BaseType.resolve_related_type(iface)
         if iface.is_a?(GraphQL::InterfaceType)
-          type_memberships << iface.type_membership_class.new(iface, self, options)
+          type_memberships << iface.type_membership_class.new(iface, self, **options)
         end
       end
     end


### PR DESCRIPTION
Fixes the following warning:
```
/Users/hasghari/github/graphql-ruby/lib/graphql/object_type.rb:91: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/hasghari/github/graphql-ruby/lib/graphql/schema/type_membership.rb:22: warning: The called method `initialize' is defined here
```