### PR TITLE
Improve documentation around `m` gem in running tests

### DIFF
--- a/guides/development.md
+++ b/guides/development.md
@@ -50,8 +50,11 @@ bundle exec rake test TEST=spec/graphql/query_spec.rb
 Alternatively, you can run a __specific file__ with the [m](https://github.com/qrush/m) gem:
 
 ```
-m spec/graphql/query_spec.rb
+gem install m
+bundle exec m spec/graphql/query_spec.rb
 # run tests in `query_spec.rb` only
+bundle exec m spec/graphql/query_spec.rb:68
+# run test for `query_spec.rb:68` only
 ```
 
 You can focus on a __specific example__ with `focus`:


### PR DESCRIPTION
My Environment
---

```sh
docker container run --user=root --volume="$(pwd)/:/usr/src/graphql-ruby" --workdir='/usr/src/graphql-ruby' -it 'ruby:3.0' '/bin/bash'
```

Problem
---

Executing `m` failed as below.

```
root@d99835641f8a:/usr/src/graphql-ruby# m spec/graphql/query_spec.rb:68
Your Gemfile lists the gem jekyll-redirect-from (>= 0) more than once.
You should probably keep only one of them.
Remove any duplicate entries and specify the gem only once.
While it's not a problem now, it could cause errors if you change the version of one of them later.
Failed loading test file:
You have already activated rake 13.0.3, but your Gemfile requires rake 12.3.3. Prepending `bundle exec` to your command may solve this.
There were no tests found.
```

So I solved as below.

```sh
gem install m
bundle exec m spec/graphql/query_spec.rb:68
```

Additionally, I didn't know using `m` benefit instead of `bundle exec rake test TEST=spec/graphql/query_spec.rb`.  I guess, it is the `specifying line number`.
So adding it to documentation might help someone 😄 