### PR TITLE
Pass along extended args even when an extension shortcuts the normal resolve

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -746,10 +746,8 @@ module GraphQL
 
       def run_extensions_before_resolve(memos, obj, args, ctx, idx: 0)
         extension = @extensions[idx]
-        yielded = false
         return_value = if extension
           extension.resolve(object: obj, arguments: args, context: ctx) do |extended_obj, extended_args, memo|
-            yielded = true
             memos << memo
             next_obj, next_args, next_val = run_extensions_before_resolve(memos, extended_obj, extended_args, ctx, idx: idx + 1) { |o, a| yield(o, a) }
             next_val

--- a/spec/graphql/schema/field_extension_spec.rb
+++ b/spec/graphql/schema/field_extension_spec.rb
@@ -167,6 +167,7 @@ describe GraphQL::Schema::FieldExtension do
 
   describe "passing along extended arguments" do
     it "works even when shortcut" do
+      ctx = {}
       res =  exec_query("{ extendedThenShortcut }", context: ctx)
       assert_equal 3, res["data"]["extendedThenShortcut"]
       assert_equal true, ctx[:extended_args]

--- a/spec/graphql/schema/field_extension_spec.rb
+++ b/spec/graphql/schema/field_extension_spec.rb
@@ -65,6 +65,25 @@ describe GraphQL::Schema::FieldExtension do
       end
     end
 
+    class ExtendsArguments < GraphQL::Schema::FieldExtension
+      def resolve(object:, arguments:, **_rest)
+        new_args = arguments.dup
+        new_args[:extended] = true
+        yield(object, new_args)
+      end
+
+      def after_resolve(arguments:, context:, value:, **_rest)
+        context[:extended_args] = arguments[:extended]
+        value
+      end
+    end
+
+    class ShortcutsResolve < GraphQL::Schema::FieldExtension
+      def resolve(**_args)
+        options[:shortcut_value]
+      end
+    end
+
     class BaseObject < GraphQL::Schema::Object
     end
 
@@ -118,6 +137,11 @@ describe GraphQL::Schema::FieldExtension do
         extensions: [DoubleFilter, { MultiplyByOption => { factor: 3 } }] do
           argument :input, Integer, required: true
         end
+
+      field :extended_then_shortcut, Integer, null: true do
+        extension ExtendsArguments
+        extension ShortcutsResolve, shortcut_value: 3
+      end
     end
 
     class Schema < GraphQL::Schema
@@ -138,6 +162,14 @@ describe GraphQL::Schema::FieldExtension do
       field = FilterTestSchema::Query.fields["multiplyInput"]
       assert_equal 1, field.extensions.size
       assert_instance_of FilterTestSchema::MultiplyByArgument, field.extensions.first
+    end
+  end
+
+  describe "passing along extended arguments" do
+    it "works even when shortcut" do
+      res =  exec_query("{ extendedThenShortcut }", context: ctx)
+      assert_equal 3, res["data"]["extendedThenShortcut"]
+      assert_equal true, ctx[:extended_args]
     end
   end
 


### PR DESCRIPTION
Previously, any modifications to `args` were lost. cc @swalkinshaw 

This is a hack, but it's a _hack with a test_ 🎉 . 