### PR TITLE
Arguments#each_value should yield ArgumentValues

### DIFF
--- a/lib/graphql/execution/interpreter/arguments.rb
+++ b/lib/graphql/execution/interpreter/arguments.rb
@@ -21,15 +21,11 @@ module GraphQL
           @argument_values = argument_values
         end
 
-        # Yields `ArgumentValue` instances which contain detailed metadata about each argument.
-        def each_value
-          argument_values.each { |arg_v| yield(arg_v) }
-        end
-
         # @return [Hash{Symbol => ArgumentValue}]
         attr_reader :argument_values
 
         def_delegators :@keyword_arguments, :key?, :[], :keys, :each, :values
+        def_delegators :@argument_values, :each_value
 
         def inspect
           "#<#{self.class} @keyword_arguments=#{keyword_arguments.inspect}>"

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -937,6 +937,9 @@ describe GraphQL::Query do
       assert_equal({direction: "ASC"}, detailed_args[:order_by].to_h)
       assert_equal({direction: "ASC"}, order_by_argument_value.value.to_h)
       assert_equal "order_by", order_by_argument_value.definition.graphql_name
+
+      assert_equal [source_arg_value, fat_content_arg_value, organic_arg_value, order_by_argument_value, detailed_args.argument_values[:origin_dairy]].to_set,
+                   detailed_args.each_value.to_set
     end
 
     it "provides access to nested input objects" do


### PR DESCRIPTION
`GraphQL::Execution::Interpreter::Arguments#each_value` currently yields `[<argument_keyword>, ArgumentValue]` arrays but I believe it was meant to yield `ArgumentValue`s to be consistent with `GraphQL::Query::Arguments#each_value`.