### PR TITLE
Freeze Interpreter::Arguments instances

### DIFF
--- a/lib/graphql/execution/interpreter/arguments.rb
+++ b/lib/graphql/execution/interpreter/arguments.rb
@@ -5,6 +5,9 @@ module GraphQL
     class Interpreter
       # A wrapper for argument hashes in GraphQL queries.
       #
+      # This object is immutable so that the runtime code can be sure that
+      # modifications don't leak from one use to another
+      #
       # @see GraphQL::Query#arguments_for to get access to these objects.
       class Arguments
         extend Forwardable
@@ -17,8 +20,22 @@ module GraphQL
         attr_reader :keyword_arguments
 
         def initialize(keyword_arguments:, argument_values:)
-          @keyword_arguments = keyword_arguments
-          @argument_values = argument_values
+          # This is a little crazy. We expect the `:argument_details` extra to _include extras_,
+          # but the object isn't created until _after_ extras are put together.
+          # So, we have to use a special flag here to say, "at the last minute, add yourself to the keyword args."
+          #
+          # Otherwise:
+          # - We can't access the final Arguments instance _while_ we're preparing extras
+          # - After we _can_ access it, it's frozen, so we can't add anything.
+          #
+          # So, this flag gives us a chance to sneak it in before freezing, _and_ while we have access
+          # to the new Arguments instance itself.
+          if keyword_arguments[:argument_details] == :__arguments_add_self
+            keyword_arguments[:argument_details] = self
+          end
+          @keyword_arguments = keyword_arguments.freeze
+          @argument_values = argument_values.freeze
+          freeze
         end
 
         # @return [Hash{Symbol => ArgumentValue}]
@@ -29,6 +46,20 @@ module GraphQL
 
         def inspect
           "#<#{self.class} @keyword_arguments=#{keyword_arguments.inspect}>"
+        end
+
+        # Create a new arguments instance which includes these extras.
+        #
+        # This is called by the runtime to implement field `extras: [...]`
+        #
+        # @param extra_args [Hash<Symbol => Object>]
+        # @return [Interpreter::Arguments]
+        # @api private
+        def merge_extras(extra_args)
+          self.class.new(
+            argument_values: argument_values,
+            keyword_arguments: keyword_arguments.merge(extra_args)
+          )
         end
       end
     end

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -468,9 +468,7 @@ module GraphQL
         end
 
         def arguments(graphql_object, arg_owner, ast_node)
-          # Don't cache arguments if field extras or extensions are requested since they can mutate the argument data structure
-          if arg_owner.arguments_statically_coercible? &&
-              (!arg_owner.is_a?(GraphQL::Schema::Field) || (arg_owner.extras.empty? && arg_owner.extensions.empty?))
+          if arg_owner.arguments_statically_coercible? && !arg_owner.is_a?(GraphQL::Schema::Field)
             query.arguments_for(ast_node, arg_owner)
           else
             # The arguments must be prepared in the context of the given object

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -468,7 +468,7 @@ module GraphQL
         end
 
         def arguments(graphql_object, arg_owner, ast_node)
-          if arg_owner.arguments_statically_coercible? && !arg_owner.is_a?(GraphQL::Schema::Field)
+          if arg_owner.arguments_statically_coercible?
             query.arguments_for(ast_node, arg_owner)
           else
             # The arguments must be prepared in the context of the given object

--- a/spec/graphql/execution/interpreter/arguments_spec.rb
+++ b/spec/graphql/execution/interpreter/arguments_spec.rb
@@ -41,4 +41,17 @@ describe "GraphQL::Execution::Interpreter::Arguments" do
     assert_nil args.dig(:params, :nothing)
     assert_nil args.dig(:nothing, :nothing, :nothing)
   end
+
+  it "is frozen, and so are its constituent hashes" do
+    query_str = <<-GRAPHQL
+    {
+      search(limit: 10, params: { query: "abcde" } )
+    }
+    GRAPHQL
+    args = arguments(query_str)
+
+    assert args.frozen?
+    assert args.argument_values.frozen?
+    assert args.keyword_arguments.frozen?
+  end
 end

--- a/spec/graphql/schema/field_extension_spec.rb
+++ b/spec/graphql/schema/field_extension_spec.rb
@@ -27,7 +27,7 @@ describe GraphQL::Schema::FieldExtension do
       end
 
       def resolve(object:, arguments:, context:)
-        factor = arguments.delete(:factor)
+        factor = arguments[:factor]
         yield(object, arguments, factor)
       end
 
@@ -44,7 +44,7 @@ describe GraphQL::Schema::FieldExtension do
       # `yield` returns the user-returned value
       # This method's return value is passed along
       def resolve(object:, arguments:, context:)
-        factor = arguments.delete(:factor)
+        factor = arguments[:factor]
         yield(object, arguments) * factor
       end
     end


### PR DESCRIPTION


Fixes #3004 , addresses issues described in #3003 

TL;DR: it's possible to make mistakes where objects from the arguments cache are reused, even after they're modified in field-specific ways. This will make that impossible, since arguments objects can't be modified.

It could well be a breaking change, because arguments hashes won't play nicely with `.delete` anymore (as shown in updated test here, same goes for other destructive Hash methods).