### PR TITLE
Use graphql_name in UnauthorizedError constructor when constructing default message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug fixes
 
+- Use `graphql_name` in `UnauthorizedError` default message #3174
+
 ## 1.11.5 (30 September 2020)
 
 ### New features

--- a/lib/graphql/unauthorized_error.rb
+++ b/lib/graphql/unauthorized_error.rb
@@ -22,7 +22,7 @@ module GraphQL
       @object = object
       @type = type
       @context = context
-      message ||= "An instance of #{object.class} failed #{type.name}'s authorization check"
+      message ||= "An instance of #{object.class} failed #{type.graphql_name}'s authorization check"
       super(message)
     end
   end


### PR DESCRIPTION
This PR is a fix for #3174 

It uses `graphql_name` which is both more appropriate and fixes a potential performance issue with calling `name` in the constructor.