### PR TITLE
Only check used input arguments visibility

### DIFF
--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -169,7 +169,7 @@ module GraphQL
           # We're not actually _using_ the coerced result, we're just
           # using these methods to make sure that the object will
           # behave like a hash below, when we call `each` on it.
-          begin
+          input = begin
             input.to_h
           rescue
             begin
@@ -183,7 +183,7 @@ module GraphQL
           end
 
           # Inject missing required arguments
-          required_inputs = self.arguments.reduce({}) do |m, (argument_name, argument)|
+          missing_required_inputs = self.arguments.reduce({}) do |m, (argument_name, argument)|
             if !input.key?(argument_name) && argument.type.non_null? && warden.get_argument(self, argument_name)
               m[argument_name] = nil
             end
@@ -191,7 +191,7 @@ module GraphQL
             m
           end
 
-          input.to_h.merge(required_inputs).each do |argument_name, value|
+          input.merge(missing_required_inputs).each do |argument_name, value|
             argument = warden.get_argument(self, argument_name)
             # Items in the input that are unexpected
             unless argument

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -166,9 +166,6 @@ module GraphQL
             return result
           end
 
-          # We're not actually _using_ the coerced result, we're just
-          # using these methods to make sure that the object will
-          # behave like a hash below, when we call `each` on it.
           input = begin
             input.to_h
           rescue

--- a/lib/graphql/schema/member/has_arguments.rb
+++ b/lib/graphql/schema/member/has_arguments.rb
@@ -58,6 +58,20 @@ module GraphQL
           end
         end
 
+        # @return [GraphQL::Schema::Argument, nil] Argument defined on this thing, fetched by name.
+        def get_argument(argument_name)
+          if (a = own_arguments[argument_name])
+            a
+          else
+            for ancestor in ancestors
+              if ancestor.respond_to?(:own_arguments) && a = ancestor.own_arguments[argument_name]
+                return a
+              end
+            end
+            nil
+          end
+        end
+
         # @param new_arg_class [Class] A class to use for building argument definitions
         def argument_class(new_arg_class = nil)
           self.class.argument_class(new_arg_class)

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -108,7 +108,7 @@ module GraphQL
 
       # @return [GraphQL::Argument, nil] The argument named `argument_name` on `parent_type`, if it exists and is visible
       def get_argument(parent_type, argument_name)
-        argument = parent_type.arguments[argument_name]
+        argument = parent_type.get_argument(argument_name)
         return argument if argument && visible_argument?(argument)
       end
 

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -106,6 +106,12 @@ module GraphQL
         @visible_parent_fields[parent_type][field_name]
       end
 
+      # @return [GraphQL::Argument, nil] The argument named `argument_name` on `parent_type`, if it exists and is visible
+      def get_argument(parent_type, argument_name)
+        argument = parent_type.arguments[argument_name]
+        return argument if argument && visible_argument?(argument)
+      end
+
       # @return [Array<GraphQL::BaseType>] The types which may be member of `type_defn`
       def possible_types(type_defn)
         @visible_possible_types ||= read_through { |type_defn|

--- a/spec/graphql/query/executor_spec.rb
+++ b/spec/graphql/query/executor_spec.rb
@@ -329,5 +329,27 @@ describe GraphQL::Query::Executor do
         assert_equal(expected, result.to_h)
       end
     end
+
+    describe "for input objects with nil value for a required input" do
+      let(:variables) { {"input" => [{ "source" => nil }]} }
+      let(:query_string) {%| query Q($input: [DairyProductInput]) { searchDairy(product: $input) { __typename, ... on Cheese { id, source } } } |}
+      it "returns a variable validation error" do
+        expected = {
+          "errors"=>[
+            {
+              "message" => "Variable $input of type [DairyProductInput] was provided invalid value for 0.source (Expected value to not be null)",
+              "locations" => [{ "line" => 1, "column" => 10 }],
+              "extensions" => {
+                "value" => [{ "source" => nil }],
+                "problems" => [
+                  { "path" => [0, "source"], "explanation" => "Expected value to not be null" }
+                ]
+              }
+            }
+          ]
+        }
+        assert_equal(expected, result.to_h)
+      end
+    end
   end
 end


### PR DESCRIPTION
This line:

`visible_arguments_map = warden.arguments(self).reduce({}) { |m, f| m[f.name] = f; m}`

Was straightforward, but was also making visibility calls to arguments that we did not need to check.

I have sacrificed a small bit of readability here in order to reduce the number of `visible?` calls being made in warden.

There are three steps to this process to make sure it remained the same and didn't break tests:

1. Inject all required arguments as `nil` that were missing from input. This is to satisfy this test:
https://github.com/rmosolgo/graphql-ruby/blob/39b78e5e46b654d5fc9b170025e3b690e463b9e8/spec/graphql/query/executor_spec.rb#L293
2. Check to see if the input/required args are visible on the object. Satisfies this test:
https://github.com/rmosolgo/graphql-ruby/blob/39b78e5e46b654d5fc9b170025e3b690e463b9e8/spec/graphql/query/executor_spec.rb#L313
3. Confirm that the value being provided is valid. Satisfies this test: https://github.com/rmosolgo/graphql-ruby/pull/2985/files#diff-3f549290bd93783c3126a4eeded156ceR336