### PR TITLE
Update controller generator so that provided_variables has .size

### DIFF
--- a/lib/generators/graphql/templates/graphql_controller.erb
+++ b/lib/generators/graphql/templates/graphql_controller.erb
@@ -30,8 +30,10 @@ class GraphqlController < ApplicationController
       else
         {}
       end
-    when Hash, ActionController::Parameters
+    when Hash
       ambiguous_param
+    when ActionController::Parameters
+      ambiguous_param.to_unsafe_hash
     when nil
       {}
     else

--- a/lib/generators/graphql/templates/graphql_controller.erb
+++ b/lib/generators/graphql/templates/graphql_controller.erb
@@ -26,7 +26,7 @@ class GraphqlController < ApplicationController
     case ambiguous_param
     when String
       if ambiguous_param.present?
-        ensure_hash(JSON.parse(ambiguous_param))
+        JSON.parse(ambiguous_param) || {}
       else
         {}
       end

--- a/lib/generators/graphql/templates/graphql_controller.erb
+++ b/lib/generators/graphql/templates/graphql_controller.erb
@@ -5,7 +5,6 @@ class GraphqlController < ApplicationController
   # protect_from_forgery with: :null_session
 
   def execute
-    variables = ensure_hash(params[:variables])
     query = params[:query]
     operation_name = params[:operationName]
     context = {
@@ -21,8 +20,9 @@ class GraphqlController < ApplicationController
 
   private
 
-  # Handle form data, JSON body, or a blank value
-  def ensure_hash(ambiguous_param)
+  # Handle variables in form data, JSON body, or a blank value
+  def variables
+    ambiguous_param = params[:variables]
     case ambiguous_param
     when String
       if ambiguous_param.present?

--- a/lib/generators/graphql/templates/graphql_controller.erb
+++ b/lib/generators/graphql/templates/graphql_controller.erb
@@ -5,6 +5,7 @@ class GraphqlController < ApplicationController
   # protect_from_forgery with: :null_session
 
   def execute
+    variables = prepare_variables(params[:variables])
     query = params[:query]
     operation_name = params[:operationName]
     context = {
@@ -21,23 +22,22 @@ class GraphqlController < ApplicationController
   private
 
   # Handle variables in form data, JSON body, or a blank value
-  def variables
-    ambiguous_param = params[:variables]
-    case ambiguous_param
+  def prepare_variables(variables_param)
+    case variables_param
     when String
-      if ambiguous_param.present?
-        JSON.parse(ambiguous_param) || {}
+      if variables_param.present?
+        JSON.parse(variables_param) || {}
       else
         {}
       end
     when Hash
-      ambiguous_param
+      variables_param
     when ActionController::Parameters
-      ambiguous_param.to_unsafe_hash # GraphQL-Ruby will validate name and type of incoming variables.
+      variables_param.to_unsafe_hash # GraphQL-Ruby will validate name and type of incoming variables.
     when nil
       {}
     else
-      raise ArgumentError, "Unexpected parameter: #{ambiguous_param}"
+      raise ArgumentError, "Unexpected parameter: #{variables_param}"
     end
   end
 

--- a/lib/generators/graphql/templates/graphql_controller.erb
+++ b/lib/generators/graphql/templates/graphql_controller.erb
@@ -33,7 +33,7 @@ class GraphqlController < ApplicationController
     when Hash
       ambiguous_param
     when ActionController::Parameters
-      ambiguous_param.to_unsafe_hash
+      ambiguous_param.to_unsafe_hash # GraphQL-Ruby will validate name and type of incoming variables.
     when nil
       {}
     else

--- a/spec/integration/rails/generators/graphql/install_generator_spec.rb
+++ b/spec/integration/rails/generators/graphql/install_generator_spec.rb
@@ -215,7 +215,7 @@ class GraphqlController < ApplicationController
   # protect_from_forgery with: :null_session
 
   def execute
-    variables = ensure_hash(params[:variables])
+    variables = prepare_variables(params[:variables])
     query = params[:query]
     operation_name = params[:operationName]
     context = {
@@ -231,21 +231,23 @@ class GraphqlController < ApplicationController
 
   private
 
-  # Handle form data, JSON body, or a blank value
-  def ensure_hash(ambiguous_param)
-    case ambiguous_param
+  # Handle variables in form data, JSON body, or a blank value
+  def prepare_variables(variables_param)
+    case variables_param
     when String
-      if ambiguous_param.present?
-        ensure_hash(JSON.parse(ambiguous_param))
+      if variables_param.present?
+        JSON.parse(variables_param) || {}
       else
         {}
       end
-    when Hash, ActionController::Parameters
-      ambiguous_param
+    when Hash
+      variables_param
+    when ActionController::Parameters
+      variables_param.to_unsafe_hash # GraphQL-Ruby will validate name and type of incoming variables.
     when nil
       {}
     else
-      raise ArgumentError, "Unexpected parameter: #{ambiguous_param}"
+      raise ArgumentError, "Unexpected parameter: #{variables_param}"
     end
   end
 


### PR DESCRIPTION
One possible solution to #3028.

The variables_fingerprint calls size on the variables.  When variables are an instance of ActionController::Parameters, then this will raise an error as size in not defined. Converting ActionController::Parameters to a hash resolves the issue.