### PR TITLE
Optimize GraphQL::Query::Context#dig

### DIFF
--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -168,7 +168,6 @@ module GraphQL
       attr_accessor :scoped_context
 
       def_delegators :@provided_values, :[]=
-      def_delegators :to_h, :dig
       def_delegators :@query, :trace, :interpreter?
 
       # @!method []=(key, value)
@@ -194,6 +193,10 @@ module GraphQL
         else
           raise KeyError.new(key: key)
         end
+      end
+
+      def dig(key, *other_keys)
+        @scoped_context.key?(key) ? @scoped_context.dig(key, *other_keys) : @provided_values.dig(key, *other_keys)
       end
 
       def to_h


### PR DESCRIPTION
This PR optimizes `GraphQL::Query::Context#dig` to avoid allocating a temporary hash with a merge of `@scoped_context` and `@provided_values`. It turned out to be simpler than I initially thought since `GraphQL::Query::Context#to_h` isn't doing any sophisticated recursive merging of the two hashes 😄 