### PR TITLE
Ably robustness improvements

### DIFF
--- a/javascript_client/package.json
+++ b/javascript_client/package.json
@@ -15,7 +15,8 @@
     "@types/node": "^13.7.1",
     "jest": "^25.0.0",
     "nock": "^11.0.0",
-    "ts-jest": "^25.2.0"
+    "ts-jest": "^25.2.0",
+    "prettier": "^1.19.1"
   },
   "scripts": {
     "test": "tsc && jest",


### PR DESCRIPTION
- Refactor to use async/await
- Fix `unsubscribe` call (cf. ably/ably-js#667)
- Report missing `X-Subscription-ID` header
- Report errors when entering or leaving presence, and when detaching
- Wait for leave and detach to complete before releasing channel

The last item is the main reason for this PR. Currently, the ack messages that Ably sends back especially for detach won't be processed correctly because by the time they arrive, the channel has already been released and Ably can't find it in its mapping. I _think_ this should be harmless but there is a chance this is causing problems.

The code could be a lot nicer if we could use `Ably.Promise`, but that would be a breaking change so I left it for another day.
