### PR TITLE
Dataloader source errors

### DIFF
--- a/lib/graphql/dataloader/request.rb
+++ b/lib/graphql/dataloader/request.rb
@@ -12,12 +12,7 @@ module GraphQL
       #
       # @return [Object] the object loaded for `key`
       def load
-        if @source.results.key?(@key)
-          @source.results[@key]
-        else
-          @source.sync
-          @source.results[@key]
-        end
+        @source.load(@key)
       end
     end
   end

--- a/lib/graphql/dataloader/request_all.rb
+++ b/lib/graphql/dataloader/request_all.rb
@@ -12,10 +12,7 @@ module GraphQL
       #
       # @return [Array<Object>] One object for each of `keys`
       def load
-        if @keys.any? { |k| !@source.results.key?(k) }
-          @source.sync
-        end
-        @keys.map { |k| @source.results[k] }
+        @source.load_all(@keys)
       end
     end
   end

--- a/lib/graphql/dataloader/source.rb
+++ b/lib/graphql/dataloader/source.rb
@@ -43,7 +43,8 @@ module GraphQL
       # @param keys [Array<Object>] Loading keys which will be passed to `#fetch` (or read from the internal cache).
       # @return [Object] The result from {#fetch} for `keys`. If `keys` haven't been loaded yet, the Fiber will yield until they're loaded.
       def load_all(keys)
-        if pending_keys = keys.select { |k| !@results.key?(k) }
+        if keys.any? { |k| !@results.key?(k) }
+          pending_keys = keys.select { |k| !@results.key?(k) }
           @pending_keys.concat(pending_keys)
           sync
         end

--- a/lib/graphql/dataloader/source.rb
+++ b/lib/graphql/dataloader/source.rb
@@ -3,9 +3,6 @@
 module GraphQL
   class Dataloader
     class Source
-      # @api private
-      attr_reader :results
-
       # Called by {Dataloader} to prepare the {Source}'s internal state
       # @api private
       def setup(dataloader)

--- a/lib/graphql/dataloader/source.rb
+++ b/lib/graphql/dataloader/source.rb
@@ -35,11 +35,11 @@ module GraphQL
       # @return [Object] The result from {#fetch} for `key`. If `key` hasn't been loaded yet, the Fiber will yield until it's loaded.
       def load(key)
         if @results.key?(key)
-          @results[key]
+          result_for(key)
         else
           @pending_keys << key
           sync
-          @results[key]
+          result_for(key)
         end
       end
 
@@ -52,7 +52,7 @@ module GraphQL
           sync
         end
 
-        keys.map { |k| @results[k] }
+        keys.map { |k| result_for(k) }
       end
 
       # Subclasses must implement this method to return a value for each of `keys`
@@ -86,7 +86,24 @@ module GraphQL
         fetch_keys.each_with_index do |key, idx|
           @results[key] = results[idx]
         end
+      rescue StandardError => error
+        fetch_keys.each { |key| @results[key] = error }
+      ensure
         nil
+      end
+
+      private
+
+      # Reads and returns the result for the key from the internal cache, or raises an error if the result was an error
+      # @param key [Object] key passed to {#load} or {#load_all}
+      # @return [Object] The result from {#fetch} for `key`.
+      # @api private
+      def result_for(key)
+        result = @results[key]
+
+        raise result if result.class <= StandardError
+
+        result
       end
     end
   end

--- a/lib/graphql/dataloader/source.rb
+++ b/lib/graphql/dataloader/source.rb
@@ -43,8 +43,7 @@ module GraphQL
       # @param keys [Array<Object>] Loading keys which will be passed to `#fetch` (or read from the internal cache).
       # @return [Object] The result from {#fetch} for `keys`. If `keys` haven't been loaded yet, the Fiber will yield until they're loaded.
       def load_all(keys)
-        if keys.any? { |k| !@results.key?(k) }
-          pending_keys = keys.select { |k| !@results.key?(k) }
+        if pending_keys = keys.select { |k| !@results.key?(k) }
           @pending_keys.concat(pending_keys)
           sync
         end

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -419,7 +419,6 @@ describe GraphQL::Dataloader do
     assert_equal expected_log, database_log
   end
 
-  focus
   it "Works with error handlers" do
     context = { errors: [] }
 

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -197,10 +197,27 @@ describe GraphQL::Dataloader do
     end
 
     class Query < GraphQL::Schema::Object
-      field :error, String, null: false
+      field :load, String, null: false
+      field :load_all, String, null: false
+      field :request, String, null: false
+      field :request_all, String, null: false
 
-      def error
+      def load
         dataloader.with(ErrorObject).load(123)
+      end
+
+      def load_all
+        dataloader.with(ErrorObject).load_all([123])
+      end
+
+      def request
+        req = dataloader.with(ErrorObject).request(123)
+        req.load
+      end
+
+      def request_all
+        req = dataloader.with(ErrorObject).request_all([123])
+        req.load
       end
     end
 
@@ -422,9 +439,16 @@ describe GraphQL::Dataloader do
   it "Works with error handlers" do
     context = { errors: [] }
 
-    res = FiberErrorSchema.execute("{ error }", context: context)
+    res = FiberErrorSchema.execute("{ load loadAll request requestAll }", context: context)
+
+    expected_errors = [
+      "Nope (FiberErrorSchema::Query.load, nil, {})",
+      "Nope (FiberErrorSchema::Query.loadAll, nil, {})",
+      "Nope (FiberErrorSchema::Query.request, nil, {})",
+      "Nope (FiberErrorSchema::Query.requestAll, nil, {})",
+    ]
 
     assert_equal(nil, res["data"])
-    assert_equal ["Nope (FiberErrorSchema::Query.error, nil, {})"], context[:errors]
+    assert_equal(expected_errors, context[:errors].sort)
   end
 end


### PR DESCRIPTION
Applying the changes suggested in #3317.

We're now rescuing all the errors happening in dataloader sources while fetching records and then re-raise the error later in the GraphQL runtime context where they can be handled by any defined error handlers.

Fixes #3317