### PR TITLE
Remove unused instance variable in GraphQL::Schema::InputObject

### DIFF
--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -21,10 +21,8 @@ module GraphQL
           @ruby_style_hash = @arguments.to_kwargs
         end
         # Apply prepares, not great to have it duplicated here.
-        @arguments_by_keyword = {}
         maybe_lazies = []
-        self.class.arguments.each do |name, arg_defn|
-          @arguments_by_keyword[arg_defn.keyword] = arg_defn
+        self.class.arguments.each_value do |arg_defn|
           ruby_kwargs_key = arg_defn.keyword
 
           if @ruby_style_hash.key?(ruby_kwargs_key)


### PR DESCRIPTION
I was doing some code spelunking and noticed that the `@arguments_by_keyword` instance variable in `GraphQL::Schema::InputObject` was unused.