### PR TITLE
Fix lazy loads: in lists of inputs

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -672,6 +672,8 @@ module GraphQL
                 else
                   load_application_object(arg_defn, loads, value, field_ctx.query.context)
                 end
+              elsif arg_defn.type.list? && value.is_a?(Array)
+                field_ctx.schema.after_any_lazies(value, &:itself)
               else
                 value
               end

--- a/lib/graphql/schema/list.rb
+++ b/lib/graphql/schema/list.rb
@@ -44,7 +44,8 @@ module GraphQL
         if value.nil?
           nil
         else
-          ensure_array(value).map { |item| item.nil? ? item : of_type.coerce_input(item, ctx) }
+          coerced = ensure_array(value).map { |item| item.nil? ? item : of_type.coerce_input(item, ctx) }
+          ctx.schema.after_any_lazies(coerced, &:itself)
         end
       end
 


### PR DESCRIPTION
If:

1. `object_from_id` returns a lazy value
2. An input object `A` has a `loads:` argument
3. An input object `B` has an argument of type `[A]`

Then in the resolver, `B`'s argument will be an array of `GraphQL::Execution::Lazy` objects rather than `A` objects.

This PR makes it so that lists of lazy input objects are properly synced before being passed to resolvers.