### PR TITLE
Use edge_class: with new pagination implementation

### DIFF
--- a/lib/graphql/pagination/connections.rb
+++ b/lib/graphql/pagination/connections.rb
@@ -58,7 +58,6 @@ module GraphQL
         @schema.ancestors.reverse_each do |schema_class|
           if schema_class.respond_to?(:connections) && (c = schema_class.connections)
             all_wrappers.merge!(c.wrappers)
-
           end
         end
         all_wrappers

--- a/lib/graphql/pagination/connections.rb
+++ b/lib/graphql/pagination/connections.rb
@@ -58,6 +58,7 @@ module GraphQL
         @schema.ancestors.reverse_each do |schema_class|
           if schema_class.respond_to?(:connections) && (c = schema_class.connections)
             all_wrappers.merge!(c.wrappers)
+
           end
         end
         all_wrappers
@@ -86,9 +87,21 @@ module GraphQL
           after: arguments[:after],
           last: arguments[:last],
           before: arguments[:before],
+          edge_class: edge_class_for_field(field),
         )
       end
 
+      # use an override if there is one
+      # @api private
+      def edge_class_for_field(field)
+        conn_type = field.type.unwrap
+        conn_type_edge_type = conn_type.respond_to?(:edge_class) && conn_type.edge_class
+        if conn_type_edge_type && conn_type_edge_type != Relay::Edge
+          conn_type_edge_type
+        else
+          nil
+        end
+      end
       protected
 
       attr_reader :wrappers

--- a/lib/graphql/schema/field/connection_extension.rb
+++ b/lib/graphql/schema/field/connection_extension.rb
@@ -39,6 +39,9 @@ module GraphQL
             if field.has_max_page_size? && !value.has_max_page_size_override?
               value.max_page_size = field.max_page_size
             end
+            if (custom_t = context.schema.connections.edge_class_for_field(@field))
+              value.edge_class = custom_t
+            end
             value
           elsif context.schema.new_connections?
             wrappers = context.namespace(:connections)[:all_wrappers] ||= context.schema.connections.all_wrappers

--- a/spec/graphql/pagination/connections_spec.rb
+++ b/spec/graphql/pagination/connections_spec.rb
@@ -35,7 +35,7 @@ describe GraphQL::Pagination::Connections do
   end
 
   it "returns connections by class, using inherited mappings and local overrides" do
-    field_defn = OpenStruct.new(max_page_size: 10)
+    field_defn = OpenStruct.new(max_page_size: 10, type: GraphQL::Types::Relay::BaseConnection)
 
     set_wrapper = schema.connections.wrap(field_defn, nil, Set.new([1,2,3]), {}, nil)
     assert_instance_of SetConnection, set_wrapper


### PR DESCRIPTION
The new connection module didn't properly use `edge_class:` configurations.

Fixes #3005 
Fixes https://github.com/rmosolgo/graphql-ruby/issues/3017