### PR TITLE
Improve error messages for invalid input types

### DIFF
--- a/lib/graphql/schema/traversal.rb
+++ b/lib/graphql/schema/traversal.rb
@@ -139,7 +139,7 @@ Some late-bound types couldn't be resolved:
           prev_type = @type_map[type_defn.name]
           # Continue to visit this type if it's the first time we've seen it:
           if prev_type.nil?
-            validate_type(type_defn, context_description)
+            validate_type(type_defn)
             @type_map[type_defn.name] = type_defn
             case type_defn
             when GraphQL::ObjectType
@@ -217,10 +217,10 @@ Some late-bound types couldn't be resolved:
         GraphQL::Query::Arguments.construct_arguments_class(instrumented_field_defn)
       end
 
-      def validate_type(member, context_description)
-        error_message = GraphQL::Schema::Validation.validate(member)
+      def validate_type(type)
+        error_message = GraphQL::Schema::Validation.validate(type)
         if error_message
-          raise GraphQL::Schema::InvalidTypeError.new("#{context_description} is invalid: #{error_message}")
+          raise GraphQL::Schema::InvalidTypeError.new("#{type.name} is invalid: #{error_message}")
         end
       end
     end


### PR DESCRIPTION
Error messages when recursively validating a field argument's type don't actually include the input type's name which makes them a bit confusing. Consider the following invalid schema:

```graphql
type MyType {
  myField(myArg: MyInput)
}

input MyInput {
  # This input field is invalid because it has an output type
  someInput: MyOtherType
}

type MyOtherType {
  foo: String
}
```
This generates the following error message that doesn't mention the `MyInput` type:
```
Argument myArg on MyType.myField is invalid: argument "someInput" type must be a valid input type (Scalar or InputObject), not GraphQL::ObjectType (MyOtherType)
```
With the proposed changes the error message becomes:
```
MyInput is invalid: argument "someInput" type must be a valid input type (Scalar or InputObject), not GraphQL::ObjectType (MyOtherType)
```