### PR TITLE
Use Time objects instead of DateTime for ISO8601DateTime scalar

### DIFF
--- a/lib/graphql/types/iso_8601_date.rb
+++ b/lib/graphql/types/iso_8601_date.rb
@@ -15,7 +15,7 @@ module GraphQL
     class ISO8601Date < GraphQL::Schema::Scalar
       description "An ISO 8601-encoded date"
 
-      # @param value [Date,DateTime,String]
+      # @param value [Date,Time,DateTime,String]
       # @return [String]
       def self.coerce_result(value, _ctx)
         Date.parse(value.to_s).iso8601

--- a/lib/graphql/types/iso_8601_date_time.rb
+++ b/lib/graphql/types/iso_8601_date_time.rb
@@ -1,7 +1,9 @@
+require 'time'
+
 # frozen_string_literal: true
 module GraphQL
   module Types
-    # This scalar takes `DateTime`s and transmits them as strings,
+    # This scalar takes `Time`s and transmits them as strings,
     # using ISO 8601 format.
     #
     # Use it for fields or arguments as follows:
@@ -29,28 +31,26 @@ module GraphQL
         @time_precision = value
       end
 
-      # @param value [Date,DateTime,String]
+      # @param value [Time,Date,DateTime,String]
       # @return [String]
-      def self.coerce_result(value, _ctx)\
+      def self.coerce_result(value, _ctx)
         case value
-        when DateTime
-          return value.iso8601(time_precision)
         when Date
-          return DateTime.parse(value.to_s).iso8601(time_precision)
+          return value.to_time.iso8601(time_precision)
         when ::String
-          return DateTime.parse(value).iso8601(time_precision)
+          return Time.parse(value).iso8601(time_precision)
         else
-          # In case some other API-compliant thing is given:
+          # Time, DateTime or compatible is given:
           return value.iso8601(time_precision)
         end
       rescue StandardError => error
-        raise GraphQL::Error, "An incompatible object (#{value.class}) was given to #{self}. Make sure that only Dates, DateTimes, and well-formatted Strings are used with this type. (#{error.message})"
+        raise GraphQL::Error, "An incompatible object (#{value.class}) was given to #{self}. Make sure that only Times, Dates, DateTimes, and well-formatted Strings are used with this type. (#{error.message})"
       end
 
       # @param str_value [String]
-      # @return [DateTime]
+      # @return [Time]
       def self.coerce_input(str_value, _ctx)
-        DateTime.iso8601(str_value)
+        Time.iso8601(str_value)
       rescue ArgumentError, TypeError
         # Invalid input
         nil


### PR DESCRIPTION
As [documented by Ruby](https://ruby-doc.org/stdlib-2.3.0/libdoc/date/rdoc/DateTime.html): "Almost certainly you'll want to use Time since your app is probably dealing with current dates and times."

The tests conflated timezones with UTC offsets - the difference is subtle but important. There's plenty of sources (e.g. [Stack Overflow](https://stackoverflow.com/tags/timezone/info)) on the internet explaining this.

Also added a small speedup by using `to_time` to coerce a Date object instead of writing out and parsing a string.