### PR TITLE
Accept additional options in global_id_field macro

### DIFF
--- a/lib/graphql/define/assign_global_id_field.rb
+++ b/lib/graphql/define/assign_global_id_field.rb
@@ -2,9 +2,9 @@
 module GraphQL
   module Define
     module AssignGlobalIdField
-      def self.call(type_defn, field_name)
+      def self.call(type_defn, field_name, **field_kwargs)
         resolve = GraphQL::Relay::GlobalIdResolve.new(type: type_defn)
-        GraphQL::Define::AssignObjectField.call(type_defn, field_name, type: GraphQL::ID_TYPE.to_non_null_type, resolve: resolve)
+        GraphQL::Define::AssignObjectField.call(type_defn, field_name, **field_kwargs, type: GraphQL::ID_TYPE.to_non_null_type, resolve: resolve)
       end
     end
   end

--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -82,9 +82,9 @@ module GraphQL
           end
         end
 
-        def global_id_field(field_name)
+        def global_id_field(field_name, **kwargs)
           id_resolver = GraphQL::Relay::GlobalIdResolve.new(type: self)
-          field field_name, "ID", null: false
+          field field_name, "ID", **kwargs, null: false
           define_method(field_name) do
             id_resolver.call(object, {}, context)
           end

--- a/spec/graphql/schema/interface_spec.rb
+++ b/spec/graphql/schema/interface_spec.rb
@@ -95,13 +95,14 @@ describe GraphQL::Schema::Interface do
     object = Module.new do
       include GraphQL::Schema::Interface
       graphql_name 'GlobalIdFieldTest'
-      global_id_field :uuid
+      global_id_field :uuid, description: 'The UUID field'
     end.to_graphql
 
     uuid_field = object.fields["uuid"]
 
     assert_equal GraphQL::NonNullType, uuid_field.type.class
     assert_equal GraphQL::ScalarType, uuid_field.type.unwrap.class
+    assert_equal 'The UUID field', uuid_field.description
     assert_equal(
       GraphQL::Schema::Member::GraphQLTypeNames::ID,
       uuid_field.type.unwrap.name


### PR DESCRIPTION
Accept options in `global_id_field` macro and pass them to as field definition options. This would be extremely useful with https://github.com/Gusto/apollo-federation-ruby/ turning:
```
global_id_field :id
field :id, ID, null: false, external: true
```
into:
```
global_id_field :id, external: true
```