### PR TITLE
Put frozen_string_literal at the first line

### DIFF
--- a/lib/graphql/types/iso_8601_date_time.rb
+++ b/lib/graphql/types/iso_8601_date_time.rb
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
+
 require 'time'
 
-# frozen_string_literal: true
 module GraphQL
   module Types
     # This scalar takes `Time`s and transmits them as strings,


### PR DESCRIPTION
frozen_string_literal comment only works if the comment is at the first line of the file.
But `iso_8601_date_time.rb` had a frozen_string_literal comment after `require`. So this pull request swaps the require and frozen-string_literal comment.

We can confirm this problem with `-w` option of ruby.

```bash
$ ruby -cw lib/graphql/types/iso_8601_date_time.rb
lib/graphql/types/iso_8601_date_time.rb:3: warning: `frozen_string_literal' is ignored after any tokens
Syntax OK
```