### PR TITLE
Update method signature example in extension docs

### DIFF
--- a/guides/type_definitions/extensions.md
+++ b/guides/type_definitions/extensions.md
@@ -68,7 +68,7 @@ Fields are generated in a different way. Instead of using classes, they are gene
 field :name, String, null: false
 # ...
 # Leads to:
-field_config = GraphQL::Schema::Field.new(:name, String, null: false)
+field_config = GraphQL::Schema::Field.new(name: :name, type: String, null: false)
 ```
 
 So, you can customize this process by:


### PR DESCRIPTION
While spending some time extending the graphql-ruby type system in a project of mine I noticed that the documentation that describes how the `field` DSL generates a `GraphQL::Schema::Field` object wasn't using the correct method signature. It looks like the method signature changed in 82d95dd, but this documentation was never updated.

The method signature is quite complex with a large number of keyword arguments, but hopefully only using the required arguments is sufficient for this particular documentation example.