### PR TITLE
Avoid allocations tracking type at path

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -500,23 +500,11 @@ module GraphQL
         # at previous parts of the response.
         # This hash matches the response
         def type_at(path)
-          t = @types_at_paths
-          path.each do |part|
-            t = t[part] || (raise("Invariant: #{part.inspect} not found in #{t}"))
-          end
-          t = t[:__type]
-          t
+          @types_at_paths.fetch(path)
         end
 
         def set_type_at_path(path, type)
-          types = @types_at_paths
-          path.each do |part|
-            types = types[part] ||= {}
-          end
-          # Use this magic key so that the hash contains:
-          # - string keys for nested fields
-          # - :__type for the object type of a selection
-          types[:__type] ||= type
+          @types_at_paths[path] = type
           nil
         end
 


### PR DESCRIPTION
Profiling memory allocations of queries that return a large number of objects revealed a large number of bytes being allocated in `GraphQL::Execution::Interpreter::Runtime#set_type_at_path`. For one of our particularly painful queries, it was responsible for 16% of the total bytes allocated during query execution (after applying the optimizations from #2978). This PR changes the `@types_at_paths` data structure to map directly from a path array to the type which avoids allocating nested hashes.