### PR TITLE
Rescue SystemStackErrors during validation

### DIFF
--- a/lib/graphql/query/validation_pipeline.rb
+++ b/lib/graphql/query/validation_pipeline.rb
@@ -90,6 +90,9 @@ module GraphQL
         end
 
         @valid = @validation_errors.empty?
+      rescue SystemStackError => err
+        @valid = false
+        @schema.query_stack_error(@query, err)
       end
 
       # If there are max_* values, add them,

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -1663,6 +1663,10 @@ module GraphQL
         end
       end
 
+      def query_stack_error(query, err)
+        query.analysis_errors.push(GraphQL::AnalysisError.new("This query is too large to execute."))
+      end
+
       private
 
       def lazy_methods

--- a/spec/graphql/analysis/ast/max_query_depth_spec.rb
+++ b/spec/graphql/analysis/ast/max_query_depth_spec.rb
@@ -131,4 +131,20 @@ describe GraphQL::Analysis::AST::MaxQueryDepth do
       assert_equal "Query has depth of 7, which exceeds max depth of 4", result.message
     end
   end
+
+  describe "when the query would cause a stack error" do
+    let(:query_string) {
+      str = "query { cheese(id: 1) { ".dup
+      n = 10_000
+      n.times { str << "similarCheese(source: SHEEP) { " }
+      str << "id "
+      n.times { str << "} " }
+      str << "} }"
+      str
+    }
+
+    it "returns an error" do
+      assert_equal ["This query is too large to execute."], query.static_errors.map(&:message)
+    end
+  end
 end


### PR DESCRIPTION
Even with `max_depth ...`, if a query is too big, it will raise a stack error. 

This is the easiest, most catch-all fix. (It covers all of validation, regardless of `max_depth ...`.) 

The handling of this error can be customized in your schema definition, eg: 

```ruby 
class MySchema < GraphQL::Schema
  def self.query_stack_error(query, err)
    raise err # to raise the original Ruby error 
  end 
end 
```

Although I think this fix is appropriate in any case, more subtle changes might be possible: 

- Change `MaxQueryDepth` to _halt_ analysis when the max depth is exceeded. We'd have to change the error message, which currently contains the actual query depth. We could also add a hard cap to MaxQueryDepth (configurable, default 500?). TODO: would validation still raise a stack error?
- Refactor validation/analysis to be less stack-dependent. The current visitor implementation uses `super` to visit child nodes, but it's possible that another implementation could visit the tree without building a big Ruby stack. But this would only be useful if there's a _good reason_ to inspect a GraphQL query whose depth is greater than Ruby's stack limit!

If anyone's interested in exploring those (or another solution) further, let me know

Fixes #3089 
