### PR TITLE
Convert to string in case it is not

### DIFF
--- a/lib/graphql/language/block_string.rb
+++ b/lib/graphql/language/block_string.rb
@@ -63,7 +63,7 @@ module GraphQL
       end
 
       def self.print(str, indent: '')
-        lines = str.split("\n")
+        lines = str.to_s.split("\n")
 
         block_str = "#{indent}\"\"\"\n".dup
 


### PR DESCRIPTION
If we define an enum like this:

```ruby
class MyEnum < ::Types::Base::EnumType
    value "Zero", 0
end
```

When we try to get the schema in IDL using `GraphQL::Schema::Printer`, we will get an error like this:

```
NoMethodError: undefined method `split' for 0:Integer
/Users/alvaro/.rvm/gems/ruby-2.5.1@alkimii/gems/graphql-1.11.6/lib/graphql/language/block_string.rb:66:in `print'
/Users/alvaro/.rvm/gems/ruby-2.5.1@alkimii/gems/graphql-1.11.6/lib/graphql/language/printer.rb:257:in `print_description'
/Users/alvaro/.rvm/gems/ruby-2.5.1@alkimii/gems/graphql-1.11.6/lib/graphql/language/printer.rb:218:in `block in print_enum_type_definition'
/Users/alvaro/.rvm/gems/ruby-2.5.1@alkimii/gems/graphql-1.11.6/lib/graphql/language/printer.rb:217:in `each'
/Users/alvaro/.rvm/gems/ruby-2.5.1@alkimii/gems/graphql-1.11.6/lib/graphql/language/printer.rb:217:in `with_index'
/Users/alvaro/.rvm/gems/ruby-2.5.1@alkimii/gems/graphql-1.11.6/lib/graphql/language/printer.rb:217:in `print_enum_type_definition'
```

This avoids unexpected errors in case the description type can be converted to a string.