### PR TITLE
Load deprecation reason from introspection results

### DIFF
--- a/lib/graphql/schema/loader.rb
+++ b/lib/graphql/schema/loader.rb
@@ -98,7 +98,7 @@ module GraphQL
                 value(
                   enum_value["name"],
                   description: enum_value["description"],
-                  deprecation_reason: enum_value["deprecation_reason"],
+                  deprecation_reason: enum_value["deprecationReason"],
                 )
               end
             end
@@ -156,6 +156,7 @@ module GraphQL
               field_hash["name"],
               type: type_resolver.call(field_hash["type"]),
               description: field_hash["description"],
+              deprecation_reason: field_hash["deprecationReason"],
               null: true,
               camelize: false,
             ) do


### PR DESCRIPTION
This PR updates `GraphQL::Schema.from_introspection` to load field and enum value deprecation reasons from introspection results. I converted `spec/graphql/schema/loader_spec.rb` to use the not so new anymore class based API while I was adding test coverage.