### PR TITLE
Make query sanitization more extensible

### DIFF
--- a/lib/graphql/language/sanitized_printer.rb
+++ b/lib/graphql/language/sanitized_printer.rb
@@ -19,11 +19,12 @@ module GraphQL
 
       REDACTED = "\"<REDACTED>\""
 
-      def initialize(query)
+      def initialize(query, inline_variables: true)
         @query = query
         @current_type = nil
         @current_field = nil
         @current_input_type = nil
+        @inline_variables = inline_variables
       end
 
       # @return [String, nil] A scrubbed query string, if the query was valid.
@@ -36,15 +37,14 @@ module GraphQL
       end
 
       def print_node(node, indent: "")
-        if node.is_a?(String)
-          type = @current_input_type.unwrap
-          # Replace any strings that aren't IDs or Enum values with REDACTED
-          if type.kind.enum? || type.graphql_name == "ID"
-            super
+        case node
+        when FalseClass, Float, Integer, String, TrueClass
+          if @current_argument && redact_argument_value?(@current_argument, node)
+            redacted_argument_value(@current_argument)
           else
-            REDACTED
+            super
           end
-        elsif node.is_a?(Array)
+        when Array
           old_input_type = @current_input_type
           if @current_input_type && @current_input_type.list?
             @current_input_type = @current_input_type.of_type
@@ -59,15 +59,30 @@ module GraphQL
         end
       end
 
+      # Indicates whether or not to redact non-null values for the given argument. Defaults to redacting all strings
+      # arguments but this can be customized by subclasses.
+      def redact_argument_value?(argument, value)
+        # Default to redacting any strings or custom scalars encoded as strings
+        type = argument.type.unwrap
+        value.is_a?(String) && type.kind.scalar? && (type.graphql_name == "String" || !type.default_scalar?)
+      end
+
+      # Returns the value to use for redacted versions of the given argument. Defaults to the
+      # string "<REDACTED>".
+      def redacted_argument_value(argument)
+        REDACTED
+      end
+
       def print_argument(argument)
         # We won't have type information if we're recursing into a custom scalar
         return super if @current_input_type && @current_input_type.kind.scalar?
 
         arg_owner = @current_input_type || @current_directive || @current_field
-        arg_def = arg_owner.arguments[argument.name]
+        old_current_argument = @current_argument
+        @current_argument = arg_owner.arguments[argument.name]
 
         old_input_type = @current_input_type
-        @current_input_type = arg_def.type.non_null? ? arg_def.type.of_type : arg_def.type
+        @current_input_type = @current_argument.type.non_null? ? @current_argument.type.of_type : @current_argument.type
 
         argument_value = if coerce_argument_value_to_list?(@current_input_type, argument.value)
           [argument.value]
@@ -77,6 +92,7 @@ module GraphQL
         res = "#{argument.name}: #{print_node(argument_value)}".dup
 
         @current_input_type = old_input_type
+        @current_argument = old_current_argument
         res
       end
 
@@ -88,8 +104,12 @@ module GraphQL
       end
 
       def print_variable_identifier(variable_id)
-        variable_value = query.variables[variable_id.name]
-        print_node(value_to_ast(variable_value, @current_input_type))
+        if @inline_variables
+          variable_value = query.variables[variable_id.name]
+          print_node(value_to_ast(variable_value, @current_input_type))
+        else
+          super
+        end
       end
 
       def print_field(field, indent: "")
@@ -141,10 +161,14 @@ module GraphQL
         old_type = @current_type
         @current_type = query.schema.public_send(operation_definition.operation_type)
 
-        out = "#{indent}#{operation_definition.operation_type}".dup
-        out << " #{operation_definition.name}" if operation_definition.name
-        out << print_directives(operation_definition.directives)
-        out << print_selections(operation_definition.selections, indent: indent)
+        if @inline_variables
+          out = "#{indent}#{operation_definition.operation_type}".dup
+          out << " #{operation_definition.name}" if operation_definition.name
+          out << print_directives(operation_definition.directives)
+          out << print_selections(operation_definition.selections, indent: indent)
+        else
+          out = super
+        end
 
         @current_type = old_type
         out

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -259,9 +259,9 @@ module GraphQL
     # - Variables inlined to the query
     # - Strings replaced with `<REDACTED>`
     # @return [String, nil] Returns nil if the query is invalid.
-    def sanitized_query_string
+    def sanitized_query_string(inline_variables: true)
       with_prepared_ast {
-        GraphQL::Language::SanitizedPrinter.new(self).sanitized_query_string
+        GraphQL::Language::SanitizedPrinter.new(self, inline_variables: inline_variables).sanitized_query_string
       }
     end
 


### PR DESCRIPTION
We (Salsify) are implementing logging of GraphQL queries and variables but our approach is slightly different than the default behavior of `GraphQL::Language::SanitizedPrinter`:

* We log queries and variables separately to get a more faithful representation of the requests we're getting from clients
* We extended our `GraphQL::Schema::Argument` subclass to support a `redact` option rather than just redacting all strings

We were able to implement this by subclassing `GraphQL::Language::SanitizedPrinter` but it involved some unfortunate copying of code from `GraphQL::Language::Printer` to restore overridden behavior and copying of code from `GraphQL::Language::SanitizedPrinter` where we need to inject logic in the middle of a method. Alternatively we could directly subclass `GraphQL::Language::Printer` but then we would have lost the type bookkeeping from `GraphQL::Language::SanitizedPrinter`.

This PR proposes a few changes to `GraphQL::Language::SanitizedPrinter` to make it easier to customize the behavior:

1. Making the inlining of variable values optional with a default that retains the current behavior
1. Adding `redact_argument_value?` and `redacted_argument_value` hooks that subclasses can use to more easily customize the redaction behavior

