### PR TITLE
Fix issues around early disposal

### DIFF
--- a/javascript_client/src/subscriptions/createAblyHandler.ts
+++ b/javascript_client/src/subscriptions/createAblyHandler.ts
@@ -68,7 +68,6 @@ function createAblyHandler(options: AblyHandlerOptions) {
         observer.onCompleted()
       }
     }
-
     ;(async () => {
       try {
         // POST the subscription like a normal query
@@ -134,28 +133,9 @@ function createAblyHandler(options: AblyHandlerOptions) {
         try {
           if (channel) {
             const disposedChannel = channel
-            disposedChannel.unsubscribe("update", updateHandler)
+            disposedChannel.unsubscribe()
 
-            const leavePromise = new Promise((resolve, reject) => {
-              const callback = (err: Types.ErrorInfo) => {
-                if (err) {
-                  reject(new AblyError(err))
-                } else {
-                  resolve()
-                }
-              }
-
-              if (isAnonymousClient()) {
-                disposedChannel.presence.leaveClient(
-                  anonymousClientId,
-                  callback
-                )
-              } else {
-                disposedChannel.presence.leave(callback)
-              }
-            })
-
-            const detachPromise = new Promise((resolve, reject) => {
+            await new Promise((resolve, reject) => {
               disposedChannel.detach((err: Types.ErrorInfo) => {
                 if (err) {
                   reject(new AblyError(err))
@@ -165,7 +145,6 @@ function createAblyHandler(options: AblyHandlerOptions) {
               })
             })
 
-            await Promise.all([leavePromise, detachPromise])
             ably.channels.release(disposedChannel.name)
           }
         } catch (error) {

--- a/javascript_client/src/subscriptions/createAblyHandler.ts
+++ b/javascript_client/src/subscriptions/createAblyHandler.ts
@@ -74,7 +74,6 @@ function createAblyHandler(options: AblyHandlerOptions) {
         // POST the subscription like a normal query
         const response = await fetchOperation(operation, variables, cacheConfig)
 
-        dispatchResult(response.body)
         const channelName = response.headers.get("X-Subscription-ID")
         if (!channelName) {
           throw new Error("Missing X-Subscription-ID header")
@@ -123,6 +122,8 @@ function createAblyHandler(options: AblyHandlerOptions) {
         }
         // When you get an update from ably, give it to Relay
         channel.subscribe("update", updateHandler)
+
+        dispatchResult(response.body)
       } catch (error) {
         observer.onError(error)
       }


### PR DESCRIPTION
1. In certain circumstances, the initial response can cause `dispose` to be called before the subscription has finished setting up. In this situation, the channel is never detached.
2. Likewise, if the subscription is disposed while the Ably channel is still attaching, detaching the channel doesn't do anything.

This PR fixes both of those issues. I've also simplified cleanup based on feedback from Ably.
