### PR TITLE
GraphQLCollector support for prometheus' custom_labels

### DIFF
--- a/lib/graphql/tracing/prometheus_tracing/graphql_collector.rb
+++ b/lib/graphql/tracing/prometheus_tracing/graphql_collector.rb
@@ -16,7 +16,10 @@ module GraphQL
         end
 
         def collect(object)
-          labels = { key: object['key'], platform_key: object['platform_key'] }
+          default_labels = { key: object['key'], platform_key: object['platform_key'] }
+          custom = object['custom_labels']
+          labels = custom.nil? ? default_labels : default_labels.merge(custom)
+
           @graphql_gauge.observe object['duration'], labels
         end
 


### PR DESCRIPTION
I noticed that the GraphQLCollector wasn't correctly supporting ![custom_labels](https://github.com/discourse/prometheus_exporter#client-default-labels) for metrics, so I added support.

Same implementation as the `prometheus_exporter` gem's build-in collectors. https://github.com/discourse/prometheus_exporter/blob/master/lib/prometheus_exporter/server/sidekiq_collector.rb#L19-L22