### PR TITLE
Allow resolve_type to optionally return resolved object

### DIFF
--- a/guides/type_definitions/interfaces.md
+++ b/guides/type_definitions/interfaces.md
@@ -202,6 +202,31 @@ module Types::RetailItem
 end
 ```
 
+You can also optionally return a "resolved" object in addition the resolved type by returning an array:
+
+```ruby
+module Types::Claim
+  include Types::BaseInterface
+  definition_methods do
+    def resolve_type(object, context)
+      type = case object.value
+      when Success
+        Types::Approved
+      when Error
+        Types::Rejected
+      else
+        raise "Unexpected Claim: #{object.inspect}"
+      end
+
+      [type, object.value]
+    end
+  end
+end
+```
+
+The returned array must be a tuple of `[Type, object]`.
+This is useful for interface or union types which are backed by a domain object which should be unwrapped before resolving the next field.
+
 ## Orphan Types
 
 If you add an object type which implements an interface, but that object type doesn't properly appear in your schema, then you need to add that object to the interfaces's `orphan_types`, for example:

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -306,19 +306,21 @@ module GraphQL
             write_in_response(path, r)
             r
           when "UNION", "INTERFACE"
-            resolved_type_or_lazy = resolve_type(type, value, path)
+            resolved_type_or_lazy, resolved_value = resolve_type(type, value, path)
+            resolved_value ||= value
+
             after_lazy(resolved_type_or_lazy, owner: type, path: path, scoped_context: context.scoped_context, field: field, owner_object: owner_object, arguments: arguments, trace: false) do |resolved_type|
               possible_types = query.possible_types(type)
 
               if !possible_types.include?(resolved_type)
                 parent_type = field.owner
                 err_class = type::UnresolvedTypeError
-                type_error = err_class.new(value, field, parent_type, resolved_type, possible_types)
+                type_error = err_class.new(resolved_value, field, parent_type, resolved_type, possible_types)
                 schema.type_error(type_error, context)
                 write_in_response(path, nil)
                 nil
               else
-                continue_field(path, value, field, resolved_type, ast_node, next_selections, is_non_null, owner_object, arguments)
+                continue_field(path, resolved_value, field, resolved_type, ast_node, next_selections, is_non_null, owner_object, arguments)
               end
             end
           when "OBJECT"
@@ -546,7 +548,7 @@ module GraphQL
 
         def resolve_type(type, value, path)
           trace_payload = { context: context, type: type, object: value, path: path }
-          resolved_type = query.trace("resolve_type", trace_payload) do
+          resolved_type, resolved_value = query.trace("resolve_type", trace_payload) do
             query.resolve_type(type, value)
           end
 
@@ -557,7 +559,7 @@ module GraphQL
               end
             end
           else
-            resolved_type
+            [resolved_type, resolved_value]
           end
         end
 

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -1389,7 +1389,7 @@ module GraphQL
       # rubocop:disable Lint/DuplicateMethods
       module ResolveTypeWithType
         def resolve_type(type, obj, ctx)
-          first_resolved_type = if type.is_a?(Module) && type.respond_to?(:resolve_type)
+          first_resolved_type, resolved_value = if type.is_a?(Module) && type.respond_to?(:resolve_type)
             type.resolve_type(obj, ctx)
           else
             super
@@ -1397,7 +1397,11 @@ module GraphQL
 
           after_lazy(first_resolved_type) do |resolved_type|
             if resolved_type.nil? || (resolved_type.is_a?(Module) && resolved_type.respond_to?(:kind)) || resolved_type.is_a?(GraphQL::BaseType)
-              resolved_type
+              if resolved_value
+                [resolved_type, resolved_value]
+              else
+                resolved_type
+              end
             else
               raise ".resolve_type should return a type definition, but got #{resolved_type.inspect} (#{resolved_type.class}) from `resolve_type(#{type}, #{obj}, #{ctx})`"
             end


### PR DESCRIPTION
Often abstract types in GraphQL are be backed by "wrapped" domain objects such as unions, ADTs, etc. Currently `resolve_type` must return a GraphQL type only even though the wrapped domain object ideally should be unwrapped at this point as well instead of passing through to the next resolver.

This allows abstract type's `resolve_type` to return an optional "resolved"/unwrapped object in addition the resolved type. To optionally return a new object value, an array can be returned as `[type, object]`.

This is backwards compatible as well and the existing validation still applies to verify the first item in the array is a GraphQL type.

@rmosolgo this is a proposal right now to see what you think. If you think it's useful, I need to update documentation.

Also I'm not 100% sure how this works with lazy types yet. It doesn't break them, but I don't think I supported the `[lazy_type, object]` case yet. Should that case be supported?

cc @gmalette