### PR TITLE
Fix unsubscribing and error handling for Ably

### DIFF
--- a/javascript_client/package.json
+++ b/javascript_client/package.json
@@ -32,6 +32,7 @@
     "typescript": "^3.7.5"
   },
   "prettier": {
-    "semi": false
+    "semi": false,
+    "trailingComma": "none"
   }
 }

--- a/javascript_client/src/subscriptions/__tests__/createAblyHandlerTest.ts
+++ b/javascript_client/src/subscriptions/__tests__/createAblyHandlerTest.ts
@@ -11,14 +11,19 @@ const channelTemplate = {
   },
   subscribe: () => {},
   unsubscribe: () => {},
-  on: () => {}
+  on: () => {},
+  detach: () => {}
 }
 
-const createDummyConsumer = (channel: any = channelTemplate): Realtime =>
+const createDummyConsumer = (
+  channel: any = channelTemplate,
+  release = (_channelName: string) => {}
+): Realtime =>
   (({
     auth: { clientId: "foo" },
     channels: {
-      get: () => channel
+      get: () => channel,
+      release
     }
   } as unknown) as Realtime)
 
@@ -26,19 +31,33 @@ const nextTick = () => new Promise(resolve => setTimeout(resolve, 0))
 
 describe("createAblyHandler", () => {
   it("returns a function producing a disposable subscription", async () => {
-    var wasDisposed = false
+    const subscriptionId = "dummy-subscription"
+    var wasUnsubscribed = false
+    var wasDetached = false
+    var releasedChannelName
 
     const producer = createAblyHandler({
       fetchOperation: () =>
         new Promise(resolve =>
-          resolve({ headers: new Map(), body: { data: { foo: "bar" } } })
+          resolve({
+            headers: new Map([["X-Subscription-ID", subscriptionId]]),
+            body: { data: { foo: "bar" } }
+          })
         ),
-      ably: createDummyConsumer({
-        ...channelTemplate,
-        unsubscribe: () => {
-          wasDisposed = true
+      ably: createDummyConsumer(
+        {
+          ...channelTemplate,
+          unsubscribe: () => {
+            wasUnsubscribed = true
+          },
+          detach: () => {
+            wasDetached = true
+          }
+        },
+        (channelName: string) => {
+          releasedChannelName = channelName
         }
-      })
+      )
     })
 
     const subscription = producer(
@@ -50,7 +69,9 @@ describe("createAblyHandler", () => {
 
     await nextTick()
     subscription.dispose()
-    expect(wasDisposed).toEqual(true)
+    expect(wasUnsubscribed).toEqual(true)
+    expect(wasDetached).toEqual(true)
+    expect(releasedChannelName).toEqual(subscriptionId)
   })
 
   it("dispatches the immediate response in case of success", async () => {
@@ -259,5 +280,52 @@ describe("createAblyHandler", () => {
         ably.close()
       }
     )
+
+    // For executing this test you need to provide a valid Ably API key in
+    // environment variable ABLY_KEY
+    testWithAblyKey("can make more than 200 subscriptions", async () => {
+      let caughtError = null
+      const ably = new Realtime({ key, log: { level: 0 } })
+      let subscriptionCounter = 0
+      const fetchOperation = async () => {
+        subscriptionCounter += 1
+        return {
+          headers: new Map([
+            ["X-Subscription-ID", `foo-${subscriptionCounter}`]
+          ])
+        }
+      }
+      const ablyHandler = createAblyHandler({ ably, fetchOperation })
+      const operation = {}
+      const variables = {}
+      const cacheConfig = {}
+      const onError = (error: Error) => {
+        caughtError = error
+      }
+      const onNext = () => {}
+      const onCompleted = () => {}
+      const observer = {
+        onError,
+        onNext,
+        onCompleted
+      }
+      for (let i = 0; i < 201; ++i) {
+        const { dispose } = ablyHandler(
+          operation,
+          variables,
+          cacheConfig,
+          observer
+        )
+        await new Promise(resolve => setTimeout(resolve, 0))
+
+        dispose()
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 500))
+
+      ably.close()
+
+      if (caughtError) throw caughtError
+    })
   })
 })

--- a/javascript_client/src/subscriptions/createAblyHandler.ts
+++ b/javascript_client/src/subscriptions/createAblyHandler.ts
@@ -14,6 +14,22 @@ interface ApolloObserver {
   onCompleted: Function
 }
 
+class AblyError {
+  constructor(reason: Types.ErrorInfo) {
+    const error = Error(reason.message)
+    const attributes: (keyof Types.ErrorInfo)[] = ["code", "statusCode"]
+    attributes.forEach(attr => {
+      Object.defineProperty(error, attr, {
+        get() {
+          return reason[attr]
+        }
+      })
+    })
+    Error.captureStackTrace(error, AblyError)
+    return error
+  }
+}
+
 function createAblyHandler(options: AblyHandlerOptions) {
   var ably = options.ably
   var fetchOperation = options.fetchOperation
@@ -41,6 +57,31 @@ function createAblyHandler(options: AblyHandlerOptions) {
         dispatchResult(response.body)
         channelName = response.headers.get("X-Subscription-ID")
         channel = ably.channels.get(channelName)
+        channel.on("failed", function(stateChange: Types.ChannelStateChange) {
+          observer.onError(
+            stateChange.reason
+              ? new AblyError(stateChange.reason)
+              : new Error("Ably channel changed to failed state")
+          )
+        })
+        channel.on("suspended", function(
+          stateChange: Types.ChannelStateChange
+        ) {
+          // Note: suspension can be a temporary condition and isn't necessarily
+          // an error, however we handle the case where the channel gets
+          // suspended before it is attached because that's the only way to
+          // propagate error 90010 (see https://help.ably.io/error/90010)
+          if (
+            stateChange.previous === "attaching" &&
+            stateChange.current === "suspended"
+          ) {
+            observer.onError(
+              stateChange.reason
+                ? new AblyError(stateChange.reason)
+                : new Error("Ably channel suspended before being attached")
+            )
+          }
+        })
         // Register presence, so that we can detect empty channels and clean them up server-side
         if (ably.auth.clientId) {
           channel.presence.enter("subscribed")

--- a/javascript_client/src/subscriptions/createAblyHandler.ts
+++ b/javascript_client/src/subscriptions/createAblyHandler.ts
@@ -14,6 +14,8 @@ interface ApolloObserver {
   onCompleted: Function
 }
 
+const anonymousClientId = "graphql-subscriber"
+
 class AblyError {
   constructor(reason: Types.ErrorInfo) {
     const error = Error(reason.message)
@@ -33,14 +35,19 @@ class AblyError {
 function createAblyHandler(options: AblyHandlerOptions) {
   var ably = options.ably
   var fetchOperation = options.fetchOperation
+
+  const isAnonymousClient = () =>
+    !ably.auth.clientId || ably.auth.clientId === "*"
+
   return function(
     operation: object,
     variables: object,
     cacheConfig: object,
     observer: ApolloObserver
   ) {
-    var channelName
+    var channelName: string
     var channel: Types.RealtimeChannelCallbacks
+
     // POST the subscription like a normal query
     fetchOperation(operation, variables, cacheConfig)
       .then(function(response: { headers: { get: Function }; body: any }) {
@@ -83,10 +90,10 @@ function createAblyHandler(options: AblyHandlerOptions) {
           }
         })
         // Register presence, so that we can detect empty channels and clean them up server-side
-        if (ably.auth.clientId) {
-          channel.presence.enter("subscribed")
+        if (isAnonymousClient()) {
+          channel.presence.enterClient(anonymousClientId, "subscribed")
         } else {
-          channel.presence.enterClient("graphql-subscriber", "subscribed")
+          channel.presence.enter("subscribed")
         }
         // When you get an update from ably, give it to Relay
         channel.subscribe("update", function(message) {
@@ -104,12 +111,14 @@ function createAblyHandler(options: AblyHandlerOptions) {
     return {
       dispose: function() {
         if (channel) {
-          if (ably.auth.clientId) {
-            channel.presence.leave()
+          if (isAnonymousClient()) {
+            channel.presence.leaveClient(anonymousClientId)
           } else {
-            channel.presence.leaveClient("graphql-subscriber")
+            channel.presence.leave()
           }
           channel.unsubscribe()
+          channel.detach()
+          ably.channels.release(channelName)
         }
       }
     }


### PR DESCRIPTION
Hi Robert,

We've noticed that Ably sometimes raises [error 90010](https://help.ably.io/error/90010). I've investigated and found two related issues:

1. Subscriptions don't get cleaned up properly, causing this error which, afaict, effectively means that only the first 200 subscriptions work as expected.
2. Errors raised by Ably don't get propagated to the observer meaning they might go unnoticed.

See the two commit messages for more details.

Assuming you agree with these changes, could I ask you to roll a release with this ASAP?
