### PR TITLE
Optimize GraphQL::Query::Context#fetch

### DIFF
--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -168,7 +168,7 @@ module GraphQL
       attr_accessor :scoped_context
 
       def_delegators :@provided_values, :[]=
-      def_delegators :to_h, :fetch, :dig
+      def_delegators :to_h, :dig
       def_delegators :@query, :trace, :interpreter?
 
       # @!method []=(key, value)
@@ -178,6 +178,22 @@ module GraphQL
       def [](key)
         return @scoped_context[key] if @scoped_context.key?(key)
         @provided_values[key]
+      end
+
+      UNSPECIFIED_FETCH_DEFAULT = Object.new
+
+      def fetch(key, default = UNSPECIFIED_FETCH_DEFAULT)
+        if @scoped_context.key?(key)
+          @scoped_context[key]
+        elsif @provided_values.key?(key)
+          @provided_values[key]
+        elsif default != UNSPECIFIED_FETCH_DEFAULT
+          default
+        elsif block_given?
+          yield(self, key)
+        else
+          raise KeyError.new(key: key)
+        end
       end
 
       def to_h


### PR DESCRIPTION
Profiling one of our key queries revealed we were spending 17%  of the CPU time in `GraphQL::Query::Context#fetch`. The underlying problem was that this calls `GraphQL::Query::Context#to_h` which allocates a new hash when merging`@scoped_context` and `@provided_values`. This optimization avoids the allocation and merging of hashes with some conditional logic. `GraphQL::Query::Context#dig` has a similar performance issue but handling that properly is a little trickier so I'm going to leave it for another day.