### PR TITLE
Allow field lookup to be overwritten in custom field class

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -705,17 +705,22 @@ module GraphQL
               obj.object.public_send(@method_sym)
             end
           else
-            raise <<-ERR
-          Failed to implement #{@owner.graphql_name}.#{@name}, tried:
-
-          - `#{obj.class}##{@resolver_method}`, which did not exist
-          - `#{obj.object.class}##{@method_sym}`, which did not exist
-          - Looking up hash key `#{@method_sym.inspect}` or `#{@method_str.inspect}` on `#{obj.object}`, but it wasn't a Hash
-
-          To implement this field, define one of the methods above (and check for typos)
-          ERR
+            field_lookup(obj, ruby_kwargs)
           end
         end
+      end
+
+      # May be overwritten in custom field class to do some custom field lookup
+      def field_lookup(obj, ruby_kwargs)
+        raise <<-ERR
+      Failed to implement #{@owner.graphql_name}.#{@name}, tried:
+
+      - `#{obj.class}##{@resolver_method}`, which did not exist
+      - `#{obj.object.class}##{@method_sym}`, which did not exist
+      - Looking up hash key `#{@method_sym.inspect}` or `#{@method_str.inspect}` on `#{obj.object}`, but it wasn't a Hash
+
+      To implement this field, define one of the methods above (and check for typos)
+      ERR
       end
 
       # Wrap execution with hooks.


### PR DESCRIPTION
We use a custom field class to do some magic field lookup, e.g. call the field method on a decorator when a `decorated: true` flag has been set.

This is no longer possible in the 1.11.x version of this awesome gem. I know it is a bad idea to overwrite private methods and to complain when something has changed upstream. Just want to check if extracting the raise would be an option, so we can still work with our custom class.

Are yo maybe interested in adding the `decorated` feature? Would be happy to help or provide a PR for that.