### PR TITLE
Implement GraphQL::Execution::Interpreter::Arguments#fetch

### DIFF
--- a/lib/graphql/execution/interpreter/arguments.rb
+++ b/lib/graphql/execution/interpreter/arguments.rb
@@ -24,7 +24,7 @@ module GraphQL
         # @return [Hash{Symbol => ArgumentValue}]
         attr_reader :argument_values
 
-        def_delegators :@keyword_arguments, :key?, :[], :keys, :each, :values
+        def_delegators :@keyword_arguments, :key?, :[], :fetch, :keys, :each, :values
         def_delegators :@argument_values, :each_value
 
         def inspect

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -914,6 +914,7 @@ describe GraphQL::Query do
       source_arg_value = detailed_args.argument_values[:source]
       assert_equal false, source_arg_value.default_used?
       assert_equal "SHEEP", detailed_args[:source]
+      assert_equal "SHEEP", detailed_args.fetch(:source)
       assert_equal "SHEEP", source_arg_value.value
       assert_equal "source", source_arg_value.definition.graphql_name
 


### PR DESCRIPTION
`GraphQL::Execution::Interpreter::Arguments` is a hash-like class so this PR adds the `fetch` method.