### PR TITLE
Promote methods to public on relay's array conn

### DIFF
--- a/lib/graphql/relay/array_connection.rb
+++ b/lib/graphql/relay/array_connection.rb
@@ -31,8 +31,6 @@ module GraphQL
         end
       end
 
-      private
-
       def first
         @first ||= begin
           capped = limit_pagination_argument(arguments[:first], max_page_size)
@@ -46,6 +44,8 @@ module GraphQL
       def last
         @last ||= limit_pagination_argument(arguments[:last], max_page_size)
       end
+
+      private
 
       # apply first / last limit results
       def paged_nodes


### PR DESCRIPTION
I recently extracted a gem called [graphql-page_cursors](https://github.com/artsy/graphql-page_cursors) that extracts Artsy's graphql pagination approach but it relies on all connections exposing first and last methods. Unless I'm missing something, I believe in the case of Relay's Array connection these methods have been marked private by mistake. Any reason to not promote these two up?