### PR TITLE
Add Edge#parent to new connections

### DIFF
--- a/lib/graphql/pagination/connections.rb
+++ b/lib/graphql/pagination/connections.rb
@@ -65,21 +65,22 @@ module GraphQL
 
       # Used by the runtime to wrap values in connection wrappers.
       # @api Private
-      def wrap(field, object, arguments, context, wrappers: all_wrappers)
+      def wrap(field, parent, items, arguments, context, wrappers: all_wrappers)
         impl = nil
 
-        object.class.ancestors.each { |cls|
+        items.class.ancestors.each { |cls|
           impl = wrappers[cls]
           break if impl
         }
 
         if impl.nil?
-          raise ImplementationMissingError, "Couldn't find a connection wrapper for #{object.class} during #{field.path} (#{object.inspect})"
+          raise ImplementationMissingError, "Couldn't find a connection wrapper for #{items.class} during #{field.path} (#{items.inspect})"
         end
 
         impl.new(
-          object,
+          items,
           context: context,
+          parent: parent,
           max_page_size: field.max_page_size || context.schema.default_max_page_size,
           first: arguments[:first],
           after: arguments[:after],

--- a/lib/graphql/schema/field/connection_extension.rb
+++ b/lib/graphql/schema/field/connection_extension.rb
@@ -31,7 +31,7 @@ module GraphQL
           elsif value.is_a?(GraphQL::Pagination::Connection)
             # update the connection with some things that may not have been provided
             value.context ||= context
-            value.parent ||= object
+            value.parent ||= object.object
             value.first_value ||= arguments[:first]
             value.after_value ||= arguments[:after]
             value.last_value ||= arguments[:last]
@@ -42,7 +42,7 @@ module GraphQL
             value
           elsif context.schema.new_connections?
             wrappers = context.namespace(:connections)[:all_wrappers] ||= context.schema.connections.all_wrappers
-            context.schema.connections.wrap(field, object, value, arguments, context, wrappers: wrappers)
+            context.schema.connections.wrap(field, object.object, value, arguments, context, wrappers: wrappers)
           else
             if object.is_a?(GraphQL::Schema::Object)
               object = object.object

--- a/lib/graphql/schema/field/connection_extension.rb
+++ b/lib/graphql/schema/field/connection_extension.rb
@@ -31,6 +31,7 @@ module GraphQL
           elsif value.is_a?(GraphQL::Pagination::Connection)
             # update the connection with some things that may not have been provided
             value.context ||= context
+            value.parent ||= object
             value.first_value ||= arguments[:first]
             value.after_value ||= arguments[:after]
             value.last_value ||= arguments[:last]
@@ -41,7 +42,7 @@ module GraphQL
             value
           elsif context.schema.new_connections?
             wrappers = context.namespace(:connections)[:all_wrappers] ||= context.schema.connections.all_wrappers
-            context.schema.connections.wrap(field, value, arguments, context, wrappers: wrappers)
+            context.schema.connections.wrap(field, object, value, arguments, context, wrappers: wrappers)
           else
             if object.is_a?(GraphQL::Schema::Object)
               object = object.object

--- a/spec/graphql/pagination/connections_spec.rb
+++ b/spec/graphql/pagination/connections_spec.rb
@@ -37,13 +37,13 @@ describe GraphQL::Pagination::Connections do
   it "returns connections by class, using inherited mappings and local overrides" do
     field_defn = OpenStruct.new(max_page_size: 10)
 
-    set_wrapper = schema.connections.wrap(field_defn, Set.new([1,2,3]), {}, nil)
+    set_wrapper = schema.connections.wrap(field_defn, nil, Set.new([1,2,3]), {}, nil)
     assert_instance_of SetConnection, set_wrapper
 
-    hash_wrapper = schema.connections.wrap(field_defn, {1 => :a, 2 => :b}, {}, nil)
+    hash_wrapper = schema.connections.wrap(field_defn, nil, {1 => :a, 2 => :b}, {}, nil)
     assert_instance_of HashConnection, hash_wrapper
 
-    array_wrapper = schema.connections.wrap(field_defn, [1,2,3], {}, nil)
+    array_wrapper = schema.connections.wrap(field_defn, nil, [1,2,3], {}, nil)
     assert_instance_of OtherArrayConnection, array_wrapper
   end
 
@@ -51,7 +51,7 @@ describe GraphQL::Pagination::Connections do
     field_defn = OpenStruct.new(max_page_size: 10)
 
     assert_raises GraphQL::Pagination::Connections::ImplementationMissingError do
-      schema.connections.wrap(field_defn, Set.new([1,2,3]), {}, nil, wrappers: {})
+      schema.connections.wrap(field_defn, nil, Set.new([1,2,3]), {}, nil, wrappers: {})
     end
   end
 


### PR DESCRIPTION
Fixes #2960 

I'm rolling this out in a larger release than usual because it changes the API of `.wrap(...)`. It requires a new input, `parent`.

TODO: 

- [x] test