### PR TITLE
GraphQL::StaticValidation::Rules::VariablesAreUsedAndDefined - show "anonymous <operation_type>" in error message

### DIFF
--- a/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb
+++ b/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb
@@ -126,8 +126,9 @@ module GraphQL
         node_variables
           .select { |name, usage| usage.declared? && !usage.used? }
           .each { |var_name, usage|
+            declared_by_error_name = usage.declared_by.name || "anonymous #{usage.declared_by.operation_type}"
             add_error(GraphQL::StaticValidation::VariablesAreUsedAndDefinedError.new(
-              "Variable $#{var_name} is declared by #{usage.declared_by.name} but not used",
+              "Variable $#{var_name} is declared by #{declared_by_error_name} but not used",
               nodes: usage.declared_by,
               path: usage.path,
               name: var_name,
@@ -139,8 +140,9 @@ module GraphQL
         node_variables
           .select { |name, usage| usage.used? && !usage.declared? }
           .each { |var_name, usage|
+            used_by_error_name = usage.used_by.name || "anonymous #{usage.used_by.operation_type}"
             add_error(GraphQL::StaticValidation::VariablesAreUsedAndDefinedError.new(
-              "Variable $#{var_name} is used by #{usage.used_by.name} but not declared",
+              "Variable $#{var_name} is used by #{used_by_error_name} but not declared",
               nodes: usage.ast_node,
               path: usage.path,
               name: var_name,

--- a/spec/graphql/static_validation/rules/variables_are_used_and_defined_spec.rb
+++ b/spec/graphql/static_validation/rules/variables_are_used_and_defined_spec.rb
@@ -37,29 +37,61 @@ describe GraphQL::StaticValidation::VariablesAreUsedAndDefined do
     }
   '}
 
-  it "finds variables which are used-but-not-defined or defined-but-not-used" do
-    expected = [
-      {
-        "message"=>"Variable $notUsedVar is declared by getCheese but not used",
-        "locations"=>[{"line"=>2, "column"=>5}],
-        "path"=>["query getCheese"],
-        "extensions"=>{"code"=>"variableNotUsed", "variableName"=>"notUsedVar"}
-      },
-      {
-        "message"=>"Variable $undefinedVar is used by getCheese but not declared",
-        "locations"=>[{"line"=>19, "column"=>22}],
-        "path"=>["query getCheese", "c3", "id"],
-        "extensions"=>{"code"=>"variableNotDefined", "variableName"=>"undefinedVar"}
-      },
-      {
-        "message"=>"Variable $undefinedFragmentVar is used by innerCheeseFields but not declared",
-        "locations"=>[{"line"=>29, "column"=>22}],
-        "path"=>["fragment innerCheeseFields", "c4", "id"],
-        "extensions"=>{"code"=>"variableNotDefined", "variableName"=>"undefinedFragmentVar"}
-      },
-    ]
+  describe "variables which are used-but-not-defined or defined-but-not-used" do
+    it "finds the variables" do
+      expected = [
+        {
+          "message"=>"Variable $notUsedVar is declared by getCheese but not used",
+          "locations"=>[{"line"=>2, "column"=>5}],
+          "path"=>["query getCheese"],
+          "extensions"=>{"code"=>"variableNotUsed", "variableName"=>"notUsedVar"}
+        },
+        {
+          "message"=>"Variable $undefinedVar is used by getCheese but not declared",
+          "locations"=>[{"line"=>19, "column"=>22}],
+          "path"=>["query getCheese", "c3", "id"],
+          "extensions"=>{"code"=>"variableNotDefined", "variableName"=>"undefinedVar"}
+        },
+        {
+          "message"=>"Variable $undefinedFragmentVar is used by innerCheeseFields but not declared",
+          "locations"=>[{"line"=>29, "column"=>22}],
+          "path"=>["fragment innerCheeseFields", "c4", "id"],
+          "extensions"=>{"code"=>"variableNotDefined", "variableName"=>"undefinedFragmentVar"}
+        },
+      ]
 
-    assert_equal(expected, errors)
+      assert_equal(expected, errors)
+    end
+
+    describe "with an anonymous query" do
+      let(:query_string) do
+        <<-GRAPHQL
+        query($notUsedVar: Int!) {
+          c1: cheese(id: $undeclared) {
+            __typename
+          }
+        }
+        GRAPHQL
+      end
+
+      it "shows 'anonymous query' in the message" do
+        expected = [
+          {
+            "message"=>"Variable $notUsedVar is declared by anonymous query but not used",
+            "locations"=>[{"line"=>1, "column"=>9}],
+            "path"=>["query"],
+            "extensions"=>{"code"=>"variableNotUsed", "variableName"=>"notUsedVar"}
+          },
+          {
+            "message"=>"Variable $undeclared is used by anonymous query but not declared",
+            "locations"=>[{"line"=>2, "column"=>26}],
+            "path"=>["query", "c1", "id"],
+            "extensions"=>{"code"=>"variableNotDefined", "variableName"=>"undeclared"}
+          }
+        ]
+        assert_equal(expected, errors)
+      end
+    end
   end
 
   describe "usages in directives on fragment spreads" do

--- a/spec/graphql/static_validation/validator_spec.rb
+++ b/spec/graphql/static_validation/validator_spec.rb
@@ -32,7 +32,7 @@ describe GraphQL::StaticValidation::Validator do
 
     it "includes message, locations, and fields keys" do
       expected_errors = [{
-        "message" => "Variable $undefinedVar is used by  but not declared",
+        "message" => "Variable $undefinedVar is used by anonymous query but not declared",
         "locations" => [{"line" => 1, "column" => 14, "filename" => "not_a_real.graphql"}],
         "path" => ["query", "cheese", "id"],
         "extensions"=>{"code"=>"variableNotDefined", "variableName"=>"undefinedVar"}


### PR DESCRIPTION
* This provides a default behavior for anonymous operation types in `GraphQL::StaticValidation::Rules::VariablesAreUsedAndDefined` when `usage.used_by.name` or `usaged.declared_by.name` is `nil`
* fixes #3047 
