### PR TITLE
Pass symbol to respond_to? to fix NameError

### DIFF
--- a/lib/graphql/query/variable_validation_error.rb
+++ b/lib/graphql/query/variable_validation_error.rb
@@ -23,7 +23,7 @@ module GraphQL
         # a one level deep merge explicitly. However beyond that only show the
         # latest value and problems.
         super.merge({ "extensions" => { "value" => value, "problems" => validation_result.problems }}) do |key, oldValue, newValue|
-          if oldValue.respond_to? merge
+          if oldValue.respond_to?(:merge)
             oldValue.merge(newValue)
           else
             newValue

--- a/spec/graphql/query/variable_validation_error_spec.rb
+++ b/spec/graphql/query/variable_validation_error_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::Query::VariableValidationError do
+  let(:ast) { Struct.new(:name, :line, :col).new('input', 1, 2) }
+  let(:type) { Struct.new(:to_type_signature).new('TestType') }
+  let(:error_value) { 'some value' }
+  let(:problems) { [{'path' => ['path-to-problem'], 'explanation' => 'it broke'}] }
+  let(:validation_result) { Struct.new(:problems).new(problems) }
+  let(:subject) do
+    Class.new(GraphQL::Query::VariableValidationError) do
+      def extensions
+        {
+          code: 'ERROR',
+        }
+      end
+    end
+  end
+
+  describe '#to_h' do
+    it 'includes value and problems in extensions' do
+      error = subject.new(ast, type, error_value, validation_result)
+
+      as_hash = {
+        'message' => 'Variable $input of type TestType was provided invalid value for path-to-problem (it broke)',
+        'locations' => [ {'line' => 1, 'column' => 2} ],
+        'extensions' => {
+          'code' => 'ERROR',
+          'value' => error_value,
+          'problems' => problems
+        }
+      }
+      assert_equal error.to_h, as_hash
+    end
+  end
+end


### PR DESCRIPTION
I encountered this error while attempting to monkey patch `GraphQL::ExecutionError`:

```ruby
require 'graphql/execution_error'

module ExecutionErrorMonkeyPatch
  def extensions
    {
      code: 'EXECUTION_ERROR',
      group: 'GRAPHQL',
    }.merge(Hash(super))
  end
end

GraphQL::ExecutionError.prepend(ExecutionErrorMonkeyPatch)
```

This change should fix the error, but I'm going to use this opportunity to ask how I can accomplish this without monkey patching. Any ideas?