### PR TITLE
Avoid redundant loop through rules_to_use in Validator#validate

### DIFF
--- a/lib/graphql/static_validation/validator.rb
+++ b/lib/graphql/static_validation/validator.rb
@@ -32,10 +32,13 @@ module GraphQL
 
             context = GraphQL::StaticValidation::ValidationContext.new(query, visitor_class)
 
-            # Attach legacy-style rules
-            rules_to_use.each do |rule_class_or_module|
-              if rule_class_or_module.method_defined?(:validate)
-                rule_class_or_module.new.validate(context)
+            # Attach legacy-style rules.
+            # Only loop through rules if it has legacy-style rules
+            if legacy_rules = rules_to_use - GraphQL::StaticValidation::ALL_RULES
+              legacy_rules.each do |rule_class_or_module|
+                if rule_class_or_module.method_defined?(:validate)
+                  rule_class_or_module.new.validate(context)
+                end
               end
             end
 

--- a/lib/graphql/static_validation/validator.rb
+++ b/lib/graphql/static_validation/validator.rb
@@ -34,7 +34,7 @@ module GraphQL
 
             # Attach legacy-style rules.
             # Only loop through rules if it has legacy-style rules
-            if legacy_rules = rules_to_use - GraphQL::StaticValidation::ALL_RULES
+            unless (legacy_rules = rules_to_use - GraphQL::StaticValidation::ALL_RULES).empty?
               legacy_rules.each do |rule_class_or_module|
                 if rule_class_or_module.method_defined?(:validate)
                   rule_class_or_module.new.validate(context)


### PR DESCRIPTION
Currently, rules attribute has fallback value which is ALL_RULES and this array contains 27 modules (latest version). None of them is Class and has `validate` method. So for this case, loop through this Module array was a complete waste of time and resources.

To deal with legacy rules which come from GraphQL pro. We should compare `rule_to_use` and ALL_RULES array before we decide to start the loop