### PR TITLE
Validate that deprecated requirements aren't required

### DIFF
--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -61,7 +61,7 @@ module GraphQL
         @ast_node = ast_node
         @from_resolver = from_resolver
         @method_access = method_access
-        @deprecation_reason = deprecation_reason
+        self.deprecation_reason = deprecation_reason
 
         if definition_block
           if definition_block.arity == 1
@@ -91,16 +91,17 @@ module GraphQL
         end
       end
 
-      attr_writer :deprecation_reason
-
       # @return [String] Deprecation reason for this argument
       def deprecation_reason(text = nil)
         if text
+          raise ArgumentError, "Required arguments cannot be deprecated: #{path}." unless @null
           @deprecation_reason = text
         else
           @deprecation_reason
         end
       end
+
+      alias_method :deprecation_reason=, :deprecation_reason
 
       def visible?(context)
         true

--- a/spec/graphql/schema/argument_spec.rb
+++ b/spec/graphql/schema/argument_spec.rb
@@ -270,6 +270,8 @@ describe GraphQL::Schema::Argument do
 
   describe "deprecation_reason:" do
     let(:arg) { SchemaArgumentTest::Query.fields["field"].arguments["arg"] }
+    let(:required_arg) {  SchemaArgumentTest::Query.fields["field"].arguments["requiredWithDefaultArg"] }
+
     it "sets deprecation reason" do
       arg.deprecation_reason "new deprecation reason"
       assert_equal "new deprecation reason", arg.deprecation_reason
@@ -282,6 +284,28 @@ describe GraphQL::Schema::Argument do
     it "has an assignment method" do
       arg.deprecation_reason = "another new deprecation reason"
       assert_equal "another new deprecation reason", arg.deprecation_reason
+    end
+
+    it "disallows deprecating required arguments in the constructor" do
+      err = assert_raises ArgumentError do
+        Class.new(GraphQL::Schema::InputObject) do
+          graphql_name 'MyInput'
+          argument :foo, String, required: true, deprecation_reason: "Don't use me"
+        end
+      end
+      assert_equal "Required arguments cannot be deprecated: MyInput.foo.", err.message
+    end
+
+    it "disallows deprecating required arguments in deprecation_reason=" do
+      assert_raises ArgumentError do
+        required_arg.deprecation_reason = "Don't use me"
+      end
+    end
+
+    it "disallows deprecating required arguments in deprecation_reason" do
+      assert_raises ArgumentError do
+        required_arg.deprecation_reason("Don't use me")
+      end
     end
   end
 

--- a/spec/graphql/schema/argument_spec.rb
+++ b/spec/graphql/schema/argument_spec.rb
@@ -307,6 +307,28 @@ describe GraphQL::Schema::Argument do
         required_arg.deprecation_reason("Don't use me")
       end
     end
+
+    it "disallows deprecated required arguments whose type is a string" do
+      input_obj = Class.new(GraphQL::Schema::InputObject) do
+        graphql_name 'MyInput2'
+        argument :foo, "String!", required: false, deprecation_reason: "Don't use me"
+      end
+
+      query_type = Class.new(GraphQL::Schema::Object) do
+        graphql_name "Query"
+        field :f, String, null: true do
+          argument :arg, input_obj, required: false
+        end
+      end
+
+      err = assert_raises ArgumentError do
+        Class.new(GraphQL::Schema) do
+          query(query_type)
+        end
+      end
+
+      assert_equal "Required arguments cannot be deprecated: MyInput2.foo.", err.message
+    end
   end
 
   describe "invalid input types" do


### PR DESCRIPTION
Following up on the discussion in #3133, this adds validation to prevent deprecating required arguments in the class based API. The validation added in #3015 only covered the legacy API.