### PR TITLE
Update RangeAdd to use new connections when available

### DIFF
--- a/lib/graphql/pagination/connections.rb
+++ b/lib/graphql/pagination/connections.rb
@@ -63,17 +63,23 @@ module GraphQL
         all_wrappers
       end
 
-      # Used by the runtime to wrap values in connection wrappers.
-      # @api Private
-      def wrap(field, parent, items, arguments, context, wrappers: all_wrappers)
-        return items if GraphQL::Execution::Interpreter::RawValue === items
-
+      def wrapper_for(items, wrappers: all_wrappers)
         impl = nil
 
         items.class.ancestors.each { |cls|
           impl = wrappers[cls]
           break if impl
         }
+
+        impl
+      end
+
+      # Used by the runtime to wrap values in connection wrappers.
+      # @api Private
+      def wrap(field, parent, items, arguments, context, wrappers: all_wrappers)
+        return items if GraphQL::Execution::Interpreter::RawValue === items
+
+        impl = wrapper_for(itmems, wrappers: wrappers)
 
         if impl.nil?
           raise ImplementationMissingError, "Couldn't find a connection wrapper for #{items.class} during #{field.path} (#{items.inspect})"

--- a/lib/graphql/pagination/connections.rb
+++ b/lib/graphql/pagination/connections.rb
@@ -79,7 +79,7 @@ module GraphQL
       def wrap(field, parent, items, arguments, context, wrappers: all_wrappers)
         return items if GraphQL::Execution::Interpreter::RawValue === items
 
-        impl = wrapper_for(itmems, wrappers: wrappers)
+        impl = wrapper_for(items, wrappers: wrappers)
 
         if impl.nil?
           raise ImplementationMissingError, "Couldn't find a connection wrapper for #{items.class} during #{field.path} (#{items.inspect})"

--- a/lib/graphql/relay/range_add.rb
+++ b/lib/graphql/relay/range_add.rb
@@ -33,19 +33,21 @@ module GraphQL
       # @param item [Object] The newly-added item (will be wrapped in `edge_class`)
       # @param parent [Object] The owner of `collection`, will be passed to the connection if provided
       # @param context [GraphQL::Query::Context] The surrounding `ctx`, will be passed to the connection if provided (this is required for cursor encoders)
-      # @param edge_class [Class] The class to wrap `item` with
-      def initialize(collection:, item:, parent: nil, context: nil, edge_class: Relay::Edge)
-        @connection = if context && context.schema.new_connections?
+      # @param edge_class [Class] The class to wrap `item` with (defaults to the connection's edge class)
+      def initialize(collection:, item:, parent: nil, context: nil, edge_class: nil)
+        if context && context.schema.new_connections?
           conn_class = context.schema.connections.wrapper_for(collection)
           # The rest will be added by ConnectionExtension
-          conn_class.new(collection)
+          @connection = conn_class.new(collection, parent: parent, context: context, edge_class: edge_class)
+          @edge = @connection.edge_class.new(item, @connection)
         else
           connection_class = BaseConnection.connection_for_nodes(collection)
-          connection_class.new(collection, {}, parent: parent, context: context)
+          @connection = connection_class.new(collection, {}, parent: parent, context: context)
+          edge_class ||= Relay::Edge
+          @edge = edge_class.new(item, @connection)
         end
-        @parent = parent
 
-        @edge = edge_class.new(item, @connection)
+        @parent = parent
       end
     end
   end

--- a/spec/integration/rails/graphql/relay/range_add_spec.rb
+++ b/spec/integration/rails/graphql/relay/range_add_spec.rb
@@ -51,7 +51,8 @@ describe GraphQL::Relay::RangeAdd do
       argument :menu_idx, Integer, required: true
 
       field :item_edge, item.edge_type, null: false
-      field :items, item.connection_type, null: false, connection: false
+      # On the old runtime, connection: false was required here:
+      field :items, item.connection_type, null: false, connection: TESTING_INTERPRETER
       field :menu, menu, null: false
 
       define_method :resolve do |input|
@@ -82,6 +83,12 @@ describe GraphQL::Relay::RangeAdd do
       self.query(query)
       self.mutation(mutation)
       self.cursor_encoder(PassThroughEncoder)
+
+      if TESTING_INTERPRETER
+        use GraphQL::Execution::Interpreter
+        use GraphQL::Analysis::AST
+        use GraphQL::Pagination::Connections
+      end
     end
   }
 


### PR DESCRIPTION
Oops, this had a hardcoded reference to `Relay::BaseConnection`, so it always returned legacy connections.

Fixes #3191 