### PR TITLE
Fix .valid_isolated_input? on parsed schemas

### DIFF
--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -578,7 +578,7 @@ type Root {
 
       built_schema = assert_schema_and_compare_output(schema.chop)
       id_scalar = built_schema.types["ID"]
-      assert_equal true, id_scalar.valid_input?("123", OpenStruct.new(schema: built_schema))
+      assert_equal true, id_scalar.valid_isolated_input?("123")
     end
 
     it 'supports custom scalar' do
@@ -596,9 +596,8 @@ type Root {
 
       built_schema = assert_schema_and_compare_output(schema.chop)
       custom_scalar = built_schema.types["CustomScalar"]
-      dummy_ctx = OpenStruct.new(schema: built_schema)
-      assert_equal true, custom_scalar.valid_input?("anything", dummy_ctx)
-      assert_equal true, custom_scalar.valid_input?(12345, dummy_ctx)
+      assert_equal true, custom_scalar.valid_isolated_input?("anything")
+      assert_equal true, custom_scalar.valid_isolated_input?(12345)
     end
 
     it 'supports input object' do


### PR DESCRIPTION
Fixes #3181 

The only difference in retained memory was the procs for these methods, which was 0.02% in my own case :+1: 