### PR TITLE
Improve method conflict warnings

### DIFF
--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -58,9 +58,11 @@ module GraphQL
         # Register this field with the class, overriding a previous one if needed.
         # @param field_defn [GraphQL::Schema::Field]
         # @return [void]
-        def add_field(field_defn)
-          if CONFLICT_FIELD_NAMES.include?(field_defn.resolver_method) && field_defn.original_name == field_defn.resolver_method && field_defn.method_conflict_warning?
-            warn "#{self.graphql_name}'s `field :#{field_defn.name}` conflicts with a built-in method, use `resolver_method:` to pick a different resolver method for this field (for example, `resolver_method: :resolve_#{field_defn.resolver_method}` and `def resolve_#{field_defn.resolver_method}`). Or use `method_conflict_warning: false` to suppress this warning."
+        def add_field(field_defn, method_conflict_warning: field_defn.method_conflict_warning?)
+          # Check that `field_defn.original_name` equals `resolver_method` and `method_sym` --
+          # that shows that no override value was given manually.
+          if method_conflict_warning && CONFLICT_FIELD_NAMES.include?(field_defn.resolver_method) && field_defn.original_name == field_defn.resolver_method && field_defn.original_name == field_defn.method_sym
+            warn(conflict_field_name_warning(field_defn))
           end
           own_fields[field_defn.name] = field_defn
           nil
@@ -91,6 +93,14 @@ module GraphQL
         # @return [Array<GraphQL::Schema::Field>] Fields defined on this class _specifically_, not parent classes
         def own_fields
           @own_fields ||= {}
+        end
+
+        private
+
+        # @param [GraphQL::Schema::Field]
+        # @return [String] A warning to give when this field definition might conflict with a built-in method
+        def conflict_field_name_warning(field_defn)
+          "#{self.graphql_name}'s `field :#{field_defn.original_name}` conflicts with a built-in method, use `resolver_method:` to pick a different resolver method for this field (for example, `resolver_method: :resolve_#{field_defn.resolver_method}` and `def resolve_#{field_defn.resolver_method}`). Or use `method_conflict_warning: false` to suppress this warning."
         end
       end
     end

--- a/lib/graphql/schema/mutation.rb
+++ b/lib/graphql/schema/mutation.rb
@@ -78,6 +78,10 @@ module GraphQL
 
         private
 
+        def conflict_field_name_warning(field_defn)
+          "#{self.graphql_name}'s `field :#{field_defn.name}` conflicts with a built-in method, use `hash_key:` or `method:` to pick a different resolve behavior for this field (for example, `hash_key: :#{field_defn.resolver_method}_value`, and modify the return hash). Or use `method_conflict_warning: false` to suppress this warning."
+        end
+
         # Override this to attach self as `mutation`
         def generate_payload_type
           payload_class = super

--- a/lib/graphql/schema/resolver/has_payload_type.rb
+++ b/lib/graphql/schema/resolver/has_payload_type.rb
@@ -58,7 +58,8 @@ module GraphQL
             resolver_fields.each do |name, f|
               # Reattach the already-defined field here
               # (The field's `.owner` will still point to the mutation, not the object type, I think)
-              add_field(f)
+              # Don't re-warn about a method conflict. Since this type is generated, it should be fixed in the resolver instead.
+              add_field(f, method_conflict_warning: false)
             end
           end
         end

--- a/spec/graphql/schema/mutation_spec.rb
+++ b/spec/graphql/schema/mutation_spec.rb
@@ -165,4 +165,24 @@ describe GraphQL::Schema::Mutation do
       assert override_mutation.field_options[:null]
     end
   end
+
+  it "warns once for possible conflict methods" do
+    expected_warning = "X's `field :module` conflicts with a built-in method, use `hash_key:` or `method:` to pick a different resolve behavior for this field (for example, `hash_key: :module_value`, and modify the return hash). Or use `method_conflict_warning: false` to suppress this warning.\n"
+    assert_output "", expected_warning do
+      # This should warn:
+      mutation = Class.new(GraphQL::Schema::Mutation) do
+        graphql_name "X"
+        field :module, String, null: true
+      end
+      # This should not warn again, when generating the payload type with the same fields:
+      mutation.payload_type
+    end
+
+    assert_output "", "" do
+      mutation = Class.new(GraphQL::Schema::Mutation) do
+        graphql_name "X"
+        field :module, String, null: true, hash_key: :module_value
+      end
+    end
+  end
 end

--- a/spec/graphql/schema/mutation_spec.rb
+++ b/spec/graphql/schema/mutation_spec.rb
@@ -183,6 +183,7 @@ describe GraphQL::Schema::Mutation do
         graphql_name "X"
         field :module, String, null: true, hash_key: :module_value
       end
+      mutation.payload_type
     end
   end
 end

--- a/spec/graphql/schema/object_spec.rb
+++ b/spec/graphql/schema/object_spec.rb
@@ -357,11 +357,20 @@ describe GraphQL::Schema::Object do
       end
     end
 
-    it "doesn't warn with an override" do
+    it "doesn't warn with a resolver_method: override" do
       assert_output "", "" do
         Class.new(GraphQL::Schema::Object) do
           graphql_name "X"
           field :method, String, null: true, resolver_method: :resolve_method
+        end
+      end
+    end
+
+    it "doesn't warn with a method: override" do
+      assert_output "", "" do
+        Class.new(GraphQL::Schema::Object) do
+          graphql_name "X"
+          field :module, String, null: true, method: :mod
         end
       end
     end


### PR DESCRIPTION
Improve the method warnings in two ways: 

- A given `method:` value bypasses this warning since it will be called on the application object, not the graphql type definition 
- Mutations provide more specific warnings about conflicting fields (and don't warn a second time when generating payload types)


Fixes #2775 
Fixes #2723 