### PR TITLE
Add gql devise to related_projects.md

### DIFF
--- a/guides/related_projects.md
+++ b/guides/related_projects.md
@@ -16,6 +16,7 @@ Want to add something? Please open a pull request [on GitHub](https://github.com
 - [`graphql-batch`](https://github.com/shopify/graphql-batch), a batched query execution strategy
 - [`graphql-cache`](https://github.com/stackshareio/graphql-cache), a resolver-level caching solution
 - [`graphql-libgraphqlparser`](https://github.com/rmosolgo/graphql-libgraphqlparser-ruby), bindings to [libgraphqlparser](https://github.com/graphql/libgraphqlparser), a C-level parser.
+- [`graphql-devise`](https://github.com/graphql-devise/graphql_devise), a gql interface to handle authentication with Devise
 - [`graphql-docs`](https://github.com/gjtorikian/graphql-docs), a tool to automatically generate static HTML documentation from your GraphQL implementation
 - [`graphql-metrics`](https://github.com/Shopify/graphql-metrics), a plugin to extract fine-grain metrics of GraphQL queries received by your server
 - [`graphql-groups`](https://github.com/hschne/graphql-groups), a DSL to define group- and aggregation queries with graphql-ruby


### PR DESCRIPTION
Authentication is a common feature in most applications and Devise does great work providing this set of functionalities in full stack ruby world. When it comes to API's there are a number of of gems that modify Devise to work with REST endpoints, like devise Token Authentication for example, but with @mcelicalderon we couldn't find a gem that provides a graphql interface for devise and fit our needs so we created [graphql_devise](https://github.com/graphql-devise/graphql_devise) and have been working on it for almost a year now.

The gem has around 30 releases at the moment and we would love if it can be added to this gem related projects. If you have any reservations we would be glad to address them, just let us know!