### PR TITLE
Add `require 'digest/sha2'` for fingerprint

### DIFF
--- a/lib/graphql/query/fingerprint.rb
+++ b/lib/graphql/query/fingerprint.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'digest/sha2'
+
 module GraphQL
   class Query
     # @api private


### PR DESCRIPTION
It raises a NameError when `digest/sha2` library isn't loaded by another place.
For example:


```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'
  gem 'graphql', path: '.'
end

class QueryType < GraphQL::Schema::Object
  field :foo, String, null: false, resolve: -> (_, _, _) do
    'foo'
  end
end

# This tracer calls Query#fingerprint
class T
  def self.trace(key, data, &block)
    p data[:query].fingerprint if data[:query]
    block.call
  end
end

class Schema < GraphQL::Schema
  tracer T
  query QueryType
end

doc = GraphQL.parse(<<~Q)
  query {
    foo
  }
Q

Schema.execute(
  document: doc,
  variables: {},
  context: {},
)
```

```
/path/to/lib/graphql/query/fingerprint.rb:19:in `generate': uninitialized constant GraphQL::Query::Fingerprint::Digest (NameError)
        from /path/to/lib/graphql/query.rb:286:in `operation_fingerprint'
        from /path/to/lib/graphql/query.rb:281:in `fingerprint'
        from test.rb:17:in `trace'
        from /path/to/lib/graphql/tracing.rb:83:in `call_tracers'
        from /path/to/lib/graphql/tracing.rb:67:in `trace'
        from /path/to/lib/graphql/static_validation/validator.rb:25:in `validate'
        from /path/to/lib/graphql/query/validation_pipeline.rb:75:in `ensure_has_validated'
        from /path/to/lib/graphql/query/validation_pipeline.rb:47:in `internal_representation'
        from /path/to/forwardable.rb:238:in `internal_representation'
        from /path/to/lib/graphql/query.rb:235:in `irep_selection'
        from /path/to/lib/graphql/schema/member/instrumentation.rb:22:in `before_query'
        from /path/to/lib/graphql/execution/instrumentation.rb:58:in `public_send'
        from /path/to/lib/graphql/execution/instrumentation.rb:58:in `block in call_hooks'
        from /path/to/lib/graphql/execution/instrumentation.rb:57:in `each'
        from /path/to/lib/graphql/execution/instrumentation.rb:57:in `call_hooks'
        from /path/to/lib/graphql/execution/instrumentation.rb:44:in `each_query_call_hooks'
        from /path/to/lib/graphql/execution/instrumentation.rb:27:in `block in apply_instrumenters'
        from /path/to/lib/graphql/execution/instrumentation.rb:72:in `call_hooks'
        from /path/to/lib/graphql/execution/instrumentation.rb:26:in `apply_instrumenters'
        from /path/to/lib/graphql/execution/multiplex.rb:174:in `instrument_and_analyze'
        from /path/to/lib/graphql/execution/multiplex.rb:60:in `block in run_queries'
        from /path/to/lib/graphql/tracing.rb:81:in `call_tracers'
        from /path/to/lib/graphql/tracing.rb:83:in `block in call_tracers'
        from test.rb:18:in `trace'
        from /path/to/lib/graphql/tracing.rb:83:in `call_tracers'
        from /path/to/lib/graphql/tracing.rb:67:in `trace'
        from /path/to/lib/graphql/execution/multiplex.rb:58:in `run_queries'
        from /path/to/lib/graphql/execution/multiplex.rb:48:in `run_all'
        from /path/to/lib/graphql/schema.rb:1642:in `multiplex'
        from /path/to/lib/graphql/schema.rb:1613:in `execute'
        from test.rb:33:in `<main>'
```

So this patch adds an explicit `require` to avoid the error.