### PR TITLE
Tighten up some runtime performance and object allocations

### DIFF
--- a/lib/graphql/execution/interpreter/arguments.rb
+++ b/lib/graphql/execution/interpreter/arguments.rb
@@ -14,18 +14,33 @@ module GraphQL
         # This hash is the one used at runtime.
         #
         # @return [Hash<Symbol, Object>]
-        attr_reader :keyword_arguments
+        def keyword_arguments
+          @keyword_arguments ||= begin
+            kwargs = {}
+            argument_values.each do |name, arg_val|
+              kwargs[name] = arg_val.value
+            end
+            kwargs
+          end
+        end
 
-        def initialize(keyword_arguments:, argument_values:)
-          @keyword_arguments = keyword_arguments
+        # @param argument_values [nil, Hash{Symbol => ArgumentValue}]
+        def initialize(argument_values:)
           @argument_values = argument_values
+          @empty = argument_values.nil? || argument_values.empty?
         end
 
         # @return [Hash{Symbol => ArgumentValue}]
-        attr_reader :argument_values
+        def argument_values
+          @argument_values ||= {}
+        end
 
-        def_delegators :@keyword_arguments, :key?, :[], :fetch, :keys, :each, :values
-        def_delegators :@argument_values, :each_value
+        def empty?
+          @empty
+        end
+
+        def_delegators :keyword_arguments, :key?, :[], :fetch, :keys, :each, :values
+        def_delegators :argument_values, :each_value
 
         def inspect
           "#<#{self.class} @keyword_arguments=#{keyword_arguments.inspect}>"

--- a/lib/graphql/execution/interpreter/arguments_cache.rb
+++ b/lib/graphql/execution/interpreter/arguments_cache.rb
@@ -29,11 +29,16 @@ module GraphQL
 
         private
 
+        NO_ARGUMENTS = {}.freeze
+
         NO_VALUE_GIVEN = Object.new
 
         def prepare_args_hash(ast_arg_or_hash_or_value)
           case ast_arg_or_hash_or_value
           when Hash
+            if ast_arg_or_hash_or_value.empty?
+              return NO_ARGUMENTS
+            end
             args_hash = {}
             ast_arg_or_hash_or_value.each do |k, v|
               args_hash[k] = prepare_args_hash(v)
@@ -42,6 +47,9 @@ module GraphQL
           when Array
             ast_arg_or_hash_or_value.map { |v| prepare_args_hash(v) }
           when GraphQL::Language::Nodes::Field, GraphQL::Language::Nodes::InputObject, GraphQL::Language::Nodes::Directive
+            if ast_arg_or_hash_or_value.arguments.empty?
+              return NO_ARGUMENTS
+            end
             args_hash = {}
             ast_arg_or_hash_or_value.arguments.each do |arg|
               v = prepare_args_hash(arg.value)

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -47,8 +47,7 @@ module GraphQL
           root_op_type = root_operation.operation_type || "query"
           root_type = schema.root_type_for_operation(root_op_type)
           path = []
-          set_interpreter_context(:current_object, query.root_value)
-          set_interpreter_context(:current_path, path)
+          set_all_interpreter_context(query.root_value, nil, nil, path)
           object_proxy = authorized_new(root_type, query.root_value, context, path)
           object_proxy = schema.sync_lazy(object_proxy)
           if object_proxy.nil?
@@ -118,9 +117,10 @@ module GraphQL
           end
         end
 
+        NO_ARGS = {}.freeze
+
         def evaluate_selections(path, scoped_context, owner_object, owner_type, selections, root_operation_type: nil)
-          set_interpreter_context(:current_object, owner_object)
-          set_interpreter_context(:current_path, path)
+          set_all_interpreter_context(owner_object, nil, nil, path)
           selections_by_name = {}
           gather_selections(owner_object, owner_type, selections, selections_by_name)
           selections_by_name.each do |result_name, field_ast_nodes_or_ast_node|
@@ -159,8 +159,7 @@ module GraphQL
             # to propagate `null`
             set_type_at_path(next_path, return_type)
             # Set this before calling `run_with_directives`, so that the directive can have the latest path
-            set_interpreter_context(:current_path, next_path)
-            set_interpreter_context(:current_field, field_defn)
+            set_all_interpreter_context(nil, field_defn, nil, next_path)
 
             context.scoped_context = scoped_context
             object = owner_object
@@ -182,33 +181,38 @@ module GraphQL
                 next
               end
 
-              kwarg_arguments = resolved_arguments.keyword_arguments
+              if resolved_arguments.empty? && field_defn.extras.empty?
+                # We can avoid allocating the `{ Symbol => Object }` hash in this case
+                kwarg_arguments = NO_ARGS
+              else
+                kwarg_arguments = resolved_arguments.keyword_arguments
 
-              field_defn.extras.each do |extra|
-                case extra
-                when :ast_node
-                  kwarg_arguments[:ast_node] = ast_node
-                when :execution_errors
-                  kwarg_arguments[:execution_errors] = ExecutionErrors.new(context, ast_node, next_path)
-                when :path
-                  kwarg_arguments[:path] = next_path
-                when :lookahead
-                  if !field_ast_nodes
-                    field_ast_nodes = [ast_node]
+                field_defn.extras.each do |extra|
+                  case extra
+                  when :ast_node
+                    kwarg_arguments[:ast_node] = ast_node
+                  when :execution_errors
+                    kwarg_arguments[:execution_errors] = ExecutionErrors.new(context, ast_node, next_path)
+                  when :path
+                    kwarg_arguments[:path] = next_path
+                  when :lookahead
+                    if !field_ast_nodes
+                      field_ast_nodes = [ast_node]
+                    end
+                    kwarg_arguments[:lookahead] = Execution::Lookahead.new(
+                      query: query,
+                      ast_nodes: field_ast_nodes,
+                      field: field_defn,
+                    )
+                  when :argument_details
+                    kwarg_arguments[:argument_details] = resolved_arguments
+                  else
+                    kwarg_arguments[extra] = field_defn.fetch_extra(extra, context)
                   end
-                  kwarg_arguments[:lookahead] = Execution::Lookahead.new(
-                    query: query,
-                    ast_nodes: field_ast_nodes,
-                    field: field_defn,
-                  )
-                when :argument_details
-                  kwarg_arguments[:argument_details] = resolved_arguments
-                else
-                  kwarg_arguments[extra] = field_defn.fetch_extra(extra, context)
                 end
               end
 
-              set_interpreter_context(:current_arguments, kwarg_arguments)
+              set_all_interpreter_context(nil, nil, kwarg_arguments, nil)
 
               # Optimize for the case that field is selected only once
               if field_ast_nodes.nil? || field_ast_nodes.size == 1
@@ -414,6 +418,21 @@ module GraphQL
           true
         end
 
+        def set_all_interpreter_context(object, field, arguments, path)
+          if object
+            @context[:current_object] = @interpreter_context[:current_object] = object
+          end
+          if field
+            @context[:current_field] = @interpreter_context[:current_field] = field
+          end
+          if arguments
+            @context[:current_arguments] = @interpreter_context[:current_arguments] = arguments
+          end
+          if path
+            @context[:current_path] = @interpreter_context[:current_path] = path
+          end
+        end
+
         # @param obj [Object] Some user-returned value that may want to be batched
         # @param path [Array<String>]
         # @param field [GraphQL::Schema::Field]
@@ -421,16 +440,10 @@ module GraphQL
         # @param trace [Boolean] If `false`, don't wrap this with field tracing
         # @return [GraphQL::Execution::Lazy, Object] If loading `object` will be deferred, it's a wrapper over it.
         def after_lazy(lazy_obj, owner:, field:, path:, scoped_context:, owner_object:, arguments:, eager: false, trace: true, &block)
-          set_interpreter_context(:current_object, owner_object)
-          set_interpreter_context(:current_arguments, arguments)
-          set_interpreter_context(:current_path, path)
-          set_interpreter_context(:current_field, field)
+          set_all_interpreter_context(owner_object, field, arguments, path)
           if schema.lazy?(lazy_obj)
             lazy = GraphQL::Execution::Lazy.new(path: path, field: field) do
-              set_interpreter_context(:current_path, path)
-              set_interpreter_context(:current_field, field)
-              set_interpreter_context(:current_object, owner_object)
-              set_interpreter_context(:current_arguments, arguments)
+              set_all_interpreter_context(owner_object, field, arguments, path)
               context.scoped_context = scoped_context
               # Wrap the execution of _this_ method with tracing,
               # but don't wrap the continuation below

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -88,6 +88,7 @@ module GraphQL
         schema = schema.graphql_definition
       end
       @schema = schema
+      @interpreter = @schema.interpreter?
       @filter = schema.default_filter.merge(except: except, only: only)
       @context = schema.context_class.new(query: self, object: root_value, values: context)
       @warden = warden
@@ -148,7 +149,9 @@ module GraphQL
       @query_string ||= (document ? document.to_query_string : nil)
     end
 
-    def_delegators :@schema, :interpreter?
+    def interpreter?
+      @interpreter
+    end
 
     def subscription_update?
       @subscription_topic && subscription?

--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -167,7 +167,10 @@ module GraphQL
       # @api private
       attr_accessor :scoped_context
 
-      def_delegators :@provided_values, :[]=
+      def []=(key, value)
+        @provided_values[key] = value
+      end
+
       def_delegators :@query, :trace, :interpreter?
 
       # @!method []=(key, value)

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -725,37 +725,42 @@ module GraphQL
         if @extensions.empty?
           yield(obj, args)
         else
-          memos = []
           # This is a hack to get the _last_ value for extended obj and args,
           # in case one of the extensions doesn't `yield`.
           # (There's another implementation that uses multiple-return, but I'm wary of the perf cost of the extra arrays)
-          extended = { args: args, obj: obj }
-          value = run_extensions_before_resolve(memos, obj, args, ctx, extended) do |obj, args|
+          extended = { args: args, obj: obj, memos: nil }
+          value = run_extensions_before_resolve(obj, args, ctx, extended) do |obj, args|
             yield(obj, args)
           end
 
           extended_obj = extended[:obj]
           extended_args = extended[:args]
+          memos = extended[:memos] || EMPTY_HASH
 
           ctx.schema.after_lazy(value) do |resolved_value|
-            @extensions.each_with_index do |ext, idx|
+            idx = 0
+            @extensions.each do |ext|
               memo = memos[idx]
               # TODO after_lazy?
               resolved_value = ext.after_resolve(object: extended_obj, arguments: extended_args, context: ctx, value: resolved_value, memo: memo)
+              idx += 1
             end
             resolved_value
           end
         end
       end
 
-      def run_extensions_before_resolve(memos, obj, args, ctx, extended, idx: 0)
+      def run_extensions_before_resolve(obj, args, ctx, extended, idx: 0)
         extension = @extensions[idx]
         if extension
           extension.resolve(object: obj, arguments: args, context: ctx) do |extended_obj, extended_args, memo|
-            memos << memo
+            if memo
+              memos = extended[:memos] ||= {}
+              memos[idx] = memo
+            end
             extended[:obj] = extended_obj
             extended[:args] = extended_args
-            run_extensions_before_resolve(memos, extended_obj, extended_args, ctx, extended, idx: idx + 1) { |o, a| yield(o, a) }
+            run_extensions_before_resolve(extended_obj, extended_args, ctx, extended, idx: idx + 1) { |o, a| yield(o, a) }
           end
         else
           yield(obj, args)

--- a/lib/graphql/schema/field/scope_extension.rb
+++ b/lib/graphql/schema/field/scope_extension.rb
@@ -4,7 +4,7 @@ module GraphQL
   class Schema
     class Field
       class ScopeExtension < GraphQL::Schema::FieldExtension
-        def after_resolve(value:, context:, **rest)
+        def after_resolve(object:, arguments:, context:, value:, memo:)
           if value.nil?
             value
           else

--- a/lib/graphql/schema/member/has_arguments.rb
+++ b/lib/graphql/schema/member/has_arguments.rb
@@ -85,70 +85,69 @@ module GraphQL
         # @param context [GraphQL::Query::Context]
         # @return [Hash<Symbol, Object>, Execution::Lazy<Hash>]
         def coerce_arguments(parent_object, values, context)
-          argument_values = {}
-          kwarg_arguments = {}
           # Cache this hash to avoid re-merging it
           arg_defns = self.arguments
 
-          maybe_lazies = []
-          arg_lazies = arg_defns.map do |arg_name, arg_defn|
-            arg_key = arg_defn.keyword
-            has_value = false
-            default_used = false
-            if values.key?(arg_name)
-              has_value = true
-              value = values[arg_name]
-            elsif values.key?(arg_key)
-              has_value = true
-              value = values[arg_key]
-            elsif arg_defn.default_value?
-              has_value = true
-              value = arg_defn.default_value
-              default_used = true
-            end
+          if arg_defns.empty?
+            GraphQL::Execution::Interpreter::Arguments.new(argument_values: nil)
+          else
+            argument_values = {}
+            arg_lazies = arg_defns.map do |arg_name, arg_defn|
+              arg_key = arg_defn.keyword
+              has_value = false
+              default_used = false
+              if values.key?(arg_name)
+                has_value = true
+                value = values[arg_name]
+              elsif values.key?(arg_key)
+                has_value = true
+                value = values[arg_key]
+              elsif arg_defn.default_value?
+                has_value = true
+                value = arg_defn.default_value
+                default_used = true
+              end
 
-            if has_value
-              loads = arg_defn.loads
-              loaded_value = nil
-              if loads && !arg_defn.from_resolver?
-                loaded_value = if arg_defn.type.list?
-                  loaded_values = value.map { |val| load_application_object(arg_defn, loads, val, context) }
-                  context.schema.after_any_lazies(loaded_values) { |result| result }
+              if has_value
+                loads = arg_defn.loads
+                loaded_value = nil
+                if loads && !arg_defn.from_resolver?
+                  loaded_value = if arg_defn.type.list?
+                    loaded_values = value.map { |val| load_application_object(arg_defn, loads, val, context) }
+                    context.schema.after_any_lazies(loaded_values) { |result| result }
+                  else
+                    load_application_object(arg_defn, loads, value, context)
+                  end
+                end
+
+                coerced_value = if loaded_value
+                  loaded_value
                 else
-                  load_application_object(arg_defn, loads, value, context)
-                end
-              end
-
-              coerced_value = if loaded_value
-                loaded_value
-              else
-                context.schema.error_handler.with_error_handling(context) do
-                  arg_defn.type.coerce_input(value, context)
-                end
-              end
-
-              context.schema.after_lazy(coerced_value) do |coerced_value|
-                prepared_value = context.schema.error_handler.with_error_handling(context) do
-                  arg_defn.prepare_value(parent_object, coerced_value, context: context)
+                  context.schema.error_handler.with_error_handling(context) do
+                    arg_defn.type.coerce_input(value, context)
+                  end
                 end
 
-                kwarg_arguments[arg_key] = prepared_value
-                # TODO code smell to access such a deeply-nested constant in a distant module
-                argument_values[arg_key] = GraphQL::Execution::Interpreter::ArgumentValue.new(
-                  value: prepared_value,
-                  definition: arg_defn,
-                  default_used: default_used,
-                )
+                context.schema.after_lazy(coerced_value) do |coerced_value|
+                  prepared_value = context.schema.error_handler.with_error_handling(context) do
+                    arg_defn.prepare_value(parent_object, coerced_value, context: context)
+                  end
+
+                  # TODO code smell to access such a deeply-nested constant in a distant module
+                  argument_values[arg_key] = GraphQL::Execution::Interpreter::ArgumentValue.new(
+                    value: prepared_value,
+                    definition: arg_defn,
+                    default_used: default_used,
+                  )
+                end
               end
             end
-          end
 
-          maybe_lazies.concat(arg_lazies)
-          context.schema.after_any_lazies(maybe_lazies) do
-            GraphQL::Execution::Interpreter::Arguments.new(
-              keyword_arguments: kwarg_arguments,
-              argument_values: argument_values,
-            )
+            context.schema.after_any_lazies(arg_lazies) do
+              GraphQL::Execution::Interpreter::Arguments.new(
+                argument_values: argument_values,
+              )
+            end
           end
         end
 

--- a/lib/graphql/types/string.rb
+++ b/lib/graphql/types/string.rb
@@ -7,7 +7,13 @@ module GraphQL
 
       def self.coerce_result(value, ctx)
         str = value.to_s
-        str.encoding == Encoding::UTF_8 ? str : str.encode(Encoding::UTF_8)
+        if str.encoding == Encoding::UTF_8
+          str
+        elsif str.frozen?
+          str.encode(Encoding::UTF_8)
+        else
+          str.encode!(Encoding::UTF_8)
+        end
       rescue EncodingError
         err = GraphQL::StringEncodingError.new(str)
         ctx.schema.type_error(err, ctx)


### PR DESCRIPTION
Inspired by https://github.com/rmosolgo/graphql-ruby/issues/3213

For `rake bench:profile_large_result`, I see about 30% faster and 45% less memory. (But this is _just overhead_ -- application benchmarks will see less improvement, since changes here won't improve application performance.)


<details>
<summary> Before benchmark</summary>
<p>

```
Warming up --------------------------------------
Querying for 1000 objects
                         1.000  i/100ms
Calculating -------------------------------------
Querying for 1000 objects
                          2.760  (± 0.0%) i/s -     14.000  in   5.075846s
Measure Mode: wall_time
Thread ID: 407040
Fiber ID: 407020
Total: 1.595308
Sort by: self_time

 %self      total      self      wait     child     calls  name                           location
  9.64      0.307     0.154     0.000     0.153   240015   GraphQL::Execution::Interpreter::Runtime#set_interpreter_context /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:546
  8.06      1.526     0.129     0.000     1.398    52002  *GraphQL::Execution::Interpreter::Runtime#after_lazy /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:423
  7.27      0.153     0.116     0.000     0.037   240015   GraphQL::Query::Context#[]=    /Users/rmosolgo/.rbenv/versions/2.7.2/lib/ruby/2.7.0/forwardable.rb:226
  5.85      1.527     0.093     0.000     1.434    71059  *Array#each                     
  5.05      1.526     0.081     0.000     1.446    82002  *GraphQL::Execution::Interpreter::Runtime#continue_field /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:302
  4.18      0.067     0.067     0.000     0.000    41001   GraphQL::Execution::Interpreter::HashResponse#write /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/hash_response.rb:23
  3.27      0.052     0.052     0.000     0.000   368098   Kernel#is_a?                   
  3.15      0.068     0.050     0.000     0.018    41010   Array#hash                     
  2.90      0.067     0.046     0.000     0.021    42001   GraphQL::Execution::Interpreter::Runtime#continue_value /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:256
  2.64      1.526     0.042     0.000     1.484     4029  *Hash#each                      
  2.59      0.067     0.041     0.000     0.025        5   <Module::GraphQL::Execution::Interpreter::Resolve>#resolve /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/resolve.rb:29
  2.34      0.037     0.037     0.000     0.000   240015   Hash#[]=                       
  2.30      0.182     0.037     0.000     0.145    70015   GraphQL::Schema::LazyHandlingMethods#lazy_method_name /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:131
  2.29      0.121     0.037     0.000     0.084    70015   GraphQL::Execution::Lazy::LazyMethodMap#get /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/lazy/lazy_method_map.rb:35
  2.07      0.042     0.033     0.000     0.009    70015   Hash#fetch                     
  1.97      0.074     0.031     0.000     0.042    70015   Concurrent::Collection::MriMapBackend#compute_if_absent /Users/rmosolgo/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/concurrent-ruby-1.1.7/lib/concurrent-ruby/concurrent/collection/map/mri_map_backend.rb:21
  1.95      0.151     0.031     0.000     0.120    41001   GraphQL::Execution::Interpreter::Runtime#write_in_response /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:493
  1.85      0.098     0.030     0.000     0.068    41001   GraphQL::Execution::Interpreter::Runtime#set_type_at_path /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:515
  1.70      0.209     0.027     0.000     0.182    70014   GraphQL::Schema::LazyHandlingMethods#lazy? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:136
  1.53      0.024     0.024     0.000     0.000    70015   <Class::GraphQL::Schema>#lazy_methods /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1686
  1.46      0.023     0.023     0.000     0.000   180209   Kernel#hash                    
  1.25      0.053     0.020     0.000     0.033    41001   GraphQL::Execution::Interpreter::Runtime#dead_path? /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:530
  1.18      0.127     0.019     0.000     0.108    17011  *GraphQL::Schema::LazyHandlingMethods#after_lazy /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:104
  1.12      0.036     0.018     0.000     0.018    22032  *GraphQL::Schema::FindInheritedValue#find_inherited_value /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/find_inherited_value.rb:19
  1.03      0.030     0.016     0.000     0.014    41003   Kernel#dup                     
  1.00      0.059     0.016     0.000     0.043    10001   GraphQL::Execution::Interpreter::ArgumentsCache#fetch /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/arguments_cache.rb:26
  0.89      0.059     0.014     0.000     0.045    10001   GraphQL::Schema::Field#with_extensions /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:724
  0.87      0.102     0.014     0.000     0.088    10001   GraphQL::Execution::Interpreter::Runtime#arguments /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:464
  0.75      0.042     0.012     0.000     0.030    22004  *<Class::GraphQL::Schema>#error_handler /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1527
  0.70      0.152     0.011     0.000     0.141    11002   <Class::GraphQL::Execution::Errors::NullErrorHandler>#with_error_handling /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/errors.rb:29
  0.67      1.526     0.011     0.000     1.516    10001  *GraphQL::Execution::Interpreter::Runtime#resolve_with_directives /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:384
  0.65      0.010     0.010     0.000     0.000    81017   String#hash                    
  0.64      0.010     0.010     0.000     0.000    70030   Kernel#class                   
  0.63      0.010     0.010     0.000     0.000    12000   String#encode                  
  0.59      0.009     0.009     0.000     0.000    41001   GraphQL::Schema::NonNull#non_null? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/non_null.rb:21
  0.59      0.078     0.009     0.000     0.069    10001   GraphQL::Query#arguments_for   /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:248
  0.57      0.015     0.009     0.000     0.006    13020   GraphQL::Schema::Member::HasArguments#arguments /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:52
  0.56      0.009     0.009     0.000     0.000    37028   <Class::GraphQL::Schema::Scalar>#kind /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/scalar.rb:29
  0.55      0.134     0.009     0.000     0.125    10001   GraphQL::Schema::Field#resolve /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:576
  0.54      0.014     0.009     0.000     0.005    41003   Kernel#initialize_dup          
  0.53      0.009     0.009     0.000     0.000    41001   GraphQL::Schema::NonNull#kind  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/non_null.rb:16
  0.52      0.022     0.008     0.000     0.014    12000   <Class::GraphQL::Types::String>#coerce_result /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:8
  0.46      1.595     0.007     0.000     1.588    11008  *GraphQL::Tracing::Traceable#trace /Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing.rb:65
  0.46      0.012     0.007     0.000     0.005     6002  *GraphQL::Schema::Field#run_extensions_before_resolve /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:751
  0.43      0.201     0.007     0.000     0.194    11002   GraphQL::Query#with_error_handling /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:351
  0.43      0.019     0.007     0.000     0.013    10001   GraphQL::Schema::Field#authorized? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:525
  0.39      0.008     0.006     0.000     0.002    12000   <Class::GraphQL::Types::Int>#coerce_result /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/int.rb:23
  0.39      0.006     0.006     0.000     0.000    35046   Kernel#respond_to?             
  0.38      0.010     0.006     0.000     0.004    10002   GraphQL::Query#interpreter?    /Users/rmosolgo/.rbenv/versions/2.7.2/lib/ruby/2.7.0/forwardable.rb:226
  0.38      0.006     0.006     0.000     0.000    20002   GraphQL::Schema::Field#extras  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:381
  0.36      0.006     0.006     0.000     0.000    41001   Kernel#freeze                  
  0.33      0.005     0.005     0.000     0.000    41003   Array#initialize_copy          
  0.32      0.018     0.005     0.000     0.013     3008   GraphQL::Schema::Member::HasArguments#coerce_arguments /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:87
  0.29      0.005     0.005     0.000     0.000    41002   Array#shift                    
  0.28      0.064     0.004     0.000     0.059    10001   GraphQL::Schema::Field#public_send_field /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:671
  0.27      0.004     0.004     0.000     0.000    33048   Class#superclass               
  0.27      0.004     0.004     0.000     0.000    29140   Module#===                     
  0.27      0.005     0.004     0.000     0.000     9060  *GraphQL::Schema::Wrapper#unwrap /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/wrapper.rb:20
  0.26      0.004     0.004     0.000     0.000    13035   GraphQL::Schema::Field#type    /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:494
  0.25      0.006     0.004     0.000     0.002     3008   GraphQL::Execution::Interpreter::ArgumentsCache#prepare_args_hash /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/arguments_cache.rb:34
  0.25      0.005     0.004     0.000     0.001    10001   GraphQL::Execution::Interpreter::Runtime#directives_include? /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:406
  0.25      0.011     0.004     0.000     0.007     3001   GraphQL::Schema::Field::ScopeExtension#after_resolve /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field/scope_extension.rb:7
  0.23      0.006     0.004     0.000     0.002     4075  *Class#new                      
  0.22      0.004     0.004     0.000     0.000    10006   <Class::GraphQL::Schema>#interpreter? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1297
  0.21      0.003     0.003     0.000     0.000    13020   GraphQL::Schema::Member::HasArguments#own_arguments /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:234
  0.19      0.003     0.003     0.000     0.000    10001   GraphQL::Schema::Field#extensions /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:341
  0.18      0.010     0.003     0.000     0.007     3001   GraphQL::Schema::FieldExtension#resolve /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field_extension.rb:49
  0.18      0.003     0.003     0.000     0.000    10001   GraphQL::Schema::Member::HasArguments#arguments_statically_coercible? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:155
  0.18      0.003     0.003     0.000     0.000    12000   <Class::GraphQL::Types::Boolean>#coerce_result /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/boolean.rb:11
  0.17      0.007     0.003     0.000     0.004     3008   GraphQL::Schema::LazyHandlingMethods#after_any_lazies /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:144
  0.16      0.003     0.003     0.000     0.000    17011   Kernel#block_given?            
  0.14      0.002     0.002     0.000     0.000    12000   String#encoding                
  0.14      0.016     0.002     0.000     0.014     3016   Enumerable#each_with_index     
  0.13      0.002     0.002     0.000     0.000    10021   Hash#key?                      
  0.11      0.002     0.002     0.000     0.000    12000   Integer#to_i                   
  0.10      0.002     0.002     0.000     0.000    12000   String#to_s                    
  0.09      0.002     0.001     0.000     0.001     3001   Array#all?                     
  0.09      0.001     0.001     0.000     0.000     3008   GraphQL::Execution::Interpreter::Arguments#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/arguments.rb:19
  0.09      0.002     0.001     0.000     0.001     3009   Enumerable#map                 
  0.08      0.001     0.001     0.000     0.000     7015   Array#concat                   
  0.08      0.001     0.001     0.000     0.000     6071   Array#any?                     
  0.08      1.526     0.001     0.000     1.525     1001  *GraphQL::Execution::Interpreter::Runtime#evaluate_selections /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:121
  0.08      0.001     0.001     0.000     0.000    10024   Hash#each_value                
  0.07      0.018     0.001     0.000     0.017     1001   GraphQL::Execution::Interpreter::Runtime#authorized_new /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:573
  0.05      0.013     0.001     0.000     0.012     1001   <Class::GraphQL::Schema::Object>#authorized_new /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb:39
  0.05      0.001     0.001     0.000     0.000     3001   GraphQL::Schema::List#kind     /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/list.rb:16
  0.05      0.001     0.001     0.000     0.000     3001   GraphQL::Schema::Member::Scoped#scope_items /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/scoped.rb:15
  0.03      0.001     0.001     0.000     0.000     3039   Kernel#unwrap                  
  0.03      0.000     0.000     0.000     0.000     1001   GraphQL::Schema::Member::BaseDSLMethods#authorized? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/base_dsl_methods.rb:130
  0.03      0.000     0.000     0.000     0.000     1001   GraphQL::Schema::Object#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb:68
  0.02      0.018     0.000     0.000     0.017     1001   GraphQL::Execution::Interpreter::Runtime#gather_selections /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:67
  0.02      0.000     0.000     0.000     0.000     1000   <Class::GraphQL::Types::ID>#coerce_result /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/id.rb:8
  0.02      0.000     0.000     0.000     0.000     1004   Hash#values                    
  0.02      0.000     0.000     0.000     0.000     1039   <Class::GraphQL::Schema::Object>#kind /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb:186
  0.00      0.000     0.000     0.000     0.000       33   <Class::GraphQL::Schema>#get_field /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1191
  0.00      0.000     0.000     0.000     0.000       21   GraphQL::Schema::Warden#visible? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb:265
  0.00      0.001     0.000     0.000     0.001       11  *GraphQL::StaticValidation::BaseVisitor::ContextMethods#on_field /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb:95
  0.00      0.000     0.000     0.000     0.000       54  *GraphQL::Filter#call           /Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb:11
  0.00      0.000     0.000     0.000     0.000       44   GraphQL::Schema::Member::HasFields#get_field /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb:29
  0.00      0.000     0.000     0.000     0.000       11   GraphQL::Schema::Warden#get_field /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb:92
  0.00      0.000     0.000     0.000     0.000       43   Hash#initialize                
  0.00      0.001     0.000     0.000     0.001       13  *GraphQL::Language::Visitor#on_abstract_node /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb:91
  0.00      0.000     0.000     0.000     0.000       11   GraphQL::Schema::Warden#visible_type? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb:218
  0.00      0.000     0.000     0.000     0.000       14   Array#-                        
  0.00      0.000     0.000     0.000     0.000       12   GraphQL::StaticValidation::FieldsHaveAppropriateSelections#validate_field_selections /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb:25
  0.00      0.000     0.000     0.000     0.000       11   GraphQL::StaticValidation::ValidationContext#warden /Users/rmosolgo/.rbenv/versions/2.7.2/lib/ruby/2.7.0/forwardable.rb:226
  0.00      0.001     0.000     0.000     0.001       11  *GraphQL::StaticValidation::FieldsAreDefinedOnType#on_field /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb:5
  0.00      1.528     0.000     0.000     1.528       30  *Array#map                      
  0.00      0.000     0.000     0.000     0.000       11   GraphQL::StaticValidation::RequiredArgumentsArePresent#assert_required_args /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb:18
  0.00      0.000     0.000     0.000     0.000       11   Enumerable#select              
  0.00      0.000     0.000     0.000     0.000       12   GraphQL::StaticValidation::FieldsWillMerge#conflicts_within_selection_set /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:34
  0.00      0.001     0.000     0.000     0.001       11  *GraphQL::StaticValidation::FieldsHaveAppropriateSelections#on_field /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb:9
  0.00      0.000     0.000     0.000     0.000       18   <Class::GraphQL::Schema>#visible? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1456
  0.00      0.000     0.000     0.000     0.000       44   GraphQL::Schema::Member::HasFields#own_fields /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb:94
  0.00      1.595     0.000     0.000     1.595        1   <Module::GraphQLBenchmark>#profile_large_result /Users/rmosolgo/code/graphql-ruby/benchmark/run.rb:66
  0.00      0.000     0.000     0.000     0.000       19   GraphQL::Query#with_prepared_ast /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:434
  0.00      0.000     0.000     0.000     0.000       11   GraphQL::Schema::Warden#visible_field? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb:172
  0.00      0.000     0.000     0.000     0.000       45   GraphQL::TypeKinds::TypeKind#fields? /Users/rmosolgo/code/graphql-ruby/lib/graphql/type_kinds.rb:24
  0.00      0.001     0.000     0.000     0.001       11  *GraphQL::StaticValidation::FieldsWillMerge#on_field /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:27
  0.00      0.001     0.000     0.000     0.001       11  *GraphQL::StaticValidation::RequiredArgumentsArePresent#on_field /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb:5
  0.00      0.001     0.000     0.000     0.001       13  *GraphQL::Language::Visitor#on_node_with_modifications /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb:173
  0.00      0.000     0.000     0.000     0.000       18   GraphQL::Filter::MergedOnly#call /Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb:31
  0.00      0.001     0.000     0.000     0.001       11  *GraphQL::StaticValidation::UniqueDirectivesPerLocation#on_field /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/unique_directives_per_location.rb:23
  0.00      0.001     0.000     0.000     0.001       13  *GraphQL::Language::Visitor#visit_node /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb:78
  0.00      0.001     0.000     0.000     0.001       14  *Kernel#public_send             
  0.00      0.000     0.000     0.000     0.000       46   Array#last                     
  0.00      0.000     0.000     0.000     0.000        5   GraphQL::Schema::Warden#referenced? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb:241
  0.00      0.001     0.000     0.000     0.001       11  *GraphQL::StaticValidation::ArgumentNamesAreUnique#on_field /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/argument_names_are_unique.rb:7
  0.00      0.000     0.000     0.000     0.000       18   Method#call                    
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query#initialize      /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:82
  0.00      0.000     0.000     0.000     0.000       22   GraphQL::StaticValidation::BaseVisitor::ContextMethods#field_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb:170
  0.00      0.000     0.000     0.000     0.000       36   Array#push                     
  0.00      0.000     0.000     0.000     0.000       12   GraphQL::StaticValidation::FieldsWillMerge#fields_and_fragments_from_selection /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:302
  0.00      0.000     0.000     0.000     0.000       37   Array#pop                      
  0.00      0.000     0.000     0.000     0.000       13   GraphQL::StaticValidation::ValidationContext#schema /Users/rmosolgo/.rbenv/versions/2.7.2/lib/ruby/2.7.0/forwardable.rb:226
  0.00      0.001     0.000     0.000     0.001       11  *GraphQL::Language::Visitor#on_field /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb:122
  0.00      0.000     0.000     0.000     0.000       12   GraphQL::Query#warden          /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:306
  0.00      0.000     0.000     0.000     0.000       18   <Module::GraphQL::Schema::NullMask>#call /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/null_mask.rb:6
  0.00      0.000     0.000     0.000     0.000       27   BasicObject#equal?             
  0.00      1.595     0.000     0.000     1.595        2  *<Module::GraphQL::Execution::Instrumentation>#each_query_call_hooks /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/instrumentation.rb:39
  0.00      0.000     0.000     0.000     0.000       18   GraphQL::Schema::Member::CachedGraphQLDefinition#type_class /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/cached_graphql_definition.rb:19
  0.00      0.000     0.000     0.000     0.000       13   GraphQL::StaticValidation::BaseVisitor::ContextMethods#type_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb:160
  0.00      0.000     0.000     0.000     0.000        8   GraphQL::Execution::Interpreter::Runtime#delete_interpreter_context /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:551
  0.00      0.000     0.000     0.000     0.000       12   GraphQL::StaticValidation::BaseVisitor::ContextMethods#push_type /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb:200
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query#prepare_ast     /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:369
  0.00      0.000     0.000     0.000     0.000       11   <Class::GraphQL::StaticValidation::FieldsWillMerge::Field>#new 
  0.00      0.000     0.000     0.000     0.000       12   Enumerator#each                
  0.00      0.000     0.000     0.000     0.000        6   GraphQL::Query::Context#namespace /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/context.rb:227
  0.00      0.000     0.000     0.000     0.000       12   GraphQL::StaticValidation::FieldsWillMerge#find_conflicts_within /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:173
  0.00      0.002     0.000     0.000     0.002        3   GraphQL::Query::ValidationPipeline#ensure_has_validated /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb:60
  0.00      0.000     0.000     0.000     0.000       11   GraphQL::StaticValidation::ArgumentNamesAreUnique#validate_arguments /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/argument_names_are_unique.rb:17
  0.00      0.000     0.000     0.000     0.000        5   GraphQL::Schema::Member::BaseDSLMethods#graphql_name /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/base_dsl_methods.rb:20
  0.00      1.595     0.000     0.000     1.595        2  *<Module::GraphQL::Execution::Instrumentation>#call_hooks /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/instrumentation.rb:54
  0.00      0.000     0.000     0.000     0.000        2   GraphQL::Filter#merge          /Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb:16
  0.00      1.526     0.000     0.000     1.526        1   GraphQL::Execution::Interpreter::Runtime#run_eager /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:45
  0.00      0.000     0.000     0.000     0.000        6   Hash#merge                     
  0.00      0.000     0.000     0.000     0.000        4  *<Class::GraphQL::Schema>#tracers /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1578
  0.00      0.000     0.000     0.000     0.000        8   GraphQL::Query::Context#delete /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/context.rb:182
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::BaseVisitor::ContextMethods#on_operation_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb:72
  0.00      0.000     0.000     0.000     0.000        4  *<Class::GraphQL::Schema>#instrumenters /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1659
  0.00      1.593     0.000     0.000     1.593        1   <Class::GraphQL::Execution::Multiplex>#run_as_multiplex /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb:77
  0.00      0.000     0.000     0.000     0.000       12   GraphQL::TypeKinds::TypeKind#scalar? /Users/rmosolgo/code/graphql-ruby/lib/graphql/type_kinds.rb:33
  0.00      0.000     0.000     0.000     0.000       11   GraphQL::Schema::Field#visible? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:509
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::VariablesAreUsedAndDefined#on_operation_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb:33
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::FieldsWillMerge#on_operation_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:22
  0.00      0.000     0.000     0.000     0.000        5   GraphQL::Schema::Warden#read_through /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb:269
  0.00      0.000     0.000     0.000     0.000       11   GraphQL::Language::Nodes::Field#children /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/nodes.rb:198
  0.00      0.000     0.000     0.000     0.000        5   <Class::GraphQL::Schema>#query_execution_strategy /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1251
  0.00      0.000     0.000     0.000     0.000       16   Hash#delete                    
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::DefinitionDependencies#resolve_dependencies /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb:115
  0.00      0.000     0.000     0.000     0.000        3   GraphQL::Filter#initialize     /Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb:5
  0.00      1.595     0.000     0.000     1.595        1   <Module::GraphQL::Execution::Instrumentation>#apply_instrumenters /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/instrumentation.rb:19
  0.00      0.000     0.000     0.000     0.000        2  *<Class::GraphQL::Schema>#references_to /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1159
  0.00      0.000     0.000     0.000     0.000        4   Kernel#Array                   
  0.00      0.000     0.000     0.000     0.000        5   GraphQL::Schema::Member::BaseDSLMethods#introspection? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/base_dsl_methods.rb:80
  0.00      1.595     0.000     0.000     1.595        1   <Class::GraphQL::Schema>#multiplex /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1650
  0.00      0.000     0.000     0.000     0.000       11   GraphQL::Language::Nodes::Field#visit_method (eval):1
  0.00      0.000     0.000     0.000     0.000        4   Hash#select                    
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Schema::Warden#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb:43
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::BaseVisitor#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb:5
  0.00      1.595     0.000     0.000     1.595        1   <Class::GraphQL::Execution::Multiplex>#run_all /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb:46
  0.00      0.000     0.000     0.000     0.000        5   GraphQL::Schema::Member::BaseDSLMethods#visible? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/base_dsl_methods.rb:114
  0.00      0.000     0.000     0.000     0.000        5   GraphQL::Schema::Member::BaseDSLMethods#introspection /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/base_dsl_methods.rb:70
  0.00      0.000     0.000     0.000     0.000        2  *<Class::GraphQL::Schema>#directives /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1551
  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Execution::Multiplex>#finish_query /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb:123
  0.00      1.595     0.000     0.000     1.595        1   <Class::GraphQL::Schema>#execute /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1613
  0.00      0.000     0.000     0.000     0.000        4   <Class::GraphQL::Schema>#own_tracers /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1735
  0.00      0.000     0.000     0.000     0.000        1   Array#uniq!                    
  0.00      0.000     0.000     0.000     0.000        4   <Class::GraphQL::Filter::MergedOnly>#build /Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb:35
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query::Context#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/context.rb:146
  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Execution::Multiplex>#supports_multiplexing? /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb:164
  0.00      0.000     0.000     0.000     0.000        2  *<Class::GraphQL::Schema>#max_depth /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1319
  0.00      0.000     0.000     0.000     0.000        3   <Class::GraphQL::Schema>#query /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1049
  0.00      0.067     0.000     0.000     0.067        1   <Class::GraphQL::Execution::Interpreter>#finish_multiplex /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:49
  0.00      0.067     0.000     0.000     0.067        1   GraphQL::Execution::Interpreter#sync_lazies /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:81
  0.00      0.000     0.000     0.000     0.000        2   <Module::GraphQL::Execution::Instrumentation>#call_after_hooks /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/instrumentation.rb:79
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::DefinitionDependencies#on_document /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb:32
  0.00      0.000     0.000     0.000     0.000        2   <Class::GraphQL::Schema>#root_type_for_operation /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1094
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::DirectivesAreDefined#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/directives_are_defined.rb:5
  0.00      0.002     0.000     0.000     0.002        2   GraphQL::Query#valid?          /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:302
  0.00      0.067     0.000     0.000     0.067        1   <Module::GraphQL::Execution::Interpreter::Resolve>#resolve_all /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/resolve.rb:9
  0.00      0.000     0.000     0.000     0.000       22   GraphQL::StaticValidation::FieldsWillMerge::Field#node 
  0.00      0.000     0.000     0.000     0.000        3   GraphQL::Query#validation_pipeline /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:294
  0.00      1.526     0.000     0.000     1.526        1   GraphQL::Execution::Interpreter#evaluate /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:62
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::FragmentsAreUsed#on_document /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragments_are_used.rb:5
  0.00      1.527     0.000     0.000     1.527        1   <Class::GraphQL::Execution::Multiplex>#begin_query /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb:105
  0.00      0.000     0.000     0.000     0.000        5   GraphQL::Schema::Warden#root_type? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb:235
  0.00      0.000     0.000     0.000     0.000        2  *<Class::GraphQL::Schema>#context_class /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1390
  0.00      0.000     0.000     0.000     0.000        2  *<Class::GraphQL::Schema>#multiplex_analyzers /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1606
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::DefinitionDependencies#on_operation_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb:44
  0.00      0.000     0.000     0.000     0.000       11   Struct#initialize              
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::FieldsHaveAppropriateSelections#on_operation_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb:16
  0.00      0.000     0.000     0.000     0.000        2  *<Class::GraphQL::Schema>#query_analyzers /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1589
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Filter::MergedOnly#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb:26
  0.00      1.526     0.000     0.000     1.526        1   <Class::GraphQL::Execution::Interpreter>#begin_query /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:39
  0.00      1.595     0.000     0.000     1.595        1   <Class::GraphQL::Execution::Multiplex>#run_queries /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb:56
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query::ValidationPipeline#build_analyzers /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb:100
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::ValidationContext#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/validation_context.rb:22
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query::Variables#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/variables.rb:13
  0.00      0.000     0.000     0.000     0.000        2  *<Class::GraphQL::Schema>#mutation /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1063
  0.00      0.000     0.000     0.000     0.000        2  *<Class::GraphQL::Schema>#max_complexity /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1277
  0.00      0.000     0.000     0.000     0.000        4   Array#select                   
  0.00      0.000     0.000     0.000     0.000        2  *<Class::GraphQL::Schema>#default_mask /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:922
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Execution::Interpreter::Runtime#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:20
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::LiteralValidator#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/literal_validator.rb:6
  0.00      0.000     0.000     0.000     0.000        4   Hash#any?                      
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::VariableUsagesAreAllowed#on_operation_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb:11
  0.00      0.000     0.000     0.000     0.000        4   GraphQL::Schema::Member::BaseDSLMethods#default_graphql_name /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/base_dsl_methods.rb:106
  0.00      0.000     0.000     0.000     0.000        3   Array#flatten                  
  0.00      0.000     0.000     0.000     0.000        5   GraphQL::Schema::Member::BaseDSLMethods#overridden_graphql_name /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/base_dsl_methods.rb:28
  0.00      0.000     0.000     0.000     0.000        5   GraphQL::TypeKinds::TypeKind#union? /Users/rmosolgo/code/graphql-ruby/lib/graphql/type_kinds.rb:45
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Execution::Multiplex#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb:33
  0.00      0.000     0.000     0.000     0.000        2   GraphQL::StaticValidation::ValidationContext#dependencies /Users/rmosolgo/.rbenv/versions/2.7.2/lib/ruby/2.7.0/forwardable.rb:226
  0.00      0.000     0.000     0.000     0.000        5   GraphQL::TypeKinds::TypeKind#interface? /Users/rmosolgo/code/graphql-ruby/lib/graphql/type_kinds.rb:41
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::UniqueDirectivesPerLocation#on_operation_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/unique_directives_per_location.rb:23
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query::ValidationPipeline#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb:19
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::DefinitionDependencies#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb:10
  0.00      0.000     0.000     0.000     0.000        2  *<Class::GraphQL::Schema>#subscription /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1077
  0.00      0.000     0.000     0.000     0.000        2   GraphQL::StaticValidation::FieldsWillMerge#find_fields_and_fragments /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:312
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::OperationNamesAreValid#on_document /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/operation_names_are_valid.rb:15
  0.00      0.000     0.000     0.000     0.000        3   Hash#keys                      
  0.00      0.002     0.000     0.000     0.002        2   GraphQL::Query::ValidationPipeline#valid? /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb:34
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::FragmentsAreFinite#on_document /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragments_are_finite.rb:5
  0.00      0.000     0.000     0.000     0.000        4   <Class::GraphQL::Schema>#own_instrumenters /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1731
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::VariablesAreUsedAndDefined#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb:26
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::OperationNamesAreValid#on_operation_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/operation_names_are_valid.rb:10
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::VariablesAreUsedAndDefined#follow_spreads /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb:94
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::OperationNamesAreValid#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/operation_names_are_valid.rb:5
  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Argument>#deep_stringify /Users/rmosolgo/code/graphql-ruby/lib/graphql/argument.rb:116
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::NoDefinitionsArePresent#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/no_definitions_are_present.rb:7
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::Language::Visitor#visit /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb:67
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::VariablesAreUsedAndDefined#on_document /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb:78
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::VariableNamesAreUnique#on_operation_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variable_names_are_unique.rb:5
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::DefinitionDependencies::DependencyMap#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb:86
  0.00      0.000     0.000     0.000     0.000        2   <Module::GraphQL::Analysis::AST>#analysis_errors /Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/ast.rb:77
  0.00      0.000     0.000     0.000     0.000        2   <Class::GraphQL::Schema>#own_directives /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1727
  0.00      0.000     0.000     0.000     0.000        2   Enumerable#group_by            
  0.00      1.595     0.000     0.000     1.595        1   <Class::GraphQL::Execution::Multiplex>#instrument_and_analyze /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb:173
  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Schema>#default_filter /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:918
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::FragmentSpreadsArePossible#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb:5
  0.00      0.000     0.000     0.000     0.000        1   Kernel#method                  
  0.00      0.000     0.000     0.000     0.000        2   GraphQL::Execution::Interpreter::Runtime#final_value /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:34
  0.00      0.000     0.000     0.000     0.000        2   <Class::GraphQL::Schema>#own_query_analyzers /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1739
  0.00      0.002     0.000     0.000     0.002        1   <Module::GraphQL::Analysis::AST>#analyze_multiplex /Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/ast.rb:26
  0.00      0.000     0.000     0.000     0.000        3   <Class::GraphQL::Schema>#analysis_engine /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1289
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query#result_values=  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:169
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::VariableUsagesAreAllowed#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb:5
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::ValidationContext#path /Users/rmosolgo/.rbenv/versions/2.7.2/lib/ruby/2.7.0/forwardable.rb:226
  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::StaticValidation::BaseVisitor>#including_rules /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb:37
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::MutationRootExists#on_operation_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/mutation_root_exists.rb:5
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query::Context#interpreter? /Users/rmosolgo/.rbenv/versions/2.7.2/lib/ruby/2.7.0/forwardable.rb:226
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::DefinitionDependencies#dependency_map /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb:69
  0.00      0.000     0.000     0.000     0.000        2   Array#first                    
  0.00      0.000     0.000     0.000     0.000        2   <Class::GraphQL::Schema>#own_multiplex_analyzers /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1751
  0.00      0.000     0.000     0.000     0.000        1   <Module::GraphQL::Analysis::AST>#analyze_query /Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/ast.rb:55
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::FragmentSpreadsArePossible#on_document /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb:25
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query#analyzers       /Users/rmosolgo/.rbenv/versions/2.7.2/lib/ruby/2.7.0/forwardable.rb:226
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::FieldsWillMerge#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:16
  0.00      0.000     0.000     0.000     0.000        2   GraphQL::Query#selected_operation /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:211
  0.00      0.000     0.000     0.000     0.000        3   NilClass#to_a                  
  0.00      0.000     0.000     0.000     0.000        2   Enumerable#each_with_object    
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::NoDefinitionsArePresent#on_document /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/no_definitions_are_present.rb:33
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query::Result#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/result.rb:11
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::SubscriptionRootExists#on_operation_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/subscription_root_exists.rb:5
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Schema::LazyHandlingMethods#sync_lazy /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:120
  0.00      0.000     0.000     0.000     0.000        2   <Class::GraphQL::Schema>#default_directives /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1566
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query::Context#warden /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/context.rb:220
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::FragmentNamesAreUnique#on_document /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_names_are_unique.rb:16
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::Language::Visitor#on_operation_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb:122
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::FragmentNamesAreUnique#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_names_are_unique.rb:6
  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Execution::Interpreter>#finish_query /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:54
  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Execution::Interpreter>#begin_multiplex /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:33
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query#merge_filters   /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:337
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query#result          /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:191
  0.00      0.000     0.000     0.000     0.000        2   Array#compact!                 
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::ValidationContext#document /Users/rmosolgo/.rbenv/versions/2.7.2/lib/ruby/2.7.0/forwardable.rb:226
  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Schema>#using_ast_analysis? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1293
  0.00      0.000     0.000     0.000     0.000        2   GraphQL::Query::InputValidationResult#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/input_validation_result.rb:7
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::VariablesAreUsedAndDefined#create_errors /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb:124
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query#variables       /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:221
  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Schema>#static_validator /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:930
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::Language::Visitor#on_document /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb:122
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query#find_operation  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:359
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::Validator#validate /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/validator.rb:24
  0.00      0.000     0.000     0.000     0.000        2   Array#reverse_each             
  0.00      0.000     0.000     0.000     0.000        1   Enumerable#reduce              
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Language::Visitor#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb:45
  0.00      0.000     0.000     0.000     0.000        2   GraphQL::Execution::Interpreter::HashResponse#final_value /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/hash_response.rb:13
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query::ValidationPipeline#analyzers /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb:51
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Execution::Interpreter::ArgumentsCache#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/arguments_cache.rb:7
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query#document        /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:47
  0.00      0.000     0.000     0.000     0.000        1   Enumerable#inject              
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::Validator#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/validator.rb:16
  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Schema>#mutation_execution_strategy /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1259
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Execution::Interpreter::HashResponse#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/hash_response.rb:9
  0.00      0.000     0.000     0.000     0.000        1   Array#include?                 
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::DefinitionDependencies::NodeWithPath#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb:102
  0.00      0.000     0.000     0.000     0.000        2   GraphQL::Schema::Argument#visible? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/argument.rb:106
  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Schema>#subscription_execution_strategy /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1267
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::BaseVisitor#path /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb:28
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Language::Nodes::OperationDefinition#children /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/nodes.rb:198
  0.00      0.000     0.000     0.000     0.000        1   Array#==                       
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Language::Nodes::OperationDefinition#visit_method (eval):1
  0.00      0.000     0.000     0.000     0.000        1   GraphQLBenchmark::ProfileLargeResult::QueryType#foos /Users/rmosolgo/code/graphql-ruby/benchmark/run.rb:113
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::BaseVisitor#rewrite_document /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb:18
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Language::Nodes::Document#visit_method (eval):1
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Execution::Interpreter#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:14

* recursively called methods

Columns are:

  %self     - The percentage of time spent in this method, derived from self_time/total_time.
  total     - The time spent in this method and its children.
  self      - The time spent in this method.
  wait      - The amount of time this method waited for other threads.
  child     - The time spent in this method's children.
  calls     - The number of times this method was called.
  name      - The name of the method.
  location  - The location of the method.

The interpretation of method names is:

  * MyObject#test - An instance method "test" of the class "MyObject"
  * <Object:MyObject>#test - The <> characters indicate a method on a singleton class.
Total allocated: 25945384 bytes (351497 objects)
Total retained:  0 bytes (0 objects)

allocated memory by gem
-----------------------------------
  25945008  graphql-ruby/lib
       336  other
        40  forwardable

allocated memory by file
-----------------------------------
  22430448  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb
   1128376  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb
   1106944  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb
    480000  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb
    401920  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb
    212584  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/arguments_cache.rb
    120240  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/resolve.rb
     40040  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb
      3848  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb
      3256  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb
      3160  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb
      2688  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb
      1408  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb
      1240  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb
      1104  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb
       896  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb
       856  /Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/ast.rb
       704  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/context.rb
       696  /Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb
       672  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/validation_context.rb
       560  /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb
       496  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/literal_validator.rb
       496  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/validator.rb
       440  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb
       368  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/operation_names_are_valid.rb
       360  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb
       336  /Users/rmosolgo/code/graphql-ruby/benchmark/run.rb
       168  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/hash_response.rb
       160  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/directives_are_defined.rb
       160  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_names_are_unique.rb
       120  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb
       120  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb
        80  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/instrumentation.rb
        80  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/variables.rb
        80  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb
        80  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/no_definitions_are_present.rb
        40  /Users/rmosolgo/.rbenv/versions/2.7.2/lib/ruby/2.7.0/forwardable.rb
        40  /Users/rmosolgo/code/graphql-ruby/lib/graphql/argument.rb
        40  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/find_inherited_value.rb
        40  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragments_are_finite.rb
        40  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragments_are_used.rb

allocated memory by location
-----------------------------------
   9600600  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:548
   6040000  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:349
   2097248  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:27
   1680168  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:225
    928168  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:124
    928000  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:335
    586632  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:342
    505344  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:147
    504168  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:732
    504168  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:744
    480000  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10
    400040  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:153
    400040  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:249
    168168  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:574
    120320  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/arguments_cache.rb:45
    120320  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:148
    120320  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:88
    120320  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:89
    120320  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:93
    120320  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:94
    120040  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/resolve.rb:46
    120040  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:728
     88528  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/arguments_cache.rb:11
     40040  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb:50
      3160  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb:270
      2728  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/arguments_cache.rb:10
      1536  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:307
      1496  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb:20
      1344  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:31
      1008  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/arguments_cache.rb:9
       792  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:317
       520  /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb:125
       488  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb:47
       480  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:37
       440  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb:7
       440  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:316
       440  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb:19
       440  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb:21
       440  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb:22
       440  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb:24
       416  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/context.rb:152
       416  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1661
       376  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1627
       368  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb:28
       352  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/validation_context.rb:27
       336  /Users/rmosolgo/code/graphql-ruby/benchmark/run.rb:73
       336  /Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb:21
       336  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1556
       336  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/validator.rb:25
       320  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1660

allocated memory by class
-----------------------------------
  17516792  Array
   7779968  Hash
    480040  String
    120320  GraphQL::Execution::Interpreter::Arguments
     40000  GraphQLBenchmark::ProfileLargeResult::FooType
      3840  Proc
      1632  Enumerator
       792  GraphQL::StaticValidation::FieldsWillMerge::Field
       280  GraphQL::Query
       272  GraphQL::StaticValidation::InterpreterVisitor
       136  GraphQL::Query::ValidationPipeline
       128  GraphQL::Query::Context
       120  GraphQL::Filter
       112  GraphQL::Schema::Warden
       104  GraphQL::Execution::Interpreter::Runtime
        80  GraphQL::Execution::Multiplex
        80  GraphQL::Query::InputValidationResult
        80  GraphQL::StaticValidation::ValidationContext
        72  GraphQL::Query::Variables
        72  GraphQL::StaticValidation::DefinitionDependencies::DependencyMap
        72  GraphQL::StaticValidation::LiteralValidator
        72  Method
        40  GraphQL::Execution::Interpreter
        40  GraphQL::Execution::Interpreter::ArgumentsCache
        40  GraphQL::Execution::Interpreter::HashResponse
        40  GraphQL::Filter::MergedOnly
        40  GraphQL::Query::Result
        40  GraphQL::StaticValidation::DefinitionDependencies::NodeWithPath
        40  GraphQL::StaticValidation::Validator
        40  GraphQLBenchmark::ProfileLargeResult::QueryType

allocated objects by gem
-----------------------------------
    351494  graphql-ruby/lib
         2  other
         1  forwardable

allocated objects by file
-----------------------------------
    297027  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb
     18048  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb
     12000  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb
     10023  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb
      9003  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb
      3054  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/arguments_cache.rb
      1006  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/resolve.rb
      1001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb
        58  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb
        55  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb
        30  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb
        22  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb
        15  /Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/ast.rb
        15  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb
        15  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb
        14  /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb
        13  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb
        11  /Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb
        11  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb
         9  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb
         8  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb
         7  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/context.rb
         7  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/validation_context.rb
         6  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/literal_validator.rb
         5  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/operation_names_are_valid.rb
         5  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/validator.rb
         4  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/directives_are_defined.rb
         3  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb
         3  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_names_are_unique.rb
         3  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb
         2  /Users/rmosolgo/code/graphql-ruby/benchmark/run.rb
         2  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/instrumentation.rb
         2  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/variables.rb
         2  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb
         2  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/no_definitions_are_present.rb
         1  /Users/rmosolgo/.rbenv/versions/2.7.2/lib/ruby/2.7.0/forwardable.rb
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/argument.rb
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/hash_response.rb
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/find_inherited_value.rb
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragments_are_finite.rb
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragments_are_used.rb

allocated objects by location
-----------------------------------
    240015  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:548
     31000  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:349
     12000  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10
     10001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:153
     10001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:225
     10001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:249
      3008  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/arguments_cache.rb:45
      3008  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:147
      3008  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:148
      3008  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:88
      3008  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:89
      3008  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:93
      3008  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:94
      3001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:342
      3001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:728
      3001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:732
      3001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:744
      1001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/resolve.rb:46
      1001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:124
      1001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:574
      1001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb:50
      1000  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:335
        22  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/arguments_cache.rb:10
        22  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/arguments_cache.rb:11
        15  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb:270
        13  /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb:125
        13  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:307
        12  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:37
        11  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb:7
        11  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:316
        11  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:317
        11  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb:19
        11  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb:20
        11  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb:21
        11  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb:22
        11  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb:24
         6  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1660
         5  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/resolve.rb:30
         4  /Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/ast.rb:78
         4  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:31
         4  /Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb:17
         4  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1579
         4  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1661
         4  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb:130
         4  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:306
         4  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb:28
         3  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb:47
         3  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/context.rb:152
         3  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1627
         3  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/literal_validator.rb:10

allocated objects by class
-----------------------------------
    304251  Array
     31141  Hash
     12001  String
      3008  GraphQL::Execution::Interpreter::Arguments
      1000  GraphQLBenchmark::ProfileLargeResult::FooType
        48  Proc
        12  Enumerator
        11  GraphQL::StaticValidation::FieldsWillMerge::Field
         3  GraphQL::Filter
         2  GraphQL::Query::InputValidationResult
         1  GraphQL::Execution::Interpreter
         1  GraphQL::Execution::Interpreter::ArgumentsCache
         1  GraphQL::Execution::Interpreter::HashResponse
         1  GraphQL::Execution::Interpreter::Runtime
         1  GraphQL::Execution::Multiplex
         1  GraphQL::Filter::MergedOnly
         1  GraphQL::Query
         1  GraphQL::Query::Context
         1  GraphQL::Query::Result
         1  GraphQL::Query::ValidationPipeline
         1  GraphQL::Query::Variables
         1  GraphQL::Schema::Warden
         1  GraphQL::StaticValidation::DefinitionDependencies::DependencyMap
         1  GraphQL::StaticValidation::DefinitionDependencies::NodeWithPath
         1  GraphQL::StaticValidation::InterpreterVisitor
         1  GraphQL::StaticValidation::LiteralValidator
         1  GraphQL::StaticValidation::ValidationContext
         1  GraphQL::StaticValidation::Validator
         1  GraphQLBenchmark::ProfileLargeResult::QueryType
         1  Method

retained memory by gem
-----------------------------------
NO DATA

retained memory by file
-----------------------------------
NO DATA

retained memory by location
-----------------------------------
NO DATA

retained memory by class
-----------------------------------
NO DATA

retained objects by gem
-----------------------------------
NO DATA

retained objects by file
-----------------------------------
NO DATA

retained objects by location
-----------------------------------
NO DATA

retained objects by class
-----------------------------------
NO DATA


Allocated String Report
-----------------------------------
         1  "++y2Bz7qlTSqec6RLXlSRg=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+/4Hbvo+Qs3Kk2xQ8DWxuA=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+/6EpNJGW7sIMnY9mvn3uA=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+/6kttjX/5A6RwFCIOrfSw=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+/D0QCbfAjfpmVzsUBTIVQ=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+/HWw5MJGWTVdtOQUrEprg=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+/xwrBLDTo6jtnq/jryKGA=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+0/6x5nf2CNV6sD42+KLLg=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+00EGkWEfDHQu8BQcuCA6g=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+00IK4Vst1zKe6vHNPEuOg=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+0PRGrgvByNDJcZQafkv5g=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+0Q3vPfGveFoNFhjgbUxWA=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+0ieYZNPTz94WqxF8ldRMA=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+0tG1o/z5lw2uNL4GguvuQ=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+1Ci4kyOgfsWTOvPN2+IyA=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+1dw3vmVG17+8dCidWzsZw=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+357fdRYdmA4ABzFNmeIjA=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+3GkU5yZiBjHUYbx5gYXOQ=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+3U3E5LUAVYZsLC5oS/y9Q=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+3ee0iOnmj2YPJT3478khQ=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+45u/gB9n+koOWCeHatCyA=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+4Cs4mheTGI+4k9khW5I7w=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+4W2OCVnBX2LAsP++cuWNQ=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+6HyTNyAveR6jQXp46aXEA=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+6I23rQE3QE5LPdNgqge4Q=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+6JKTovXqbpsPWrZZ+SEuA=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+6VG7L5VcR1lG9pDfnf3jg=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+72N1Ib99ZPWNX68367ULQ=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+743gm14JqMq3own4BFlaA=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+7EFby9tnpIYTZBibuoXKg=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+7SKoeuhr2Y5sis+MVzp/A=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+7qwdS9LfNOEQhBy8zbOhw=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+8AANbfDqj5jixFL8qXG8g=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+8YDpa4jmWXeGMUtyAHO1Q=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+9+NQwO48IY3h+ceUaa8ag=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+9OdYpTisiH55QHWiRbcHQ=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+9W4GBwa5B6j1JqYAOb7qw=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+9hLTCY8XnQsegbzd8JzZw=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+9k5Tp8X9QjjOPqB7UMeAA=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+ACH9lVciJaHSOAVdZaJvg=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+AHCpfSlcqa3FcGM+6upnQ=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+AHoYk6X87uIgAMUdXlb2g=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+AL7tr8IAo2seECs7q3Dpw=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+AvtGXFJBEy8WhMNYztmag=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+Ay0smpMpi/l5/tm3Nl6eA=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+Bm1xg1EgYdXwHhEmS5fvw=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+BmkhOdLLxuzl/pPz2i0Kg=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+BrmwSOQpnKXCnx93WEoMw=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+COua3VH7/e992X4wl/Leg=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

         1  "+CS9yhCfR0ilYrjV3FlzVg=="
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:10

```

</p>
</details> 

<details>
<summary> After benchmark</summary>
<p>

```
Warming up --------------------------------------
Querying for 1000 objects
                         1.000  i/100ms
Calculating -------------------------------------
Querying for 1000 objects
                          3.623  (± 0.0%) i/s -     19.000  in   5.246208s
Measure Mode: wall_time
Thread ID: 527140
Fiber ID: 527120
Total: 1.345878
Sort by: self_time

 %self      total      self      wait     child     calls  name                           location
  7.46      0.155     0.100     0.000     0.054    73006   GraphQL::Execution::Interpreter::Runtime#set_all_interpreter_context /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:421
  7.21      1.276     0.097     0.000     1.179    52002  *GraphQL::Execution::Interpreter::Runtime#after_lazy /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:442
  6.57      1.278     0.088     0.000     1.189    58050  *Array#each                     
  5.95      1.276     0.080     0.000     1.196    82002  *GraphQL::Execution::Interpreter::Runtime#continue_field /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:306
  4.80      0.065     0.065     0.000     0.000    41001   GraphQL::Execution::Interpreter::HashResponse#write /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/hash_response.rb:23
  4.03      0.054     0.054     0.000     0.000   240014   GraphQL::Query::Context#[]=    /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/context.rb:170
  3.81      0.051     0.051     0.000     0.000   368098   Kernel#is_a?                   
  3.58      0.065     0.048     0.000     0.017    41010   Array#hash                     
  3.37      0.066     0.045     0.000     0.020    42001   GraphQL::Execution::Interpreter::Runtime#continue_value /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:260
  3.09      0.067     0.042     0.000     0.026        5   <Module::GraphQL::Execution::Interpreter::Resolve>#resolve /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/resolve.rb:29
  2.89      1.276     0.039     0.000     1.238     1021  *Hash#each                      
  2.68      0.177     0.036     0.000     0.141    70015   GraphQL::Schema::LazyHandlingMethods#lazy_method_name /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:131
  2.66      0.115     0.036     0.000     0.080    70015   GraphQL::Execution::Lazy::LazyMethodMap#get /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/lazy/lazy_method_map.rb:35
  2.31      0.040     0.031     0.000     0.009    70015   Hash#fetch                     
  2.24      0.148     0.030     0.000     0.118    41001   GraphQL::Execution::Interpreter::Runtime#write_in_response /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:506
  2.22      0.070     0.030     0.000     0.040    70015   Concurrent::Collection::MriMapBackend#compute_if_absent /Users/rmosolgo/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/concurrent-ruby-1.1.7/lib/concurrent-ruby/concurrent/collection/map/mri_map_backend.rb:21
  2.06      0.093     0.028     0.000     0.065    41001   GraphQL::Execution::Interpreter::Runtime#set_type_at_path /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:528
  1.92      0.203     0.026     0.000     0.177    70014   GraphQL::Schema::LazyHandlingMethods#lazy? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:136
  1.89      0.025     0.025     0.000     0.000    70015   <Class::GraphQL::Schema>#lazy_methods /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1686
  1.72      0.023     0.023     0.000     0.000   180207   Kernel#hash                    
  1.48      0.053     0.020     0.000     0.033    41001   GraphQL::Execution::Interpreter::Runtime#dead_path? /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:543
  1.37      0.119     0.018     0.000     0.101    17011  *GraphQL::Schema::LazyHandlingMethods#after_lazy /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:104
  1.29      0.035     0.017     0.000     0.018    22032  *GraphQL::Schema::FindInheritedValue#find_inherited_value /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/find_inherited_value.rb:19
  1.11      0.047     0.015     0.000     0.032    10001   GraphQL::Execution::Interpreter::ArgumentsCache#fetch /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/arguments_cache.rb:26
  1.00      0.054     0.013     0.000     0.041    10001   GraphQL::Schema::Field#with_extensions /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:724
  0.99      0.081     0.013     0.000     0.068    10001   GraphQL::Execution::Interpreter::Runtime#arguments /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:477
  0.91      0.026     0.012     0.000     0.014    41003   Kernel#dup                     
  0.85      0.041     0.011     0.000     0.029    22004  *<Class::GraphQL::Schema>#error_handler /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1527
  0.77      1.276     0.010     0.000     1.266    10001  *GraphQL::Execution::Interpreter::Runtime#resolve_with_directives /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:388
  0.77      0.145     0.010     0.000     0.135    11002   <Class::GraphQL::Execution::Errors::NullErrorHandler>#with_error_handling /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/errors.rb:29
  0.72      0.010     0.010     0.000     0.000    70030   Kernel#class                   
  0.69      0.015     0.009     0.000     0.006    13020   GraphQL::Schema::Member::HasArguments#arguments /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:52
  0.68      0.009     0.009     0.000     0.000    81017   String#hash                    
  0.67      0.009     0.009     0.000     0.000    41001   GraphQL::Schema::NonNull#non_null? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/non_null.rb:21
  0.65      0.128     0.009     0.000     0.120    10001   GraphQL::Schema::Field#resolve /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:576
  0.64      0.014     0.009     0.000     0.005    41003   Kernel#initialize_dup          
  0.63      0.008     0.008     0.000     0.000    41001   GraphQL::Schema::NonNull#kind  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/non_null.rb:16
  0.62      0.058     0.008     0.000     0.049    10001   GraphQL::Query#arguments_for   /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:251
  0.61      0.008     0.008     0.000     0.000    37028   <Class::GraphQL::Schema::Scalar>#kind /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/scalar.rb:29
  0.55      0.020     0.007     0.000     0.013    10001   GraphQL::Schema::Field#authorized? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:525
  0.54      0.011     0.007     0.000     0.003    12000   <Class::GraphQL::Types::String>#coerce_result /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/string.rb:8
  0.53      0.012     0.007     0.000     0.005     6002  *GraphQL::Schema::Field#run_extensions_before_resolve /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:753
  0.51      1.346     0.007     0.000     1.339    11008  *GraphQL::Tracing::Traceable#trace /Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing.rb:65
  0.49      0.193     0.007     0.000     0.186    11002   GraphQL::Query#with_error_handling /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:354
  0.48      0.006     0.006     0.000     0.000    20002   GraphQL::Schema::Field#extras  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:381
  0.46      0.008     0.006     0.000     0.002    12000   <Class::GraphQL::Types::Int>#coerce_result /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/int.rb:16
  0.44      0.006     0.006     0.000     0.000    35046   Kernel#respond_to?             
  0.43      0.006     0.006     0.000     0.000    41001   Kernel#freeze                  
  0.39      0.005     0.005     0.000     0.000    41003   Array#initialize_copy          
  0.37      0.005     0.005     0.000     0.000    41002   Array#shift                    
  0.32      0.004     0.004     0.000     0.000    33048   Class#superclass               
  0.31      0.058     0.004     0.000     0.054    10001   GraphQL::Schema::Field#public_send_field /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:671
  0.31      0.004     0.004     0.000     0.000    29140   Module#===                     
  0.29      0.004     0.004     0.000     0.000     9060  *GraphQL::Schema::Wrapper#unwrap /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/wrapper.rb:20
  0.29      0.005     0.004     0.000     0.001    10001   GraphQL::Execution::Interpreter::Runtime#directives_include? /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:410
  0.29      0.004     0.004     0.000     0.000    13035   GraphQL::Schema::Field#type    /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:494
  0.28      0.010     0.004     0.000     0.006     3001   GraphQL::Schema::Field::ScopeExtension#after_resolve /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field/scope_extension.rb:7
  0.23      0.003     0.003     0.000     0.000    13020   GraphQL::Schema::Member::HasArguments#own_arguments /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:233
  0.22      0.010     0.003     0.000     0.007     3001   GraphQL::Schema::FieldExtension#resolve /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field_extension.rb:49
  0.21      0.004     0.003     0.000     0.001     3008   GraphQL::Execution::Interpreter::ArgumentsCache#prepare_args_hash /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/arguments_cache.rb:36
  0.21      0.003     0.003     0.000     0.000    10001   GraphQL::Schema::Member::HasArguments#arguments_statically_coercible? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:154
  0.21      0.003     0.003     0.000     0.000    12000   <Class::GraphQL::Types::Boolean>#coerce_result /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/boolean.rb:11
  0.20      0.003     0.003     0.000     0.000    10001   GraphQL::Schema::Field#extensions /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:341
  0.20      0.010     0.003     0.000     0.007     3008   GraphQL::Schema::Member::HasArguments#coerce_arguments /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:87
  0.19      0.005     0.003     0.000     0.002     4075  *Class#new                      
  0.18      0.002     0.002     0.000     0.000    17011   Kernel#block_given?            
  0.18      0.002     0.002     0.000     0.000    10001   GraphQL::Execution::Interpreter::Arguments#empty? /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/arguments.rb:38
  0.18      0.002     0.002     0.000     0.000    10002   GraphQL::Query#interpreter?    /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:152
  0.16      0.002     0.002     0.000     0.000    10021   Hash#key?                      
  0.14      0.002     0.002     0.000     0.000    12000   String#encoding                
  0.12      0.002     0.002     0.000     0.000    12000   Integer#to_i                   
  0.11      0.002     0.002     0.000     0.000    12000   String#to_s                    
  0.11      0.002     0.001     0.000     0.000     3001   Array#all?                     
  0.10      0.001     0.001     0.000     0.000     3008   GraphQL::Execution::Interpreter::Arguments#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/arguments.rb:28
  0.10      0.001     0.001     0.000     0.000    10024   Hash#each_value                
  0.08      0.016     0.001     0.000     0.015     1001   GraphQL::Execution::Interpreter::Runtime#authorized_new /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:586
  0.08      1.276     0.001     0.000     1.275     1001  *GraphQL::Execution::Interpreter::Runtime#evaluate_selections /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:122
  0.06      0.001     0.001     0.000     0.000     4007   Array#concat                   
  0.06      0.012     0.001     0.000     0.011     1001   <Class::GraphQL::Schema::Object>#authorized_new /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb:39
  0.06      0.001     0.001     0.000     0.000     3001   GraphQL::Schema::Member::Scoped#scope_items /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/scoped.rb:15
  0.06      0.001     0.001     0.000     0.000     3063   Array#any?                     
  0.05      0.001     0.001     0.000     0.000     3001   GraphQL::Schema::List#kind     /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/list.rb:16
  0.03      0.000     0.000     0.000     0.000     3039   Kernel#unwrap                  
  0.03      0.000     0.000     0.000     0.000     1001   GraphQL::Schema::Object#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb:68
  0.03      0.000     0.000     0.000     0.000     1001   GraphQL::Schema::Member::BaseDSLMethods#authorized? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/base_dsl_methods.rb:130
  0.03      0.000     0.000     0.000     0.000     1000   <Class::GraphQL::Types::ID>#coerce_result /Users/rmosolgo/code/graphql-ruby/lib/graphql/types/id.rb:8
  0.03      0.017     0.000     0.000     0.017     1001   GraphQL::Execution::Interpreter::Runtime#gather_selections /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:66
  0.02      0.000     0.000     0.000     0.000     1004   Hash#values                    
  0.02      0.000     0.000     0.000     0.000     1039   <Class::GraphQL::Schema::Object>#kind /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb:186
  0.00      0.000     0.000     0.000     0.000       33   <Class::GraphQL::Schema>#get_field /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1191
  0.00      0.001     0.000     0.000     0.001       11  *GraphQL::StaticValidation::BaseVisitor::ContextMethods#on_field /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb:95
  0.00      0.000     0.000     0.000     0.000       21   GraphQL::Schema::Warden#visible? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb:265
  0.00      0.000     0.000     0.000     0.000       54  *GraphQL::Filter#call           /Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb:11
  0.00      0.000     0.000     0.000     0.000       44   GraphQL::Schema::Member::HasFields#get_field /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb:29
  0.00      0.000     0.000     0.000     0.000       11   GraphQL::Schema::Warden#get_field /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb:92
  0.00      0.000     0.000     0.000     0.000       43   Hash#initialize                
  0.00      0.000     0.000     0.000     0.000       11   GraphQL::Schema::Warden#visible_type? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb:218
  0.00      0.001     0.000     0.000     0.001       13  *GraphQL::Language::Visitor#on_abstract_node /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb:91
  0.00      0.000     0.000     0.000     0.000       12   GraphQL::StaticValidation::FieldsHaveAppropriateSelections#validate_field_selections /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb:25
  0.00      0.000     0.000     0.000     0.000       14   Array#-                        
  0.00      0.001     0.000     0.000     0.001       11  *GraphQL::StaticValidation::FieldsAreDefinedOnType#on_field /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb:5
  0.00      1.346     0.000     0.000     1.346        1   <Module::GraphQLBenchmark>#profile_large_result /Users/rmosolgo/code/graphql-ruby/benchmark/run.rb:66
  0.00      0.000     0.000     0.000     0.000       18   <Class::GraphQL::Schema>#visible? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1456
  0.00      0.000     0.000     0.000     0.000       11   GraphQL::StaticValidation::RequiredArgumentsArePresent#assert_required_args /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb:18
  0.00      0.001     0.000     0.000     0.001       11  *GraphQL::StaticValidation::FieldsHaveAppropriateSelections#on_field /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb:9
  0.00      0.000     0.000     0.000     0.000       44   GraphQL::Schema::Member::HasFields#own_fields /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb:94
  0.00      0.000     0.000     0.000     0.000       12   GraphQL::StaticValidation::FieldsWillMerge#conflicts_within_selection_set /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:34
  0.00      1.278     0.000     0.000     1.278       30  *Array#map                      
  0.00      0.000     0.000     0.000     0.000       11   GraphQL::Schema::Warden#visible_field? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb:172
  0.00      0.001     0.000     0.000     0.001       11  *GraphQL::StaticValidation::RequiredArgumentsArePresent#on_field /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb:5
  0.00      0.000     0.000     0.000     0.000       19   GraphQL::Query#with_prepared_ast /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:437
  0.00      0.000     0.000     0.000     0.000       45   GraphQL::TypeKinds::TypeKind#fields? /Users/rmosolgo/code/graphql-ruby/lib/graphql/type_kinds.rb:24
  0.00      0.001     0.000     0.000     0.001       13  *GraphQL::Language::Visitor#on_node_with_modifications /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb:173
  0.00      0.001     0.000     0.000     0.001       11  *GraphQL::StaticValidation::FieldsWillMerge#on_field /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:27
  0.00      0.001     0.000     0.000     0.001       11  *GraphQL::StaticValidation::UniqueDirectivesPerLocation#on_field /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/unique_directives_per_location.rb:23
  0.00      0.000     0.000     0.000     0.000       18   GraphQL::Filter::MergedOnly#call /Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb:31
  0.00      0.001     0.000     0.000     0.001       11  *GraphQL::StaticValidation::ArgumentNamesAreUnique#on_field /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/argument_names_are_unique.rb:7
  0.00      0.001     0.000     0.000     0.001       14  *Kernel#public_send             
  0.00      0.001     0.000     0.000     0.001       13  *GraphQL::Language::Visitor#visit_node /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb:78
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query#initialize      /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:82
  0.00      0.000     0.000     0.000     0.000       46   Array#last                     
  0.00      0.000     0.000     0.000     0.000        5   GraphQL::Schema::Warden#referenced? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb:241
  0.00      0.000     0.000     0.000     0.000       15   Enumerable#each_with_index     
  0.00      0.000     0.000     0.000     0.000       18   Method#call                    
  0.00      0.000     0.000     0.000     0.000       37   Array#pop                      
  0.00      0.000     0.000     0.000     0.000       22   GraphQL::StaticValidation::BaseVisitor::ContextMethods#field_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb:170
  0.00      0.000     0.000     0.000     0.000       13   GraphQL::StaticValidation::ValidationContext#schema /Users/rmosolgo/.rbenv/versions/2.7.2/lib/ruby/2.7.0/forwardable.rb:226
  0.00      0.000     0.000     0.000     0.000       36   Array#push                     
  0.00      0.000     0.000     0.000     0.000       12   GraphQL::StaticValidation::FieldsWillMerge#fields_and_fragments_from_selection /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:302
  0.00      0.000     0.000     0.000     0.000       11   GraphQL::StaticValidation::ValidationContext#warden /Users/rmosolgo/.rbenv/versions/2.7.2/lib/ruby/2.7.0/forwardable.rb:226
  0.00      0.001     0.000     0.000     0.001       11  *GraphQL::Language::Visitor#on_field /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb:122
  0.00      1.346     0.000     0.000     1.346        2  *<Module::GraphQL::Execution::Instrumentation>#each_query_call_hooks /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/instrumentation.rb:39
  0.00      0.000     0.000     0.000     0.000       12   GraphQL::Query#warden          /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:309
  0.00      0.000     0.000     0.000     0.000        8   GraphQL::Execution::Interpreter::Runtime#delete_interpreter_context /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:564
  0.00      0.000     0.000     0.000     0.000       18   GraphQL::Schema::Member::CachedGraphQLDefinition#type_class /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/cached_graphql_definition.rb:19
  0.00      0.000     0.000     0.000     0.000       27   BasicObject#equal?             
  0.00      0.000     0.000     0.000     0.000       13   GraphQL::StaticValidation::BaseVisitor::ContextMethods#type_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb:160
  0.00      0.000     0.000     0.000     0.000       18   <Module::GraphQL::Schema::NullMask>#call /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/null_mask.rb:6
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query#prepare_ast     /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:372
  0.00      0.000     0.000     0.000     0.000       11   GraphQL::StaticValidation::ArgumentNamesAreUnique#validate_arguments /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/argument_names_are_unique.rb:17
  0.00      0.000     0.000     0.000     0.000        6   GraphQL::Query::Context#namespace /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/context.rb:230
  0.00      0.067     0.000     0.000     0.067        1   GraphQL::Execution::Interpreter#sync_lazies /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:81
  0.00      0.002     0.000     0.000     0.002        3   GraphQL::Query::ValidationPipeline#ensure_has_validated /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb:60
  0.00      0.000     0.000     0.000     0.000       12   GraphQL::StaticValidation::FieldsWillMerge#find_conflicts_within /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:173
  0.00      0.000     0.000     0.000     0.000       12   GraphQL::StaticValidation::BaseVisitor::ContextMethods#push_type /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb:200
  0.00      0.000     0.000     0.000     0.000       12   Enumerator#each                
  0.00      1.346     0.000     0.000     1.346        2  *<Module::GraphQL::Execution::Instrumentation>#call_hooks /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/instrumentation.rb:54
  0.00      1.277     0.000     0.000     1.277        1   GraphQL::Execution::Interpreter::Runtime#run_eager /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:45
  0.00      0.000     0.000     0.000     0.000        5   GraphQL::Schema::Member::BaseDSLMethods#graphql_name /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/base_dsl_methods.rb:20
  0.00      0.000     0.000     0.000     0.000       11   <Class::GraphQL::StaticValidation::FieldsWillMerge::Field>#new 
  0.00      0.000     0.000     0.000     0.000        6   Hash#merge                     
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::BaseVisitor::ContextMethods#on_operation_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb:72
  0.00      0.000     0.000     0.000     0.000        2   GraphQL::Filter#merge          /Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb:16
  0.00      0.000     0.000     0.000     0.000        4  *<Class::GraphQL::Schema>#tracers /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1578
  0.00      0.000     0.000     0.000     0.000        8   GraphQL::Query::Context#delete /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/context.rb:185
  0.00      1.344     0.000     0.000     1.344        1   <Class::GraphQL::Execution::Multiplex>#run_as_multiplex /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb:77
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::VariablesAreUsedAndDefined#on_operation_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb:33
  0.00      0.000     0.000     0.000     0.000       11   Enumerable#select              
  0.00      0.000     0.000     0.000     0.000       11   GraphQL::Schema::Field#visible? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:509
  0.00      0.000     0.000     0.000     0.000       12   GraphQL::TypeKinds::TypeKind#scalar? /Users/rmosolgo/code/graphql-ruby/lib/graphql/type_kinds.rb:33
  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Execution::Multiplex>#finish_query /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb:123
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::BaseVisitor#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb:5
  0.00      0.000     0.000     0.000     0.000        4  *<Class::GraphQL::Schema>#instrumenters /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1659
  0.00      0.000     0.000     0.000     0.000        4   Kernel#Array                   
  0.00      0.000     0.000     0.000     0.000       16   Hash#delete                    
  0.00      1.346     0.000     0.000     1.346        1   <Class::GraphQL::Schema>#multiplex /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1650
  0.00      0.000     0.000     0.000     0.000        5   <Class::GraphQL::Schema>#interpreter? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1297
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Schema::Warden#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb:43
  0.00      0.000     0.000     0.000     0.000        1   Array#uniq!                    
  0.00      0.000     0.000     0.000     0.000        5   <Class::GraphQL::Schema>#query_execution_strategy /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1251
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::FieldsWillMerge#on_operation_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:22
  0.00      1.346     0.000     0.000     1.346        1   <Class::GraphQL::Execution::Multiplex>#run_all /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb:46
  0.00      0.000     0.000     0.000     0.000        5   GraphQL::Schema::Warden#read_through /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb:269
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::DefinitionDependencies#resolve_dependencies /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb:115
  0.00      0.000     0.000     0.000     0.000       11   GraphQL::Language::Nodes::Field#children /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/nodes.rb:198
  0.00      0.067     0.000     0.000     0.067        1   <Module::GraphQL::Execution::Interpreter::Resolve>#resolve_all /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/resolve.rb:9
  0.00      0.000     0.000     0.000     0.000        5   GraphQL::Schema::Member::BaseDSLMethods#visible? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/base_dsl_methods.rb:114
  0.00      0.000     0.000     0.000     0.000        2  *<Class::GraphQL::Schema>#references_to /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1159
  0.00      0.000     0.000     0.000     0.000        2  *<Class::GraphQL::Schema>#directives /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1551
  0.00      1.346     0.000     0.000     1.346        1   <Module::GraphQL::Execution::Instrumentation>#apply_instrumenters /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/instrumentation.rb:19
  0.00      0.000     0.000     0.000     0.000        3   GraphQL::Filter#initialize     /Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb:5
  0.00      1.346     0.000     0.000     1.346        1   <Class::GraphQL::Schema>#execute /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1613
  0.00      0.000     0.000     0.000     0.000       11   GraphQL::Language::Nodes::Field#visit_method (eval):1
  0.00      0.000     0.000     0.000     0.000        5   GraphQL::Schema::Member::BaseDSLMethods#introspection /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/base_dsl_methods.rb:70
  0.00      0.000     0.000     0.000     0.000        4   <Class::GraphQL::Schema>#own_tracers /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1735
  0.00      0.000     0.000     0.000     0.000        5   GraphQL::Schema::Member::BaseDSLMethods#introspection? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/base_dsl_methods.rb:80
  0.00      0.000     0.000     0.000     0.000        4   Hash#select                    
  0.00      0.000     0.000     0.000     0.000        2   <Class::GraphQL::Schema>#root_type_for_operation /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1094
  0.00      0.067     0.000     0.000     0.067        1   <Class::GraphQL::Execution::Interpreter>#finish_multiplex /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:49
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query::Context#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/context.rb:146
  0.00      1.277     0.000     0.000     1.277        1   GraphQL::Execution::Interpreter#evaluate /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:62
  0.00      0.000     0.000     0.000     0.000        2   GraphQL::StaticValidation::ValidationContext#dependencies /Users/rmosolgo/.rbenv/versions/2.7.2/lib/ruby/2.7.0/forwardable.rb:226
  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Execution::Multiplex>#supports_multiplexing? /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb:164
  0.00      0.000     0.000     0.000     0.000       22   GraphQL::StaticValidation::FieldsWillMerge::Field#node 
  0.00      0.000     0.000     0.000     0.000        4   <Class::GraphQL::Filter::MergedOnly>#build /Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb:35
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::DefinitionDependencies#on_operation_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb:44
  0.00      0.000     0.000     0.000     0.000        3   GraphQL::Query#validation_pipeline /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:297
  0.00      1.346     0.000     0.000     1.346        1   <Class::GraphQL::Execution::Multiplex>#run_queries /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb:56
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::DirectivesAreDefined#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/directives_are_defined.rb:5
  0.00      0.000     0.000     0.000     0.000        3   <Class::GraphQL::Schema>#query /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1049
  0.00      0.000     0.000     0.000     0.000        5   GraphQL::Schema::Warden#root_type? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb:235
  0.00      0.000     0.000     0.000     0.000        2  *<Class::GraphQL::Schema>#max_depth /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1319
  0.00      0.002     0.000     0.000     0.002        2   GraphQL::Query#valid?          /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:305
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::DefinitionDependencies#on_document /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb:32
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::ValidationContext#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/validation_context.rb:22
  0.00      0.000     0.000     0.000     0.000        2   <Module::GraphQL::Execution::Instrumentation>#call_after_hooks /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/instrumentation.rb:79
  0.00      0.000     0.000     0.000     0.000        2  *<Class::GraphQL::Schema>#context_class /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1390
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::FragmentsAreUsed#on_document /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragments_are_used.rb:5
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Execution::Interpreter::Runtime#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:20
  0.00      1.277     0.000     0.000     1.277        1   <Class::GraphQL::Execution::Multiplex>#begin_query /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb:105
  0.00      0.000     0.000     0.000     0.000        4   Hash#any?                      
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::VariablesAreUsedAndDefined#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb:26
  0.00      0.000     0.000     0.000     0.000       11   Struct#initialize              
  0.00      0.000     0.000     0.000     0.000        2  *<Class::GraphQL::Schema>#multiplex_analyzers /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1606
  0.00      1.277     0.000     0.000     1.277        1   <Class::GraphQL::Execution::Interpreter>#begin_query /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:39
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query::Variables#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/variables.rb:13
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::VariablesAreUsedAndDefined#on_document /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb:78
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::VariableUsagesAreAllowed#on_operation_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb:11
  0.00      0.000     0.000     0.000     0.000        4   <Class::GraphQL::Schema>#own_instrumenters /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1731
  0.00      0.000     0.000     0.000     0.000        2  *<Class::GraphQL::Schema>#default_mask /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:922
  0.00      0.000     0.000     0.000     0.000        4   Array#select                   
  0.00      0.000     0.000     0.000     0.000        2  *<Class::GraphQL::Schema>#query_analyzers /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1589
  0.00      0.000     0.000     0.000     0.000        2  *<Class::GraphQL::Schema>#max_complexity /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1277
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query::ValidationPipeline#build_analyzers /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb:100
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::LiteralValidator#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/literal_validator.rb:6
  0.00      0.000     0.000     0.000     0.000        5   GraphQL::Schema::Member::BaseDSLMethods#overridden_graphql_name /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/base_dsl_methods.rb:28
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Filter::MergedOnly#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb:26
  0.00      0.000     0.000     0.000     0.000        5   GraphQL::TypeKinds::TypeKind#union? /Users/rmosolgo/code/graphql-ruby/lib/graphql/type_kinds.rb:45
  0.00      0.000     0.000     0.000     0.000        4   GraphQL::Schema::Member::BaseDSLMethods#default_graphql_name /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/base_dsl_methods.rb:106
  0.00      0.000     0.000     0.000     0.000        2  *<Class::GraphQL::Schema>#mutation /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1063
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::FieldsHaveAppropriateSelections#on_operation_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb:16
  0.00      0.002     0.000     0.000     0.002        2   GraphQL::Query::ValidationPipeline#valid? /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb:34
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::DefinitionDependencies#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb:10
  0.00      0.000     0.000     0.000     0.000        5   GraphQL::TypeKinds::TypeKind#interface? /Users/rmosolgo/code/graphql-ruby/lib/graphql/type_kinds.rb:41
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::OperationNamesAreValid#on_operation_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/operation_names_are_valid.rb:10
  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Argument>#deep_stringify /Users/rmosolgo/code/graphql-ruby/lib/graphql/argument.rb:116
  0.00      0.000     0.000     0.000     0.000        2   GraphQL::StaticValidation::FieldsWillMerge#find_fields_and_fragments /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:312
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::UniqueDirectivesPerLocation#on_operation_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/unique_directives_per_location.rb:23
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::VariablesAreUsedAndDefined#follow_spreads /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb:94
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::NoDefinitionsArePresent#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/no_definitions_are_present.rb:7
  0.00      0.000     0.000     0.000     0.000        3   Array#flatten                  
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::OperationNamesAreValid#on_document /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/operation_names_are_valid.rb:15
  0.00      0.000     0.000     0.000     0.000        1   Enumerable#map                 
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query::Context#interpreter? /Users/rmosolgo/.rbenv/versions/2.7.2/lib/ruby/2.7.0/forwardable.rb:226
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query::ValidationPipeline#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb:19
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Execution::Multiplex#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb:33
  0.00      0.000     0.000     0.000     0.000        2  *<Class::GraphQL::Schema>#subscription /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1077
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::VariableNamesAreUnique#on_operation_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variable_names_are_unique.rb:5
  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Execution::Interpreter>#finish_query /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:54
  0.00      1.346     0.000     0.000     1.346        1   <Class::GraphQL::Execution::Multiplex>#instrument_and_analyze /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb:173
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::FragmentSpreadsArePossible#on_document /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb:25
  0.00      0.000     0.000     0.000     0.000        3   <Class::GraphQL::Schema>#analysis_engine /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1289
  0.00      0.000     0.000     0.000     0.000        2   GraphQL::Execution::Interpreter::Runtime#final_value /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:34
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::FieldsWillMerge#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:16
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::FragmentsAreFinite#on_document /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragments_are_finite.rb:5
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::NoDefinitionsArePresent#on_document /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/no_definitions_are_present.rb:33
  0.00      0.000     0.000     0.000     0.000        2   Enumerable#group_by            
  0.00      0.000     0.000     0.000     0.000        2   <Module::GraphQL::Analysis::AST>#analysis_errors /Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/ast.rb:77
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query#result_values=  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:172
  0.00      0.002     0.000     0.000     0.002        1   <Module::GraphQL::Analysis::AST>#analyze_multiplex /Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/ast.rb:26
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query#analyzers       /Users/rmosolgo/.rbenv/versions/2.7.2/lib/ruby/2.7.0/forwardable.rb:226
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::DefinitionDependencies::DependencyMap#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb:86
  0.00      0.000     0.000     0.000     0.000        2   <Class::GraphQL::Schema>#own_multiplex_analyzers /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1751
  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Execution::Interpreter>#begin_multiplex /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:33
  0.00      0.000     0.000     0.000     0.000        3   Hash#keys                      
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::MutationRootExists#on_operation_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/mutation_root_exists.rb:5
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::FragmentNamesAreUnique#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_names_are_unique.rb:6
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::FragmentNamesAreUnique#on_document /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_names_are_unique.rb:16
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::OperationNamesAreValid#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/operation_names_are_valid.rb:5
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::FragmentSpreadsArePossible#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb:5
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::VariableUsagesAreAllowed#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb:5
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query::Result#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/result.rb:11
  0.00      0.000     0.000     0.000     0.000        2   <Class::GraphQL::Schema>#own_query_analyzers /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1739
  0.00      0.000     0.000     0.000     0.000        2   GraphQL::Query#selected_operation /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:214
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::ValidationContext#document /Users/rmosolgo/.rbenv/versions/2.7.2/lib/ruby/2.7.0/forwardable.rb:226
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::Language::Visitor#visit /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb:67
  0.00      0.000     0.000     0.000     0.000        2   Enumerable#each_with_object    
  0.00      0.000     0.000     0.000     0.000        2   <Class::GraphQL::Schema>#own_directives /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1727
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query#result          /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:194
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::SubscriptionRootExists#on_operation_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/subscription_root_exists.rb:5
  0.00      0.000     0.000     0.000     0.000        3   NilClass#to_a                  
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::DefinitionDependencies#dependency_map /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb:69
  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::StaticValidation::BaseVisitor>#including_rules /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb:37
  0.00      0.000     0.000     0.000     0.000        2   <Class::GraphQL::Schema>#default_directives /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1566
  0.00      0.000     0.000     0.000     0.000        1   Kernel#method                  
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Schema::LazyHandlingMethods#sync_lazy /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:120
  0.00      0.000     0.000     0.000     0.000        2   Array#first                    
  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Schema>#default_filter /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:918
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query#merge_filters   /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:340
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::ValidationContext#path /Users/rmosolgo/.rbenv/versions/2.7.2/lib/ruby/2.7.0/forwardable.rb:226
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Language::Visitor#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb:45
  0.00      0.000     0.000     0.000     0.000        2   GraphQL::Execution::Interpreter::HashResponse#final_value /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/hash_response.rb:13
  0.00      0.000     0.000     0.000     0.000        1   <Module::GraphQL::Analysis::AST>#analyze_query /Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/ast.rb:55
  0.00      0.000     0.000     0.000     0.000        2   GraphQL::Query::InputValidationResult#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/input_validation_result.rb:7
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::VariablesAreUsedAndDefined#create_errors /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb:124
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::StaticValidation::Validator#validate /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/validator.rb:24
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::Language::Visitor#on_document /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb:122
  0.00      0.000     0.000     0.000     0.000        2   Array#compact!                 
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query#variables       /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:224
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query#find_operation  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:362
  0.00      0.001     0.000     0.000     0.001        1   GraphQL::Language::Visitor#on_operation_definition /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb:122
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query::Context#warden /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/context.rb:223
  0.00      0.000     0.000     0.000     0.000        1   Enumerable#reduce              
  0.00      0.000     0.000     0.000     0.000        1   Array#include?                 
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Execution::Interpreter::ArgumentsCache#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/arguments_cache.rb:7
  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Schema>#using_ast_analysis? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1293
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query::ValidationPipeline#analyzers /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb:51
  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Schema>#static_validator /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:930
  0.00      0.000     0.000     0.000     0.000        2   Array#reverse_each             
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Language::Nodes::OperationDefinition#visit_method (eval):1
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Query#document        /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:47
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::DefinitionDependencies::NodeWithPath#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb:102
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::Validator#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/validator.rb:16
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Execution::Interpreter::HashResponse#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/hash_response.rb:9
  0.00      0.000     0.000     0.000     0.000        1   Enumerable#inject              
  0.00      0.000     0.000     0.000     0.000        2   GraphQL::Schema::Argument#visible? /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/argument.rb:106
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Language::Nodes::OperationDefinition#children /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/nodes.rb:198
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::BaseVisitor#path /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb:28
  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Schema>#subscription_execution_strategy /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1267
  0.00      0.000     0.000     0.000     0.000        1   <Class::GraphQL::Schema>#mutation_execution_strategy /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1259
  0.00      0.000     0.000     0.000     0.000        1   GraphQLBenchmark::ProfileLargeResult::QueryType#foos /Users/rmosolgo/code/graphql-ruby/benchmark/run.rb:113
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Language::Nodes::Document#visit_method (eval):1
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::Execution::Interpreter#initialize /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:14
  0.00      0.000     0.000     0.000     0.000        1   Array#==                       
  0.00      0.000     0.000     0.000     0.000        1   GraphQL::StaticValidation::BaseVisitor#rewrite_document /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb:18

* recursively called methods

Columns are:

  %self     - The percentage of time spent in this method, derived from self_time/total_time.
  total     - The time spent in this method and its children.
  self      - The time spent in this method.
  wait      - The amount of time this method waited for other threads.
  child     - The time spent in this method's children.
  calls     - The number of times this method was called.
  name      - The name of the method.
  location  - The location of the method.

The interpretation of method names is:

  * MyObject#test - An instance method "test" of the class "MyObject"
  * <Object:MyObject>#test - The <> characters indicate a method on a singleton class.
Total allocated: 14238904 bytes (68438 objects)
Total retained:  0 bytes (0 objects)

allocated memory by gem
-----------------------------------
  14238568  graphql-ruby/lib
       336  other

allocated memory by file
-----------------------------------
  12829848  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb
    625664  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb
    504168  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb
    120240  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/resolve.rb
     92264  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/arguments_cache.rb
     40040  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb
      3848  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb
      3256  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb
      3160  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb
      2688  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb
      1880  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb
      1416  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb
      1240  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb
      1104  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb
       896  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb
       856  /Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/ast.rb
       704  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/context.rb
       696  /Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb
       672  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/validation_context.rb
       560  /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb
       496  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/literal_validator.rb
       496  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/validator.rb
       440  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb
       368  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/operation_names_are_valid.rb
       360  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb
       336  /Users/rmosolgo/code/graphql-ruby/benchmark/run.rb
       168  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/hash_response.rb
       160  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/directives_are_defined.rb
       160  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_names_are_unique.rb
       120  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb
       120  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb
        80  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/instrumentation.rb
        80  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/variables.rb
        80  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb
        80  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/no_definitions_are_present.rb
        40  /Users/rmosolgo/code/graphql-ruby/lib/graphql/argument.rb
        40  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/find_inherited_value.rb
        40  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragments_are_finite.rb
        40  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragments_are_used.rb

allocated memory by location
-----------------------------------
   6040000  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:353
   2097248  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:27
   1680168  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:229
    928168  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:124
    928000  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:339
    586632  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:346
    505344  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:152
    504168  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:731
    400040  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:153
    168168  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:587
    120320  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:92
    120040  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/resolve.rb:46
     88528  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/arguments_cache.rb:11
     40040  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb:50
      3160  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb:270
      2728  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/arguments_cache.rb:10
      1536  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:307
      1496  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb:20
      1344  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:31
      1008  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/arguments_cache.rb:9
       792  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:317
       520  /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb:125
       496  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb:47
       480  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:37
       440  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb:7
       440  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:316
       440  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb:19
       440  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb:21
       440  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb:22
       440  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb:24
       416  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/context.rb:152
       416  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1661
       376  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1627
       368  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb:28
       352  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/validation_context.rb:27
       336  /Users/rmosolgo/code/graphql-ruby/benchmark/run.rb:73
       336  /Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb:21
       336  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1556
       336  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/validator.rb:25
       320  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1660
       320  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:306
       304  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:425
       296  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:93
       288  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/operation_names_are_valid.rb:7
       288  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb:29
       280  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb:374
       272  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:66
       248  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb:57
       248  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/literal_validator.rb:10
       248  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/literal_validator.rb:9

allocated memory by class
-----------------------------------
   7155432  Array
   6914840  Hash
    120320  GraphQL::Execution::Interpreter::Arguments
     40000  GraphQLBenchmark::ProfileLargeResult::FooType
      3840  Proc
      1632  Enumerator
       792  GraphQL::StaticValidation::FieldsWillMerge::Field
       288  GraphQL::Query
       272  GraphQL::StaticValidation::InterpreterVisitor
       136  GraphQL::Query::ValidationPipeline
       128  GraphQL::Query::Context
       120  GraphQL::Filter
       112  GraphQL::Schema::Warden
       104  GraphQL::Execution::Interpreter::Runtime
        80  GraphQL::Execution::Multiplex
        80  GraphQL::Query::InputValidationResult
        80  GraphQL::StaticValidation::ValidationContext
        72  GraphQL::Query::Variables
        72  GraphQL::StaticValidation::DefinitionDependencies::DependencyMap
        72  GraphQL::StaticValidation::LiteralValidator
        72  Method
        40  GraphQL::Execution::Interpreter
        40  GraphQL::Execution::Interpreter::ArgumentsCache
        40  GraphQL::Execution::Interpreter::HashResponse
        40  GraphQL::Filter::MergedOnly
        40  GraphQL::Query::Result
        40  GraphQL::StaticValidation::DefinitionDependencies::NodeWithPath
        40  GraphQL::StaticValidation::Validator
        40  GraphQLBenchmark::ProfileLargeResult::QueryType
        40  String

allocated objects by gem
-----------------------------------
     68436  graphql-ruby/lib
         2  other

allocated objects by file
-----------------------------------
     57012  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb
      6016  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb
      3001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb
      1006  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/resolve.rb
      1001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb
        58  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb
        55  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb
        46  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/arguments_cache.rb
        30  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb
        22  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query.rb
        22  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb
        15  /Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/ast.rb
        15  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb
        15  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb
        14  /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb
        13  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb
        11  /Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb
        11  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb
         9  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb
         8  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb
         7  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/context.rb
         7  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/validation_context.rb
         6  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/literal_validator.rb
         5  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/operation_names_are_valid.rb
         5  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/validator.rb
         4  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/directives_are_defined.rb
         3  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/validation_pipeline.rb
         3  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_names_are_unique.rb
         3  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb
         2  /Users/rmosolgo/code/graphql-ruby/benchmark/run.rb
         2  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/instrumentation.rb
         2  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/variables.rb
         2  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb
         2  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/no_definitions_are_present.rb
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/argument.rb
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/hash_response.rb
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/find_inherited_value.rb
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragments_are_finite.rb
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fragments_are_used.rb

allocated objects by location
-----------------------------------
     31000  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:353
     10001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:153
     10001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:229
      3008  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:152
      3008  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:92
      3001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:346
      3001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:731
      1001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/resolve.rb:46
      1001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:124
      1001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:587
      1001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/object.rb:50
      1000  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:339
        22  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/arguments_cache.rb:10
        22  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/arguments_cache.rb:11
        15  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb:270
        13  /Users/rmosolgo/code/graphql-ruby/lib/graphql/language/visitor.rb:125
        13  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:307
        12  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:37
        11  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb:7
        11  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:316
        11  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:317
        11  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb:19
        11  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb:20
        11  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb:21
        11  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb:22
        11  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/required_arguments_are_present.rb:24
         6  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1660
         5  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/resolve.rb:30
         4  /Users/rmosolgo/code/graphql-ruby/lib/graphql/analysis/ast.rb:78
         4  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:31
         4  /Users/rmosolgo/code/graphql-ruby/lib/graphql/filter.rb:17
         4  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1579
         4  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1661
         4  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/definition_dependencies.rb:130
         4  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/fields_will_merge.rb:306
         4  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb:28
         3  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb:47
         3  /Users/rmosolgo/code/graphql-ruby/lib/graphql/query/context.rb:152
         3  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1627
         3  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/literal_validator.rb:10
         3  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/literal_validator.rb:9
         3  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/directives_are_defined.rb:7
         3  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/operation_names_are_valid.rb:7
         3  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/rules/variables_are_used_and_defined.rb:29
         3  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/validation_context.rb:27
         2  /Users/rmosolgo/code/graphql-ruby/benchmark/run.rb:73
         2  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/instrumentation.rb:56
         2  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:66
         2  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/arguments_cache.rb:9
         2  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/multiplex.rb:37

allocated objects by class
-----------------------------------
     45217  Array
     19116  Hash
      3008  GraphQL::Execution::Interpreter::Arguments
      1000  GraphQLBenchmark::ProfileLargeResult::FooType
        48  Proc
        12  Enumerator
        11  GraphQL::StaticValidation::FieldsWillMerge::Field
         3  GraphQL::Filter
         2  GraphQL::Query::InputValidationResult
         1  GraphQL::Execution::Interpreter
         1  GraphQL::Execution::Interpreter::ArgumentsCache
         1  GraphQL::Execution::Interpreter::HashResponse
         1  GraphQL::Execution::Interpreter::Runtime
         1  GraphQL::Execution::Multiplex
         1  GraphQL::Filter::MergedOnly
         1  GraphQL::Query
         1  GraphQL::Query::Context
         1  GraphQL::Query::Result
         1  GraphQL::Query::ValidationPipeline
         1  GraphQL::Query::Variables
         1  GraphQL::Schema::Warden
         1  GraphQL::StaticValidation::DefinitionDependencies::DependencyMap
         1  GraphQL::StaticValidation::DefinitionDependencies::NodeWithPath
         1  GraphQL::StaticValidation::InterpreterVisitor
         1  GraphQL::StaticValidation::LiteralValidator
         1  GraphQL::StaticValidation::ValidationContext
         1  GraphQL::StaticValidation::Validator
         1  GraphQLBenchmark::ProfileLargeResult::QueryType
         1  Method
         1  String

retained memory by gem
-----------------------------------
NO DATA

retained memory by file
-----------------------------------
NO DATA

retained memory by location
-----------------------------------
NO DATA

retained memory by class
-----------------------------------
NO DATA

retained objects by gem
-----------------------------------
NO DATA

retained objects by file
-----------------------------------
NO DATA

retained objects by location
-----------------------------------
NO DATA

retained objects by class
-----------------------------------
NO DATA


Allocated String Report
-----------------------------------
         1  "query"
         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/static_validation/base_visitor.rb:75

```
</p>
</details>