### PR TITLE
Fix custom connection total_count example

### DIFF
--- a/guides/type_definitions/extensions.md
+++ b/guides/type_definitions/extensions.md
@@ -122,7 +122,7 @@ class Types::MyCustomConnection < GraphQL::Types::Relay::BaseConnection
   field :total_count, Integer, null: false
 
   def total_count
-    object.items.size
+    nodes.size
   end
 end
 ```


### PR DESCRIPTION
As of 1.11.* the previous example of `object.items.count` no longer works for providing a count of nodes on a connection.

This appears to be a result of renaming `object` to `nodes` in f768ea. This changes allows the example to work again.