### PR TITLE
Document resolvers have an overridable load method

### DIFF
--- a/guides/mutations/mutation_authorization.md
+++ b/guides/mutations/mutation_authorization.md
@@ -84,6 +84,16 @@ It works like this: if you pass a `loads:` option, it will:
 
 In this case, if the argument value is provided by `object_from_id` doesn't return a value, the mutation will fail with an error.
 
+Alternatively if your `ID` doesn't specify both class _and_ id, resolvers have a `load_#{argument}` method that can be overridden.
+
+```ruby
+argument :employee_id, ID, required: true, loads: Types::Employee
+
+def load_employee(id)
+  ::Employee.find(id)
+end
+```
+
 If you don't want this behavior, don't use it. Instead, create arguments with type `ID` and use them your own way, for example:
 
 ```ruby


### PR DESCRIPTION
I noticed the overridable `load_#{argument}` method from this issue: (https://github.com/rmosolgo/graphql-ruby/issues/1733#issuecomment-510072753) on resolvers wasn't documented and found it useful.