### PR TITLE
Correct multiplex documentation regarding the _json field in the params variable

### DIFF
--- a/guides/queries/multiplex.md
+++ b/guides/queries/multiplex.md
@@ -8,7 +8,7 @@ desc: Run multiple queries concurrently
 index: 10
 ---
 
-Some clients may send _several_ queries to the server at once (for example, [Apollo Client's query batching](https://www.apollographql.com/docs/react/advanced/network-layer.html#query-batching)). You can execute them concurrently with {{ "Schema#multiplex" | api_doc }}.
+Some clients may send _several_ queries to the server at once (for example, [Apollo Client's query batching](https://www.apollographql.com/docs/react/api/link/apollo-link-batch-http/)). You can execute them concurrently with {{ "Schema#multiplex" | api_doc }}.
 
 Multiplex runs have their own context, analyzers and instrumentation.
 
@@ -51,14 +51,14 @@ results = MySchema.multiplex(queries)
 
 ## Apollo Query Batching
 
-Apollo sends the batch variables in a `_json` param, you also need to ensure that your schema can handle both batched and non-batched queries, below is an example of the default GraphqlController rewritten to handle Apollo batches:
+Apollo sends batches of queries as an array of queries. Rails' ActionDispatch will parse the request and put the result into the `_json` field of the `params` variable. You also need to ensure that your schema can handle both batched and non-batched queries, below is an example of the default GraphqlController rewritten to handle Apollo batches:
 
 ```ruby
 def execute
   context = {}
 
-  # Apollo sends the params in a _json variable when batching is enabled
-  # see the Apollo Documentation about query batching: https://www.apollographql.com/docs/react/advanced/network-layer.html#query-batching
+  # Apollo sends the queries in an array when batching is enabled. The data ends up in the _json field of the params variable.
+  # see the Apollo Documentation about query batching: https://www.apollographql.com/docs/react/api/link/apollo-link-batch-http/
   result = if params[:_json]
     queries = params[:_json].map do |param|
       {


### PR DESCRIPTION
I was implementing multiplexing for my server, and in the documentation it was mentioned that Apollo sends the batched queries in a `_json` field. However when I inspected the request from the client, there was no `_json` field.

I dug deeper, and found that Apollo client sends the queries in a JSON array, and that Rails' ActionDispatch is the one who populates the "_json" field when the parsed data is not a Hash ([source](https://github.com/rails/rails/blob/e82c10b49ad9cb949f77297e6a814fd8f09d3c8f/actionpack/lib/action_dispatch/http/parameters.rb#L13)).

I also fixed some dead links.