### PR TITLE
Fix arguments caching - check for field extensions

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -460,8 +460,9 @@ module GraphQL
         end
 
         def arguments(graphql_object, arg_owner, ast_node)
-          # Don't cache arguments if field extras are requested since extras mutate the argument data structure
-          if arg_owner.arguments_statically_coercible? && (!arg_owner.is_a?(GraphQL::Schema::Field) || arg_owner.extras.empty?)
+          # Don't cache arguments if field extras or extensions are requested since they can mutate the argument data structure
+          if arg_owner.arguments_statically_coercible? &&
+              (!arg_owner.is_a?(GraphQL::Schema::Field) || (arg_owner.extras.empty? && arg_owner.extensions.empty?))
             query.arguments_for(ast_node, arg_owner)
           else
             # The arguments must be prepared in the context of the given object


### PR DESCRIPTION
Previously this only checked for field extras but field extensions should be checked as well since they can mutate arguments.

@jturkel does this makes sense to you as well? I guess you didn't have any instances of field extensions mutating args?