### PR TITLE
Validation: fields will merge: Faster argument comparison 

### DIFF
--- a/benchmark/run.rb
+++ b/benchmark/run.rb
@@ -19,6 +19,9 @@ module GraphQLBenchmark
   BIG_SCHEMA = GraphQL::Schema.from_definition(File.join(BENCHMARK_PATH, "big_schema.graphql"))
   BIG_QUERY = GraphQL.parse(File.read(File.join(BENCHMARK_PATH, "big_query.graphql")))
 
+  FIELDS_WILL_MERGE_SCHEMA = GraphQL::Schema.from_definition("type Query { hello: String }")
+  FIELDS_WILL_MERGE_QUERY = GraphQL.parse("{ #{Array.new(5000, "hello").join(" ")} }")
+
   module_function
   def self.run(task)
     Benchmark.ips do |x|
@@ -30,6 +33,7 @@ module GraphQLBenchmark
         x.report("validate - abstract fragments") { CARD_SCHEMA.validate(ABSTRACT_FRAGMENTS) }
         x.report("validate - abstract fragments 2") { CARD_SCHEMA.validate(ABSTRACT_FRAGMENTS_2) }
         x.report("validate - big query") { BIG_SCHEMA.validate(BIG_QUERY) }
+        x.report("validate - fields will merge") { FIELDS_WILL_MERGE_SCHEMA.validate(FIELDS_WILL_MERGE_QUERY) }
       else
         raise("Unexpected task #{task}")
       end


### PR DESCRIPTION
## Background

The Fields Will Merge validation rule seeks to ensure that when multiple field selections with the same response names are encountered during execution, the field and arguments to execute and the resulting value are to be unambiguous ([spec](http://spec.graphql.org/June2018/#sec-Field-Selection-Merging)). There are some examples of this behaviour within [GraphQL Java blog post](https://www.graphql-java.com/blog/deep-dive-merged-fields/).

## Problem

The runtime of the graphql-ruby algorithm implementation grows exponentially. As a more extreme example, for `n = 5000` repetitions of the same field: `1/2 * (n^2 - n) = 12497500`
![MSP902411hdg308adc0d44c0000632ib29337c0efc8](https://user-images.githubusercontent.com/3410466/98860493-c1e5ea80-2431-11eb-947c-f60cf97b1003.gif)

As far as I can tell, this is not a perfectly solved problem in other GraphQL server implementations either. For example, [graphql-js reproduction repo](https://github.com/ravangen/graphql-js-merge-fields) and this [XING engineering blog post](https://tech.xing.com/graphql-overlapping-fields-can-be-merged-fast-ea6e92e0a01).

## Suggestion

I did some basic profiling, and it seemed that the majority of time was spent on `GraphQL::StaticValidation::FieldsWillMerge#possible_arguments` and `GraphQL::StaticValidation::FieldsWillMerge#find_conflicts_between_sub_selection_sets`. This work tries to optimize `possible_arguments`.

The rule was originally based on the graphql-js implementation, and I think they diverged in this case to provide an improved error message in graphql-ruby. Due to the increase in number of iterations as the number of fields grows, smaller tweaks can provide a benefit.

This proposes returning to the [graphql-js reference implementation](https://github.com/graphql/graphql-js/blob/00eab30fb269b6e2a4e8e61d097d3e249319420e/src/validation/rules/OverlappingFieldsCanBeMergedRule.js#L626-L643). The performance gain is from the happy path where there are fewer objects/allocations without the use `uniq`. This still maintains the original error details.

## Benchmarks

<details>
<summary>Figure 1: Original, Sample 1</summary>

```bash
$ bundle exec rake bench:validate
Warming up --------------------------------------
validate - introspection 
                        63.000  i/100ms
validate - abstract fragments
                       548.000  i/100ms
validate - abstract fragments 2
                       407.000  i/100ms
validate - big query     5.000  i/100ms
validate - fields will merge
                         1.000  i/100ms
Calculating -------------------------------------
validate - introspection 
                        546.473  (±11.5%) i/s -      2.709k in   5.022966s
validate - abstract fragments
                          4.160k (± 8.8%) i/s -     20.824k in   5.048538s
validate - abstract fragments 2
                          3.160k (± 8.1%) i/s -     15.873k in   5.057849s
validate - big query     45.263  (± 2.2%) i/s -    230.000  in   5.085945s
validate - fields will merge
                          0.030  (± 0.0%) i/s -      1.000  in  32.913349s
```

</details>

<details>
<summary>Figure 2: Original, Sample 2</summary>

```bash
$ bundle exec rake bench:validate
Warming up --------------------------------------
validate - introspection 
                        42.000  i/100ms
validate - abstract fragments
                       387.000  i/100ms
validate - abstract fragments 2
                       320.000  i/100ms
validate - big query     4.000  i/100ms
validate - fields will merge
                         1.000  i/100ms
Calculating -------------------------------------
validate - introspection 
                        471.898  (± 4.9%) i/s -      2.394k in   5.085980s
validate - abstract fragments
                          4.225k (± 5.0%) i/s -     21.285k in   5.051741s
validate - abstract fragments 2
                          3.517k (± 5.2%) i/s -     17.600k in   5.017897s
validate - big query     50.486  (± 4.0%) i/s -    252.000  in   5.002424s
validate - fields will merge
                          0.032  (± 0.0%) i/s -      1.000  in  31.525522s
```

</details>

<details>

<summary>Figure 3: Updated, Sample 1</summary>

```bash
$ bundle exec rake bench:validate
Warming up --------------------------------------
validate - introspection 
                        51.000  i/100ms
validate - abstract fragments
                       465.000  i/100ms
validate - abstract fragments 2
                       384.000  i/100ms
validate - big query     5.000  i/100ms
validate - fields will merge
                         1.000  i/100ms
Calculating -------------------------------------
validate - introspection 
                        508.377  (± 4.7%) i/s -      2.550k in   5.027187s
validate - abstract fragments
                          4.478k (± 4.3%) i/s -     22.785k in   5.098101s
validate - abstract fragments 2
                          3.709k (± 4.0%) i/s -     18.816k in   5.081693s
validate - big query     54.156  (± 5.5%) i/s -    270.000  in   5.006528s
validate - fields will merge
                          0.052  (± 0.0%) i/s -      1.000  in  19.127847s
```

</details>

<details>

<summary>Figure 4: Updated, Sample 2</summary>

```bash
$ bundle exec rake bench:validate
Warming up --------------------------------------
validate - introspection 
                        51.000  i/100ms
validate - abstract fragments
                       456.000  i/100ms
validate - abstract fragments 2
                       381.000  i/100ms
validate - big query     5.000  i/100ms
validate - fields will merge
                         1.000  i/100ms
Calculating -------------------------------------
validate - introspection 
                        581.214  (± 9.3%) i/s -      2.907k in   5.046322s
validate - abstract fragments
                          4.577k (±13.9%) i/s -     22.800k in   5.094230s
validate - abstract fragments 2
                          3.038k (±17.3%) i/s -     14.859k in   5.047211s
validate - big query     47.441  (±19.0%) i/s -    230.000  in   5.046090s
validate - fields will merge
                          0.051  (± 0.0%) i/s -      1.000  in  19.545309s
```

</details>

## Possible Future Improvements

We could have a configuration option to set an upper bound on how long the validation phase is permitted to run before aborting the request and returning an error. Ideally we are not spending all of our cycles on validation. EDIT: See https://github.com/rmosolgo/graphql-ruby/pull/3234

👶 I'm new to the Ruby ecosystem, so welcome any tips and suggestions on how to make this even better!