### PR TITLE
Add graphql-groups to the list of related projects

### DIFF
--- a/guides/related_projects.md
+++ b/guides/related_projects.md
@@ -18,6 +18,7 @@ Want to add something? Please open a pull request [on GitHub](https://github.com
 - [`graphql-libgraphqlparser`](https://github.com/rmosolgo/graphql-libgraphqlparser-ruby), bindings to [libgraphqlparser](https://github.com/graphql/libgraphqlparser), a C-level parser.
 - [`graphql-docs`](https://github.com/gjtorikian/graphql-docs), a tool to automatically generate static HTML documentation from your GraphQL implementation
 - [`graphql-metrics`](https://github.com/Shopify/graphql-metrics), a plugin to extract fine-grain metrics of GraphQL queries received by your server
+- [`graphql-groups`](https://github.com/hschne/graphql-groups), a DSL to define group- and aggregation queries with graphql-ruby
 - Rails Helpers:
   - [`graphql-activerecord`](https://github.com/goco-inc/graphql-activerecord)
   - [`graphql-rails-resolve`](https://github.com/colepatrickturner/graphql-rails-resolver)


### PR DESCRIPTION
Some time ago, I needed to retrieve statistical information (e.g. counts, sums...) about a set of data using a GraphQL API. To make it easier to retrieve such information (while at the same time providing a clear and flexible query interface) I created [graphql-groups](https://github.com/hschne/graphql-groups). 

While the gem is still in early development I would be happy to add it to the list of related projects. If you have any reservations I'd gladly address them :blush: 