### PR TITLE
customize ActionCable subscriptions

### DIFF
--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -9,7 +9,7 @@ gem "pry-stack_explorer", platform: :ruby
 gem "rails", "~> 4.2", require: "rails/all"
 gem "activerecord", "~> 4.2.4"
 gem "actionpack", "~> 4.2.4"
-gem "concurrent-ruby", "1.0.0"
+gem "concurrent-ruby", "~> 1.0"
 gem "sqlite3", "~> 1.3.6", platform: :ruby
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sequel"

--- a/lib/graphql/subscriptions.rb
+++ b/lib/graphql/subscriptions.rb
@@ -4,9 +4,7 @@ require "graphql/subscriptions/broadcast_analyzer"
 require "graphql/subscriptions/event"
 require "graphql/subscriptions/instrumentation"
 require "graphql/subscriptions/serialize"
-if defined?(ActionCable)
-  require "graphql/subscriptions/action_cable_subscriptions"
-end
+require "graphql/subscriptions/action_cable_subscriptions"
 require "graphql/subscriptions/subscription_root"
 require "graphql/subscriptions/default_subscription_resolve_extension"
 

--- a/lib/graphql/subscriptions/action_cable_subscriptions.rb
+++ b/lib/graphql/subscriptions/action_cable_subscriptions.rb
@@ -4,7 +4,7 @@ module GraphQL
     # A subscriptions implementation that sends data
     # as ActionCable broadcastings.
     #
-    # Experimental, some things to keep in mind:
+    # Some things to keep in mind:
     #
     # - No queueing system; ActiveJob should be added
     # - Take care to reload context when re-delivering the subscription. (see {Query#subscription_update?})
@@ -87,11 +87,13 @@ module GraphQL
 
       # @param serializer [<#dump(obj), #load(string)] Used for serializing messages before handing them to `.broadcast(msg)`
       # @param namespace [string] Used to namespace events and subscriptions (default: '')
-      def initialize(serializer: Serialize, namespace: '', **rest)
+      def initialize(serializer: Serialize, namespace: '', action_cable: ActionCable, action_cable_coder: ActiveSupport::JSON, **rest)
         # A per-process map of subscriptions to deliver.
         # This is provided by Rails, so let's use it
         @subscriptions = Concurrent::Map.new
         @events = Concurrent::Map.new { |h, k| h[k] = Concurrent::Map.new { |h2, k2| h2[k2] = Concurrent::Array.new } }
+        @action_cable = action_cable
+        @action_cable_coder = action_cable_coder
         @serializer = serializer
         @transmit_ns = namespace
         super
@@ -102,14 +104,14 @@ module GraphQL
       def execute_all(event, object)
         stream = stream_event_name(event)
         message = @serializer.dump(object)
-        ActionCable.server.broadcast(stream, message)
+        @action_cable.server.broadcast(stream, message)
       end
 
       # This subscription was re-evaluated.
       # Send it to the specific stream where this client was waiting.
       def deliver(subscription_id, result)
         payload = { result: result.to_h, more: true }
-        ActionCable.server.broadcast(stream_subscription_name(subscription_id), payload)
+        @action_cable.server.broadcast(stream_subscription_name(subscription_id), payload)
       end
 
       # A query was run where these events were subscribed to.
@@ -143,7 +145,7 @@ module GraphQL
       #
       def setup_stream(channel, initial_event)
         topic = initial_event.topic
-        channel.stream_from(stream_event_name(initial_event), coder: ActiveSupport::JSON) do |message|
+        channel.stream_from(stream_event_name(initial_event), coder: @action_cable_coder) do |message|
           object = @serializer.load(message)
           events_by_fingerprint = @events[topic]
           events_by_fingerprint.each do |_fingerprint, events|

--- a/spec/graphql/subscriptions/action_cable_subscriptions_spec.rb
+++ b/spec/graphql/subscriptions/action_cable_subscriptions_spec.rb
@@ -1,23 +1,162 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-if testing_rails? && defined?(ActionCable) # not all rails versions have ActionCable
-  describe GraphQL::Subscriptions::ActionCableSubscriptions do
-    class ActionCableSchema < GraphQL::Schema
-      class Tick < GraphQL::Schema::Subscription
-        field :value, Integer, null: false
+
+describe GraphQL::Subscriptions::ActionCableSubscriptions do
+  # A stub implementation of ActionCable.
+  # Any methods to support the mock backend have `mock` in the name.
+  class MockActionCable
+    class MockChannel
+      def initialize
+        @mock_broadcasted_messages = []
       end
 
-      class Subscription < GraphQL::Schema::Object
-        field :tick, subscription: Tick
+      attr_reader :mock_broadcasted_messages
+
+      def stream_from(stream_name, coder: nil, &block)
+        # Rails uses `coder`, we don't
+        block ||= ->(msg) { @mock_broadcasted_messages << msg }
+        MockActionCable.mock_stream_for(stream_name).add_mock_channel(self, block)
+      end
+    end
+
+    class MockStream
+      def initialize
+        @mock_channels = {}
       end
 
-      use GraphQL::Subscriptions::ActionCableSubscriptions
+      def add_mock_channel(channel, handler)
+        @mock_channels[channel] = handler
+      end
+
+      def mock_broadcast(message)
+        @mock_channels.each do |channel, handler|
+          handler && handler.call(message)
+        end
+      end
     end
 
-    it "handles `execute_update` for a missing subscription ID" do
-      res = ActionCableSchema.subscriptions.execute_update("nonsense-id", {}, {})
-      assert_nil res
+    class << self
+      def clear_mocks
+        @mock_streams = {}
+      end
+
+      def server
+        self
+      end
+
+      def broadcast(stream_name, message)
+        stream = @mock_streams[stream_name]
+        stream && stream.mock_broadcast(message)
+      end
+
+      def mock_stream_for(stream_name)
+        @mock_streams[stream_name] ||= MockStream.new
+      end
+
+      def get_mock_channel
+        MockChannel.new
+      end
+
+      def mock_stream_names
+        @mock_streams.keys
+      end
     end
+  end
+
+  class ActionCableTestSchema < GraphQL::Schema
+    class Query < GraphQL::Schema::Object
+      field :int, Integer, null: true
+    end
+
+    class NewsFlash < GraphQL::Schema::Subscription
+      field :text, String, null: false
+    end
+
+    class Subscription < GraphQL::Schema::Object
+      field :news_flash, subscription: NewsFlash
+    end
+
+    query(Query)
+    subscription(Subscription)
+    use GraphQL::Execution::Interpreter
+    use GraphQL::Analysis::AST
+    use GraphQL::Subscriptions::ActionCableSubscriptions,
+      action_cable: MockActionCable,
+      action_cable_coder: JSON
+  end
+
+  class NamespacedActionCableTestSchema < GraphQL::Schema
+    query(ActionCableTestSchema::Query)
+    subscription(ActionCableTestSchema::Subscription)
+    use GraphQL::Execution::Interpreter
+    use GraphQL::Analysis::AST
+    use GraphQL::Subscriptions::ActionCableSubscriptions,
+      namespace: "other:",
+      action_cable: MockActionCable,
+      action_cable_coder: JSON
+  end
+
+  before do
+    MockActionCable.clear_mocks
+  end
+
+  def subscription_update(data)
+    { result: { "data" => data }, more: true }
+  end
+
+  it "sends updates over the given `action_cable:`" do
+    mock_channel = MockActionCable.get_mock_channel
+    ActionCableTestSchema.execute("subscription { newsFlash { text } }", context: { channel: mock_channel })
+    ActionCableTestSchema.subscriptions.trigger(:news_flash, {}, {text: "After yesterday's rain, someone stopped on Rio Road to help a box turtle across five lanes of traffic"})
+    expected_msg = subscription_update({
+      "newsFlash" => {
+        "text" => "After yesterday's rain, someone stopped on Rio Road to help a box turtle across five lanes of traffic"
+      }
+    })
+    assert_equal [expected_msg], mock_channel.mock_broadcasted_messages
+  end
+
+  it "uses namespace to divide traffic" do
+    mock_channel_1 = MockActionCable.get_mock_channel
+    ctx_1 = { channel: mock_channel_1 }
+    ActionCableTestSchema.execute("subscription { newsFlash { text } }", context: ctx_1)
+
+    mock_channel_2 = MockActionCable.get_mock_channel
+    ctx_2 = { channel: mock_channel_2 }
+    NamespacedActionCableTestSchema.execute("subscription { newsFlash { text } }", context: ctx_2)
+
+    ActionCableTestSchema.subscriptions.trigger(:news_flash, {}, {text: "Neighbor shares bumper crop of summer squash with widow next door"})
+    NamespacedActionCableTestSchema.subscriptions.trigger(:news_flash, {}, {text: "Sunrise enjoyed over a cup of coffee"})
+
+    expected_msg_1 = subscription_update({
+      "newsFlash" => {
+        "text" => "Neighbor shares bumper crop of summer squash with widow next door"
+      }
+    })
+
+    expected_msg_2 = subscription_update({
+      "newsFlash" => {
+        "text" => "Sunrise enjoyed over a cup of coffee"
+      }
+    })
+
+    assert_equal [expected_msg_1], mock_channel_1.mock_broadcasted_messages
+    assert_equal [expected_msg_2], mock_channel_2.mock_broadcasted_messages
+
+    expected_streams = [
+      # No namespace
+      "graphql-subscription:#{ctx_1[:subscription_id]}",
+      "graphql-event::newsFlash:",
+      # Namespaced with `other:`
+      "graphql-subscription:other:#{ctx_2[:subscription_id]}",
+      "graphql-event:other::newsFlash:",
+    ]
+    assert_equal expected_streams, MockActionCable.mock_stream_names
+  end
+
+  it "handles `execute_update` for a missing subscription ID" do
+    res = ActionCableTestSchema.subscriptions.execute_update("nonsense-id", {}, {})
+    assert_nil res
   end
 end


### PR DESCRIPTION
```ruby
class FooSchema < GraphQL::Schema
  use GraphQL::Subscriptions::ActionCableSubscriptions

  subscription(Foo::Types::SubscriptionType)
end

module Foo
  class SubscriptionType < ::Types::BaseObject
    field :foo_subscription, subscription: Foo::FooSubscription
  end
end

class BarSchema < GraphQL::Schema
  use GraphQL::Subscriptions::ActionCableSubscriptions

  subscription(Bar::Types::SubscriptionType)
end

module Foo
  class SubscriptionType < ::Types::BaseObject
    field :foo_subscription, subscription: Bar::FooSubscription
  end
end

# somewhere, following default configuration with channel in context
#
# FooChannel < ApplicationCable::Channel
# BarChannel < ApplicationCable::Channel

FooSchema.subscriptions.trigger(:foo_subscription, {}, {}, scope: nil) # => transmitting graphql-event:XXX
BarSchema.subscriptions.trigger(:foo_subscription, {}, {}, scope: nil) # => transmitting graphql-event:XXX
```

Multiple schemas will generate the same event stream name if parameters (object / scope) are identical and then will broadcast multiple time the same event / mixing pushes.

**BREAKING CHANGES:**

Anyone using `context[:action_cable_stream]`. But judging by [this line](https://github.com/rmosolgo/graphql-ruby/blob/master/lib/graphql/subscriptions/action_cable_subscriptions.rb#L110), it seems it was broken already anyway.

**How to use**

```ruby
class FooSchema < GraphQL::Schema
  # if not set, still defaults to 'graphql-event:' and 'graphql-subscription:'
  use(GraphQL::Subscriptions::ActionCableSubscriptions, event_prefix: 'graphql:foo:event:',
                                                        subscription_prefix: 'graphql:foo:subscription:')
end

# will transmit to graphql:foo:event:XXX

class BarSchema < GraphQL::Schema
  # if not set, still defaults to 'graphql-event:' and 'graphql-subscription:'
  use(GraphQL::Subscriptions::ActionCableSubscriptions, event_prefix: 'graphql:bar:event:',
                                                        subscription_prefix: 'graphql:bar:subscription:')
end

# will transmit to graphql:bar:event:XXX
```

Cheers