### PR TITLE
Add InputObjectNamesAreUnique static validation

### DIFF
--- a/lib/graphql/static_validation/all_rules.rb
+++ b/lib/graphql/static_validation/all_rules.rb
@@ -34,6 +34,7 @@ module GraphQL
       GraphQL::StaticValidation::VariableUsagesAreAllowed,
       GraphQL::StaticValidation::MutationRootExists,
       GraphQL::StaticValidation::SubscriptionRootExists,
+      GraphQL::StaticValidation::InputObjectNamesAreUnique,
     ]
   end
 end

--- a/lib/graphql/static_validation/rules/input_object_names_are_unique.rb
+++ b/lib/graphql/static_validation/rules/input_object_names_are_unique.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+module GraphQL
+  module StaticValidation
+    module InputObjectNamesAreUnique
+      def on_input_object(node, parent)
+        validate_input_fields(node)
+        super
+      end
+
+      private
+
+      def validate_input_fields(node)
+        input_field_defns = node.arguments
+        input_fields_by_name = Hash.new { |h, k| h[k] = [] }
+        input_field_defns.each { |a| input_fields_by_name[a.name] << a }
+
+        input_fields_by_name.each do |name, defns|
+          if defns.size > 1
+            error = GraphQL::StaticValidation::InputObjectNamesAreUniqueError.new(
+              "There can be only one input field named \"#{name}\"",
+              nodes: defns,
+              name: name
+            )
+            add_error(error)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/static_validation/rules/input_object_names_are_unique_error.rb
+++ b/lib/graphql/static_validation/rules/input_object_names_are_unique_error.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+module GraphQL
+  module StaticValidation
+    class InputObjectNamesAreUniqueError < StaticValidation::Error
+      attr_reader :name
+
+      def initialize(message, path: nil, nodes: [], name:)
+        super(message, path: path, nodes: nodes)
+        @name = name
+      end
+
+      # A hash representation of this Message
+      def to_h
+        extensions = {
+          "code" => code,
+          "name" => name
+        }
+
+        super.merge({
+          "extensions" => extensions
+        })
+      end
+
+      def code
+        "inputFieldNotUnique"
+      end
+    end
+  end
+end
+

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -972,4 +972,23 @@ describe GraphQL::Query do
       assert_equal "order_by", order_by_argument_value.definition.graphql_name
     end
   end
+
+  describe "when provided input object field names are not unique" do
+    let(:variables) { {} }
+    let(:result) { Dummy::Schema.execute(query_string, variables: variables) }
+
+    describe "the query is invalid" do
+      let(:query_string) {%|
+        query getCheeses{
+          searchDairy(product: [{ source: COW, source: COW }]) {
+            __typename
+          }
+        }
+      |}
+
+      it "returns errors" do
+        refute_nil(result["errors"])
+      end
+    end
+  end
 end

--- a/spec/graphql/static_validation/rules/input_object_names_are_unique_spec.rb
+++ b/spec/graphql/static_validation/rules/input_object_names_are_unique_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::StaticValidation::InputObjectNamesAreUnique do
+  include StaticValidationHelpers
+
+  let(:query_string) {%|
+    query getCheese {
+      validInputObjectName: searchDairy(product: [{source: YAK}]) { __typename }
+      duplicateInputObjectNames: searchDairy(product: [{source: YAK, source: YAK}]) { __typename }
+    }
+  |}
+
+  describe "when queries contain duplicate input fields" do
+    duplicate_input_field_error =  {
+      "message" => 'There can be only one input field named "source"',
+      "locations"=>[{ "line" => 4, "column" => 57 }, { "line" => 4, "column" => 70 }],
+      "path" => ["query getCheese", "duplicateInputObjectNames", "product", 0],
+      "extensions" => { "code" => "inputFieldNotUnique", "name" => "source" }
+    }
+
+    it "returns errors in the response" do
+      assert_includes(errors, duplicate_input_field_error)
+    end
+  end
+end


### PR DESCRIPTION
### Context

From the GraphQL spec: 
> Input objects must not contain more than one field of the same name, otherwise an ambiguity would exist which includes an ignored portion of syntax.

https://spec.graphql.org/June2018/#sec-Input-Object-Field-Uniqueness

### Expected behaviour

This query should be considered invalid and the response should contain `errors`.

### Actual behaviour

It appears the last usage of a duplicate input object field is what graphql-ruby accepts, without any errors.

# Update

This PR now contains a proposed fix. Adding `GraphQL::StaticValidation::InputObjectNamesAreUnique`. It seems like a pretty straightforward change, consistent with how existing validations like `ArgumentNamesAreUnique` work.