### PR TITLE
Validate enum values up front

### DIFF
--- a/lib/graphql/schema/enum_value.rb
+++ b/lib/graphql/schema/enum_value.rb
@@ -41,6 +41,7 @@ module GraphQL
 
       def initialize(graphql_name, desc = nil, owner:, ast_node: nil, description: nil, value: nil, deprecation_reason: nil, &block)
         @graphql_name = graphql_name.to_s
+        GraphQL::NameValidator.validate!(@graphql_name)
         @description = desc || description
         @value = value.nil? ? @graphql_name : value
         @deprecation_reason = deprecation_reason

--- a/spec/graphql/schema/enum_spec.rb
+++ b/spec/graphql/schema/enum_spec.rb
@@ -40,6 +40,17 @@ describe GraphQL::Schema::Enum do
       value = enum.values["STRING"]
       assert_equal enum, value.owner
     end
+
+    it "disallows invalid names" do
+      err = assert_raises GraphQL::InvalidNameError do
+        Class.new(GraphQL::Schema::Enum) do
+          graphql_name "Thing"
+          value "IN/VALID"
+        end
+      end
+
+      assert_includes err.message, "but 'IN/VALID' does not"
+    end
   end
 
   it "uses a custom enum value class" do


### PR DESCRIPTION
Fixes #3008 -- This used to be covered by `#to_graphql`, but since 1.11, the main codepath doesn't use that method!