### PR TITLE
Add `Object.instance_methods` to `CONFLICT_FIELD_NAMES` for warnings

### DIFF
--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -53,7 +53,7 @@ module GraphQL
         # resolve method name.
         #
         # @api private
-        CONFLICT_FIELD_NAMES = Set.new(GRAPHQL_RUBY_KEYWORDS + RUBY_KEYWORDS)
+        CONFLICT_FIELD_NAMES = Set.new(GRAPHQL_RUBY_KEYWORDS + RUBY_KEYWORDS + Object.instance_methods)
 
         # Register this field with the class, overriding a previous one if needed.
         # @param field_defn [GraphQL::Schema::Field]

--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -47,7 +47,7 @@ module GraphQL
         # A list of GraphQL-Ruby keywords.
         #
         # @api private
-        GRAPHQL_RUBY_KEYWORDS = [:context, :object, :method, :raw_value]
+        GRAPHQL_RUBY_KEYWORDS = [:context, :object, :raw_value]
 
         # A list of field names that we should advise users to pick a different
         # resolve method name.

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -405,7 +405,7 @@ module Jazz
 
     def now_playing; Models.data["Ensemble"].first; end
 
-    # For asserting that the object is initialized once:
+    # For asserting that the *resolver* object is initialized once:
     # `method_conflict_warning: false` tells graphql-ruby that exposing Object#object_id was intentional
     field :object_id, String, null: false, method_conflict_warning: false
     field :inspect_context, [String], null: false

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -406,7 +406,8 @@ module Jazz
     def now_playing; Models.data["Ensemble"].first; end
 
     # For asserting that the object is initialized once:
-    field :object_id, String, null: false
+    # `method_conflict_warning: false` tells graphql-ruby that exposing Object#object_id was intentional
+    field :object_id, String, null: false, method_conflict_warning: false
     field :inspect_context, [String], null: false
     field :hashy_ensemble, Ensemble, null: false
 


### PR DESCRIPTION
Naming your fields after Object instance methods will cause the resolver to call them on the resolver instance. This is normally not intentional, and confusing. This MR adds `Object.instance_methods` to the `CONFLICT_FIELD_NAMES` so a warning is generated.

There already was a test for the field name :method in spec/graphql/schema/object_spec.rb:341 . I have removed `:method` from the existing GRAPHQL_RUBY_KEYWORDS to ensure the test tests that it comes from Object.instance_methods instead. 

There is an example of the confusion between resolver instance resolution and actual object resolution in the jazz.rb test code, where `object_id` is exposed intentionally but this method is called on the resolver instance instead of the actual object instance. 

I am unsure if the intent of that test ("initializes root wrappers once") still stands. Since there is some 1 to 1 relation between resolver and underlying object, there might not be much of an issue, but this might change in the future if resolver objects are somehow still reused, but the underlying objects are not?

