### PR TITLE
Improve object generator

### DIFF
--- a/lib/generators/graphql/object_generator.rb
+++ b/lib/generators/graphql/object_generator.rb
@@ -15,19 +15,72 @@ module Graphql
       desc "Create a GraphQL::ObjectType with the given name and fields"
       source_root File.expand_path('../templates', __FILE__)
 
-      argument :fields,
-        type: :array,
-        default: [],
-        banner: "name:type name:type ...",
-        desc: "Fields for this object (type may be expressed as Ruby or GraphQL)"
+      argument :custom_fields,
+               type: :array,
+               default: [],
+               banner: "name:type name:type ...",
+               desc: "Fields for this object (type may be expressed as Ruby or GraphQL)"
 
       class_option :node,
-        type: :boolean,
-        default: false,
-        desc: "Include the Relay Node interface"
+                   type: :boolean,
+                   default: false,
+                   desc: "Include the Relay Node interface"
 
       def create_type_file
         template "object.erb", "#{options[:directory]}/types/#{type_file_name}.rb"
+      end
+
+      def fields
+        columns = []
+        columns += klass.columns.map { |c| generate_column_string(c) } if class_exists?
+        columns + custom_fields
+      end
+
+      def self.normalize_type_expression(type_expression, mode:, null: true)
+        case type_expression
+        when "Text"
+          ["String", null]
+        when "DateTime", "Datetime"
+          ["GraphQL::Types::ISO8601DateTime", null]
+        when "Date"
+          ["GraphQL::Types::ISO8601Date", null]
+        else
+          super
+        end
+      end
+
+      private
+
+      def generate_column_string(column)
+        name = column.name
+        required = column.null ? "" : "!"
+        type = column_type_string(column)
+        "#{name}:#{required}#{type}"
+      end
+
+      def column_type_string(column)
+        return "ID" if column.name == "id"
+        column_type = column.type.to_s
+        case column_type
+        when "datetime"
+          "DateTime"
+        when "text"
+          "String"
+        when "date"
+          "Date"
+        else
+          column_type.camelize
+        end
+      end
+
+      def class_exists?
+        klass.is_a?(Class) && klass.ancestors.include?(ApplicationRecord)
+      rescue NameError
+        return false
+      end
+
+      def klass
+        Module.const_get(type_name.camelize)
       end
     end
   end

--- a/lib/generators/graphql/object_generator.rb
+++ b/lib/generators/graphql/object_generator.rb
@@ -59,18 +59,7 @@ module Graphql
       end
 
       def column_type_string(column)
-        return "ID" if column.name == "id"
-
-        column_type = column.type.to_s
-        
-        case column_type
-        when "datetime"
-          "DateTime"
-        when "text"
-          "String"
-        else
-          column_type.camelize
-        end
+        column.name == "id" ? "ID" : column.type.to_s.camelize
       end
 
       def class_exists?

--- a/lib/generators/graphql/object_generator.rb
+++ b/lib/generators/graphql/object_generator.rb
@@ -63,7 +63,7 @@ module Graphql
       end
 
       def class_exists?
-        klass.is_a?(Class) && klass.ancestors.include?(ApplicationRecord)
+        klass.is_a?(Class) && klass.ancestors.include?(ActiveRecord::Base)
       rescue NameError
         return false
       end

--- a/lib/generators/graphql/object_generator.rb
+++ b/lib/generators/graphql/object_generator.rb
@@ -69,7 +69,7 @@ module Graphql
       end
 
       def klass
-        Module.const_get(type_name.camelize)
+        @klass ||= Module.const_get(type_name.camelize)
       end
     end
   end

--- a/lib/generators/graphql/object_generator.rb
+++ b/lib/generators/graphql/object_generator.rb
@@ -60,14 +60,14 @@ module Graphql
 
       def column_type_string(column)
         return "ID" if column.name == "id"
+
         column_type = column.type.to_s
+        
         case column_type
         when "datetime"
           "DateTime"
         when "text"
           "String"
-        when "date"
-          "Date"
         else
           column_type.camelize
         end

--- a/spec/integration/rails/generators/graphql/object_generator_spec.rb
+++ b/spec/integration/rails/generators/graphql/object_generator_spec.rb
@@ -13,8 +13,10 @@ class GraphQLGeneratorsObjectGeneratorTest < BaseGeneratorTest
     end
   end
 
+  # rubocop:disable Style/ClassAndModuleChildren
   class ::TestUser < ActiveRecord::Base
   end
+  # rubocop:enable Style/ClassAndModuleChildren
 
   test "it generates fields with types" do
     commands = [

--- a/spec/integration/rails/generators/graphql/object_generator_spec.rb
+++ b/spec/integration/rails/generators/graphql/object_generator_spec.rb
@@ -5,6 +5,17 @@ require "generators/graphql/object_generator"
 class GraphQLGeneratorsObjectGeneratorTest < BaseGeneratorTest
   tests Graphql::Generators::ObjectGenerator
 
+  ActiveRecord::Schema.define do
+    create_table :test_users do |t|
+      t.datetime :created_at
+      t.date :birthday
+      t.integer :points, null: false
+    end
+  end
+
+  class ::TestUser < ActiveRecord::Base
+  end
+
   test "it generates fields with types" do
     commands = [
       # GraphQL-style:
@@ -47,6 +58,35 @@ RUBY
 module Types
   class PageType < Types::BaseObject
     implements GraphQL::Relay::Node.interface
+  end
+end
+RUBY
+  end
+
+  test "it generates objects based on ActiveRecord schema" do
+    run_generator(["TestUser"])
+    assert_file "app/graphql/types/test_user_type.rb", <<-RUBY
+module Types
+  class TestUserType < Types::BaseObject
+    field :id, ID, null: false
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: true
+    field :birthday, GraphQL::Types::ISO8601Date, null: true
+    field :points, Integer, null: false
+  end
+end
+RUBY
+  end
+
+  test "it generates objects based on ActiveRecord schema with additional custom fields" do
+    run_generator(["TestUser", "name:!String"])
+    assert_file "app/graphql/types/test_user_type.rb", <<-RUBY
+module Types
+  class TestUserType < Types::BaseObject
+    field :id, ID, null: false
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: true
+    field :birthday, GraphQL::Types::ISO8601Date, null: true
+    field :points, Integer, null: false
+    field :name, String, null: false
   end
 end
 RUBY


### PR DESCRIPTION
Resolves #2951

Added support for existing Models in object generator. If a ActiveRecord's class exists the generator will fetch columns info based on Model's schema.

Example usage:

`rails generate graphql:object User`

You can also add custom fields which don't exist in your schema, example:

`rails generate graphql:object User custom_field:String`

Also added support for "datetime" and "date" field types.