### PR TITLE
Update object generator to use Float for AR decimal columns

### DIFF
--- a/lib/generators/graphql/object_generator.rb
+++ b/lib/generators/graphql/object_generator.rb
@@ -40,6 +40,8 @@ module Graphql
         case type_expression
         when "Text"
           ["String", null]
+        when "Decimal"
+          ["Float", null]
         when "DateTime", "Datetime"
           ["GraphQL::Types::ISO8601DateTime", null]
         when "Date"

--- a/spec/integration/rails/generators/graphql/object_generator_spec.rb
+++ b/spec/integration/rails/generators/graphql/object_generator_spec.rb
@@ -10,6 +10,7 @@ class GraphQLGeneratorsObjectGeneratorTest < BaseGeneratorTest
       t.datetime :created_at
       t.date :birthday
       t.integer :points, null: false
+      t.decimal :rating, null: false
     end
   end
 
@@ -74,6 +75,7 @@ module Types
     field :created_at, GraphQL::Types::ISO8601DateTime, null: true
     field :birthday, GraphQL::Types::ISO8601Date, null: true
     field :points, Integer, null: false
+    field :rating, Float, null: false
   end
 end
 RUBY
@@ -88,6 +90,7 @@ module Types
     field :created_at, GraphQL::Types::ISO8601DateTime, null: true
     field :birthday, GraphQL::Types::ISO8601Date, null: true
     field :points, Integer, null: false
+    field :rating, Float, null: false
     field :name, String, null: false
   end
 end


### PR DESCRIPTION
This PR is an attempt to fix `object_generator` as described on https://github.com/rmosolgo/graphql-ruby/issues/3244

Given the following schema:

```ruby
create_table "posts", force: :cascade do |t|
    t.string "title"
    t.text "body"
    t.decimal "rating", precision: 2, scale: 1
    t.datetime "created_at", precision: 6, null: false
    t.datetime "updated_at", precision: 6, null: false
  end
```

When we generate `Post` object type with:

```ruby
#> rails g graphql:object post comments:[Comment]
create  app/graphql/types/post_type.rb
```

We get the following `app/graphql/types/post_type.rb` output:

```ruby
module Types
  class PostType < Types::BaseObject
    field :id, ID, null: false
    field :title, String, null: true
    field :body, String, null: true
    field :rating, Types::DecimalType, null: true
    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
    field :comments, [Types::CommentType], null: true
  end
end
```

With this change, ActiveRecord decimal columns would use `Float` graphql type instead of custom `Types::DecimalType`.

File: `app/graphql/types/post_type.rb`

**NOTE**: See the change for `:rating` field

```ruby
module Types
  class PostType < Types::BaseObject
    field :id, ID, null: false
    field :title, String, null: true
    field :body, String, null: true
    field :rating, Float, null: true
    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
    field :comments, [Types::CommentType], null: true
  end
end
```