### PR TITLE
Load directives from introspection results

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -1534,9 +1534,9 @@ module GraphQL
 
       # Add several directives at once
       # @param new_directives [Class]
-      def directives(new_directives = nil)
-        if new_directives
-          new_directives.each { |d| directive(d) }
+      def directives(*new_directives)
+        if new_directives.any?
+          new_directives.flatten.each { |d| directive(d) }
         end
 
         find_inherited_value(:directives, default_directives).merge(own_directives)
@@ -1550,11 +1550,11 @@ module GraphQL
       end
 
       def default_directives
-        {
+        @default_directives ||= {
           "include" => GraphQL::Schema::Directive::Include,
           "skip" => GraphQL::Schema::Directive::Skip,
           "deprecated" => GraphQL::Schema::Directive::Deprecated,
-        }
+        }.freeze
       end
 
       def tracer(new_tracer)

--- a/spec/graphql/schema/loader_spec.rb
+++ b/spec/graphql/schema/loader_spec.rb
@@ -137,6 +137,7 @@ describe GraphQL::Schema::Loader do
       query query_root
       mutation mutation_root
       orphan_types audio_type, video_type
+      directives GraphQL::Schema::Directive::Transform
     end
   }
 
@@ -154,6 +155,7 @@ describe GraphQL::Schema::Loader do
         assert_equal expected_type.graphql_name, actual_type.graphql_name
         assert_equal expected_type.description, actual_type.description
         assert_equal expected_type.deprecation_reason, actual_type.deprecation_reason
+        assert_equal expected_type.arguments.keys.sort, actual_type.arguments.keys.sort
         assert_deep_equal expected_type.arguments.values.sort_by(&:graphql_name), actual_type.arguments.values.sort_by(&:graphql_name)
       elsif actual_type.is_a?(GraphQL::Schema::EnumValue)
         assert_equal expected_type.graphql_name, actual_type.graphql_name
@@ -170,19 +172,25 @@ describe GraphQL::Schema::Loader do
         assert_equal expected_type.query.graphql_name, actual_type.query.graphql_name
         assert_equal expected_type.mutation.graphql_name, actual_type.mutation.graphql_name
         assert_equal expected_type.directives.keys.sort, actual_type.directives.keys.sort
+        assert_deep_equal expected_type.directives.values.sort_by(&:graphql_name), actual_type.directives.values.sort_by(&:graphql_name)
+        assert_equal expected_type.types.keys.sort, actual_type.types.keys.sort
         assert_deep_equal expected_type.types.values.sort_by(&:graphql_name), actual_type.types.values.sort_by(&:graphql_name)
       elsif actual_type < GraphQL::Schema::Object
         assert_equal expected_type.graphql_name, actual_type.graphql_name
         assert_equal expected_type.description, actual_type.description
+        assert_equal expected_type.interfaces.map(&:graphql_name).sort, actual_type.interfaces.map(&:graphql_name).sort
         assert_deep_equal expected_type.interfaces.sort_by(&:graphql_name), actual_type.interfaces.sort_by(&:graphql_name)
+        assert_equal expected_type.fields.keys.sort, actual_type.fields.keys.sort
         assert_deep_equal expected_type.fields.values.sort_by(&:graphql_name), actual_type.fields.values.sort_by(&:graphql_name)
       elsif actual_type < GraphQL::Schema::Interface
         assert_equal expected_type.graphql_name, actual_type.graphql_name
         assert_equal expected_type.description, actual_type.description
+        assert_equal expected_type.fields.keys.sort, actual_type.fields.keys.sort
         assert_deep_equal expected_type.fields.values.sort_by(&:graphql_name), actual_type.fields.values.sort_by(&:graphql_name)
       elsif actual_type < GraphQL::Schema::Union
         assert_equal expected_type.graphql_name, actual_type.graphql_name
         assert_equal expected_type.description, actual_type.description
+        assert_equal expected_type.possible_types.map(&:graphql_name).sort, actual_type.possible_types.map(&:graphql_name).sort
         assert_deep_equal expected_type.possible_types.sort_by(&:graphql_name), actual_type.possible_types.sort_by(&:graphql_name)
       elsif actual_type < GraphQL::Schema::Scalar
         assert_equal expected_type.graphql_name, actual_type.graphql_name
@@ -192,6 +200,13 @@ describe GraphQL::Schema::Loader do
         assert_deep_equal expected_type.values.values.sort_by(&:graphql_name), actual_type.values.values.sort_by(&:graphql_name)
       elsif actual_type < GraphQL::Schema::InputObject
         assert_equal expected_type.graphql_name, actual_type.graphql_name
+        assert_equal expected_type.arguments.keys.sort, actual_type.arguments.keys.sort
+        assert_deep_equal expected_type.arguments.values.sort_by(&:graphql_name), actual_type.arguments.values.sort_by(&:graphql_name)
+      elsif actual_type < GraphQL::Schema::Directive
+        assert_equal expected_type.graphql_name, actual_type.graphql_name
+        assert_equal expected_type.description, actual_type.description
+        assert_equal expected_type.locations.sort, actual_type.locations.sort
+        assert_equal expected_type.arguments.keys.sort, actual_type.arguments.keys.sort
         assert_deep_equal expected_type.arguments.values.sort_by(&:graphql_name), actual_type.arguments.values.sort_by(&:graphql_name)
       else
         assert_equal expected_type, actual_type


### PR DESCRIPTION
This PR updates `GraphQL::Schema.from_introspection` to load directives from introspection results. While I was in here I made a few related changes:

* Updated `GraphQL::Schema.directives` to accept an array or varargs to be consistent with `orphan_types` and make the DSL a bit more ergonomic
* Updated `loader_spec.rb` `assert_deep_equal` to check that collection element names match before doing recursive equality checking for better error messages. This was previously done for some collections but not all.