### PR TITLE
Improve active record dataloader example

### DIFF
--- a/guides/dataloader/sources.md
+++ b/guides/dataloader/sources.md
@@ -65,7 +65,7 @@ class Sources::ActiveRecordObject < GraphQL::Dataloader::Source
   def fetch(ids)
     records = @model_class.where(id: ids)
     # return a list with `nil` for any ID that wasn't found
-    ids.map { |id| records.find { |r| r.id == id } }
+    ids.map { |id| records.find { |r| r.id == id.to_i } }
   end
 end
 ```


### PR DESCRIPTION
It is returns always empty because ActiveRecord primary key is being Integer instance by default and ID scalar type is regarded as String instance.

I suppose it needs `String#to_i` method call in this guides.