### PR TITLE
Per-query timeout duration

### DIFF
--- a/guides/queries/timeout.md
+++ b/guides/queries/timeout.md
@@ -20,6 +20,8 @@ After `max_seconds`, no new fields will be resolved. Instead, errors will be add
 
 __Note__ that this _does not interrupt_ field execution (doing so is [buggy](https://www.mikeperham.com/2015/05/08/timeout-rubys-most-dangerous-api/)). If you're making external calls (eg, HTTP requests or database queries), make sure to use a library-specific timeout for that operation (eg, [Redis timeout](https://github.com/redis/redis-rb#timeouts), [Net::HTTP](https://ruby-doc.org/stdlib-2.4.1/libdoc/net/http/rdoc/Net/HTTP.html)'s `ssl_timeout`, `open_timeout`, and `read_timeout`).
 
+### Custom Error Handling
+
 To log the error, provide a subclass of `GraphQL::Schema::Timeout` with an overridden `handle_timeout` method:
 
 ```ruby
@@ -31,5 +33,32 @@ end
 
 class MySchema < GraphQL::Schema
   use MyTimeout, max_seconds: 2
+end
+```
+
+### Customizing the Timeout Window
+
+To dynamically pick a timeout duration (or bypass it), override {{ "GraphQL::Schema::Timeout#max_seconds" | api_doc }} in your subclass. To bypass the timeout altogether, `max_seconds` can return `false`.
+
+For example:
+
+```ruby
+class MyTimeout < GraphQL::Schema::Timeout
+  # Allow 10s for an incoming mutation, but don't apply any timeout for an admin user.
+  def max_seconds(query)
+    if query.context[:current_user]&.admin?
+      false
+    elsif query.mutation?
+      10
+    else
+      super
+    end
+  end
+end
+
+# ...
+
+class MySchema < GraphQL::Schema
+  use MyTimeout, max_seconds: 5
 end
 ```

--- a/spec/graphql/schema/timeout_spec.rb
+++ b/spec/graphql/schema/timeout_spec.rb
@@ -220,25 +220,33 @@ describe GraphQL::Schema::Timeout do
     }
 
     let(:query_context) {
-      { max_seconds: 2.9 }
+      { max_seconds: 1.9 }
     }
 
     let(:query_string) {%|
       {
-        a: sleepFor(seconds: 0.8)
-        b: sleepFor(seconds: 0.8)
-        c: sleepFor(seconds: 0.8)
-        d: sleepFor(seconds: 0.8)
-        e: sleepFor(seconds: 0.8)
+        a: sleepFor(seconds: 0.5)
+        b: sleepFor(seconds: 0.5)
+        c: sleepFor(seconds: 0.5)
+        d: sleepFor(seconds: 0.5)
+        e: sleepFor(seconds: 0.5)
       }
     |}
 
     it "uses the configured #max_seconds(query) method" do
-      expected_data = {"a"=>0.8, "b"=>0.8, "c"=>0.8, "d"=>0.8, "e"=>nil}
+      expected_data = {"a"=>0.5, "b"=>0.5, "c"=>0.5, "d"=>0.5, "e"=>nil}
       assert_equal(expected_data, result["data"])
       errors = result["errors"]
-      expected_message = "Query timed out after 2.9s: Timeout on Query.sleepFor"
+      expected_message = "Query timed out after 1.9s: Timeout on Query.sleepFor"
       assert_equal [expected_message], errors.map { |e| e["message"] }
+    end
+
+    describe "when max_seconds returns false" do
+      let(:query_context) { {max_seconds: false} }
+      it "doesn't apply any timeout" do
+        expected_data = {"a"=>0.5, "b"=>0.5, "c"=>0.5, "d"=>0.5, "e"=>0.5}
+        assert_equal(expected_data, result["data"])
+      end
     end
   end
 end

--- a/spec/graphql/schema/timeout_spec.rb
+++ b/spec/graphql/schema/timeout_spec.rb
@@ -56,8 +56,8 @@ describe GraphQL::Schema::Timeout do
     schema.use timeout_class, max_seconds: max_seconds
     schema
   }
-
-  let(:result) { timeout_schema.execute(query_string) }
+  let(:query_context) { {} }
+  let(:result) { timeout_schema.execute(query_string, context: query_context) }
 
   describe "timeout part-way through" do
     let(:query_string) {%|
@@ -202,6 +202,43 @@ describe GraphQL::Schema::Timeout do
     it "calls the block" do
       err = assert_raises(RuntimeError) { result }
       assert_equal "Query timed out after 2s: Timeout on Query.sleepFor", err.message
+    end
+  end
+
+  describe "query-specific timeout duration" do
+    let(:timeout_class) {
+      Class.new(GraphQL::Schema::Timeout) do
+        def max_seconds(query)
+          query.context[:max_seconds]
+        end
+
+        def handle_timeout(err, query)
+          max_s = query.context[:max_seconds]
+          raise(GraphQL::ExecutionError, "Query timed out after #{max_s}s: #{err.message}")
+        end
+      end
+    }
+
+    let(:query_context) {
+      { max_seconds: 2.9 }
+    }
+
+    let(:query_string) {%|
+      {
+        a: sleepFor(seconds: 0.8)
+        b: sleepFor(seconds: 0.8)
+        c: sleepFor(seconds: 0.8)
+        d: sleepFor(seconds: 0.8)
+        e: sleepFor(seconds: 0.8)
+      }
+    |}
+
+    it "uses the configured #max_seconds(query) method" do
+      expected_data = {"a"=>0.8, "b"=>0.8, "c"=>0.8, "d"=>0.8, "e"=>nil}
+      assert_equal(expected_data, result["data"])
+      errors = result["errors"]
+      expected_message = "Query timed out after 2.9s: Timeout on Query.sleepFor"
+      assert_equal [expected_message], errors.map { |e| e["message"] }
     end
   end
 end


### PR DESCRIPTION
This would allow dynamically determining `max_seconds` on a query-by-query basis. You'd use a custom subclass of `GraphQL::Schema::Timeout` to do that. 

Fixes #3162 