### PR TITLE
Update GraphQL spec link which is moved permanently

### DIFF
--- a/guides/errors/execution_errors.md
+++ b/guides/errors/execution_errors.md
@@ -62,7 +62,7 @@ When this error is raised, its `message` will be added to the `"errors"` key and
 
 ## Customizing Error JSON
 
-The default error JSON includes `"message"`, `"locations"` and `"path"`. The [forthcoming version](https://graphql.github.io/graphql-spec/draft/#example-fce18) of the GraphQL spec recommends putting custom data in the `"extensions"` key of the error JSON.
+The default error JSON includes `"message"`, `"locations"` and `"path"`. The [forthcoming version](https://spec.graphql.org/draft/#example-fce18) of the GraphQL spec recommends putting custom data in the `"extensions"` key of the error JSON.
 
 You can customize this in two ways:
 


### PR DESCRIPTION
Current link: https://graphql.github.io/graphql-spec/draft/#example-fce18
New link: https://spec.graphql.org/draft/#example-fce18

The server uses 301 https code but with non-HTTPS scheme for new website.

Update the link to avoid further redirection and keep using HTTPS scheme.