### PR TITLE
RelayClassicMutation: set description for auto-generated input argument

### DIFF
--- a/lib/graphql/schema/relay_classic_mutation.rb
+++ b/lib/graphql/schema/relay_classic_mutation.rb
@@ -105,7 +105,7 @@ module GraphQL
           sig = super
           # Arguments were added at the root, but they should be nested
           sig[:arguments].clear
-          sig[:arguments][:input] = { type: input_type, required: true, description: input_type.description }
+          sig[:arguments][:input] = { type: input_type, required: true, description: "Parameters for #{graphql_name}" }
           sig
         end
 

--- a/lib/graphql/schema/relay_classic_mutation.rb
+++ b/lib/graphql/schema/relay_classic_mutation.rb
@@ -105,7 +105,7 @@ module GraphQL
           sig = super
           # Arguments were added at the root, but they should be nested
           sig[:arguments].clear
-          sig[:arguments][:input] = { type: input_type, required: true }
+          sig[:arguments][:input] = { type: input_type, required: true, description: input_type.description }
           sig
         end
 

--- a/spec/graphql/schema/relay_classic_mutation_spec.rb
+++ b/spec/graphql/schema/relay_classic_mutation_spec.rb
@@ -36,6 +36,16 @@ describe GraphQL::Schema::RelayClassicMutation do
     end
   end
 
+  describe "input argument" do
+    it "sets a description for the input argument" do
+      mutation = Class.new(GraphQL::Schema::RelayClassicMutation) do
+        graphql_name "SomeMutation"
+      end
+
+      assert_equal "Parameters for SomeMutation", mutation.field_options[:arguments][:input][:description]
+    end
+  end
+
   describe "execution" do
     after do
       Jazz::Models.reset


### PR DESCRIPTION
We automatically generate a description for the auto-generated input type, but we don't assign that description to the mutation's argument for the new input type.

This updates the code to copy the description from the input type to the argument on the mutation.

This was prompted by the graphql-schema-linter tool saying the argument `mutationName.input` doesn't have a description.