### PR TITLE
add node_nullable option to RelayShortcuts#connection_type

### DIFF
--- a/lib/graphql/schema/member/relay_shortcuts.rb
+++ b/lib/graphql/schema/member/relay_shortcuts.rb
@@ -31,13 +31,13 @@ module GraphQL
           end
         end
 
-        def connection_type
+        def connection_type(node_nullable: true)
           @connection_type ||= begin
             conn_name = self.graphql_name + "Connection"
             edge_type_class = self.edge_type
             Class.new(connection_type_class) do
               graphql_name(conn_name)
-              edge_type(edge_type_class)
+              edge_type(edge_type_class, node_nullable: node_nullable)
             end
           end
         end

--- a/spec/graphql/schema/member/relay_shortcut_spec.rb
+++ b/spec/graphql/schema/member/relay_shortcut_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+
+describe GraphQL::Schema::Member::RelayShortcuts do
+  describe 'connection_type' do
+    module NonNullAbleConnectionShortcutsDummy
+      class Node < GraphQL::Schema::Object
+        field :some_field, String, null: true
+      end
+
+      class Query < GraphQL::Schema::Object
+        field :connection, Node.connection_type(node_nullable: false), null: false
+      end
+
+      class Schema < GraphQL::Schema
+        query Query
+      end
+    end
+
+    it "node_nullable option is works" do
+      res = NonNullAbleConnectionShortcutsDummy::Schema.execute(GraphQL::Introspection::INTROSPECTION_QUERY)
+      edge_type = res["data"]["__schema"]["types"].find { |t| t["name"] == "NodeConnection" }
+      nodes_field = edge_type["fields"].find { |f| f["name"] == "nodes" }
+      assert_equal "NON_NULL",nodes_field["type"]["kind"]
+      assert_equal "NON_NULL",nodes_field["type"]["ofType"]["ofType"]["kind"]
+    end
+  end
+end
+


### PR DESCRIPTION
Thank you for maintaining a great library.

#3083 has eased the burden of the null check.
I hope to be able to use this option in shortcuts as well.