### PR TITLE
Clarify documentation on using field extension options

### DIFF
--- a/guides/type_definitions/field_extensions.md
+++ b/guides/type_definitions/field_extensions.md
@@ -96,8 +96,8 @@ In this case, `{limit: 20}` will be passed as `options:` to `#initialize` and `o
 For example, options can be used for modifying execution:
 
 ```ruby
-def after_resolve(value:, **options)
-  # Apply the limit from the options
+def after_resolve(value:, **rest)
+  # Apply the limit from the options, a readable attribute on the class
   value.limit(options[:limit])
 end
 ```


### PR DESCRIPTION
I was puzzled on how to retrieve the options passed to an `extension`, since the hash passed to `after_resolve` simply did not contain them. I poked around at the test specs and realized that `options` is actually an attribute on the `GraphQL::Schema::FieldExtension`, not a function parameter of `after_resolve`.