### PR TITLE
Handle JSON scalars during query sanitization

### DIFF
--- a/lib/graphql/language/sanitized_printer.rb
+++ b/lib/graphql/language/sanitized_printer.rb
@@ -60,6 +60,9 @@ module GraphQL
       end
 
       def print_argument(argument)
+        # We won't have type information if we're recursing into a custom scalar
+        return super if @current_input_type && @current_input_type.kind.scalar?
+
         arg_owner = @current_input_type || @current_directive || @current_field
         arg_def = arg_owner.arguments[argument.name]
 


### PR DESCRIPTION
Query sanitization fails with the following exception for queries with JSON scalar argument values:

```
NoMethodError: undefined method `arguments' for GraphQL::Types::JSON:Class
    graphql-ruby/lib/graphql/language/sanitized_printer.rb:64:in `print_argument'
    graphql-ruby/lib/graphql/language/printer.rb:96:in `block in print_input_object'
    graphql-ruby/lib/graphql/language/printer.rb:96:in `map'
    graphql-ruby/lib/graphql/language/printer.rb:96:in `print_input_object'
    graphql-ruby/lib/graphql/language/printer.rb:310:in `print_node'
    graphql-ruby/lib/graphql/language/sanitized_printer.rb:58:in `print_node'
    graphql-ruby/lib/graphql/language/printer.rb:38:in `print_argument'
    graphql-ruby/lib/graphql/language/sanitized_printer.rb:68:in `print_argument'
    graphql-ruby/lib/graphql/language/printer.rb:63:in `block in print_field'
    graphql-ruby/lib/graphql/language/printer.rb:63:in `map'
    graphql-ruby/lib/graphql/language/printer.rb:63:in `print_field'
    graphql-ruby/lib/graphql/language/sanitized_printer.rb:90:in `print_field'
    graphql-ruby/lib/graphql/language/printer.rb:302:in `print_node'
    graphql-ruby/lib/graphql/language/sanitized_printer.rb:58:in `print_node'
    graphql-ruby/lib/graphql/language/printer.rb:281:in `block in print_selections'
    graphql-ruby/lib/graphql/language/printer.rb:280:in `each'
    graphql-ruby/lib/graphql/language/printer.rb:280:in `print_selections'
    graphql-ruby/lib/graphql/language/sanitized_printer.rb:138:in `print_operation_definition'
    graphql-ruby/lib/graphql/language/printer.rb:316:in `print_node'
    graphql-ruby/lib/graphql/language/sanitized_printer.rb:58:in `print_node'
    graphql-ruby/lib/graphql/language/printer.rb:34:in `block in print_document'
    graphql-ruby/lib/graphql/language/printer.rb:34:in `map'
    graphql-ruby/lib/graphql/language/printer.rb:34:in `print_document'
    graphql-ruby/lib/graphql/language/printer.rb:292:in `print_node'
    graphql-ruby/lib/graphql/language/sanitized_printer.rb:58:in `print_node'
    graphql-ruby/lib/graphql/language/printer.rb:28:in `print'
    graphql-ruby/lib/graphql/language/sanitized_printer.rb:32:in `sanitized_query_string'
    graphql-ruby/lib/graphql/query.rb:264:in `block in sanitized_query_string'
    graphql-ruby/lib/graphql/query.rb:438:in `with_prepared_ast'
    graphql-ruby/lib/graphql/query.rb:263:in `sanitized_query_string'
```
The problem is the input object corresponding to the JSON scalar has no type information so we need to guard against that in `GraphQL::Language::SanitizedPrinter#print_argument`.