### PR TITLE
Remove rewrite from Phases of execution doc

### DIFF
--- a/guides/queries/phases_of_execution.md
+++ b/guides/queries/phases_of_execution.md
@@ -13,7 +13,6 @@ When GraphQL receives a query string, it goes through these steps:
 - Tokenize: {{ "GraphQL::Language::Lexer" | api_doc }} splits the string into a stream of tokens
 - Parse: {{ "GraphQL::Language::Parser" | api_doc }} builds an abstract syntax tree (AST) out of the stream of tokens
 - Validate: {{ "GraphQL::StaticValidation::Validator" | api_doc }} validates the incoming AST as a valid query for the schema
-- Rewrite: {{ "GraphQL::InternalRepresentation::Rewrite" | api_doc }} builds a tree of {{ "GraphQL::InternalRepresentation::Node" | api_doc }}s which express the query in a simpler way than the AST
 - Analyze: If there are any query analyzers, they are run with {{ "GraphQL::Analysis.analyze_query" | api_doc }}
 - Execute: The query is traversed, `resolve` functions are called and the response is built
 - Respond: The response is returned as a Hash


### PR DESCRIPTION
This step/phase no longer applies when the interpreter is used which is the default now.

I figured it's easier just to remove this entirely instead of adding some note/explanation about it being interpreter dependent?