### PR TITLE
Fix underscored names in introspection loader

### DIFF
--- a/lib/graphql/schema/loader.rb
+++ b/lib/graphql/schema/loader.rb
@@ -157,6 +157,7 @@ module GraphQL
               type: type_resolver.call(field_hash["type"]),
               description: field_hash["description"],
               null: true,
+              camelize: false,
             ) do
               if field_hash["args"].any?
                 loader.build_arguments(self, field_hash["args"], type_resolver)
@@ -172,6 +173,7 @@ module GraphQL
               description: arg["description"],
               required: false,
               method_access: false,
+              camelize: false,
             }
 
             if arg["defaultValue"]

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -30,6 +30,20 @@ type HelloScalars {
       assert_schema_and_compare_output(schema.chop)
     end
 
+    it 'can build a schema with underscored names' do
+      schema = <<-SCHEMA
+type A_Type {
+  f(argument_1: Int, argument_two: Int): Int
+}
+
+type Query {
+  some_field: A_Type
+}
+      SCHEMA
+
+      assert_schema_and_compare_output(schema.chop)
+    end
+
     it 'can build a schema with default input object values' do
       schema = <<-SCHEMA
 input InputObject {

--- a/spec/graphql/schema/loader_spec.rb
+++ b/spec/graphql/schema/loader_spec.rb
@@ -191,7 +191,7 @@ describe GraphQL::Schema::Loader do
       end
     end
 
-    let(:loaded_schema) { GraphQL::Schema::Loader.load(schema_json) }
+    let(:loaded_schema) { GraphQL::Schema.from_introspection(schema_json) }
 
     it "returns the schema" do
       assert_instance_of Class, loaded_schema
@@ -274,6 +274,23 @@ describe GraphQL::Schema::Loader do
 
       assert type.arguments['sub'].default_value?
       assert type.arguments['sub'].default_value.nil?
+    end
+
+    it "works with underscored names" do
+      schema_sdl = <<-GRAPHQL.chomp
+type A_Type {
+  f(argument_1: Int, argument_two: Int): Int
+}
+
+type Query {
+  some_field: A_Type
+}
+      GRAPHQL
+
+      introspection_res = GraphQL::Schema.from_definition(schema_sdl).as_json
+      rebuilt_schema = GraphQL::Schema.from_introspection(introspection_res)
+
+      assert_equal schema_sdl, rebuilt_schema.to_definition
     end
 
     it "doesnt warn about method conflicts (because it doesn't make method accesses)" do


### PR DESCRIPTION
Oops, I refactored `Schema::Loader` to build class-based schemas, but I broke underscored fields that are loaded.

Fixes #2939
Fixes #2940