### PR TITLE
Add raw_value to GRAPHQL_RUBY_KEYWORDS

### DIFF
--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -47,7 +47,7 @@ module GraphQL
         # A list of GraphQL-Ruby keywords.
         #
         # @api private
-        GRAPHQL_RUBY_KEYWORDS = [:context, :object, :method]
+        GRAPHQL_RUBY_KEYWORDS = [:context, :object, :method, :raw_value]
 
         # A list of field names that we should advise users to pick a different
         # resolve method name.


### PR DESCRIPTION
All object types have the method `raw_value` via `GraphQL::Schema::Object.include(HandlesRawValue)` so this should be
considered reserved too.