### PR TITLE
Disable method access when loading schema to prevent warnings

### DIFF
--- a/lib/graphql/schema/loader.rb
+++ b/lib/graphql/schema/loader.rb
@@ -171,6 +171,7 @@ module GraphQL
               type: type_resolver.call(arg["type"]),
               description: arg["description"],
               required: false,
+              method_access: false,
             }
 
             if arg["defaultValue"]

--- a/spec/graphql/schema/loader_spec.rb
+++ b/spec/graphql/schema/loader_spec.rb
@@ -336,7 +336,7 @@ describe GraphQL::Schema::Loader do
               ]
             }
           }
-        })
+        }).graphql_definition
       end
     end
 


### PR DESCRIPTION
When loading schemas, disable method name access to prevent any warnings
that occur when method names already exist.

Re-applies 3e75532 after cf70a75 reverted the change.

The existing spec has been updated to trigger the warning which is
emitted only when the GraphQL classes are built.

Fixes #2933