### PR TITLE
Fix race conditions with Ably subscriptions

### DIFF
--- a/javascript_client/src/subscriptions/createAblyHandler.ts
+++ b/javascript_client/src/subscriptions/createAblyHandler.ts
@@ -86,7 +86,7 @@ function createAblyHandler(options: AblyHandlerOptions) {
 
         channel = ably.channels.get(channelName, {
           params: { rewind: String(maxNumRewindMessages) },
-          cipher: null,
+          cipher: undefined,
           modes: ["SUBSCRIBE", "PRESENCE"]
         })
 


### PR DESCRIPTION
Specify the [`rewind`](https://www.ably.io/blog/channel-rewind/) parameter for each channel so that early messages don't get lost.

Without this change, any messages sent during a specific time window are lost. This time window begins when the subscription is established server-side and ends when the client-side call to `subscribe` takes effect, i.e. once the subscription request has been received and processed by Ably servers.  I've observed this window to be up to three seconds long,  although obviously it can be of arbitrary length depending on network latency etc.

Note that Ably promises to keep messages (with the default channel configuration) for two minutes, which should be enough even for pathological cases.  However, technically messages can still get lost when establishment of the subscription takes longer than two minutes and the Ably channel hasn't been configured for persistence, or when more than 100 messages are sent before the subscription is established. Perhaps these edge cases can be further improved in the future.

This change should be safe with respect to the danger of more-than-once delivery since every subscription gets a fresh channel.

Also, fix a second race condition, where an error was raised in the `enter` callback when the subscription is disposed immediately after creation.

Also, add an integration test for message rewinding, and make an existing integration test more robust by doing away with an arbitrary timeout value.
