### PR TITLE
Handle GraphQL::UnauthorizedError in execution interpreter runtime

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -170,13 +170,14 @@ module GraphQL
 
             begin
               kwarg_arguments = arguments(object, field_defn, ast_node)
-            rescue GraphQL::ExecutionError => e
+            rescue GraphQL::ExecutionError, GraphQL::UnauthorizedError => e
               continue_value(next_path, e, owner_type, field_defn, return_type.non_null?, ast_node)
               next
             end
 
             after_lazy(kwarg_arguments, owner: owner_type, field: field_defn, path: next_path, scoped_context: context.scoped_context, owner_object: object, arguments: kwarg_arguments) do |resolved_arguments|
-              if resolved_arguments.is_a? GraphQL::ExecutionError
+              case resolved_arguments
+              when GraphQL::ExecutionError, GraphQL::UnauthorizedError
                 continue_value(next_path, resolved_arguments, owner_type, field_defn, return_type.non_null?, ast_node)
                 next
               end


### PR DESCRIPTION
Fixes #3266

Fixes problems in my initial example (see original issue). I've also tested it with our internal GraphQL API at $DAYJOB and looks OK. 