### PR TITLE
Store prepared arguments on resolver instance when they're ready

### DIFF
--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -40,6 +40,7 @@ module GraphQL
           @arguments_by_keyword[arg.keyword] = arg
         end
         @arguments_loads_as_type = self.class.arguments_loads_as_type
+        @prepared_arguments = nil
       end
 
       # @return [Object] The application object this field is being resolved on
@@ -50,6 +51,10 @@ module GraphQL
 
       # @return [GraphQL::Schema::Field]
       attr_reader :field
+
+      def arguments
+        @prepared_arguments || raise("Arguments have not been prepared yet, still waiting for #load_arguments to resolve. (Call `.arguments` later in the code.)")
+      end
 
       # This method is _actually_ called by the runtime,
       # it does some preparation and then eventually calls
@@ -74,6 +79,7 @@ module GraphQL
             # for that argument, or may return a lazy object
             load_arguments_val = load_arguments(args)
             context.schema.after_lazy(load_arguments_val) do |loaded_args|
+              @prepared_arguments = loaded_args
               # Then call `authorized?`, which may raise or may return a lazy object
               authorized_val = if loaded_args.any?
                 authorized?(**loaded_args)

--- a/spec/graphql/schema/resolver_spec.rb
+++ b/spec/graphql/schema/resolver_spec.rb
@@ -334,7 +334,7 @@ describe GraphQL::Schema::Resolver do
     end
 
     class ResolverWithAuthArgs < GraphQL::Schema::RelayClassicMutation
-      argument :number_s, String, required: true, prepare: -> (v, ctx) { v.to_i }
+      argument :number_s, String, required: true, prepare: ->(v, ctx) { v.to_i }
       argument :loads_id, ID, required: true, loads: IntegerWrapper
 
       field :result, Integer, null: false

--- a/spec/graphql/schema/resolver_spec.rb
+++ b/spec/graphql/schema/resolver_spec.rb
@@ -333,6 +333,25 @@ describe GraphQL::Schema::Resolver do
       end
     end
 
+    class ResolverWithAuthArgs < GraphQL::Schema::RelayClassicMutation
+      argument :number_s, String, required: true, prepare: -> (v, ctx) { v.to_i }
+      argument :loads_id, ID, required: true, loads: IntegerWrapper
+
+      field :result, Integer, null: false
+
+      def authorized?(**_args)
+        if arguments[:number_s] == 1 && arguments[:loads] == 1
+          true
+        else
+          raise GraphQL::ExecutionError, "Auth failed (#{arguments[:number_s].inspect})"
+        end
+      end
+
+      def resolve(number_s:, loads:)
+        { result: number_s + loads }
+      end
+    end
+
     class MutationWithNullableLoadsArgument < GraphQL::Schema::Mutation
       argument :label_id, ID, required: false, loads: HasValue
       argument :label_ids, [ID], required: false, loads: HasValue
@@ -410,6 +429,7 @@ describe GraphQL::Schema::Resolver do
       field :prep_resolver_12, resolver: PrepResolver12
       field :prep_resolver_13, resolver: PrepResolver13
       field :prep_resolver_14, resolver: PrepResolver14
+      field :resolver_with_auth_args, resolver: ResolverWithAuthArgs
       field :resolver_with_error_handler, resolver: ResolverWithErrorHandler
     end
 
@@ -435,6 +455,15 @@ describe GraphQL::Schema::Resolver do
 
   def exec_query(*args, **kwargs)
     ResolverTest::Schema.execute(*args, **kwargs)
+  end
+
+  it "can access self.arguments inside authorized?" do
+    res = exec_query("{ resolverWithAuthArgs(input: { numberS: \"1\", loadsId: 1 }) { result } }")
+    assert_equal 2, res["data"]["resolverWithAuthArgs"]["result"]
+
+    # Test auth failure:
+    res = exec_query("{ resolverWithAuthArgs(input: { numberS: \"2\", loadsId: 1 }) { result } }")
+    assert_equal ["Auth failed (2)"], res["errors"].map { |e| e["message"] }
   end
 
   describe ".path" do


### PR DESCRIPTION
This way `mutation.arguments` will return the arguments during authorization. (This is especially helpful for the CanCan integration.) 