### PR TITLE
Allow types to be prepended by a module

### DIFF
--- a/lib/graphql/schema/find_inherited_value.rb
+++ b/lib/graphql/schema/find_inherited_value.rb
@@ -20,7 +20,9 @@ module GraphQL
         if self.is_a?(Class)
           superclass.respond_to?(method_name, true) ? superclass.send(method_name) : default_value
         else
-          (ancestors - [self]).each do |ancestor|
+          ancestors_except_self = ancestors
+          ancestors_except_self.delete(self)
+          ancestors_except_self.each do |ancestor|
             if ancestor.respond_to?(method_name, true)
               return ancestor.send(method_name)
             end

--- a/lib/graphql/schema/find_inherited_value.rb
+++ b/lib/graphql/schema/find_inherited_value.rb
@@ -20,7 +20,7 @@ module GraphQL
         if self.is_a?(Class)
           superclass.respond_to?(method_name, true) ? superclass.send(method_name) : default_value
         else
-          ancestors[1..-1].each do |ancestor|
+          (ancestors - [self]).each do |ancestor|
             if ancestor.respond_to?(method_name, true)
               return ancestor.send(method_name)
             end

--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -74,11 +74,8 @@ module GraphQL
             @field_class = new_field_class
           elsif defined?(@field_class) && @field_class
             @field_class
-          elsif self.is_a?(Class)
-            superclass.respond_to?(:field_class) ? superclass.field_class : GraphQL::Schema::Field
           else
-            ancestor = (ancestors - [self]).find { |a| a.respond_to?(:field_class) && a.field_class }
-            ancestor ? ancestor.field_class : GraphQL::Schema::Field
+            find_inherited_value(:field_class, GraphQL::Schema::Field)
           end
         end
 

--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -77,7 +77,7 @@ module GraphQL
           elsif self.is_a?(Class)
             superclass.respond_to?(:field_class) ? superclass.field_class : GraphQL::Schema::Field
           else
-            ancestor = ancestors[1..-1].find { |a| a.respond_to?(:field_class) && a.field_class }
+            ancestor = (ancestors - [self]).find { |a| a.respond_to?(:field_class) && a.field_class }
             ancestor ? ancestor.field_class : GraphQL::Schema::Field
           end
         end

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -167,9 +167,15 @@ module Jazz
     end
   end
 
+  module WithNameField
+    def self.prepended(base)
+      base.field :name, String, null: false
+    end
+  end
+
   module NamedEntity
     include BaseInterface
-    field :name, String, null: false
+    prepend WithNameField
   end
 
   class PrivateMembership < GraphQL::Schema::TypeMembership


### PR DESCRIPTION
Prior this commit the following failed with `SystemStackError`:

```ruby
  module WithNameField
    def self.prepended(base)
      base.field :name, String, null: false
    end
  end

  module NamedEntity
    include BaseInterface
    prepend WithNameField
  end

  # This raised
  # graphql-ruby/lib/graphql/schema/member/has_fields.rb:80:in `find': stack level too deep (SystemStackError)
```

This :point_up: is a reproduction of [some code from the GitLab](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/53629/diffs#note_504260946).