### PR TITLE
Add Scout transaction naming

### DIFF
--- a/lib/graphql/tracing/new_relic_tracing.rb
+++ b/lib/graphql/tracing/new_relic_tracing.rb
@@ -26,18 +26,7 @@ module GraphQL
         if key == "execute_query"
           set_this_txn_name =  data[:query].context[:set_new_relic_transaction_name]
           if set_this_txn_name == true || (set_this_txn_name.nil? && @set_transaction_name)
-            query = data[:query]
-            # Set the transaction name based on the operation type and name
-            selected_op = query.selected_operation
-            if selected_op
-              op_type = selected_op.operation_type
-              op_name = selected_op.name || "anonymous"
-            else
-              op_type = "query"
-              op_name = "anonymous"
-            end
-
-            NewRelic::Agent.set_transaction_name("GraphQL/#{op_type}.#{op_name}")
+            NewRelic::Agent.set_transaction_name(transaction_name(data[:query]))
           end
         end
 

--- a/lib/graphql/tracing/platform_tracing.rb
+++ b/lib/graphql/tracing/platform_tracing.rb
@@ -102,6 +102,21 @@ module GraphQL
         schema_defn.tracer(tracer)
       end
 
+      protected
+
+      # Get the transaction name based on the operation type and name
+      def transaction_name(query)
+        selected_op = query.selected_operation
+        if selected_op
+          op_type = selected_op.operation_type
+          op_name = selected_op.name || "anonymous"
+        else
+          op_type = "query"
+          op_name = "anonymous"
+        end
+        "GraphQL/#{op_type}.#{op_name}"
+      end
+
       private
       attr_reader :options
 

--- a/lib/graphql/tracing/platform_tracing.rb
+++ b/lib/graphql/tracing/platform_tracing.rb
@@ -102,7 +102,7 @@ module GraphQL
         schema_defn.tracer(tracer)
       end
 
-      protected
+      private
 
       # Get the transaction name based on the operation type and name
       def transaction_name(query)
@@ -117,7 +117,6 @@ module GraphQL
         "GraphQL/#{op_type}.#{op_name}"
       end
 
-      private
       attr_reader :options
 
       def platform_key_cache(ctx)

--- a/lib/graphql/tracing/scout_tracing.rb
+++ b/lib/graphql/tracing/scout_tracing.rb
@@ -16,12 +16,33 @@ module GraphQL
         "execute_query_lazy" => "execute.graphql",
       }
 
+      # @param set_transaction_name [Boolean] If true, the GraphQL operation name will be used as the transaction name.
+      #   This is not advised if you run more than one query per HTTP request, for example, with `graphql-client` or multiplexing.
+      #   It can also be specified per-query with `context[:set_scout_transaction_name]`.
       def initialize(options = {})
         self.class.include ScoutApm::Tracer
+        @set_transaction_name = options.fetch(:set_transaction_name, false)
         super(options)
       end
 
       def platform_trace(platform_key, key, data)
+        if key == "execute_query"
+          set_this_txn_name = data[:query].context[:set_scout_transaction_name]
+          if set_this_txn_name == true || (set_this_txn_name.nil? && @set_transaction_name)
+            query = data[:query]
+            selected_op = query.selected_operation
+            if selected_op
+              op_type = selected_op.operation_type
+              op_name = selected_op.name || "anonymous"
+            else
+              op_type = "query"
+              op_name = "anonymous"
+            end
+
+            ScoutApm::Transaction.rename("GraphQL/#{op_type}.#{op_name}")
+          end
+        end
+
         self.class.instrument("GraphQL", platform_key, INSTRUMENT_OPTS) do
           yield
         end

--- a/lib/graphql/tracing/scout_tracing.rb
+++ b/lib/graphql/tracing/scout_tracing.rb
@@ -29,17 +29,7 @@ module GraphQL
         if key == "execute_query"
           set_this_txn_name = data[:query].context[:set_scout_transaction_name]
           if set_this_txn_name == true || (set_this_txn_name.nil? && @set_transaction_name)
-            query = data[:query]
-            selected_op = query.selected_operation
-            if selected_op
-              op_type = selected_op.operation_type
-              op_name = selected_op.name || "anonymous"
-            else
-              op_type = "query"
-              op_name = "anonymous"
-            end
-
-            ScoutApm::Transaction.rename("GraphQL/#{op_type}.#{op_name}")
+            ScoutApm::Transaction.rename(transaction_name(data[:query]))
           end
         end
 

--- a/spec/support/scout_apm.rb
+++ b/spec/support/scout_apm.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# A stub for the NewRelic agent, so we can make assertions about how it is used
+# A stub for the Scout agent, so we can make assertions about how it is used
 if defined?(ScoutApm)
   raise "Expected ScoutApm to be undefined, so that we could define a stub for it."
 end

--- a/spec/support/scout_apm.rb
+++ b/spec/support/scout_apm.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+# A stub for the NewRelic agent, so we can make assertions about how it is used
+if defined?(ScoutApm)
+  raise "Expected ScoutApm to be undefined, so that we could define a stub for it."
+end
+
+class ScoutApm
+  TRANSACTION_NAMES = []
+
+  def self.clear_all
+    TRANSACTION_NAMES.clear
+  end
+
+  module Tracer
+    def self.included(klass)
+      klass.extend ClassMethods
+    end
+
+    module ClassMethods
+      def instrument(type, name, options = {})
+        yield
+      end
+    end
+  end
+
+  module Transaction
+    def self.rename(name)
+      ScoutApm::TRANSACTION_NAMES << name
+    end
+  end
+end


### PR DESCRIPTION
This adds code to `GraphQL::Tracing::ScoutTracing` to write the transaction name for single query execution.

Fixes #2968 

---

This seems like an opportunity to refactor a bit since the 16 line method is identical to `GraphQL::Tracing::NewRelicTracing` except for one line. I didn't want to make this change without checking first, though.

It seems like a simple improvement would be to move the code that determines the transaction name into `PlatformTracing` as `transaction_name`, like:

```ruby
# platform_tracing.rb

# Get the transaction name based on the operation type and name
def transaction_name
  query = data[:query]
  selected_op = query.selected_operation
  if selected_op
    op_type = selected_op.operation_type
    op_name = selected_op.name || "anonymous"
  else
    op_type = "query"
    op_name = "anonymous"
  end
  "GraphQL/#{op_type}.#{op_name}"
end
```

And then in Scout/NewRelic it can do this:

```ruby
def platform_trace(platform_key, key, data)
  if key == "execute_query"
    set_this_txn_name = data[:query].context[:set_scout_transaction_name]
    if set_this_txn_name == true || (set_this_txn_name.nil? && @set_transaction_name)
      ScoutApm::Transaction.rename(transaction_name)
    end
  end
```

Thoughts?