### PR TITLE
Check for visible interfaces on the type

### DIFF
--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -199,7 +199,7 @@ module GraphQL
             if (iface_field_defn = interface_type.get_field(field_defn.graphql_name))
               any_interface_has_field = true
 
-              if visible?(interface_type) && visible_field?(interface_type, iface_field_defn)
+              if interfaces(type_defn).include?(interface_type) && visible_field?(interface_type, iface_field_defn)
                 any_interface_has_visible_field = true
               end
             end

--- a/spec/graphql/schema/introspection_system_spec.rb
+++ b/spec/graphql/schema/introspection_system_spec.rb
@@ -61,30 +61,58 @@ describe GraphQL::Schema::IntrospectionSystem do
       assert_equal "MUSICIAN", res["data"]["__type"]["possibleTypes"].first["name"]
     end
 
-    it "does not include hidden interfaces based on context" do
+    it "does not include hidden interfaces by membership based on context" do
       context = { private: false }
       res = Jazz::Schema.execute('{ __type(name: "Ensemble") { interfaces { name } } }', context: context)
 
       assert res["data"]["__type"]["interfaces"].none? { |i| i["name"] == "PRIVATENAMEENTITY" }
     end
 
-    it "includes hidden interfaces based on the context" do
+    it "includes hidden interfaces by membership based on the context" do
       context = { private: true }
       res = Jazz::Schema.execute('{ __type(name: "Ensemble") { interfaces { name } } }', context: context)
 
       assert res["data"]["__type"]["interfaces"].any? { |i| i["name"] == "PRIVATENAMEENTITY" }
     end
 
-    it "does not include fields from hidden  interfaces based on the context" do
+    it "does not include hidden interfaces by membership based on context" do
+      context = { private: false }
+      res = Jazz::Schema.execute('{ __type(name: "Ensemble") { interfaces { name } } }', context: context)
+
+      assert res["data"]["__type"]["interfaces"].none? { |i| i["name"] == "INVISIBLENAMEENTITY" }
+    end
+
+    it "includes hidden interfaces by membership based on the context" do
+      context = { private: true }
+      res = Jazz::Schema.execute('{ __type(name: "Ensemble") { interfaces { name } } }', context: context)
+
+      assert res["data"]["__type"]["interfaces"].any? { |i| i["name"] == "INVISIBLENAMEENTITY" }
+    end
+
+    it "does not include fields from hidden interfaces by membership based on the context" do
       context = { private: false }
       res = Jazz::Schema.execute('{ __type(name: "Ensemble") { fields { name } } }', context: context)
+
       assert res["data"]["__type"]["fields"].none? { |i| i["name"] == "privateName" }
+    end
+
+    it "includes fields from interfaces by membership based on the context" do
+      context = { private: true }
+      res = Jazz::Schema.execute('{ __type(name: "Ensemble") { fields { name } } }', context: context)
+      assert res["data"]["__type"]["fields"].any? { |i| i["name"] == "privateName" }
+    end
+
+    it "does not include fields from hidden interfaces based on the context" do
+      context = { private: false }
+      res = Jazz::Schema.execute('{ __type(name: "Ensemble") { fields { name } } }', context: context)
+
+      assert res["data"]["__type"]["fields"].none? { |i| i["name"] == "invisibleName" }
     end
 
     it "includes fields from interfaces based on the context" do
       context = { private: true }
       res = Jazz::Schema.execute('{ __type(name: "Ensemble") { fields { name } } }', context: context)
-      assert res["data"]["__type"]["fields"].any? { |i| i["name"] == "privateName" }
+      assert res["data"]["__type"]["fields"].any? { |i| i["name"] == "invisibleName" }
     end
 
     if TESTING_INTERPRETER

--- a/spec/graphql/schema/object_spec.rb
+++ b/spec/graphql/schema/object_spec.rb
@@ -7,10 +7,21 @@ describe GraphQL::Schema::Object do
     it "tells type data" do
       assert_equal "Ensemble", object_class.graphql_name
       assert_equal "A group of musicians playing together", object_class.description
-      assert_equal 8, object_class.fields.size
-      assert_equal ["GloballyIdentifiable", "HasMusicians", "NamedEntity", "PrivateNameEntity"], object_class.interfaces.map(&:graphql_name).sort
+      assert_equal 9, object_class.fields.size
+      assert_equal [
+          "GloballyIdentifiable",
+          "HasMusicians",
+          "InvisibleNameEntity",
+          "NamedEntity",
+          "PrivateNameEntity",
+        ], object_class.interfaces.map(&:graphql_name).sort
       # It filters interfaces, too
-      assert_equal ["GloballyIdentifiable", "HasMusicians", "NamedEntity"], object_class.interfaces({}).map(&:graphql_name).sort
+      assert_equal [
+          "GloballyIdentifiable",
+          "HasMusicians",
+          "InvisibleNameEntity",
+          "NamedEntity"
+        ], object_class.interfaces({}).map(&:graphql_name).sort
       # Compatibility methods are delegated to the underlying BaseType
       assert object_class.respond_to?(:connection_type)
     end
@@ -28,9 +39,15 @@ describe GraphQL::Schema::Object do
       end
 
       # one more than the parent class
-      assert_equal 9, new_object_class.fields.size
+      assert_equal 10, new_object_class.fields.size
       # inherited interfaces are present
-      assert_equal ["GloballyIdentifiable", "HasMusicians", "NamedEntity", "PrivateNameEntity"], new_object_class.interfaces.map(&:graphql_name).sort
+      assert_equal [
+          "GloballyIdentifiable",
+          "HasMusicians",
+          "InvisibleNameEntity",
+          "NamedEntity",
+          "PrivateNameEntity",
+        ], new_object_class.interfaces.map(&:graphql_name).sort
       # The new field is present
       assert new_object_class.fields.key?("newField")
       # The overridden field is present:
@@ -51,7 +68,7 @@ describe GraphQL::Schema::Object do
 
     it "implements visibility constrained interface when context is private" do
       found_interfaces = object_class.interfaces({ private: true })
-      assert_equal 4, found_interfaces.count
+      assert_equal 5, found_interfaces.count
       assert found_interfaces.any? { |int| int.graphql_name == 'PrivateNameEntity' }
     end
 
@@ -243,7 +260,7 @@ describe GraphQL::Schema::Object do
     it "returns a matching GraphQL::ObjectType" do
       assert_equal "Ensemble", obj_type.name
       assert_equal "A group of musicians playing together", obj_type.description
-      assert_equal 8, obj_type.all_fields.size
+      assert_equal 9, obj_type.all_fields.size
 
       name_field = obj_type.all_fields[3]
       assert_equal "name", name_field.name

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -191,14 +191,20 @@ module Jazz
     type_membership_class PrivateMembership
 
     field :private_name, String, null: false
-    field :overridden_name, String, null: false
 
     def private_name
       "private name"
     end
+  end
+
+  module InvisibleNameEntity
+    include BaseInterface
+
+    field :invisible_name, String, null: false
+    field :overridden_name, String, null: false
 
     def self.visible?(ctx)
-      ctx[:private] == true
+      ctx[:private]
     end
   end
 
@@ -222,7 +228,7 @@ module Jazz
     # Test string type names
     # This method should override inherited one
     field :name, "String", null: false, resolver_method: :overridden_name
-    implements GloballyIdentifiableType, NamedEntity, HasMusicians
+    implements GloballyIdentifiableType, NamedEntity, HasMusicians, InvisibleNameEntity
     implements PrivateNameEntity, visibility: { private: true }
     description "A group of musicians playing together"
     config :config, :configged


### PR DESCRIPTION
There was a couple of tests that were testing the wrong thing.

They were checking Visibility of an interface, not the visibility of an interface ON A TYPE.

I added some tests to make sure that was working, but it turns out we were only checking `visible?(interface_type` instead of if the `type_defn` has that interface.

the main change here is visible?(interface_type)` -> `interfaces(type_defn).includ?(interface_type)`


I tried messing around with this method a bit more to clean it up, as I thought we could just use `interfaces` from the get-go instead of the `unfiltered_interfaces` method. However, this does not work because we don't have a good way of checking of the field belongs to the owner type because of `LateBoundTypes`.

Initially I thought:

`((field_defn.respond_to?(:owner) && field_defn.owner == owner_type) || field_on_visible_interface?(field_defn, owner_type))` 

(a few lines above in `visible_field?`)

I thought this owner checking would cover it, but late bound types/fields have really messed up owner classes that don't relate to the actual owner, but are also not on an interface.

A better fix would be to fix the above line to better represent that the field belongs to the owner vs an interface, and then using the usual `interfaces` method.




I think this is a fine fix for now though to make fields properly show up for `TypeMembership` visibility on interfaces.