### PR TITLE
Fix fields nullability in subscriptions documentation

### DIFF
--- a/guides/subscriptions/subscription_classes.md
+++ b/guides/subscriptions/subscription_classes.md
@@ -102,8 +102,8 @@ Like mutations, you can use a generated return type for subscriptions. When you 
 
 ```ruby
 class Subscriptions::MessageWasPosted < Subscriptions::BaseSubscription
-  field :room, Types::RoomType, null: true
-  field :message, Types::MessageType, null: true
+  field :room, Types::RoomType, null: false
+  field :message, Types::MessageType, null: false
 end
 ```
 


### PR DESCRIPTION
The documentation on subscriptions page show `Room` and `Message` as mandatory in the client side, but the ruby class show them as `null: true`. This change makes them not nullable in the ruby gql class to have consistency

```javascript
type MessageWasPostedPayload {
  room: Room!
  message: Message!
}
```