### PR TITLE
Use module_namespacing for graphql templates

### DIFF
--- a/lib/generators/graphql/core.rb
+++ b/lib/generators/graphql/core.rb
@@ -41,6 +41,14 @@ module Graphql
         end
       end
 
+      def module_namespacing_when_supported
+        if defined?(module_namespacing)
+          module_namespacing { yield }
+        else
+          yield
+        end
+      end
+
       private
 
       def schema_name

--- a/lib/generators/graphql/templates/base_argument.erb
+++ b/lib/generators/graphql/templates/base_argument.erb
@@ -1,4 +1,6 @@
+<% module_namespacing do -%>
 module Types
   class BaseArgument < GraphQL::Schema::Argument
   end
 end
+<% end -%>

--- a/lib/generators/graphql/templates/base_argument.erb
+++ b/lib/generators/graphql/templates/base_argument.erb
@@ -1,4 +1,4 @@
-<% module_namespacing do -%>
+<% module_namespacing_when_supported do -%>
 module Types
   class BaseArgument < GraphQL::Schema::Argument
   end

--- a/lib/generators/graphql/templates/base_enum.erb
+++ b/lib/generators/graphql/templates/base_enum.erb
@@ -1,4 +1,4 @@
-<% module_namespacing do -%>
+<% module_namespacing_when_supported do -%>
 module Types
   class BaseEnum < GraphQL::Schema::Enum
   end

--- a/lib/generators/graphql/templates/base_enum.erb
+++ b/lib/generators/graphql/templates/base_enum.erb
@@ -1,4 +1,6 @@
+<% module_namespacing do -%>
 module Types
   class BaseEnum < GraphQL::Schema::Enum
   end
 end
+<% end -%>

--- a/lib/generators/graphql/templates/base_field.erb
+++ b/lib/generators/graphql/templates/base_field.erb
@@ -1,5 +1,7 @@
+<% module_namespacing do -%>
 module Types
   class BaseField < GraphQL::Schema::Field
     argument_class Types::BaseArgument
   end
 end
+<% end -%>

--- a/lib/generators/graphql/templates/base_field.erb
+++ b/lib/generators/graphql/templates/base_field.erb
@@ -1,4 +1,4 @@
-<% module_namespacing do -%>
+<% module_namespacing_when_supported do -%>
 module Types
   class BaseField < GraphQL::Schema::Field
     argument_class Types::BaseArgument

--- a/lib/generators/graphql/templates/base_input_object.erb
+++ b/lib/generators/graphql/templates/base_input_object.erb
@@ -1,5 +1,7 @@
+<% module_namespacing do -%>
 module Types
   class BaseInputObject < GraphQL::Schema::InputObject
     argument_class Types::BaseArgument
   end
 end
+<% end -%>

--- a/lib/generators/graphql/templates/base_input_object.erb
+++ b/lib/generators/graphql/templates/base_input_object.erb
@@ -1,4 +1,4 @@
-<% module_namespacing do -%>
+<% module_namespacing_when_supported do -%>
 module Types
   class BaseInputObject < GraphQL::Schema::InputObject
     argument_class Types::BaseArgument

--- a/lib/generators/graphql/templates/base_interface.erb
+++ b/lib/generators/graphql/templates/base_interface.erb
@@ -1,3 +1,4 @@
+<% module_namespacing do -%>
 module Types
   module BaseInterface
     include GraphQL::Schema::Interface
@@ -5,3 +6,4 @@ module Types
     field_class Types::BaseField
   end
 end
+<% end -%>

--- a/lib/generators/graphql/templates/base_interface.erb
+++ b/lib/generators/graphql/templates/base_interface.erb
@@ -1,4 +1,4 @@
-<% module_namespacing do -%>
+<% module_namespacing_when_supported do -%>
 module Types
   module BaseInterface
     include GraphQL::Schema::Interface

--- a/lib/generators/graphql/templates/base_mutation.erb
+++ b/lib/generators/graphql/templates/base_mutation.erb
@@ -1,4 +1,4 @@
-<% module_namespacing do -%>
+<% module_namespacing_when_supported do -%>
 module Mutations
   class BaseMutation < GraphQL::Schema::RelayClassicMutation
     argument_class Types::BaseArgument

--- a/lib/generators/graphql/templates/base_mutation.erb
+++ b/lib/generators/graphql/templates/base_mutation.erb
@@ -1,3 +1,4 @@
+<% module_namespacing do -%>
 module Mutations
   class BaseMutation < GraphQL::Schema::RelayClassicMutation
     argument_class Types::BaseArgument
@@ -6,3 +7,4 @@ module Mutations
     object_class Types::BaseObject
   end
 end
+<% end -%>

--- a/lib/generators/graphql/templates/base_object.erb
+++ b/lib/generators/graphql/templates/base_object.erb
@@ -1,4 +1,4 @@
-<% module_namespacing do -%>
+<% module_namespacing_when_supported do -%>
 module Types
   class BaseObject < GraphQL::Schema::Object
     field_class Types::BaseField

--- a/lib/generators/graphql/templates/base_object.erb
+++ b/lib/generators/graphql/templates/base_object.erb
@@ -1,5 +1,7 @@
+<% module_namespacing do -%>
 module Types
   class BaseObject < GraphQL::Schema::Object
     field_class Types::BaseField
   end
 end
+<% end -%>

--- a/lib/generators/graphql/templates/base_scalar.erb
+++ b/lib/generators/graphql/templates/base_scalar.erb
@@ -1,4 +1,6 @@
+<% module_namespacing do -%>
 module Types
   class BaseScalar < GraphQL::Schema::Scalar
   end
 end
+<% end -%>

--- a/lib/generators/graphql/templates/base_scalar.erb
+++ b/lib/generators/graphql/templates/base_scalar.erb
@@ -1,4 +1,4 @@
-<% module_namespacing do -%>
+<% module_namespacing_when_supported do -%>
 module Types
   class BaseScalar < GraphQL::Schema::Scalar
   end

--- a/lib/generators/graphql/templates/base_union.erb
+++ b/lib/generators/graphql/templates/base_union.erb
@@ -1,4 +1,4 @@
-<% module_namespacing do -%>
+<% module_namespacing_when_supported do -%>
 module Types
   class BaseUnion < GraphQL::Schema::Union
   end

--- a/lib/generators/graphql/templates/base_union.erb
+++ b/lib/generators/graphql/templates/base_union.erb
@@ -1,4 +1,6 @@
+<% module_namespacing do -%>
 module Types
   class BaseUnion < GraphQL::Schema::Union
   end
 end
+<% end -%>

--- a/lib/generators/graphql/templates/enum.erb
+++ b/lib/generators/graphql/templates/enum.erb
@@ -1,4 +1,4 @@
-<% module_namespacing do -%>
+<% module_namespacing_when_supported do -%>
 module Types
   class <%= type_ruby_name.split('::')[-1] %> < Types::BaseEnum
 <% prepared_values.each do |v| %>    value "<%= v[0] %>"<%= v.length > 1 ? ", value: #{v[1]}" : "" %>

--- a/lib/generators/graphql/templates/enum.erb
+++ b/lib/generators/graphql/templates/enum.erb
@@ -1,5 +1,7 @@
+<% module_namespacing do -%>
 module Types
   class <%= type_ruby_name.split('::')[-1] %> < Types::BaseEnum
 <% prepared_values.each do |v| %>    value "<%= v[0] %>"<%= v.length > 1 ? ", value: #{v[1]}" : "" %>
 <% end %>  end
 end
+<% end -%>

--- a/lib/generators/graphql/templates/graphql_controller.erb
+++ b/lib/generators/graphql/templates/graphql_controller.erb
@@ -1,3 +1,4 @@
+<% module_namespacing do -%>
 class GraphqlController < ApplicationController
   # If accessing from outside this domain, nullify the session
   # This allows for outside API access while preventing CSRF attacks,
@@ -48,3 +49,4 @@ class GraphqlController < ApplicationController
     render json: { errors: [{ message: e.message, backtrace: e.backtrace }], data: {} }, status: 500
   end
 end
+<% end -%>

--- a/lib/generators/graphql/templates/graphql_controller.erb
+++ b/lib/generators/graphql/templates/graphql_controller.erb
@@ -1,4 +1,4 @@
-<% module_namespacing do -%>
+<% module_namespacing_when_supported do -%>
 class GraphqlController < ApplicationController
   # If accessing from outside this domain, nullify the session
   # This allows for outside API access while preventing CSRF attacks,

--- a/lib/generators/graphql/templates/interface.erb
+++ b/lib/generators/graphql/templates/interface.erb
@@ -1,4 +1,4 @@
-<% module_namespacing do -%>
+<% module_namespacing_when_supported do -%>
 module Types
   module <%= type_ruby_name.split('::')[-1] %>
     include Types::BaseInterface

--- a/lib/generators/graphql/templates/interface.erb
+++ b/lib/generators/graphql/templates/interface.erb
@@ -1,6 +1,8 @@
+<% module_namespacing do -%>
 module Types
   module <%= type_ruby_name.split('::')[-1] %>
     include Types::BaseInterface
 <% normalized_fields.each do |f| %>    <%= f.to_ruby %>
 <% end %>  end
 end
+<% end -%>

--- a/lib/generators/graphql/templates/loader.erb
+++ b/lib/generators/graphql/templates/loader.erb
@@ -1,3 +1,4 @@
+<% module_namespacing do -%>
 module Loaders
   class <%= class_name %> < GraphQL::Batch::Loader
     # Define `initialize` to store grouping arguments, eg
@@ -15,3 +16,4 @@ module Loaders
     end
   end
 end
+<% end -%>

--- a/lib/generators/graphql/templates/loader.erb
+++ b/lib/generators/graphql/templates/loader.erb
@@ -1,4 +1,4 @@
-<% module_namespacing do -%>
+<% module_namespacing_when_supported do -%>
 module Loaders
   class <%= class_name %> < GraphQL::Batch::Loader
     # Define `initialize` to store grouping arguments, eg

--- a/lib/generators/graphql/templates/mutation.erb
+++ b/lib/generators/graphql/templates/mutation.erb
@@ -1,3 +1,4 @@
+<% module_namespacing do -%>
 module Mutations
   class <%= mutation_name %> < BaseMutation
     # TODO: define return fields
@@ -12,3 +13,4 @@ module Mutations
     # end
   end
 end
+<% end -%>

--- a/lib/generators/graphql/templates/mutation.erb
+++ b/lib/generators/graphql/templates/mutation.erb
@@ -1,4 +1,4 @@
-<% module_namespacing do -%>
+<% module_namespacing_when_supported do -%>
 module Mutations
   class <%= mutation_name %> < BaseMutation
     # TODO: define return fields

--- a/lib/generators/graphql/templates/mutation_type.erb
+++ b/lib/generators/graphql/templates/mutation_type.erb
@@ -1,3 +1,4 @@
+<% module_namespacing do -%>
 module Types
   class MutationType < Types::BaseObject
     # TODO: remove me
@@ -8,3 +9,4 @@ module Types
     end
   end
 end
+<% end -%>

--- a/lib/generators/graphql/templates/mutation_type.erb
+++ b/lib/generators/graphql/templates/mutation_type.erb
@@ -1,4 +1,4 @@
-<% module_namespacing do -%>
+<% module_namespacing_when_supported do -%>
 module Types
   class MutationType < Types::BaseObject
     # TODO: remove me

--- a/lib/generators/graphql/templates/object.erb
+++ b/lib/generators/graphql/templates/object.erb
@@ -1,6 +1,8 @@
+<% module_namespacing do -%>
 module Types
   class <%= type_ruby_name.split('::')[-1] %> < Types::BaseObject
 <% if options.node %>    implements GraphQL::Relay::Node.interface
 <% end %><% normalized_fields.each do |f| %>    <%= f.to_ruby %>
 <% end %>  end
 end
+<% end -%>

--- a/lib/generators/graphql/templates/object.erb
+++ b/lib/generators/graphql/templates/object.erb
@@ -1,4 +1,4 @@
-<% module_namespacing do -%>
+<% module_namespacing_when_supported do -%>
 module Types
   class <%= type_ruby_name.split('::')[-1] %> < Types::BaseObject
 <% if options.node %>    implements GraphQL::Relay::Node.interface

--- a/lib/generators/graphql/templates/query_type.erb
+++ b/lib/generators/graphql/templates/query_type.erb
@@ -1,3 +1,4 @@
+<% module_namespacing do -%>
 module Types
   class QueryType < Types::BaseObject
     # Add root-level fields here.
@@ -13,3 +14,4 @@ module Types
     field :node, field: GraphQL::Relay::Node.field
 <% end %>  end
 end
+<% end -%>

--- a/lib/generators/graphql/templates/query_type.erb
+++ b/lib/generators/graphql/templates/query_type.erb
@@ -1,4 +1,4 @@
-<% module_namespacing do -%>
+<% module_namespacing_when_supported do -%>
 module Types
   class QueryType < Types::BaseObject
     # Add root-level fields here.

--- a/lib/generators/graphql/templates/scalar.erb
+++ b/lib/generators/graphql/templates/scalar.erb
@@ -1,4 +1,4 @@
-<% module_namespacing do -%>
+<% module_namespacing_when_supported do -%>
 module Types
   class <%= type_ruby_name.split('::')[-1] %> < Types::BaseScalar
     def self.coerce_input(input_value, context)

--- a/lib/generators/graphql/templates/scalar.erb
+++ b/lib/generators/graphql/templates/scalar.erb
@@ -1,3 +1,4 @@
+<% module_namespacing do -%>
 module Types
   class <%= type_ruby_name.split('::')[-1] %> < Types::BaseScalar
     def self.coerce_input(input_value, context)
@@ -11,3 +12,4 @@ module Types
     end
   end
 end
+<% end -%>

--- a/lib/generators/graphql/templates/schema.erb
+++ b/lib/generators/graphql/templates/schema.erb
@@ -1,4 +1,4 @@
-<% module_namespacing do -%>
+<% module_namespacing_when_supported do -%>
 class <%= schema_name %> < GraphQL::Schema
   query(Types::QueryType)
 

--- a/lib/generators/graphql/templates/schema.erb
+++ b/lib/generators/graphql/templates/schema.erb
@@ -1,3 +1,4 @@
+<% module_namespacing do -%>
 class <%= schema_name %> < GraphQL::Schema
   query(Types::QueryType)
 
@@ -38,3 +39,4 @@ class <%= schema_name %> < GraphQL::Schema
   # GraphQL::Batch setup:
   use GraphQL::Batch
 <% end %>end
+<% end -%>

--- a/lib/generators/graphql/templates/union.erb
+++ b/lib/generators/graphql/templates/union.erb
@@ -1,4 +1,4 @@
-<% module_namespacing do -%>
+<% module_namespacing_when_supported do -%>
 module Types
   class <%= type_ruby_name.split('::')[-1] %> < Types::BaseUnion
 <% if possible_types.any? %>    possible_types [<%= normalized_possible_types.join(", ") %>]

--- a/lib/generators/graphql/templates/union.erb
+++ b/lib/generators/graphql/templates/union.erb
@@ -1,5 +1,7 @@
+<% module_namespacing do -%>
 module Types
   class <%= type_ruby_name.split('::')[-1] %> < Types::BaseUnion
 <% if possible_types.any? %>    possible_types [<%= normalized_possible_types.join(", ") %>]
 <% end %>  end
 end
+<% end -%>


### PR DESCRIPTION
Currently, running the generators from within an engine produces files that are not namespaced properly.

For example, if you run `rails g graphql:scalar Date` in the engine `blorgh`, you'll end up with a new ruby file that looks like:

```ruby
module Types
  class Date < Types::BaseScalar
  end
end
```

It should look like this:

```ruby
module Blorgh
  module Types
    class Date < Types::BaseScalar
    end
  end
end
```

Wrapping the template contents in [#module_namespacing](https://github.com/rails/rails/blob/master/railties/lib/rails/generators/base.rb#L288-L292) provides the correct namespace in a generator is called from within an engine.

🎩  Results:
![Screen Shot 2020-08-20 at 4 17 02 PM](https://user-images.githubusercontent.com/22918438/90821258-9ce54e00-e300-11ea-9dcf-6c15c8ffe515.png)

