### PR TITLE
Replace reverse.each with reverse_each

### DIFF
--- a/lib/graphql/execution/instrumentation.rb
+++ b/lib/graphql/execution/instrumentation.rb
@@ -77,7 +77,7 @@ module GraphQL
         end
 
         def call_after_hooks(instrumenters, object, after_hook_name, ex)
-          instrumenters.reverse.each do |instrumenter|
+          instrumenters.reverse_each do |instrumenter|
             begin
               instrumenter.public_send(after_hook_name, object)
             rescue => e


### PR DESCRIPTION
Small performance optimization on instrumentation.rb
Below are the benchmark results
```
ruby 2.6.5p114 (2019-10-01 revision 67812) [x86_64-darwin19]
MacBook Pro 2015, 16GB Ram, i7 2.8 GHz
```
Although the performance increase might not be that significant, we get a memory improvement by calling `reverse_each` since it saves us the allocation of the array that happens with `reverse`
 (https://github.com/rails/rails/pull/17244)
# Before
```
Warming up --------------------------------------
validate - introspection 
                        56.000  i/100ms
validate - abstract fragments
                       474.000  i/100ms
validate - abstract fragments 2
                       371.000  i/100ms
validate - big query     4.000  i/100ms
Calculating -------------------------------------
validate - introspection 
                        567.398  (± 2.6%) i/s -      2.856k in   5.037012s
validate - abstract fragments
                          4.691k (± 4.4%) i/s -     23.700k in   5.063705s
validate - abstract fragments 2
                          3.788k (± 4.2%) i/s -     18.921k in   5.003839s
validate - big query     58.028  (± 5.2%) i/s -    292.000  in   5.045840s
```

# After
```
Warming up --------------------------------------
validate - introspection 
                        51.000  i/100ms
validate - abstract fragments
                       445.000  i/100ms
validate - abstract fragments 2
                       389.000  i/100ms
validate - big query     6.000  i/100ms
Calculating -------------------------------------
validate - introspection 
                        564.867  (± 3.2%) i/s -      2.856k in   5.061669s
validate - abstract fragments
                          4.756k (± 5.5%) i/s -     24.030k in   5.071915s
validate - abstract fragments 2
                          4.020k (± 2.1%) i/s -     20.228k in   5.033696s
validate - big query     61.680  (± 3.2%) i/s -    312.000  in   5.064458s
```