### PR TITLE
Update possible types on schema class for interfaces

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -1117,6 +1117,8 @@ module GraphQL
               next true unless type.kind.interface?
               next true unless possible_type.kind.object?
 
+              # Use `.graphql_name` comparison to match legacy vs class-based types. 
+              # When we don't need to support legacy `.define` types, use `.include?(type)` instead.
               possible_type.interfaces(context).any? { |interface| interface.graphql_name == type.graphql_name }
             end if stored_possible_types
             visible_possible_types ||

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -1112,7 +1112,14 @@ module GraphQL
           if type.kind.union?
             type.possible_types(context: context)
           else
-            own_possible_types[type.graphql_name] ||
+            stored_possible_types = own_possible_types[type.graphql_name]
+            visible_possible_types = stored_possible_types.select do |possible_type|
+              next true unless type.kind.interface?
+              next true unless possible_type.kind.object?
+
+              possible_type.interfaces(context).any? { |interface| interface.graphql_name == type.graphql_name }
+            end if stored_possible_types
+            visible_possible_types ||
               introspection_system.possible_types[type.graphql_name] ||
               (
                 superclass.respond_to?(:possible_types) ?

--- a/lib/graphql/schema/interface.rb
+++ b/lib/graphql/schema/interface.rb
@@ -30,7 +30,7 @@ module GraphQL
 
         # The interface is accessible if any of its possible types are accessible
         def accessible?(context)
-          context.schema.possible_types(self).each do |type|
+          context.schema.possible_types(self, context).each do |type|
             if context.schema.accessible?(type, context)
               return true
             end

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -395,6 +395,16 @@ describe GraphQL::Schema do
       unknown_union = Class.new(GraphQL::Schema::Union) { graphql_name("Unknown") }
       assert_equal [], Dummy::Schema.possible_types(unknown_union)
     end
+
+    it "returns correct types for interfaces based on the context" do
+      assert_equal [], Jazz::Schema.possible_types(Jazz::PrivateNameEntity, { private: false })
+      assert_equal [Jazz::Ensemble], Jazz::Schema.possible_types(Jazz::PrivateNameEntity, { private: true })
+    end
+
+    it "returns correct types for unions based on the context" do
+      assert_equal [Jazz::Musician], Jazz::Schema.possible_types(Jazz::PerformingAct, { hide_ensemble: true })
+      assert_equal [Jazz::Musician, Jazz::Ensemble], Jazz::Schema.possible_types(Jazz::PerformingAct, { hide_ensemble: false })
+    end
   end
 
   describe "duplicate type names" do


### PR DESCRIPTION
To fix: https://github.com/rmosolgo/graphql-ruby/issues/3123

Fixed up the `possible_types` method on the `Schema` class object. Previously this was not taking into account the `context` which meant that some interfaces could be shown when they shouldn't be.