### PR TITLE
Remove unintentional dependency on React

### DIFF
--- a/javascript_client/package.json
+++ b/javascript_client/package.json
@@ -22,7 +22,6 @@
     "pako": "^2.0.3",
     "prettier": "^1.19.1",
     "pusher-js": "^7.0.3",
-    "react": "^17.0.1",
     "ts-jest": "^25.2.0"
   },
   "scripts": {

--- a/javascript_client/src/subscriptions/AblyLink.ts
+++ b/javascript_client/src/subscriptions/AblyLink.ts
@@ -36,7 +36,7 @@
 //     // Do something with `data` and/or `errors`
 //   }})
 //
-import { ApolloLink, Observable, FetchResult, NextLink, Operation } from "@apollo/client"
+import { ApolloLink, Observable, FetchResult, NextLink, Operation } from "@apollo/client/core"
 import { Realtime } from "ably"
 
 type RequestResult = Observable<FetchResult<{ [key: string]: any; }, Record<string, any>, Record<string, any>>>

--- a/javascript_client/src/subscriptions/ActionCableLink.ts
+++ b/javascript_client/src/subscriptions/ActionCableLink.ts
@@ -1,4 +1,4 @@
-import { ApolloLink, Observable, FetchResult, Operation, NextLink } from "@apollo/client"
+import { ApolloLink, Observable, FetchResult, Operation, NextLink } from "@apollo/client/core"
 import { Cable } from "actioncable"
 import { print } from "graphql"
 

--- a/javascript_client/src/subscriptions/PusherLink.ts
+++ b/javascript_client/src/subscriptions/PusherLink.ts
@@ -34,7 +34,7 @@
 //     // Do something with `data` and/or `errors`
 //   }})
 //
-import { ApolloLink, Observable, Observer, Operation, NextLink, FetchResult } from "@apollo/client"
+import { ApolloLink, Observable, Observer, Operation, NextLink, FetchResult } from "@apollo/client/core"
 import Pusher from "pusher-js"
 
 type RequestResult = FetchResult<{ [key: string]: any; }, Record<string, any>, Record<string, any>>

--- a/javascript_client/src/subscriptions/__tests__/ActionCableLinkTest.ts
+++ b/javascript_client/src/subscriptions/__tests__/ActionCableLinkTest.ts
@@ -1,7 +1,7 @@
 import ActionCableLink from "../ActionCableLink"
 import { parse } from "graphql"
 import { Cable } from "actioncable"
-import { Operation } from "@apollo/client"
+import { Operation } from "@apollo/client/core"
 
 describe("ActionCableLink", () => {
   var log: any[]

--- a/javascript_client/src/subscriptions/__tests__/PusherLinkTest.ts
+++ b/javascript_client/src/subscriptions/__tests__/PusherLinkTest.ts
@@ -1,7 +1,7 @@
 import PusherLink from "../PusherLink"
 import { parse } from "graphql"
 import Pusher from "pusher-js"
-import { Operation } from "@apollo/client"
+import { Operation } from "@apollo/client/core"
 import pako from 'pako'
 
 type MockChannel = {


### PR DESCRIPTION
Quick fix for #3348 

This is just a find/replace to change imports from `@apollo/client` to `@apollo/client/core`. The JS tests pass, but I have not yet done more thorough testing.  My plan is to test this more thoroughly in our application's QA environment tomorrow.