### PR TITLE
Show fields when they override inherited ones

### DIFF
--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -166,7 +166,13 @@ module GraphQL
       end
 
       def visible_field?(owner_type, field_defn)
-        visible?(field_defn) && visible_type?(field_defn.type.unwrap) && field_on_visible_interface?(field_defn, owner_type)
+        # This field is visible in its own right
+        visible?(field_defn) &&
+          # This field's return type is visible
+          visible_type?(field_defn.type.unwrap) &&
+          # This field is either defined on this object type,
+          # or the interface it's inherited from is also visible
+          ((field_defn.respond_to?(:owner) && field_defn.owner == owner_type) || field_on_visible_interface?(field_defn, owner_type))
       end
 
       # We need this to tell whether a field was inherited by an interface

--- a/spec/graphql/schema/introspection_system_spec.rb
+++ b/spec/graphql/schema/introspection_system_spec.rb
@@ -87,10 +87,13 @@ describe GraphQL::Schema::IntrospectionSystem do
       assert res["data"]["__type"]["fields"].any? { |i| i["name"] == "privateName" }
     end
 
-    it "includes fields that are defined locally on the object, even when the interface's implementation is private" do
-      context = { private: false }
-      res = Jazz::Schema.execute('{ __type(name: "Ensemble") { fields { name } } }', context: context)
-      assert res["data"]["__type"]["fields"].any? { |i| i["name"] == "overriddenName" }
+    if TESTING_INTERPRETER
+      # This behavior isn't possible in legacy runtime because there's no `field.owner` to detect own fields vs interface fields
+      it "includes fields that are defined locally on the object, even when the interface's implementation is private" do
+        context = { private: false }
+        res = Jazz::Schema.execute('{ __type(name: "Ensemble") { fields { name } } }', context: context)
+        assert res["data"]["__type"]["fields"].any? { |i| i["name"] == "overriddenName" }
+      end
     end
   end
 

--- a/spec/graphql/schema/introspection_system_spec.rb
+++ b/spec/graphql/schema/introspection_system_spec.rb
@@ -86,6 +86,12 @@ describe GraphQL::Schema::IntrospectionSystem do
       res = Jazz::Schema.execute('{ __type(name: "Ensemble") { fields { name } } }', context: context)
       assert res["data"]["__type"]["fields"].any? { |i| i["name"] == "privateName" }
     end
+
+    it "includes fields that are defined locally on the object, even when the interface's implementation is private" do
+      context = { private: false }
+      res = Jazz::Schema.execute('{ __type(name: "Ensemble") { fields { name } } }', context: context)
+      assert res["data"]["__type"]["fields"].any? { |i| i["name"] == "overriddenName" }
+    end
   end
 
   describe "copying the built-ins" do

--- a/spec/graphql/schema/object_spec.rb
+++ b/spec/graphql/schema/object_spec.rb
@@ -7,7 +7,7 @@ describe GraphQL::Schema::Object do
     it "tells type data" do
       assert_equal "Ensemble", object_class.graphql_name
       assert_equal "A group of musicians playing together", object_class.description
-      assert_equal 7, object_class.fields.size
+      assert_equal 8, object_class.fields.size
       assert_equal ["GloballyIdentifiable", "HasMusicians", "NamedEntity", "PrivateNameEntity"], object_class.interfaces.map(&:graphql_name).sort
       # It filters interfaces, too
       assert_equal ["GloballyIdentifiable", "HasMusicians", "NamedEntity"], object_class.interfaces({}).map(&:graphql_name).sort
@@ -28,7 +28,7 @@ describe GraphQL::Schema::Object do
       end
 
       # one more than the parent class
-      assert_equal 8, new_object_class.fields.size
+      assert_equal 9, new_object_class.fields.size
       # inherited interfaces are present
       assert_equal ["GloballyIdentifiable", "HasMusicians", "NamedEntity", "PrivateNameEntity"], new_object_class.interfaces.map(&:graphql_name).sort
       # The new field is present
@@ -243,7 +243,7 @@ describe GraphQL::Schema::Object do
     it "returns a matching GraphQL::ObjectType" do
       assert_equal "Ensemble", obj_type.name
       assert_equal "A group of musicians playing together", obj_type.description
-      assert_equal 7, obj_type.all_fields.size
+      assert_equal 8, obj_type.all_fields.size
 
       name_field = obj_type.all_fields[3]
       assert_equal "name", name_field.name

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -191,6 +191,7 @@ module Jazz
     type_membership_class PrivateMembership
 
     field :private_name, String, null: false
+    field :overridden_name, String, null: false
 
     def private_name
       "private name"
@@ -226,6 +227,9 @@ module Jazz
     description "A group of musicians playing together"
     config :config, :configged
     field :formed_at, String, null: true, hash_key: "formedAtDate"
+
+    # This overrides the visibility from PrivateNameEntity
+    field :overridden_name, String, null: false
 
     def overridden_name
       @object.name.sub("Robert Glasper", "ROBERT GLASPER")


### PR DESCRIPTION
Oops, long story short, we have some code that took advantage of the previously-broken behavior with hidden interfaces. (Fields on hidden interfaces _were_ added to object types.) I need an option to add fields to objects even when the interface is hidden.