### PR TITLE
Use throw instead of raise to halt subscriptions early

### DIFF
--- a/lib/graphql/schema/subscription.rb
+++ b/lib/graphql/schema/subscription.rb
@@ -12,16 +12,6 @@ module GraphQL
     #
     # Also, `#unsubscribe` terminates the subscription.
     class Subscription < GraphQL::Schema::Resolver
-      class EarlyTerminationError < StandardError
-      end
-
-      # Raised when `unsubscribe` is called; caught by `subscriptions.rb`
-      class UnsubscribedError < EarlyTerminationError
-      end
-
-      # Raised when `no_update` is returned; caught by `subscriptions.rb`
-      class NoUpdateError < EarlyTerminationError
-      end
       extend GraphQL::Schema::Resolver::HasPayloadType
       extend GraphQL::Schema::Member::HasFields
 
@@ -65,7 +55,7 @@ module GraphQL
       def resolve_update(**args)
         ret_val = args.any? ? update(**args) : update
         if ret_val == :no_update
-          raise NoUpdateError
+          throw :graphql_no_subscription_update
         else
           ret_val
         end
@@ -90,7 +80,7 @@ module GraphQL
 
       # Call this to halt execution and remove this subscription from the system
       def unsubscribe
-        raise UnsubscribedError
+        throw :graphql_subscription_unsubscribed
       end
 
       READING_SCOPE = ::Object.new

--- a/lib/graphql/subscriptions.rb
+++ b/lib/graphql/subscriptions.rb
@@ -101,8 +101,9 @@ module GraphQL
       query_data = read_subscription(subscription_id)
       if query_data.nil?
         delete_subscription(subscription_id)
-        nil
+        return nil
       end
+
       # Fetch the required keys from the saved data
       query_string = query_data.fetch(:query_string)
       variables = query_data.fetch(:variables)

--- a/lib/graphql/subscriptions.rb
+++ b/lib/graphql/subscriptions.rb
@@ -100,31 +100,42 @@ module GraphQL
       # Lookup the saved data for this subscription
       query_data = read_subscription(subscription_id)
       if query_data.nil?
-        # Jump down to the `delete_subscription` call
-        raise GraphQL::Schema::Subscription::UnsubscribedError
+        delete_subscription(subscription_id)
+        nil
       end
       # Fetch the required keys from the saved data
       query_string = query_data.fetch(:query_string)
       variables = query_data.fetch(:variables)
       context = query_data.fetch(:context)
       operation_name = query_data.fetch(:operation_name)
-      # Re-evaluate the saved query
-      @schema.execute(
-        query: query_string,
-        context: context,
-        subscription_topic: event.topic,
-        operation_name: operation_name,
-        variables: variables,
-        root_value: object,
-      )
-    rescue GraphQL::Schema::Subscription::NoUpdateError
-      # This update was skipped in user code; do nothing.
-      nil
-    rescue GraphQL::Schema::Subscription::UnsubscribedError
-      # `unsubscribe` was called, clean up on our side
-      # TODO also send `{more: false}` to client?
-      delete_subscription(subscription_id)
-      nil
+      result = nil
+      # this will be set to `false` unless `.execute` is terminated
+      # with a `throw :graphql_subscription_unsubscribed`
+      unsubscribed = true
+      catch(:graphql_subscription_unsubscribed) do
+        catch(:graphql_no_subscription_update) do
+          # Re-evaluate the saved query,
+          # but if it terminates early with a `throw`,
+          # it will stay `nil`
+          result = @schema.execute(
+            query: query_string,
+            context: context,
+            subscription_topic: event.topic,
+            operation_name: operation_name,
+            variables: variables,
+            root_value: object,
+          )
+        end
+        unsubscribed = false
+      end
+
+      if unsubscribed
+        # `unsubscribe` was called, clean up on our side
+        # TODO also send `{more: false}` to client?
+        delete_subscription(subscription_id)
+      end
+
+      result
     end
 
     # Run the update query for this subscription and deliver it

--- a/spec/graphql/schema/subscription_spec.rb
+++ b/spec/graphql/schema/subscription_spec.rb
@@ -126,6 +126,11 @@ describe GraphQL::Schema::Subscription do
     subscription(Subscription)
     use GraphQL::Execution::Interpreter
     use GraphQL::Analysis::AST
+    use GraphQL::Execution::Errors
+
+    rescue_from(StandardError) { |err, *rest|
+      raise "This should never happen: #{err.class}: #{err.message}"
+    }
 
     def self.object_from_id(id, ctx)
       USERS[id]
@@ -397,6 +402,8 @@ describe GraphQL::Schema::Subscription do
       assert_equal "Merry Christmas, here's a new Ruby version", mailbox1.first["data"]["tootWasTooted"]["toot"]["body"]
       # But not matz:
       assert_equal [], mailbox2
+      # `:no_update` doesn't cause an unsubscribe
+      assert_equal 2, in_memory_subscription_count
     end
 
     it "unsubscribes if a `loads:` argument is not found" do


### PR DESCRIPTION
Oops, using errors for control flow (🙈 I know, I know) was interfering with catch-all error handlers (`rescue_from(StandardError)`). So, use `throw` instead (🙈 I know, I know. I just don't know how else to reliably propagate that information from deep in the query runtime to the subscription update call. `ctx.skip` could work for `no_update`, but I don't know how that could work for `unsubscribe`.) 

Fixes #3044 

cc @hattmarris this should also fix https://github.com/rmosolgo/graphql-ruby/issues/3035#issuecomment-662098266