### PR TITLE
Fixed NoMethodError when using extras in a subscription field 

### DIFF
--- a/lib/graphql/subscriptions/subscription_root.rb
+++ b/lib/graphql/subscriptions/subscription_root.rb
@@ -40,7 +40,7 @@ module GraphQL
             # for the backend to register:
             events << Subscriptions::Event.new(
               name: field.name,
-              arguments: arguments,
+              arguments: arguments_without_field_extras(arguments: arguments),
               context: context,
               field: field,
             )
@@ -48,7 +48,7 @@ module GraphQL
             value
           elsif context.query.subscription_topic == Subscriptions::Event.serialize(
               field.name,
-              arguments,
+              arguments_without_field_extras(arguments: arguments),
               field,
               scope: (field.subscription_scope ? context[field.subscription_scope] : nil),
             )
@@ -58,6 +58,14 @@ module GraphQL
           else
             # This is a subscription update, but this event wasn't triggered.
             context.skip
+          end
+        end
+
+        private
+
+        def arguments_without_field_extras(arguments:)
+          arguments.dup.tap do |event_args|
+            field.extras.each { |k| event_args.delete(k) }
           end
         end
       end

--- a/spec/graphql/schema/subscription_spec.rb
+++ b/spec/graphql/schema/subscription_spec.rb
@@ -39,7 +39,7 @@ describe GraphQL::Schema::Subscription do
       field :toot, Toot, null: false
       field :user, User, null: false
       # Can't subscribe to private users
-      def authorized?(user:)
+      def authorized?(user:, **args)
         if user[:private]
           raise GraphQL::ExecutionError, "Can't subscribe to private user"
         else
@@ -47,7 +47,7 @@ describe GraphQL::Schema::Subscription do
         end
       end
 
-      def subscribe(user:)
+      def subscribe(user:, **args)
         if context[:prohibit_subscriptions]
           raise GraphQL::ExecutionError, "You don't have permission to subscribe"
         else
@@ -56,7 +56,7 @@ describe GraphQL::Schema::Subscription do
         end
       end
 
-      def update(user:)
+      def update(user:, **args)
         if context[:viewer] == user
           # don't update for one's own toots.
           # (IRL it would make more sense to implement this in `#subscribe`)
@@ -103,7 +103,7 @@ describe GraphQL::Schema::Subscription do
 
     class Subscription < GraphQL::Schema::Object
       extend GraphQL::Subscriptions::SubscriptionRoot
-      field :toot_was_tooted, subscription: TootWasTooted
+      field :toot_was_tooted, subscription: TootWasTooted, extras: [:path, :query]
       field :direct_toot_was_tooted, subscription: DirectTootWasTooted
       field :users_joined, subscription: UsersJoined
       field :new_users_joined, subscription: NewUsersJoined


### PR DESCRIPTION
This resolves #2982 by filtering out the arguments before creating the event

If we want to be explicit with the tests, I can create a new field with extras in the subscription and duplicate one test for subscribe and another one for update using that new field