### PR TITLE
Use field name as defined for hash key or method name

### DIFF
--- a/lib/graphql/introspection/schema_type.rb
+++ b/lib/graphql/introspection/schema_type.rb
@@ -9,9 +9,9 @@ module GraphQL
                   "query, mutation, and subscription operations."
 
       field :types, [GraphQL::Schema::LateBoundType.new("__Type")], "A list of all types supported by this server.", null: false
-      field :queryType, GraphQL::Schema::LateBoundType.new("__Type"), "The type that query operations will be rooted at.", null: false
-      field :mutationType, GraphQL::Schema::LateBoundType.new("__Type"), "If this server supports mutation, the type that mutation operations will be rooted at.", null: true
-      field :subscriptionType, GraphQL::Schema::LateBoundType.new("__Type"), "If this server support subscription, the type that subscription operations will be rooted at.", null: true
+      field :query_type, GraphQL::Schema::LateBoundType.new("__Type"), "The type that query operations will be rooted at.", null: false
+      field :mutation_type, GraphQL::Schema::LateBoundType.new("__Type"), "If this server supports mutation, the type that mutation operations will be rooted at.", null: true
+      field :subscription_type, GraphQL::Schema::LateBoundType.new("__Type"), "If this server support subscription, the type that subscription operations will be rooted at.", null: true
       field :directives, [GraphQL::Schema::LateBoundType.new("__Directive")], "A list of all directives supported by this server.", null: false
 
       def types

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -237,8 +237,8 @@ module GraphQL
         end
 
         # TODO: I think non-string/symbol hash keys are wrongly normalized (eg `1` will not work)
-        method_name = method || hash_key || @underscored_name
-        resolver_method ||= @underscored_name.to_sym
+        method_name = method || hash_key || name_s
+        resolver_method ||= name_s.to_sym
 
         @method_str = method_name.to_s
         @method_sym = method_name.to_sym

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -170,7 +170,7 @@ describe GraphQL::Execution::Interpreter do
         end
       end
 
-      field :findMany, [Entity, null: true], null: false do
+      field :find_many, [Entity, null: true], null: false do
         argument :ids, [ID], required: true
       end
 

--- a/spec/integration/mongoid/star_trek/schema.rb
+++ b/spec/integration/mongoid/star_trek/schema.rb
@@ -148,8 +148,8 @@ module StarTrek
       all_bases
     end
 
-    field :basesClone, BaseType.connection_type, null: true
-    field :basesByName, BaseType.connection_type, null: true do
+    field :bases_clone, BaseType.connection_type, null: true
+    field :bases_by_name, BaseType.connection_type, null: true do
       argument :order, String, default_value: "name", required: false
     end
     def bases_by_name(order: nil)
@@ -174,7 +174,7 @@ module StarTrek
     field :basesWithDefaultMaxLimitArray, BaseType.connection_type, null: true, resolver_method: :all_bases_array
     field :basesWithLargeMaxLimitRelation, BaseType.connection_type, null: true, max_page_size: 1000, resolver_method: :all_bases
 
-    field :basesWithCustomEdge, CustomEdgeBaseConnectionType, null: true, connection: true
+    field :bases_with_custom_edge, CustomEdgeBaseConnectionType, null: true, connection: true
     def bases_with_custom_edge
       LazyNodesWrapper.new(object.bases)
     end
@@ -304,7 +304,7 @@ module StarTrek
       Base.find(3)
     end
 
-    field :newestBasesGroupedByFaction, BaseType.connection_type, null: true
+    field :newest_bases_grouped_by_faction, BaseType.connection_type, null: true
 
     def newest_bases_grouped_by_faction
       agg = Base.collection.aggregate([{
@@ -318,7 +318,7 @@ module StarTrek
         order_by(faction_id: -1)
     end
 
-    field :basesWithNullName, BaseType.connection_type, null: false
+    field :bases_with_null_name, BaseType.connection_type, null: false
 
     def bases_with_null_name
       [OpenStruct.new(id: nil)]
@@ -363,7 +363,7 @@ module StarTrek
       )
     end
 
-    field :batchedBase, BaseType, null: true do
+    field :batched_base, BaseType, null: true do
       argument :id, ID, required: true
     end
 

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -483,7 +483,7 @@ module Dummy
       GLOBAL_VALUES
     end
 
-    field :replaceValues, [Integer], "Replace the global array with new values", null: false do
+    field :replace_values, [Integer], "Replace the global array with new values", null: false do
       argument :input, ReplaceValuesInput, required: true
     end
 

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -404,7 +404,7 @@ module Jazz
     # For asserting that the object is initialized once:
     field :object_id, String, null: false
     field :inspect_context, [String], null: false
-    field :hashyEnsemble, Ensemble, null: false
+    field :hashy_ensemble, Ensemble, null: false
 
     field :echo_json, GraphQL::Types::JSON, null: false do
       argument :input, GraphQL::Types::JSON, required: true

--- a/spec/support/lazy_helpers.rb
+++ b/spec/support/lazy_helpers.rb
@@ -67,7 +67,7 @@ module LazyHelpers
       end
     end
 
-    field :nestedSum, LazySum, null: false do
+    field :nested_sum, LazySum, null: false do
       argument :value, Integer, required: true
     end
 
@@ -79,7 +79,7 @@ module LazyHelpers
       end
     end
 
-    field :nullableNestedSum, LazySum, null: true do
+    field :nullable_nested_sum, LazySum, null: true do
       argument :value, Integer, required: true
     end
     alias :nullable_nested_sum :nested_sum

--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -177,8 +177,8 @@ module StarWars
       all_bases
     end
 
-    field :basesClone, BaseConnection, null: true
-    field :basesByName, BaseConnection, null: true do
+    field :bases_clone, BaseConnection, null: true
+    field :bases_by_name, BaseConnection, null: true do
       argument :order, String, default_value: "name", required: false
     end
     def bases_by_name(order: nil)
@@ -204,7 +204,7 @@ module StarWars
     field :basesWithLargeMaxLimitRelation, BaseConnection, null: true, max_page_size: 1000, resolver_method: :all_bases
     field :basesWithoutNodes, BaseConnectionWithoutNodes, null: true, resolver_method: :all_bases_array
 
-    field :basesAsSequelDataset, BasesConnectionWithTotalCountType, null: true, connection: true, max_page_size: 1000 do
+    field :bases_as_sequel_dataset, BasesConnectionWithTotalCountType, null: true, connection: true, max_page_size: 1000 do
       argument :name_includes, String, required: false
     end
 
@@ -333,13 +333,13 @@ module StarWars
       StarWars::DATA["Faction"]["2"]
     end
 
-    field :largestBase, BaseType, null: true
+    field :largest_base, BaseType, null: true
 
     def largest_base
       Base.find(3)
     end
 
-    field :newestBasesGroupedByFaction, BaseConnection, null: true
+    field :newest_bases_grouped_by_faction, BaseConnection, null: true
 
     def newest_bases_grouped_by_faction
       Base
@@ -348,7 +348,7 @@ module StarWars
         .order('faction_id desc')
     end
 
-    field :basesWithNullName, BaseConnection, null: false
+    field :bases_with_null_name, BaseConnection, null: false
 
     def bases_with_null_name
       [OpenStruct.new(id: nil)]
@@ -393,7 +393,7 @@ module StarWars
       )
     end
 
-    field :batchedBase, BaseType, null: true do
+    field :batched_base, BaseType, null: true do
       argument :id, ID, required: true
     end
 


### PR DESCRIPTION
This is a bit of a breaking change. If a field is defined in camel case (`field :doStuff`), but the method is underscored (`def do_stuff`), then it will stop working. But altogether, I think defaulting to matching Ruby values is an improvement. 

Fixes #2906 