### PR TITLE
Allow using graphql@15 in javascript client

### DIFF
--- a/javascript_client/package.json
+++ b/javascript_client/package.json
@@ -34,7 +34,7 @@
     "@types/actioncable": "^5.2.3",
     "@types/pusher-js": "^4.2.2",
     "glob": "^7.1.4",
-    "graphql": "^14.3.1",
+    "graphql": "^14.3.1 || ^15.0.0",
     "minimist": "^1.2.0",
     "request": "^2.88.2",
     "typescript": "^3.7.5"


### PR DESCRIPTION
Right now, If I use the javascript client(specifically ActionCableLink) in a project that uses the javascript graphql dependency at version 15 my bundle will include 2 full versions of the graphql dependency(one at 14 for the graphql-ruby-client dependency and version 15 from the product)

This _SHOULD_ make it so you can use either graphql 14 OR 15 without having duplicate dependencies in your bundle, but I am having trouble testing that.