### PR TITLE
Add subscription broadcasts

### DIFF
--- a/guides/subscriptions/broadcast.md
+++ b/guides/subscriptions/broadcast.md
@@ -6,7 +6,6 @@ section: Subscriptions
 title: Broadcasts
 desc: Delivering the same GraphQL result to multiple subscribers
 index: 3
-pro: true
 ---
 
 GraphQL-Ruby 1.11+ introduced a new algorithm for tracking subscriptions and delivering updates, _broadcasts_.

--- a/guides/subscriptions/broadcast.md
+++ b/guides/subscriptions/broadcast.md
@@ -1,0 +1,89 @@
+---
+layout: guide
+doc_stub: false
+search: true
+section: Subscriptions
+title: Broadcasts
+desc: Delivering the same GraphQL result to multiple subscribers
+index: 3
+pro: true
+---
+
+GraphQL-Ruby 1.11+ introduced a new algorithm for tracking subscriptions and delivering updates, _broadcasts_.
+
+A broadcast is a subscription update which is executed _once_, then delivered to _any number_ of subscribers. This reduces the time your server spends running GraphQL queries, since it doesn't have to re-run the query for every subscriber.
+
+But, __take care__: this approach risks leaking information to subscribers who shouldn't receive it.
+
+## Setup
+
+To enable broadcasts, add `broadcast: true` to your subscription setup:
+
+```ruby
+class MyAppSchema < GraphQL::Schema
+  # ...
+  use GraphQL::Execution::Interpreter
+  use GraphQL::Analysis::AST
+  use SomeSubscriptionImplementation,
+    broadcast: true # <----
+end
+```
+
+Then, any broadcastable field can be configured with `broadcastable: true`:
+
+```ruby
+field :name, String, null: false,
+  broadcastable: true
+```
+
+When a subscription comes in where _all_ of its fields are `broadcastable: true`, then it will be handled as a broadcast.
+
+Additionally, you can set `default_broadcastable: true`:
+
+```ruby
+class MyAppSchema < GraphQL::Schema
+  # ...
+  use GraphQL::Execution::Interpreter
+  use GraphQL::Analysis::AST
+  use SomeSubscriptionImplementation,
+    broadcast: true,
+    default_broadcastable: true # <----
+end
+```
+
+With this setting, fields are broadcastable by default. Only a field with `broadcastable: false` in its configuration will cause a subscription to be handled on a subscriber-by-subscriber basis.
+
+## What fields are broadcastable?
+
+GraphQL-Ruby can't infer whether a field is broadcastable or not. You must configure it explicitly with `broadcastable: true` or `broadcastable: false`. (The subscription plugin also accepts `default_broadcastable: true|false`.)
+
+A field is broadcastable if _all clients who request the field will see the same value_. For example:
+
+- General facts: celebrity names, laws of physics, historical dates
+- Public information: object names, document updated-at timestamps, boilerplate info
+
+For fields like this, you can add `broadcastable: true`.
+
+A field is __not broadcastable__ if its value is different for different clients. For example:
+
+- __Viewer-specific information:__ if a field is specifically viewer-based, then it can't be broadcasted to other viewers. For example, `discussion { viewerCanModerate }` might be true for a moderator, but it shouldn't be broadcasted to other viewers.
+- __Context-specific information:__ if a field's value takes the request context into consideration, it shouldn't be broadcasted. For example, IP addresses or HTTP header values probably can't be broadcasted. If a field reflects the viewer's timezone, it can't be broadcasted.
+- __Restricted information:__ if some viewers see one value, while other viewers see a different value, then it's not broadcastable. Broadcasting this data might leak private information to unauthorized clients. (This includes filtered lists: if the filtering is viewer-by-viewer, it's not broadcastable.)
+- __Fields with side effects:__ if the system requires a side effect (eg, logging a metric, updating a database, incrementing a counter) whenever a resolver is executed, it's not a good candidate for broadcasting because some executions will be optimized away.
+
+These fields can be tagged with `broadcastable: false` so that GraphQL-Ruby will handle them on a subscriber-by-subscriber basis.
+
+If you want to use subscriptions but have a lot of non-broadcastable fields in your schema, consider building a new set of subscription fields with limited access to other schema objects. Instead, optimize those subscriptions for broacastability.
+
+## Under the Hood
+
+GraphQL-Ruby determines which subscribers can receive a broadcast by inspecting:
+
+- __Query string__. Only exactly-matching query strings will receive the same broadcast.
+- __Variables__. Only exactly-matching variable values will receive the same broadcast.
+- __Field and Arguments__ given to `.trigger`. They must match the ones initially sent when subscribing. (Subscriptions always worked this way.)
+- __Subscription scope__. Only clients with exactly-matching subscription scope can receive the same broadcasts.
+
+So, take care to {% internal_link "set subscription_scope", "subscriptions/subscription_classes#scope" %} whenever a subscription should be implicitly scoped!
+
+(See {{ "GraphQL::Subscriptions::Event#fingerprint" | api_doc }} for the implementation of broadcast fingerprints.)

--- a/guides/subscriptions/implementation.md
+++ b/guides/subscriptions/implementation.md
@@ -12,7 +12,7 @@ The {{ "GraphQL::Subscriptions" | api_doc }} plugin is a base class for implemen
 
 Each method corresponds to a step in the subscription lifecycle. See the API docs for method-by-method documentation: {{ "GraphQL::Subscriptions" | api_doc }}.
 
-Also, see the {% internal_link "Pusher implementation guide", "subscriptions/pusher_implementation" %}, the {% internal_link "ActionCable implementation guide", "subscriptions/action_cable_implementation" %} or {{ "GraphQL::Subscriptions::ActionCableSubscriptions" | api_doc }} docs for an example implementation.
+Also, see the {% internal_link "Pusher implementation guide", "subscriptions/pusher_implementation" %}, the {% internal_link "Ably implementation guide", "subscriptions/ably_implementation" %}, the {% internal_link "ActionCable implementation guide", "subscriptions/action_cable_implementation" %} or {{ "GraphQL::Subscriptions::ActionCableSubscriptions" | api_doc }} docs for an example implementation.
 
 ## Considerations
 
@@ -22,3 +22,21 @@ Every Ruby application is different, so consider these points when implementing 
 - What components of your application can be used for persistence and message passing?
 - How will you deliver push updates to subscribed clients? (For example, websockets, ActionCable, Pusher, webhooks, or something else?)
 - How will you handle [thundering herd](https://en.wikipedia.org/wiki/Thundering_herd_problem)s? When an event is triggered, how will you manage database access to update clients without swamping your system?
+
+## Broadcasts
+
+GraphQL-Ruby 1.11+ introduced a new algorithm for tracking subscriptions and delivering updates, _broadcasts_. This could result in __breaking changes__ for systems that assumed that every subscription would be re-evaluated in isolation.
+
+A broadcast is a subscription update which is executed _once_, then delivered to _any number_ of subscribers. Broadcasts have several performance advantages:
+
+- __Less GraphQL runtime__: since updates are only evaluated _once_, regardless of the number of subscribers, your server spends less time resolving GraphQL queries.
+- __Less pub/sub overhead__: since identical messages can be routed over the same channels, you can use one publish operation to update any number of subscribers.
+
+GraphQL-Ruby determines which subscribers can receive a broadcast by inspecting:
+
+- __Query string__. Only exactly-matching query strings will receive the same broadcast.
+- __Variables__. Only exactly-matching variable values will receive the same broadcast.
+- __Field and Arguments__ given to `.trigger`. They must match the ones initially sent when subscribing. (Subscriptions always worked this way.)
+- __Subscription scope__. Only clients with exactly-matching subscription scope can receive the same broadcasts.
+
+So, take care to {% internal_link "set subscription_scope", "subscriptions/subscription_classes#scope" %} whenever a subscription should be implicitly scoped!

--- a/guides/subscriptions/implementation.md
+++ b/guides/subscriptions/implementation.md
@@ -25,18 +25,4 @@ Every Ruby application is different, so consider these points when implementing 
 
 ## Broadcasts
 
-GraphQL-Ruby 1.11+ introduced a new algorithm for tracking subscriptions and delivering updates, _broadcasts_. This could result in __breaking changes__ for systems that assumed that every subscription would be re-evaluated in isolation.
-
-A broadcast is a subscription update which is executed _once_, then delivered to _any number_ of subscribers. Broadcasts have several performance advantages:
-
-- __Less GraphQL runtime__: since updates are only evaluated _once_, regardless of the number of subscribers, your server spends less time resolving GraphQL queries.
-- __Less pub/sub overhead__: since identical messages can be routed over the same channels, you can use one publish operation to update any number of subscribers.
-
-GraphQL-Ruby determines which subscribers can receive a broadcast by inspecting:
-
-- __Query string__. Only exactly-matching query strings will receive the same broadcast.
-- __Variables__. Only exactly-matching variable values will receive the same broadcast.
-- __Field and Arguments__ given to `.trigger`. They must match the ones initially sent when subscribing. (Subscriptions always worked this way.)
-- __Subscription scope__. Only clients with exactly-matching subscription scope can receive the same broadcasts.
-
-So, take care to {% internal_link "set subscription_scope", "subscriptions/subscription_classes#scope" %} whenever a subscription should be implicitly scoped!
+_Broadcasting_ updates to multiple subscribers is supported by GraphQL-Ruby, but requires implementation-specific work, see more in the {% internal_link "Broadcast guide", "subscriptions/broadcast" %}.

--- a/guides/subscriptions/overview.md
+++ b/guides/subscriptions/overview.md
@@ -11,6 +11,7 @@ index: 0
 _Subscriptions_ allow GraphQL clients to observe specific events and receive updates from the server when those events occur. This supports live updates, such as websocket pushes. Subscriptions introduce several new concepts:
 
 - The __Subscription type__ is the entry point for subscription queries
+- __Subscription classes__ are resolvers for handing initial subscription requests and subsequent updates
 - __Triggers__ begin the update process
 - The __Implementation__ provides application-specific methods for executing & delivering updates.
 
@@ -19,6 +20,12 @@ _Subscriptions_ allow GraphQL clients to observe specific events and receive upd
 `subscription` is an entry point to your GraphQL schema, like `query` or `mutation`. It is defined by your `SubscriptionType`, a root-level `GraphQL::Schema::Object`.
 
 Read more in the {% internal_link "Subscription Type guide", "subscriptions/subscription_type" %}.
+
+### Subscription Classes
+
+{{ "GraphQL::Schema::Subscription" | api_doc }} is a resolver class with subscription-specific behaviors. Each subscription field should be implemented by a subscription class.
+
+Read more in the {% internal_link "Subscription Classes guide", "subscriptions/subscription_classes" %}
 
 ### Triggers
 
@@ -34,4 +41,4 @@ Besides the GraphQL component, your application must provide some subscription-r
 - __transport__: How does your application deliver payloads to clients?
 - __queueing__: How does your application distribute the work of re-running subscription queries?
 
-Read more in the {% internal_link "Implementation guide", "subscriptions/implementation" %} or check out the {% internal_link "ActionCable implementation", "subscriptions/action_cable_implementation" %} or {% internal_link "Pusher implementation", "subscriptions/pusher_implementation" %}.
+Read more in the {% internal_link "Implementation guide", "subscriptions/implementation" %} or check out the {% internal_link "ActionCable implementation", "subscriptions/action_cable_implementation" %}, {% internal_link "Pusher implementation", "subscriptions/pusher_implementation" %} or {% internal_link "Ably implementation", "subscriptions/ably_implementation" %}.

--- a/guides/subscriptions/overview.md
+++ b/guides/subscriptions/overview.md
@@ -14,6 +14,7 @@ _Subscriptions_ allow GraphQL clients to observe specific events and receive upd
 - __Subscription classes__ are resolvers for handing initial subscription requests and subsequent updates
 - __Triggers__ begin the update process
 - The __Implementation__ provides application-specific methods for executing & delivering updates.
+- __Broadcasts__ can send the same GraphQL result to any number of subscribers.
 
 ### Subscription Type
 
@@ -42,3 +43,7 @@ Besides the GraphQL component, your application must provide some subscription-r
 - __queueing__: How does your application distribute the work of re-running subscription queries?
 
 Read more in the {% internal_link "Implementation guide", "subscriptions/implementation" %} or check out the {% internal_link "ActionCable implementation", "subscriptions/action_cable_implementation" %}, {% internal_link "Pusher implementation", "subscriptions/pusher_implementation" %} or {% internal_link "Ably implementation", "subscriptions/ably_implementation" %}.
+
+### Broadcasts
+
+By default, the subscription implementations listed above handle each subscription in total isolation. However, this behavior can be optimized by setting up broadcasts. Read more in the {% internal_link "Broadcast guide", "subscriptions/broadcast" %}.

--- a/guides/subscriptions/subscription_type.md
+++ b/guides/subscriptions/subscription_type.md
@@ -43,8 +43,7 @@ class Types::SubscriptionType < GraphQL::Schema::Object
   # If you're using the interpreter, also add:
   extend GraphQL::Subscriptions::SubscriptionRoot
 
-  field :post_was_published, Types::PostType, null: false,
-    description: "A post was published to the blog"
+  field :post_was_published, subscription: Subscriptions::PostWasPublished
   # ...
 end
 ```
@@ -63,37 +62,4 @@ end
 
 See {% internal_link "Implementing Subscriptions","subscriptions/implementation" %} for more about actually delivering updates.
 
-## Authorizing Subscriptions
-
-When a client first sends a `subscription` operation, the root fields are resolved, so their corresponding methods are called, for example:
-
-```ruby
-class Types::SubscriptionType < GraphQL::Schema::Object
-  extend GraphQL::Subscriptions::SubscriptionRoot
-
-  field :post_was_published, Types::PostType, null: false,
-    description: "A post was published to the blog" do
-      argument :topic, Types::PostTopic, required: true
-    end
-
-  def post_was_published(topic:)
-    # This will be called on the initial request
-  end
-end
-```
-
-During that method, you can raise an error to _prevent_ establishing the subscription. For example:
-
-```ruby
-def post_was_published(topic:)
-  if context[:viewer].can_subscribe_to?(topic)
-    # Allow the request
-  else
-    raise GraphQL::ExecutionError.new("Can't subscribe to this topic: #{topic}")
-  end
-end
-```
-
-If the error is raised, it will be added to the response's `"errors"` key and the subscription won't be created.
-
-The return value of the method is not used; only the raised error affects the behavior of the subscription.
+See {% internal_link "Subscription Classes", "subscriptions/subscription_classes" %} for more about implementing subscription root fields.

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -191,6 +191,7 @@ module GraphQL
       # @param subscription_scope [Symbol, String] A key in `context` which will be used to scope subscription payloads
       # @param extensions [Array<Class, Hash<Class => Object>>] Named extensions to apply to this field (see also {#extension})
       # @param trace [Boolean] If true, a {GraphQL::Tracing} tracer will measure this scalar field
+      # @param broadcastable [Boolean] Whether or not this field can be distributed in subscription broadcasts
       # @param ast_node [Language::Nodes::FieldDefinition, nil] If this schema was parsed from definition, this AST node defined the field
       # @param method_conflict_warning [Boolean] If false, skip the warning if this field's method conflicts with a built-in method
       def initialize(type: nil, name: nil, owner: nil, null: nil, field: nil, function: nil, description: nil, deprecation_reason: nil, method: nil, hash_key: nil, resolver_method: nil, resolve: nil, connection: nil, max_page_size: :not_given, scope: nil, introspection: false, camelize: true, trace: nil, complexity: 1, ast_node: nil, extras: [], extensions: EMPTY_ARRAY, connection_extension: self.class.connection_extension, resolver_class: nil, subscription_scope: nil, relay_node_field: false, relay_nodes_field: false, method_conflict_warning: true, broadcastable: nil, arguments: EMPTY_HASH, &definition_block)

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -193,7 +193,7 @@ module GraphQL
       # @param trace [Boolean] If true, a {GraphQL::Tracing} tracer will measure this scalar field
       # @param ast_node [Language::Nodes::FieldDefinition, nil] If this schema was parsed from definition, this AST node defined the field
       # @param method_conflict_warning [Boolean] If false, skip the warning if this field's method conflicts with a built-in method
-      def initialize(type: nil, name: nil, owner: nil, null: nil, field: nil, function: nil, description: nil, deprecation_reason: nil, method: nil, hash_key: nil, resolver_method: nil, resolve: nil, connection: nil, max_page_size: :not_given, scope: nil, introspection: false, camelize: true, trace: nil, complexity: 1, ast_node: nil, extras: [], extensions: EMPTY_ARRAY, connection_extension: self.class.connection_extension, resolver_class: nil, subscription_scope: nil, relay_node_field: false, relay_nodes_field: false, method_conflict_warning: true, arguments: EMPTY_HASH, &definition_block)
+      def initialize(type: nil, name: nil, owner: nil, null: nil, field: nil, function: nil, description: nil, deprecation_reason: nil, method: nil, hash_key: nil, resolver_method: nil, resolve: nil, connection: nil, max_page_size: :not_given, scope: nil, introspection: false, camelize: true, trace: nil, complexity: 1, ast_node: nil, extras: [], extensions: EMPTY_ARRAY, connection_extension: self.class.connection_extension, resolver_class: nil, subscription_scope: nil, relay_node_field: false, relay_nodes_field: false, method_conflict_warning: true, broadcastable: nil, arguments: EMPTY_HASH, &definition_block)
         if name.nil?
           raise ArgumentError, "missing first `name` argument or keyword `name:`"
         end
@@ -251,6 +251,7 @@ module GraphQL
         @max_page_size = max_page_size == :not_given ? nil : max_page_size
         @introspection = introspection
         @extras = extras
+        @broadcastable = broadcastable
         @resolver_class = resolver_class
         @scope = scope
         @trace = trace
@@ -293,6 +294,13 @@ module GraphQL
             instance_eval(&definition_block)
           end
         end
+      end
+
+      # If true, subscription updates with this field can be shared between viewers
+      # @return [Boolean]
+      # @see GraphQL::Subscriptions::BroadcastAnalyzer
+      def broadcastable?
+        @broadcastable
       end
 
       # @param text [String]

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -297,7 +297,7 @@ module GraphQL
       end
 
       # If true, subscription updates with this field can be shared between viewers
-      # @return [Boolean]
+      # @return [Boolean, nil]
       # @see GraphQL::Subscriptions::BroadcastAnalyzer
       def broadcastable?
         @broadcastable

--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -250,6 +250,19 @@ module GraphQL
           @complexity || (superclass.respond_to?(:complexity) ? superclass.complexity : 1)
         end
 
+        def broadcastable(new_broadcastable)
+          @broadcastable = new_broadcastable
+        end
+
+        # @return [Boolean, nil]
+        def broadcastable?
+          if defined?(@broadcastable)
+            @broadcastable
+          else
+            (superclass.respond_to?(:broadcastable?) ? superclass.broadcastable? : nil)
+          end
+        end
+
         def field_options
           {
             type: type_expr,
@@ -261,6 +274,7 @@ module GraphQL
             null: null,
             complexity: complexity,
             extensions: extensions,
+            broadcastable: broadcastable?,
           }
         end
 

--- a/lib/graphql/schema/subscription.rb
+++ b/lib/graphql/schema/subscription.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "securerandom"
 
 module GraphQL
   class Schema
@@ -93,11 +94,11 @@ module GraphQL
         raise UnsubscribedError
       end
 
+      READING_SCOPE = ::Object.new
       # Call this method to provide a new subscription_scope; OR
       # call it without an argument to get the subscription_scope
       # @param new_scope [Symbol]
       # @return [Symbol]
-      READING_SCOPE = ::Object.new
       def self.subscription_scope(new_scope = READING_SCOPE)
         if new_scope != READING_SCOPE
           @subscription_scope = new_scope

--- a/lib/graphql/schema/subscription.rb
+++ b/lib/graphql/schema/subscription.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "securerandom"
 
 module GraphQL
   class Schema

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -91,7 +91,6 @@ module GraphQL
 
       # @return [GraphQL::Field, nil] The field named `field_name` on `parent_type`, if it exists
       def get_field(parent_type, field_name)
-
         @visible_parent_fields ||= read_through do |type|
           read_through do |f_name|
             field_defn = @schema.get_field(type, f_name)

--- a/lib/graphql/subscriptions.rb
+++ b/lib/graphql/subscriptions.rb
@@ -209,6 +209,16 @@ module GraphQL
       Schema::Member::BuildType.camelize(event_or_arg_name.to_s)
     end
 
+    # @return [Boolean] if true, then a query like this one would be broadcasted
+    def broadcastable?(query_str, **query_options)
+      query = GraphQL::Query.new(@schema, query_str, **query_options)
+      if !query.valid?
+        raise "Invalid query: #{query.validation_errors.map(&:to_h).inspect}"
+      end
+      GraphQL::Analysis::AST.analyze_query(query, @schema.query_analyzers)
+      query.context.namespace(:subscriptions)[:subscription_broadcastable]
+    end
+
     private
 
     # Recursively normalize `args` as belonging to `arg_owner`:

--- a/lib/graphql/subscriptions.rb
+++ b/lib/graphql/subscriptions.rb
@@ -36,7 +36,7 @@ module GraphQL
     end
 
     # @param schema [Class] the GraphQL schema this manager belongs to
-    def initialize(schema:, broadcast: false, default_broadcastable: true, **rest)
+    def initialize(schema:, broadcast: false, default_broadcastable: false, **rest)
       if broadcast
         if !schema.using_ast_analysis?
           raise ArgumentError, "`broadcast: true` requires AST analysis, add `using GraphQL::Analysis::AST` to your schema or see https://graphql-ruby.org/queries/ast_analysis.html."

--- a/lib/graphql/subscriptions.rb
+++ b/lib/graphql/subscriptions.rb
@@ -133,7 +133,9 @@ module GraphQL
     # @return [void]
     def execute(subscription_id, event, object)
       res = execute_update(subscription_id, event, object)
-      deliver(subscription_id, res)
+      if !res.nil?
+        deliver(subscription_id, res)
+      end
     end
 
     # Event `event` occurred on `object`,
@@ -143,10 +145,7 @@ module GraphQL
     # @return [void]
     def execute_all(event, object)
       each_subscription_id(event) do |subscription_id|
-        result = execute_update(subscription_id, event, object)
-        if !result.nil?
-          deliver(subscription_id, result)
-        end
+        execute(subscription_id, event, object)
       end
     end
 

--- a/lib/graphql/subscriptions/action_cable_subscriptions.rb
+++ b/lib/graphql/subscriptions/action_cable_subscriptions.rb
@@ -175,7 +175,7 @@ module GraphQL
 
       # The channel was closed, forget about it.
       def delete_subscription(subscription_id)
-        query, events = @subscriptions.delete(subscription_id)
+        _query, events = @subscriptions.delete(subscription_id)
         events.each do |event|
           ev_by_fingerprint = @events[event.topic]
           ev_for_fingerprint = ev_by_fingerprint[event.fingerprint]

--- a/lib/graphql/subscriptions/action_cable_subscriptions.rb
+++ b/lib/graphql/subscriptions/action_cable_subscriptions.rb
@@ -184,13 +184,6 @@ module GraphQL
             ev_by_fingerprint.delete(event.fingerprint)
           end
         end
-        debug = {}
-        @events.each do |topic, ev_by_fingerprint|
-          debug[topic] = {}
-          ev_by_fingerprint.each do |fp, evs|
-            debug[topic][fp] = evs.map { |ev| ev.context[:subscription_id] }
-          end
-        end
       end
     end
   end

--- a/lib/graphql/subscriptions/broadcast_analyzer.rb
+++ b/lib/graphql/subscriptions/broadcast_analyzer.rb
@@ -53,7 +53,7 @@ module GraphQL
 
       # Modify `@subscription_broadcastable` based on `field_defn`'s configuration (and/or the default value)
       def apply_broadcastable(field_defn)
-        current_field_broadcastable = field_defn.broadcastable?
+        current_field_broadcastable = field_defn.introspection? || field_defn.broadcastable?
         case current_field_broadcastable
         when nil
           # If the value wasn't set, mix in the default value:

--- a/lib/graphql/subscriptions/broadcast_analyzer.rb
+++ b/lib/graphql/subscriptions/broadcast_analyzer.rb
@@ -7,6 +7,8 @@ module GraphQL
     # - Is completely broadcastable
     #
     # Assign the result to `context.namespace(:subscriptions)[:subscription_broadcastable]`
+    # @api private
+    # @see Subscriptions#broadcastable? for a public API
     class BroadcastAnalyzer < GraphQL::Analysis::AST::Analyzer
       def initialize(subject)
         super

--- a/lib/graphql/subscriptions/broadcast_analyzer.rb
+++ b/lib/graphql/subscriptions/broadcast_analyzer.rb
@@ -47,8 +47,13 @@ module GraphQL
         end
       end
 
+
+      # Assign the result to context.
+      # (This method is allowed to return an error, but we don't need to)
+      # @return [void]
       def result
         query.context.namespace(:subscriptions)[:subscription_broadcastable] = @subscription_broadcastable
+        nil
       end
 
       private

--- a/lib/graphql/subscriptions/broadcast_analyzer.rb
+++ b/lib/graphql/subscriptions/broadcast_analyzer.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module GraphQL
+  class Subscriptions
+    # Detect whether the current operation:
+    # - Is a subscription operation
+    # - Is completely broadcastable
+    #
+    # Assign the result to `context.namespace(:subscriptions)[:subscription_broadcastable]`
+    class BroadcastAnalyzer < GraphQL::Analysis::AST::Analyzer
+      def initialize(subject)
+        super
+        @default_broadcastable = subject.schema.subscriptions.default_broadcastable
+        # Maybe this will get set to false while analyzing
+        @subscription_broadcastable = true
+      end
+
+      # Only analyze subscription operations
+      def analyze?
+        @query.subscription?
+      end
+
+      def on_enter_field(node, parent, visitor)
+        if (@subscription_broadcastable == false) || visitor.skipping?
+          return
+        end
+
+        current_field = visitor.field_definition
+        current_field_broadcastable = current_field.broadcastable?
+        case current_field_broadcastable
+        when nil
+          # If the value wasn't set, mix in the default value:
+          # - If the default is false and the current value is true, make it false
+          # - If the default is true and the current value is true, it stays true
+          # - If the default is false and the current value is false, keep it false
+          # - If the default is true and the current value is false, keep it false
+          @subscription_broadcastable = @subscription_broadcastable && @default_broadcastable
+        when false
+          # One non-broadcastable field is enough to make the whole subscription non-broadcastable
+          @subscription_broadcastable = false
+        when true
+          # Leave `@broadcastable_query` true if it's already true,
+          # but don't _set_ it to true if it was set to false by something else.
+          # Actually, just leave it!
+        else
+          raise ArgumentError, "Unexpected `.broadcastable?` value for #{current_field.path}: #{current_field_broadcastable}"
+        end
+      end
+
+      def result
+        query.context.namespace(:subscriptions)[:subscription_broadcastable] = @subscription_broadcastable
+      end
+    end
+  end
+end

--- a/lib/graphql/subscriptions/broadcast_analyzer.rb
+++ b/lib/graphql/subscriptions/broadcast_analyzer.rb
@@ -47,7 +47,6 @@ module GraphQL
         end
       end
 
-
       # Assign the result to context.
       # (This method is allowed to return an error, but we don't need to)
       # @return [void]

--- a/lib/graphql/subscriptions/event.rb
+++ b/lib/graphql/subscriptions/event.rb
@@ -27,7 +27,7 @@ module GraphQL
         @arguments = arguments
         @context = context
         @field = field || context.field
-        scope_val = scope || (context && field.subscription_scope && context[@field.subscription_scope])
+        scope_val = scope || (context && @field.subscription_scope && context[@field.subscription_scope])
 
         @topic = self.class.serialize(name, arguments, @field, scope: scope_val)
       end

--- a/lib/graphql/subscriptions/event.rb
+++ b/lib/graphql/subscriptions/event.rb
@@ -19,17 +19,14 @@ module GraphQL
       # @return [String] An opaque string which identifies this event, derived from `name` and `arguments`
       attr_reader :topic
 
-      # @return [GraphQL::Schema::Field]
-      attr_reader :field
-
       def initialize(name:, arguments:, field: nil, context: nil, scope: nil)
         @name = name
         @arguments = arguments
         @context = context
-        @field = field || context.field
-        scope_val = scope || (context && @field.subscription_scope && context[@field.subscription_scope])
+        field ||= context.field
+        scope_val = scope || (context && field.subscription_scope && context[field.subscription_scope])
 
-        @topic = self.class.serialize(name, arguments, @field, scope: scope_val)
+        @topic = self.class.serialize(name, arguments, field, scope: scope_val)
       end
 
       # @return [String] an identifier for this unit of subscription

--- a/spec/dummy/Gemfile
+++ b/spec/dummy/Gemfile
@@ -10,3 +10,5 @@ gem 'graphql', path: File.expand_path('../../', __dir__)
 group :development do
   gem 'listen'
 end
+
+gem "webdrivers", "~> 4.1"

--- a/spec/dummy/app/assets/javascripts/application.js
+++ b/spec/dummy/app/assets/javascripts/application.js
@@ -22,16 +22,10 @@
 
   App.cable = ActionCable.createConsumer();
 
-  function appendItem(parentId, text) {
-    var list = document.getElementById(parentId)
-    var child = document.createElement("li")
-    child.id = parentId + "-" + text
-    child.innerText = text
-    list.appendChild(child)
-  }
-
-  App.subscribe = function(elementId) {
-    var value = 1
+  App.subscribe = function(options) {
+    var query = options.query
+    var variables = options.variables
+    var receivedCallback = options.received
     // Unique-ish
     var uuid = Math.round(Date.now() + Math.random() * 100000).toString(16)
     return {
@@ -41,22 +35,19 @@
         }, {
           connected: function() {
             this.perform("execute", {
-              query: "subscription($id: ID!) { payload(id: $id) { value } }",
-              variables: { id: elementId },
+              query: query,
+              variables: variables,
             })
-            console.log("Connected")
-            appendItem(elementId, "connected")
+            console.log("Connected", query, variables)
           },
           received: function(data) {
-            if (data.result.data) {
-              var value = data.result.data.payload.value
-              appendItem(elementId, value)
-            }
+            console.log("received", query, variables, data)
+            receivedCallback(data)
           }
         }
       ),
-      trigger: function() {
-        this.subscription.perform("make_trigger", { id: elementId, value: value++ })
+      trigger: function(options) {
+        this.subscription.perform("make_trigger", options)
       },
       unsubscribe: function() {
         this.subscription.unsubscribe()

--- a/spec/dummy/app/channels/graphql_channel.rb
+++ b/spec/dummy/app/channels/graphql_channel.rb
@@ -105,6 +105,7 @@ class GraphqlChannel < ActionCable::Channel::Base
 
   def unsubscribed
     @subscription_ids.each { |sid|
+      puts "Unsubscribing from #{sid}"
       GraphQLSchema.subscriptions.delete_subscription(sid)
     }
   end

--- a/spec/dummy/app/channels/graphql_channel.rb
+++ b/spec/dummy/app/channels/graphql_channel.rb
@@ -55,11 +55,12 @@ class GraphqlChannel < ActionCable::Channel::Base
   class GraphQLSchema < GraphQL::Schema
     query(QueryType)
     subscription(SubscriptionType)
-    use GraphQL::Subscriptions::ActionCableSubscriptions,
-      serializer: CustomSerializer
-
     use GraphQL::Execution::Interpreter
     use GraphQL::Analysis::AST
+    use GraphQL::Subscriptions::ActionCableSubscriptions,
+      serializer: CustomSerializer,
+      broadcast: true,
+      default_broadcastable: true
   end
 
   def subscribed

--- a/spec/dummy/app/channels/graphql_channel.rb
+++ b/spec/dummy/app/channels/graphql_channel.rb
@@ -11,10 +11,25 @@ class GraphqlChannel < ActionCable::Channel::Base
     field :value, Integer, null: false
   end
 
+  class CounterIncremented < GraphQL::Schema::Subscription
+    @@call_count = 0
+    subscription_scope :subscriber_id
+
+    field :new_value, Integer, null: false
+
+    def update
+      {
+        new_value: @@call_count += 1
+      }
+    end
+  end
+
   class SubscriptionType < GraphQL::Schema::Object
     field :payload, PayloadType, null: false do
       argument :id, ID, required: true
     end
+
+    field :counter_incremented, subscription: CounterIncremented
   end
 
   # Wacky behavior around the number 4
@@ -82,7 +97,10 @@ class GraphqlChannel < ActionCable::Channel::Base
   end
 
   def make_trigger(data)
-    GraphQLSchema.subscriptions.trigger("payload", {"id" => data["id"]}, ExamplePayload.new(data["value"]))
+    field = data["field"]
+    args = data["arguments"]
+    value = data["value"]
+    GraphQLSchema.subscriptions.trigger(field, args, value && ExamplePayload.new(value))
   end
 
   def unsubscribed

--- a/spec/dummy/app/channels/graphql_channel.rb
+++ b/spec/dummy/app/channels/graphql_channel.rb
@@ -105,7 +105,6 @@ class GraphqlChannel < ActionCable::Channel::Base
 
   def unsubscribed
     @subscription_ids.each { |sid|
-      puts "Unsubscribing from #{sid}"
       GraphQLSchema.subscriptions.delete_subscription(sid)
     }
   end

--- a/spec/dummy/app/views/pages/show.html
+++ b/spec/dummy/app/views/pages/show.html
@@ -1,6 +1,6 @@
 <h1>ActionCable Test Page</h1>
-<button onClick="sub1.trigger()">Trigger 1</button>
-<button onClick="sub2.trigger()">Trigger 2</button>
+<button onClick="sub1.trigger({field: 'payload', arguments: { id: 'updates-1' }, value: val1++})">Trigger 1</button>
+<button onClick="sub1.trigger({field: 'payload', arguments: { id: 'updates-2' }, value: val2++})">Trigger 2</button>
 <p>ActionCable updates:</p>
 <ul id="updates-1">
 </ul>
@@ -10,7 +10,64 @@
 
 <button onClick="sub1.unsubscribe()">Unsubscribe 1</button>
 <button onClick="sub2.unsubscribe()">Unsubscribe 2</button>
+
+
+<p>Fingerprint test</p>
+<button onClick="subscribeWithFingerprint()">Subscribe with fingerprint</button>
+<ul id="fingerprint-updates">
+</ul>
+<button onClick="triggerWithFingerprint()">Trigger with fingerprint</button>
+
 <script>
-var sub1 = App.subscribe("updates-1")
-var sub2 = App.subscribe("updates-2")
+function appendItem(parentId, text) {
+  var list = document.getElementById(parentId)
+  var child = document.createElement("li")
+  child.id = parentId + "-" + text
+  child.innerText = text
+  list.appendChild(child)
+}
+
+var payloadString = "subscription($id: ID!) { payload(id: $id) { value } }"
+function handleResponse(elementId, data) {
+  console.log("handleResponse", elementId, data)
+  if (data.result.data) {
+    if (data.result.data.payload) {
+      var value = data.result.data.payload.value
+      appendItem(elementId, value)
+    } else {
+      appendItem(elementId, "connected")
+    }
+  }
+}
+var sub1 = App.subscribe({
+  query: payloadString,
+  variables: { "id": "updates-1" },
+  received: function(data) { handleResponse("updates-1", data) },
+})
+var val1 = 1
+var sub2 = App.subscribe({
+  query: payloadString,
+  variables: { "id": "updates-2" },
+  received: function(data) { handleResponse("updates-2", data) }
+})
+var val2 = 1
+
+var fingerprintSubscription = null
+function subscribeWithFingerprint() {
+  fingerprintSubscription = App.subscribe({
+    query: "subscription { counterIncremented { newValue } }",
+    variables: {},
+    received: function(data) {
+      if (data.result.data.counterIncremented) {
+        appendItem("fingerprint-updates", data.result.data.counterIncremented.newValue)
+      } else {
+        appendItem("fingerprint-updates", "connected")
+      }
+    }
+  })
+}
+
+function triggerWithFingerprint() {
+  fingerprintSubscription.trigger({field: "counterIncremented", arguments: {}, value: null})
+}
 </script>

--- a/spec/dummy/app/views/pages/show.html
+++ b/spec/dummy/app/views/pages/show.html
@@ -1,6 +1,6 @@
 <h1>ActionCable Test Page</h1>
 <button onClick="sub1.trigger({field: 'payload', arguments: { id: 'updates-1' }, value: val1++})">Trigger 1</button>
-<button onClick="sub1.trigger({field: 'payload', arguments: { id: 'updates-2' }, value: val2++})">Trigger 2</button>
+<button onClick="sub2.trigger({field: 'payload', arguments: { id: 'updates-2' }, value: val2++})">Trigger 2</button>
 <p>ActionCable updates:</p>
 <ul id="updates-1">
 </ul>

--- a/spec/dummy/app/views/pages/show.html
+++ b/spec/dummy/app/views/pages/show.html
@@ -11,12 +11,23 @@
 <button onClick="sub1.unsubscribe()">Unsubscribe 1</button>
 <button onClick="sub2.unsubscribe()">Unsubscribe 2</button>
 
+<hr>
 
 <p>Fingerprint test</p>
-<button onClick="subscribeWithFingerprint()">Subscribe with fingerprint</button>
-<ul id="fingerprint-updates">
+
+<button onClick="subscribeWithFingerprint('1')">Subscribe with fingerprint 1</button>
+<ul id="fingerprint-updates-1">
 </ul>
-<button onClick="triggerWithFingerprint()">Trigger with fingerprint</button>
+<button onClick="triggerWithFingerprint('1')">Trigger with fingerprint 1</button>
+<button onClick="unsubscribeWithFingerprint('1')">Unsubscribe with fingerprint 1</button>
+
+<br>
+
+<button onClick="subscribeWithFingerprint('2')">Subscribe with fingerprint 2</button>
+<ul id="fingerprint-updates-2">
+</ul>
+<button onClick="triggerWithFingerprint('2')">Trigger with fingerprint 2</button>
+<button onClick="unsubscribeWithFingerprint('2')">Unsubscribe with fingerprint 2</button>
 
 <script>
 function appendItem(parentId, text) {
@@ -52,22 +63,36 @@ var sub2 = App.subscribe({
 })
 var val2 = 1
 
-var fingerprintSubscription = null
-function subscribeWithFingerprint() {
-  fingerprintSubscription = App.subscribe({
-    query: "subscription { counterIncremented { newValue } }",
+var fingerprintSubscriptions = {}
+function subscribeWithFingerprint(key) {
+  if (!fingerprintSubscriptions[key]) {
+    fingerprintSubscriptions[key] = []
+  }
+  var subs = fingerprintSubscriptions[key]
+  var newSub = App.subscribe({
+    query: "subscription fingerprint" + key + " { counterIncremented { newValue } }",
     variables: {},
     received: function(data) {
       if (data.result.data.counterIncremented) {
-        appendItem("fingerprint-updates", data.result.data.counterIncremented.newValue)
+        appendItem("fingerprint-updates-" + key, "update-" + newSub.number + "-value-" + data.result.data.counterIncremented.newValue)
       } else {
-        appendItem("fingerprint-updates", "connected")
+        appendItem("fingerprint-updates-" + key, "connected-" + newSub.number)
       }
     }
   })
+  newSub.number = subs.length + 1
+  subs.push(newSub)
 }
 
-function triggerWithFingerprint() {
-  fingerprintSubscription.trigger({field: "counterIncremented", arguments: {}, value: null})
+function triggerWithFingerprint(key) {
+  var sub = fingerprintSubscriptions[key][0]
+  sub.trigger({field: "counterIncremented", arguments: {}, value: null})
+}
+
+function unsubscribeWithFingerprint(key) {
+  fingerprintSubscriptions[key].forEach(function(sub) {
+    sub.unsubscribe()
+  })
+  fingerprintSubscriptions[key] = []
 }
 </script>

--- a/spec/dummy/test/system/action_cable_subscription_test.rb
+++ b/spec/dummy/test/system/action_cable_subscription_test.rb
@@ -45,6 +45,8 @@ class ActionCableSubscriptionsTest < ApplicationSystemTestCase
 
 
   test "it only re-runs queries once for subscriptions with matching fingerprints" do
+    visit "/"
+
     # Make 3 subscriptions to the same payload
     click_on("Subscribe with fingerprint 1")
     click_on("Subscribe with fingerprint 1")
@@ -64,30 +66,40 @@ class ActionCableSubscriptionsTest < ApplicationSystemTestCase
     # - Another is built & delivered to the next two
     click_on("Trigger with fingerprint 2")
 
+    # The order here is random, I think depending on ActionCable's internal storage:
+    if page.has_css?("#fingerprint-updates-1-update-1-value-1")
+      fingerprint_1_value = 1
+      fingerprint_2_value = 2
+    else
+      fingerprint_1_value = 2
+      fingerprint_2_value = 1
+    end
+
     # These all share the first value:
-    assert_selector "#fingerprint-updates-1-update-1-value-1"
-    assert_selector "#fingerprint-updates-1-update-2-value-1"
-    assert_selector "#fingerprint-updates-1-update-3-value-1"
+    assert_selector "#fingerprint-updates-1-update-1-value-#{fingerprint_1_value}"
+    assert_selector "#fingerprint-updates-1-update-2-value-#{fingerprint_1_value}"
+    assert_selector "#fingerprint-updates-1-update-3-value-#{fingerprint_1_value}"
     # and these share the second value:
-    assert_selector "#fingerprint-updates-2-update-1-value-2"
-    assert_selector "#fingerprint-updates-2-update-2-value-2"
+    assert_selector "#fingerprint-updates-2-update-1-value-#{fingerprint_2_value}"
+    assert_selector "#fingerprint-updates-2-update-2-value-#{fingerprint_2_value}"
 
     click_on("Unsubscribe with fingerprint 2")
     click_on("Trigger with fingerprint 1")
 
     # These get an update
-    assert_selector "#fingerprint-updates-1-update-1-value-3"
-    assert_selector "#fingerprint-updates-1-update-2-value-3"
-    assert_selector "#fingerprint-updates-1-update-3-value-3"
+    assert_selector "#fingerprint-updates-1-update-1-value-#{fingerprint_1_value + 2}"
+    assert_selector "#fingerprint-updates-1-update-2-value-#{fingerprint_1_value + 2}"
+    assert_selector "#fingerprint-updates-1-update-3-value-#{fingerprint_1_value + 2}"
     # But these are unsubscribed:
-    refute_selector "#fingerprint-updates-2-update-1-value-4"
-    refute_selector "#fingerprint-updates-2-update-2-value-4"
+    refute_selector "#fingerprint-updates-2-update-1-value-#{fingerprint_2_value + 2}"
+    refute_selector "#fingerprint-updates-2-update-2-value-#{fingerprint_2_value + 2}"
     click_on("Unsubscribe with fingerprint 1")
     # Make a new subscription and make sure it's updated:
     click_on("Subscribe with fingerprint 2")
     click_on("Trigger with fingerprint 2")
-    assert_selector "#fingerprint-updates-2-update-3-value-4"
+    assert_selector "#fingerprint-updates-2-update-1-value-#{fingerprint_2_value + 2}"
     # But this one was unsubscribed:
-    refute_selector "#fingerprint-updates-1-update-1-value-5"
+    refute_selector "#fingerprint-updates-1-update-1-value-#{fingerprint_1_value + 3}"
+    refute_selector "#fingerprint-updates-1-update-1-value-#{fingerprint_1_value + 4}"
   end
 end

--- a/spec/dummy/test/system/action_cable_subscription_test.rb
+++ b/spec/dummy/test/system/action_cable_subscription_test.rb
@@ -42,4 +42,9 @@ class ActionCableSubscriptionsTest < ApplicationSystemTestCase
     click_on("Trigger 2")
     assert_selector "#updates-2-400", text: "400"
   end
+
+
+  test "it only re-runs queries once for subscriptions with matching fingerprints" do
+    skip
+  end
 end

--- a/spec/dummy/test/system/action_cable_subscription_test.rb
+++ b/spec/dummy/test/system/action_cable_subscription_test.rb
@@ -45,6 +45,49 @@ class ActionCableSubscriptionsTest < ApplicationSystemTestCase
 
 
   test "it only re-runs queries once for subscriptions with matching fingerprints" do
-    skip
+    # Make 3 subscriptions to the same payload
+    click_on("Subscribe with fingerprint 1")
+    click_on("Subscribe with fingerprint 1")
+    click_on("Subscribe with fingerprint 1")
+    # And two to the next payload
+    click_on("Subscribe with fingerprint 2")
+    click_on("Subscribe with fingerprint 2")
+
+    assert_selector "#fingerprint-updates-1-connected-1"
+    assert_selector "#fingerprint-updates-1-connected-2"
+    assert_selector "#fingerprint-updates-1-connected-3"
+    assert_selector "#fingerprint-updates-2-connected-1"
+    assert_selector "#fingerprint-updates-2-connected-2"
+
+    # Now trigger. We expect a total of two updates:
+    # - One is built & delivered to the first three subscribers
+    # - Another is built & delivered to the next two
+    click_on("Trigger with fingerprint 2")
+
+    # These all share the first value:
+    assert_selector "#fingerprint-updates-1-update-1-value-1"
+    assert_selector "#fingerprint-updates-1-update-2-value-1"
+    assert_selector "#fingerprint-updates-1-update-3-value-1"
+    # and these share the second value:
+    assert_selector "#fingerprint-updates-2-update-1-value-2"
+    assert_selector "#fingerprint-updates-2-update-2-value-2"
+
+    click_on("Unsubscribe with fingerprint 2")
+    click_on("Trigger with fingerprint 1")
+
+    # These get an update
+    assert_selector "#fingerprint-updates-1-update-1-value-3"
+    assert_selector "#fingerprint-updates-1-update-2-value-3"
+    assert_selector "#fingerprint-updates-1-update-3-value-3"
+    # But these are unsubscribed:
+    refute_selector "#fingerprint-updates-2-update-1-value-4"
+    refute_selector "#fingerprint-updates-2-update-2-value-4"
+    click_on("Unsubscribe with fingerprint 1")
+    # Make a new subscription and make sure it's updated:
+    click_on("Subscribe with fingerprint 2")
+    click_on("Trigger with fingerprint 2")
+    assert_selector "#fingerprint-updates-2-update-3-value-4"
+    # But this one was unsubscribed:
+    refute_selector "#fingerprint-updates-1-update-1-value-5"
   end
 end

--- a/spec/dummy/test/system/action_cable_subscription_test.rb
+++ b/spec/dummy/test/system/action_cable_subscription_test.rb
@@ -43,63 +43,63 @@ class ActionCableSubscriptionsTest < ApplicationSystemTestCase
     assert_selector "#updates-2-400", text: "400"
   end
 
-
   test "it only re-runs queries once for subscriptions with matching fingerprints" do
     visit "/"
+    using_wait_time 5 do
+      # Make 3 subscriptions to the same payload
+      click_on("Subscribe with fingerprint 1")
+      assert_selector "#fingerprint-updates-1-connected-1"
+      click_on("Subscribe with fingerprint 1")
+      assert_selector "#fingerprint-updates-1-connected-2"
+      click_on("Subscribe with fingerprint 1")
+      assert_selector "#fingerprint-updates-1-connected-3"
 
-    # Make 3 subscriptions to the same payload
-    click_on("Subscribe with fingerprint 1")
-    assert_selector "#fingerprint-updates-1-connected-1"
-    click_on("Subscribe with fingerprint 1")
-    assert_selector "#fingerprint-updates-1-connected-2"
-    click_on("Subscribe with fingerprint 1")
-    assert_selector "#fingerprint-updates-1-connected-3"
+      # And two to the next payload
+      click_on("Subscribe with fingerprint 2")
+      assert_selector "#fingerprint-updates-2-connected-1"
+      click_on("Subscribe with fingerprint 2")
+      assert_selector "#fingerprint-updates-2-connected-2"
 
-    # And two to the next payload
-    click_on("Subscribe with fingerprint 2")
-    assert_selector "#fingerprint-updates-2-connected-1"
-    click_on("Subscribe with fingerprint 2")
-    assert_selector "#fingerprint-updates-2-connected-2"
+      # Now trigger. We expect a total of two updates:
+      # - One is built & delivered to the first three subscribers
+      # - Another is built & delivered to the next two
+      click_on("Trigger with fingerprint 2")
 
-    # Now trigger. We expect a total of two updates:
-    # - One is built & delivered to the first three subscribers
-    # - Another is built & delivered to the next two
-    click_on("Trigger with fingerprint 2")
+      # The order here is random, I think depending on ActionCable's internal storage:
+      if page.has_css?("#fingerprint-updates-1-update-1-value-1")
+        fingerprint_1_value = 1
+        fingerprint_2_value = 2
+      else
+        fingerprint_1_value = 2
+        fingerprint_2_value = 1
+      end
 
-    # The order here is random, I think depending on ActionCable's internal storage:
-    if page.has_css?("#fingerprint-updates-1-update-1-value-1")
-      fingerprint_1_value = 1
-      fingerprint_2_value = 2
-    else
-      fingerprint_1_value = 2
-      fingerprint_2_value = 1
+      # These all share the first value:
+      assert_selector "#fingerprint-updates-1-update-1-value-#{fingerprint_1_value}"
+      assert_selector "#fingerprint-updates-1-update-2-value-#{fingerprint_1_value}"
+      assert_selector "#fingerprint-updates-1-update-3-value-#{fingerprint_1_value}"
+      # and these share the second value:
+      assert_selector "#fingerprint-updates-2-update-1-value-#{fingerprint_2_value}"
+      assert_selector "#fingerprint-updates-2-update-2-value-#{fingerprint_2_value}"
+
+      click_on("Unsubscribe with fingerprint 2")
+      click_on("Trigger with fingerprint 1")
+
+      # These get an update
+      assert_selector "#fingerprint-updates-1-update-1-value-#{fingerprint_1_value + 2}"
+      assert_selector "#fingerprint-updates-1-update-2-value-#{fingerprint_1_value + 2}"
+      assert_selector "#fingerprint-updates-1-update-3-value-#{fingerprint_1_value + 2}"
+      # But these are unsubscribed:
+      refute_selector "#fingerprint-updates-2-update-1-value-#{fingerprint_2_value + 2}"
+      refute_selector "#fingerprint-updates-2-update-2-value-#{fingerprint_2_value + 2}"
+      click_on("Unsubscribe with fingerprint 1")
+      # Make a new subscription and make sure it's updated:
+      click_on("Subscribe with fingerprint 2")
+      click_on("Trigger with fingerprint 2")
+      assert_selector "#fingerprint-updates-2-update-1-value-#{fingerprint_2_value + 2}"
+      # But this one was unsubscribed:
+      refute_selector "#fingerprint-updates-1-update-1-value-#{fingerprint_1_value + 3}"
+      refute_selector "#fingerprint-updates-1-update-1-value-#{fingerprint_1_value + 4}"
     end
-
-    # These all share the first value:
-    assert_selector "#fingerprint-updates-1-update-1-value-#{fingerprint_1_value}"
-    assert_selector "#fingerprint-updates-1-update-2-value-#{fingerprint_1_value}"
-    assert_selector "#fingerprint-updates-1-update-3-value-#{fingerprint_1_value}"
-    # and these share the second value:
-    assert_selector "#fingerprint-updates-2-update-1-value-#{fingerprint_2_value}"
-    assert_selector "#fingerprint-updates-2-update-2-value-#{fingerprint_2_value}"
-
-    click_on("Unsubscribe with fingerprint 2")
-    click_on("Trigger with fingerprint 1")
-
-    # These get an update
-    assert_selector "#fingerprint-updates-1-update-1-value-#{fingerprint_1_value + 2}"
-    assert_selector "#fingerprint-updates-1-update-2-value-#{fingerprint_1_value + 2}"
-    assert_selector "#fingerprint-updates-1-update-3-value-#{fingerprint_1_value + 2}"
-    # But these are unsubscribed:
-    refute_selector "#fingerprint-updates-2-update-1-value-#{fingerprint_2_value + 2}"
-    refute_selector "#fingerprint-updates-2-update-2-value-#{fingerprint_2_value + 2}"
-    click_on("Unsubscribe with fingerprint 1")
-    # Make a new subscription and make sure it's updated:
-    click_on("Subscribe with fingerprint 2")
-    click_on("Trigger with fingerprint 2")
-    assert_selector "#fingerprint-updates-2-update-1-value-#{fingerprint_2_value + 2}"
-    # But this one was unsubscribed:
-    refute_selector "#fingerprint-updates-1-update-1-value-#{fingerprint_1_value + 3}"
-    refute_selector "#fingerprint-updates-1-update-1-value-#{fingerprint_1_value + 4}"
   end
 end

--- a/spec/dummy/test/system/action_cable_subscription_test.rb
+++ b/spec/dummy/test/system/action_cable_subscription_test.rb
@@ -45,7 +45,7 @@ class ActionCableSubscriptionsTest < ApplicationSystemTestCase
 
   test "it only re-runs queries once for subscriptions with matching fingerprints" do
     visit "/"
-    using_wait_time 5 do
+    using_wait_time 10 do
       # Make 3 subscriptions to the same payload
       click_on("Subscribe with fingerprint 1")
       assert_selector "#fingerprint-updates-1-connected-1"

--- a/spec/dummy/test/system/action_cable_subscription_test.rb
+++ b/spec/dummy/test/system/action_cable_subscription_test.rb
@@ -49,16 +49,16 @@ class ActionCableSubscriptionsTest < ApplicationSystemTestCase
 
     # Make 3 subscriptions to the same payload
     click_on("Subscribe with fingerprint 1")
+    assert_selector "#fingerprint-updates-1-connected-1"
     click_on("Subscribe with fingerprint 1")
+    assert_selector "#fingerprint-updates-1-connected-2"
     click_on("Subscribe with fingerprint 1")
+    assert_selector "#fingerprint-updates-1-connected-3"
+
     # And two to the next payload
     click_on("Subscribe with fingerprint 2")
-    click_on("Subscribe with fingerprint 2")
-
-    assert_selector "#fingerprint-updates-1-connected-1"
-    assert_selector "#fingerprint-updates-1-connected-2"
-    assert_selector "#fingerprint-updates-1-connected-3"
     assert_selector "#fingerprint-updates-2-connected-1"
+    click_on("Subscribe with fingerprint 2")
     assert_selector "#fingerprint-updates-2-connected-2"
 
     # Now trigger. We expect a total of two updates:

--- a/spec/graphql/subscriptions/broadcast_analyzer_spec.rb
+++ b/spec/graphql/subscriptions/broadcast_analyzer_spec.rb
@@ -65,12 +65,7 @@ describe GraphQL::Subscriptions::BroadcastAnalyzer do
 
 
   def broadcastable?(query_str, schema: BroadcastTestSchema)
-    query = GraphQL::Query.new(schema, query_str)
-    if !query.valid?
-      raise query.validation_errors.map(&:to_h).inspect
-    end
-    GraphQL::Analysis::AST.analyze_query(query, schema.query_analyzers)
-    query.context.namespace(:subscriptions)[:subscription_broadcastable]
+    schema.subscriptions.broadcastable?(query_str)
   end
 
   it "doesn't run for non-subscriptions" do

--- a/spec/graphql/subscriptions/broadcast_analyzer_spec.rb
+++ b/spec/graphql/subscriptions/broadcast_analyzer_spec.rb
@@ -81,12 +81,15 @@ describe GraphQL::Subscriptions::BroadcastAnalyzer do
 
   describe "when the default is false" do
     it "applies default false when any field is not tagged" do
-      assert_equal false, broadcastable?("subscription { __typename }", schema: BroadcastTestDefaultFalseSchema)
       assert_equal false, broadcastable?("subscription { throwableWasThrown { throwable { weight } } }", schema: BroadcastTestDefaultFalseSchema)
     end
 
     it "returns true when all fields are tagged true" do
       assert_equal true, broadcastable?("subscription { newMaxThrowRecord { distance } }", schema: BroadcastTestDefaultFalseSchema)
+    end
+
+    it "treats introspection fields as broadcastable" do
+      assert_equal true, broadcastable?("subscription { __typename }", schema: BroadcastTestDefaultFalseSchema)
     end
   end
 

--- a/spec/graphql/subscriptions/broadcast_analyzer_spec.rb
+++ b/spec/graphql/subscriptions/broadcast_analyzer_spec.rb
@@ -118,7 +118,7 @@ describe GraphQL::Subscriptions::BroadcastAnalyzer do
           }
         }
         GRAPHQL
-        assert_equal false, broadcastable?("subscription { throwableWasThrown { throwable { splitBroadcastableTest } } }")
+        assert_equal false, broadcastable?(query_str)
       end
 
       it "is ok if all explicitly-named object fields are broadcastable" do

--- a/spec/graphql/subscriptions/broadcast_analyzer_spec.rb
+++ b/spec/graphql/subscriptions/broadcast_analyzer_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::Subscriptions::BroadcastAnalyzer do
+  class BroadcastTestSchema < GraphQL::Schema
+    module Throwable
+      include GraphQL::Schema::Interface
+      field :weight, Integer, null: false
+    end
+
+    class Javelin < GraphQL::Schema::Object
+      implements Throwable
+    end
+
+    class Shot < GraphQL::Schema::Object
+      implements Throwable
+    end
+
+    class Query < GraphQL::Schema::Object
+      field :throwable, Throwable, null: true
+    end
+
+    class Mutation < GraphQL::Schema::Object
+      field :noop, String, null: true
+    end
+
+    class Subscription < GraphQL::Schema::Object
+      class ThrowableWasThrown < GraphQL::Schema::Subscription
+        field :throwable, Throwable, null: false
+      end
+
+      field :throwable_was_thrown, subscription: ThrowableWasThrown
+    end
+
+    query(Query)
+    mutation(Mutation)
+    subscription(Subscription)
+    use GraphQL::Execution::Interpreter
+    use GraphQL::Analysis::AST
+    use GraphQL::Subscriptions, broadcast: true, default_broadcastable: true
+  end
+
+
+  def broadcastable?(query_str)
+    query = GraphQL::Query.new(BroadcastTestSchema, query_str)
+    GraphQL::Analysis::AST.analyze_query(query, BroadcastTestSchema.query_analyzers)
+    query.context.namespace(:subscriptions)[:subscription_broadcastable]
+  end
+
+  it "doesn't run for non-subscriptions" do
+    assert_nil broadcastable?("{ __typename }")
+    assert_nil broadcastable?("mutation { __typename }")
+    assert_equal true, broadcastable?("subscription { __typename }")
+  end
+
+  describe "when the default is false" do
+    it "applies default false when any field is not tagged"
+    it "returns true when all fields are tagged true"
+  end
+
+  describe "when the default is true" do
+    it "returns false when any field is tagged false"
+    it "returns true no field is tagged false"
+  end
+
+  describe "abstract types" do
+    describe "when a field returns an interface" do
+      it "requires all object type fields to be broadcastable"
+      it "is ok if all explicitly-named object fields are broadcastable"
+      it "is false if any explicitly-named object fields are broadcastable"
+    end
+  end
+end

--- a/spec/graphql/subscriptions/broadcast_analyzer_spec.rb
+++ b/spec/graphql/subscriptions/broadcast_analyzer_spec.rb
@@ -6,14 +6,18 @@ describe GraphQL::Subscriptions::BroadcastAnalyzer do
     module Throwable
       include GraphQL::Schema::Interface
       field :weight, Integer, null: false
+      field :too_heavy_for_viewer, Boolean, null: false, broadcastable: false
+      field :split_broadcastable_test, Boolean, null: false
     end
 
     class Javelin < GraphQL::Schema::Object
       implements Throwable
+      field :split_broadcastable_test, Boolean, null: false, broadcastable: false
     end
 
     class Shot < GraphQL::Schema::Object
       implements Throwable
+      field :viewer_can_put, Boolean, null: false, broadcastable: false
     end
 
     class Query < GraphQL::Schema::Object
@@ -27,23 +31,45 @@ describe GraphQL::Subscriptions::BroadcastAnalyzer do
     class Subscription < GraphQL::Schema::Object
       class ThrowableWasThrown < GraphQL::Schema::Subscription
         field :throwable, Throwable, null: false
+        field :viewer, String, null: false, broadcastable: false
       end
 
       field :throwable_was_thrown, subscription: ThrowableWasThrown
+
+      class NewMaxThrowRecord < GraphQL::Schema::Subscription
+        field :distance, Integer, null: false, broadcastable: true
+      end
+
+      field :new_max_throw_record, subscription: NewMaxThrowRecord, broadcastable: true
     end
 
     query(Query)
     mutation(Mutation)
     subscription(Subscription)
+    orphan_types(Shot, Javelin)
     use GraphQL::Execution::Interpreter
     use GraphQL::Analysis::AST
     use GraphQL::Subscriptions, broadcast: true, default_broadcastable: true
   end
 
+  # Inheritance doesn't quite work, because the query analyzer is carried over.
+  class BroadcastTestDefaultFalseSchema < GraphQL::Schema
+    query(BroadcastTestSchema::Query)
+    mutation(BroadcastTestSchema::Mutation)
+    subscription(BroadcastTestSchema::Subscription)
+    orphan_types(BroadcastTestSchema::Shot, BroadcastTestSchema::Javelin)
+    use GraphQL::Execution::Interpreter
+    use GraphQL::Analysis::AST
+    use GraphQL::Subscriptions, broadcast: true, default_broadcastable: false
+  end
 
-  def broadcastable?(query_str)
-    query = GraphQL::Query.new(BroadcastTestSchema, query_str)
-    GraphQL::Analysis::AST.analyze_query(query, BroadcastTestSchema.query_analyzers)
+
+  def broadcastable?(query_str, schema: BroadcastTestSchema)
+    query = GraphQL::Query.new(schema, query_str)
+    if !query.valid?
+      raise query.validation_errors.map(&:to_h).inspect
+    end
+    GraphQL::Analysis::AST.analyze_query(query, schema.query_analyzers)
     query.context.namespace(:subscriptions)[:subscription_broadcastable]
   end
 
@@ -54,20 +80,82 @@ describe GraphQL::Subscriptions::BroadcastAnalyzer do
   end
 
   describe "when the default is false" do
-    it "applies default false when any field is not tagged"
-    it "returns true when all fields are tagged true"
+    it "applies default false when any field is not tagged" do
+      assert_equal false, broadcastable?("subscription { __typename }", schema: BroadcastTestDefaultFalseSchema)
+      assert_equal false, broadcastable?("subscription { throwableWasThrown { throwable { weight } } }", schema: BroadcastTestDefaultFalseSchema)
+    end
+
+    it "returns true when all fields are tagged true" do
+      assert_equal true, broadcastable?("subscription { newMaxThrowRecord { distance } }", schema: BroadcastTestDefaultFalseSchema)
+    end
   end
 
   describe "when the default is true" do
-    it "returns false when any field is tagged false"
-    it "returns true no field is tagged false"
+    it "returns false when any field is tagged false" do
+      assert_equal false, broadcastable?("subscription { throwableWasThrown { viewer } }")
+      assert_equal false, broadcastable?("subscription { throwableWasThrown { throwable { ... on Shot { viewerCanPut } } } }")
+    end
+
+    it "returns true no field is tagged false" do
+      assert_equal true, broadcastable?("subscription { throwableWasThrown { throwable { weight } } }")
+    end
   end
 
   describe "abstract types" do
     describe "when a field returns an interface" do
-      it "requires all object type fields to be broadcastable"
-      it "is ok if all explicitly-named object fields are broadcastable"
-      it "is false if any explicitly-named object fields are broadcastable"
+      it "observes the interface-defined configuration" do
+        assert_equal false, broadcastable?("subscription { throwableWasThrown { throwable { tooHeavyForViewer } } }")
+      end
+
+      it "requires all object type fields to be broadcastable" do
+        query_str = <<-GRAPHQL
+        subscription {
+          throwableWasThrown {
+            throwable {
+              # this is configured `false` for Javelin
+              splitBroadcastableTest
+            }
+          }
+        }
+        GRAPHQL
+        assert_equal false, broadcastable?("subscription { throwableWasThrown { throwable { splitBroadcastableTest } } }")
+      end
+
+      it "is ok if all explicitly-named object fields are broadcastable" do
+        query_str = <<-GRAPHQL
+        subscription {
+          throwableWasThrown {
+            throwable {
+              # Although this is false on Javelin, it's not overriden on Shot,
+              # so it should use the default of `true`
+              ...on Shot {
+                splitBroadcastableTest
+              }
+            }
+          }
+        }
+        GRAPHQL
+        assert_equal true, broadcastable?(query_str)
+      end
+
+      it "is false if any explicitly-named object fields are broadcastable" do
+        query_str = <<-GRAPHQL
+        subscription {
+          throwableWasThrown {
+            throwable {
+              ...on Shot {
+                splitBroadcastableTest
+              }
+              ... on Javelin {
+                # Explicitly-named Javelin has it configured `false`
+                splitBroadcastableTest
+              }
+            }
+          }
+        }
+        GRAPHQL
+        assert_equal false, broadcastable?(query_str)
+      end
     end
   end
 end

--- a/spec/graphql/subscriptions_spec.rb
+++ b/spec/graphql/subscriptions_spec.rb
@@ -61,7 +61,7 @@ class InMemoryBackend
       @deliveries[channel] << result
     end
 
-    def execute(channel, event, object)
+    def execute_update(channel, event, object)
       @pushes << channel
       super
     end

--- a/spec/graphql/subscriptions_spec.rb
+++ b/spec/graphql/subscriptions_spec.rb
@@ -47,7 +47,7 @@ class InMemoryBackend
     end
 
     def delete_subscription(subscription_id)
-      query = @queries.delete(subscription_id)
+      @queries.delete(subscription_id)
       @events.each do |topic, sub_ids_by_fp|
         sub_ids_by_fp.each do |fp, sub_ids|
           sub_ids.delete(subscription_id)


### PR DESCRIPTION
If lots of people are subscribed to the same event with the same query string, and you can be sure that they should _all receive the same data_, then we should be able to calculate the payload _once_ and distribute it to all subscribers. 

I thought I would need a new API, but I think it's possible using: 

- `Query#fingerprint`, which returns a unique string for each query string + variables 
- `Event#topic`, which includes field name, args, and subscription scope


__TODO__: 

- [x] Update general broadcast docs with opt-in info and considerations 
- [x] Add `broadcastable?` helper for tests? 
- [x] Update implementation-specific docs about considerations 
- [x] Make introspection fields broadcastable by default

Fixes #2851

Part of #2846 