### PR TITLE
Remove more visible? calls to unused arguments

### DIFF
--- a/lib/graphql/directive.rb
+++ b/lib/graphql/directive.rb
@@ -99,6 +99,10 @@ module GraphQL
     def type_class
       metadata[:type_class]
     end
+
+    def get_argument(argument_name)
+      arguments[argument_name]
+    end
   end
 end
 

--- a/lib/graphql/field.rb
+++ b/lib/graphql/field.rb
@@ -207,6 +207,10 @@ module GraphQL
       metadata[:type_class]
     end
 
+    def get_argument(argument_name)
+      arguments[argument_name]
+    end
+
     private
 
     def build_default_resolver

--- a/lib/graphql/input_object_type.rb
+++ b/lib/graphql/input_object_type.rb
@@ -58,6 +58,10 @@ module GraphQL
       result
     end
 
+    def get_argument(argument_name)
+      arguments[argument_name]
+    end
+
     private
 
     def coerce_non_null_input(value, ctx)

--- a/lib/graphql/schema/member/has_arguments.rb
+++ b/lib/graphql/schema/member/has_arguments.rb
@@ -60,7 +60,9 @@ module GraphQL
 
         # @return [GraphQL::Schema::Argument, nil] Argument defined on this thing, fetched by name.
         def get_argument(argument_name)
-          if (a = own_arguments[argument_name])
+          a = own_arguments[argument_name]
+
+          if a || !self.is_a?(Class)
             a
           else
             for ancestor in ancestors

--- a/lib/graphql/static_validation/rules/arguments_are_defined.rb
+++ b/lib/graphql/static_validation/rules/arguments_are_defined.rb
@@ -5,7 +5,7 @@ module GraphQL
       def on_argument(node, parent)
         parent_defn = parent_definition(parent)
 
-        if parent_defn && context.warden.arguments(parent_defn).any? { |arg| arg.name == node.name }
+        if parent_defn && context.warden.get_argument(parent_defn, node.name)
           super
         elsif parent_defn
           kind_of_node = node_type(parent)

--- a/lib/graphql/static_validation/rules/required_arguments_are_present.rb
+++ b/lib/graphql/static_validation/rules/required_arguments_are_present.rb
@@ -17,8 +17,8 @@ module GraphQL
 
       def assert_required_args(ast_node, defn)
         present_argument_names = ast_node.arguments.map(&:name)
-        required_argument_names = context.warden.arguments(defn)
-          .select { |a| a.type.kind.non_null? && !a.default_value? }
+        required_argument_names = defn.arguments.each_value
+          .select { |a| a.type.kind.non_null? && !a.default_value? && context.warden.get_argument(defn, a.name) }
           .map(&:name)
 
         missing_names = required_argument_names - present_argument_names

--- a/lib/graphql/static_validation/rules/required_input_object_attributes_are_present.rb
+++ b/lib/graphql/static_validation/rules/required_input_object_attributes_are_present.rb
@@ -26,8 +26,7 @@ module GraphQL
           context.field_definition
         end
 
-        parent_type = context.warden.arguments(defn)
-          .find{|f| f.name == parent_name(parent, defn) }
+        parent_type = context.warden.get_argument(defn, parent_name(parent, defn))
         parent_type ? parent_type.type.unwrap : nil
       end
 


### PR DESCRIPTION
Replaces more usages of `warden.arguments` during static validation (since they trigger `visible?` calls for all arguments on a type regardless if they are specified or not) with more selective `warden.get_argument`.

https://github.com/rmosolgo/graphql-ruby/pull/2985 which fixed some of these occurrences, but not all of them.

This also required additional backwards compatible work to port `get_argument` to the legacy types.

cc @eapache @grcooper @chrisbutcher 