### PR TITLE
Improve RangeAdd and add a guide

### DIFF
--- a/guides/relay/range_add.md
+++ b/guides/relay/range_add.md
@@ -1,0 +1,11 @@
+---
+layout: guide
+doc_stub: false
+search: true
+section: Relay
+title: RangeAdd helper for mutations
+desc: A helper for Relay's RANGE_ADD operations
+index: 1
+---
+
+Relay specifies `RANGE_ADD` operations for adding items to connections. GraphQL-Ruby ships with {{ "GraphQL::Relay::RangeAdd" | api_doc }} to help implement this. Check the API docs for a usage example.

--- a/guides/schema/sdl.md
+++ b/guides/schema/sdl.md
@@ -78,7 +78,7 @@ The hash may contain:
 
 ## Plugins
 
-{ "GraphQL::Schema.from_definition" | api_doc }} accepts a `using:` argument, which may be given as a map of `plugin => args` pairs. For example:
+{{ "GraphQL::Schema.from_definition" | api_doc }} accepts a `using:` argument, which may be given as a map of `plugin => args` pairs. For example:
 
 ```ruby
 MySchema = GraphQL::Schema.from_definition("path/to/schema.graphql", using: {

--- a/lib/graphql/pagination/connection.rb
+++ b/lib/graphql/pagination/connection.rb
@@ -105,6 +105,15 @@ module GraphQL
         end
       end
 
+      # This is called by `Relay::RangeAdd` -- it can be overridden
+      # when `item` needs some modifications based on this connection's state.
+      #
+      # @param item [Object] An item newly added to `items`
+      # @return [Edge]
+      def range_add_edge(item)
+        edge_class.new(item, self)
+      end
+
       attr_writer :last
       # @return [Integer, nil] A clamped `last` value. (The underlying instance variable doesn't have limits on it)
       def last


### PR DESCRIPTION
Add a short guide and improve support for connections that require modification to the `items` to generate cursors. 

Fixes #3316 
Fixes #2184  (with a pro release)