### PR TITLE
Remove global tracers support

### DIFF
--- a/lib/graphql/execution/multiplex.rb
+++ b/lib/graphql/execution/multiplex.rb
@@ -34,8 +34,7 @@ module GraphQL
         @schema = schema
         @queries = queries
         @context = context
-        # TODO remove support for global tracers
-        @tracers = schema.tracers + GraphQL::Tracing.tracers + (context[:tracers] || [])
+        @tracers = schema.tracers + (context[:tracers] || [])
         # Support `context: {backtrace: true}`
         if context[:backtrace] && !@tracers.include?(GraphQL::Backtrace::Tracer)
           @tracers << GraphQL::Backtrace::Tracer

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -96,8 +96,7 @@ module GraphQL
       @fragments = nil
       @operations = nil
       @validate = validate
-      # TODO: remove support for global tracers
-      @tracers = schema.tracers + GraphQL::Tracing.tracers + (context ? context.fetch(:tracers, []) : [])
+      @tracers = schema.tracers + (context ? context.fetch(:tracers, []) : [])
       # Support `ctx[:backtrace] = true` for wrapping backtraces
       if context && context[:backtrace] && !@tracers.include?(GraphQL::Backtrace::Tracer)
         @tracers << GraphQL::Backtrace::Tracer

--- a/lib/graphql/tracing.rb
+++ b/lib/graphql/tracing.rb
@@ -16,8 +16,6 @@ end
 module GraphQL
   # Library entry point for performance metric reporting.
   #
-  # __Warning:__ Installing/uninstalling tracers is not thread-safe. Do it during application boot only.
-  #
   # @example Sending custom events
   #   query.trace("my_custom_event", { ... }) do
   #     # do stuff ...
@@ -85,31 +83,6 @@ module GraphQL
         end
       end
     end
-
-    class << self
-      # Install a tracer to receive events.
-      # @param tracer [<#trace(key, metadata)>]
-      # @return [void]
-      # @deprecated See {Schema#tracer} or use `context: { tracers: [...] }`
-      def install(tracer)
-        warn("GraphQL::Tracing.install is deprecated, add it to the schema with `tracer(my_tracer)` instead.")
-        if !tracers.include?(tracer)
-          @tracers << tracer
-        end
-      end
-
-      # @deprecated See {Schema#tracer} or use `context: { tracers: [...] }`
-      def uninstall(tracer)
-        @tracers.delete(tracer)
-      end
-
-      # @deprecated See {Schema#tracer} or use `context: { tracers: [...] }`
-      def tracers
-        @tracers ||= []
-      end
-    end
-    # Initialize the array
-    tracers
 
     module NullTracer
       module_function


### PR DESCRIPTION
This has been deprecated since 1.7.4 (Oct 2017)