### PR TITLE
Improve Lexer

### DIFF
--- a/lib/graphql/language/lexer.rb
+++ b/lib/graphql/language/lexer.rb
@@ -163,7 +163,7 @@ end
 self.graphql_lexer_en_main  = 23;
 
 def self.run_lexer(query_string)
-	data = query_string.unpack("c*")
+	data = query_string.unpack(PACK_DIRECTIVE)
 	eof = data.length
 	
 	# Since `Lexer` is a module, store all lexer state
@@ -1421,7 +1421,7 @@ def self.emit_string(ts, te, meta, block:)
 quotes_length = block ? 3 : 1
 value = meta[:data][ts + quotes_length, te - ts - 2 * quotes_length].pack(PACK_DIRECTIVE).force_encoding(UTF_8_ENCODING) || ''
 line_incr = 0
-if block && !value.length.zero?
+if block && !value.empty?
 line_incr = value.count("\n")
 value = GraphQL::Language::BlockString.trim_whitespace(value)
 end

--- a/lib/graphql/language/lexer.rl
+++ b/lib/graphql/language/lexer.rl
@@ -138,7 +138,7 @@ module GraphQL
       %% write data;
 
       def self.run_lexer(query_string)
-        data = query_string.unpack("c*")
+        data = query_string.unpack(PACK_DIRECTIVE)
         eof = data.length
 
         # Since `Lexer` is a module, store all lexer state
@@ -213,7 +213,7 @@ module GraphQL
         quotes_length = block ? 3 : 1
         value = meta[:data][ts + quotes_length, te - ts - 2 * quotes_length].pack(PACK_DIRECTIVE).force_encoding(UTF_8_ENCODING) || ''
         line_incr = 0
-        if block && !value.length.zero?
+        if block && !value.empty?
           line_incr = value.count("\n")
           value = GraphQL::Language::BlockString.trim_whitespace(value)
         end


### PR DESCRIPTION
Improve our GraphQL::Lexer

- [x] Using empty? instead of length.zero?

```
Benchmark.ips do |x|
  x.report("length.zero") { !"".length.zero? }
  x.report("empty?") { !"".empty? }
  x.compare!
end

Warming up --------------------------------------
         length.zero     1.395M i/100ms
              empty?     1.735M i/100ms
Calculating -------------------------------------
         length.zero     14.010M (± 1.7%) i/s -     71.165M in   5.080898s
              empty?     17.019M (± 1.9%) i/s -     86.746M in   5.099024s

Comparison:
              empty?: 17018973.1 i/s
         length.zero: 14010232.6 i/s - 1.21x  (± 0.00) slower

```

- [x] Try to reuse PACK_DIRECTIVE constant for "c*"