### PR TITLE
Patching `AppOpticsTracing` to work with latest changes in `PlatformTracing` base class

### DIFF
--- a/lib/graphql/tracing/appoptics_tracing.rb
+++ b/lib/graphql/tracing/appoptics_tracing.rb
@@ -55,7 +55,7 @@ module GraphQL
       end
 
       def platform_field_key(type, field)
-        "graphql.#{type.name}.#{field.name}"
+        "graphql.#{type.graphql_name}.#{field.graphql_name}"
       end
       
       def platform_authorized_key(type)
@@ -115,7 +115,7 @@ module GraphQL
           else
             [key, data[key]]
           end
-        end.flatten.each_slice(2).to_h.merge(Spec: 'graphql')
+        end.flatten(2).each_slice(2).to_h.merge(Spec: 'graphql')
       end
       # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 

--- a/lib/graphql/tracing/appoptics_tracing.rb
+++ b/lib/graphql/tracing/appoptics_tracing.rb
@@ -57,6 +57,14 @@ module GraphQL
       def platform_field_key(type, field)
         "graphql.#{type.name}.#{field.name}"
       end
+      
+      def platform_authorized_key(type)
+        "graphql.authorized.#{type.graphql_name}"
+      end
+
+      def platform_resolve_type_key(type)
+        "graphql.resolve_type.#{type.graphql_name}"
+      end
 
       private
 


### PR DESCRIPTION
It looks like a couple methods were added to PlatformTracing but had not been added to the AppOptics integration, causing runtime exceptions for the missing methods.

Also, the call to `.flatten` inside `metadata` would over-flatten when the value is an array (i.e. `[:path, []]`).