### PR TITLE
Do not wrap connections when RawValue is returned from resolver

### DIFF
--- a/lib/graphql/pagination/connections.rb
+++ b/lib/graphql/pagination/connections.rb
@@ -66,6 +66,8 @@ module GraphQL
       # Used by the runtime to wrap values in connection wrappers.
       # @api Private
       def wrap(field, parent, items, arguments, context, wrappers: all_wrappers)
+        return items if GraphQL::Execution::Interpreter::RawValue === items
+
         impl = nil
 
         items.class.ancestors.each { |cls|

--- a/spec/graphql/pagination/connections_spec.rb
+++ b/spec/graphql/pagination/connections_spec.rb
@@ -45,6 +45,9 @@ describe GraphQL::Pagination::Connections do
 
     array_wrapper = schema.connections.wrap(field_defn, nil, [1,2,3], {}, nil)
     assert_instance_of OtherArrayConnection, array_wrapper
+
+    raw_value = schema.connections.wrap(field_defn, nil, GraphQL::Execution::Interpreter::RawValue.new([1,2,3]), {}, nil)
+    assert_instance_of GraphQL::Execution::Interpreter::RawValue, raw_value
   end
 
   it "uses passed-in wrappers" do


### PR DESCRIPTION
This is a followup to PR #2699, that allows returning `raw_value` from connection resolvers. In this case interpreter should stop any further processing and use the provided value (right now the value wrapped into `RawValue` will reasonably raise `Couldn't find a connection wrapper for RawValue ...`).

Example:

```ruby
class QueryType < Types::BaseObject
  field :feed, Types::Event.connection_type, null: false

  def feed
    return raw_value(value) if (value = read_cache)

    write_cache do
      Event.where(language_id: language_id, category_id: category_id)
    end
  end
end
```