### PR TITLE
SanitizedPrinter fixes for lists and JSON scalars

### DIFF
--- a/spec/graphql/language/sanitized_printer_spec.rb
+++ b/spec/graphql/language/sanitized_printer_spec.rb
@@ -11,6 +11,10 @@ describe GraphQL::Language::SanitizedPrinter do
     class Url < GraphQL::Schema::Scalar
     end
 
+    class SimpleInput < GraphQL::Schema::InputObject
+      argument :string, String, required: true
+    end
+
     class ExampleInput < GraphQL::Schema::InputObject
       argument :string, String, required: true
       argument :id, ID, required: true
@@ -32,8 +36,20 @@ describe GraphQL::Language::SanitizedPrinter do
         argument :url, Url, required: true
       end
 
+      field :nested_array_inputs, String, null: false do
+        argument :inputs, [SimpleInput], required: true
+      end
+
+      field :colors, String, null: false do
+        argument :colors, [Color], required: true
+      end
+
       field :strings, String, null: false do
         argument :strings, [String], required: true
+      end
+
+      field :custom_scalar, String, null: false do
+        argument :scalar, GraphQL::Types::JSON, required: true
       end
     end
 
@@ -128,12 +144,79 @@ describe GraphQL::Language::SanitizedPrinter do
   it "redacts from lists" do
     query_str_1 = '{ strings(strings: ["s1", "s2"]) }'
     query_str_2 = 'query($strings: [String!]!) { strings(strings: $strings) }'
+    query_str_3 = 'query($string1: String!, $string2: String!) { strings(strings: [$string1, $string2]) }'
     expected_query_string = 'query {
   strings(strings: ["<REDACTED>", "<REDACTED>"])
 }'
 
     assert_equal expected_query_string, sanitize_string(query_str_1)
-    assert_equal expected_query_string, sanitize_string(query_str_2, variables: { "strings" => ["s1", "s2"]})
+    assert_equal expected_query_string, sanitize_string(query_str_2, variables: { "strings" => ["s1", "s2"] })
+    assert_equal expected_query_string, sanitize_string(query_str_3, variables: { "string1" => "s1", "string2" => "s2" })
+  end
+
+  it "redacts from coerced lists" do
+    query_str = '
+    query {
+      strings(strings: "s1")
+      nestedArrayInputs(inputs: {string: "s2"})
+    }
+    '
+
+    expected_query_string = 'query {
+  strings(strings: ["<REDACTED>"])
+  nestedArrayInputs(inputs: [{string: "<REDACTED>"}])
+}'
+
+    assert_equal expected_query_string, sanitize_string(query_str)
+  end
+
+  it "doesn't redact enums" do
+    query_str_1 = '{ colors(colors: [RED, BLUE]) }'
+    query_str_2 = 'query($colors: [Color!]!) { colors(colors: $colors) }'
+
+    expected_query_string = 'query {
+  colors(colors: [RED, BLUE])
+}'
+
+    assert_equal expected_query_string, sanitize_string(query_str_1)
+    assert_equal expected_query_string, sanitize_string(query_str_2, variables: { "colors" => ["RED", "BLUE"] })
+  end
+
+  it "redacts strings from custom scalars" do
+    query_str_1 = '
+    query {
+      s1: customScalar(scalar: "s1")
+      s2: customScalar(scalar: 1)
+      s3: customScalar(scalar: {string: "s2"})
+      s4: customScalar(scalar: [{string: "s3"}])
+    }
+    '
+    query_str_2 = '
+    query($jsonString: JSON!, $jsonInt: JSON!, $jsonObject: JSON!, $jsonArray: JSON!) {
+      s1: customScalar(scalar: $jsonString)
+      s2: customScalar(scalar: $jsonInt)
+      s3: customScalar(scalar: $jsonObject)
+      s4: customScalar(scalar: $jsonArray)
+    }
+    '
+    expected_query_string = 'query {
+  s1: customScalar(scalar: "<REDACTED>")
+  s2: customScalar(scalar: 1)
+  s3: customScalar(scalar: {string: "<REDACTED>"})
+  s4: customScalar(scalar: [{string: "<REDACTED>"}])
+}'
+    assert_equal expected_query_string, sanitize_string(query_str_1)
+    variables = {
+      "jsonString" => "s1",
+      "jsonInt" => 1,
+      "jsonObject" => {
+        "string" => "s2"
+      },
+      "jsonArray" => [{
+        "string" => "s3"
+      }]
+    }
+    assert_equal expected_query_string, sanitize_string(query_str_2, variables: variables)
   end
 
   it "returns nil on invalid queries" do


### PR DESCRIPTION
This PR fixes a few problems with `GraphQL::Language::SanitizedPrinter`:

1. Variables with lists of enum values rendered as strings
1. Queries with argument values that needed to be coerced to lists raised `NoMethodError: undefined method `arguments' for #<GraphQL::Schema::List:0x00007fc4819dd508>` errors
1. Queries with JSON scalars raised `NoMethodError: undefined method `arguments' for GraphQL::Types::JSON:Class` errors