### PR TITLE
Add arguments reference to new connection classes

### DIFF
--- a/lib/graphql/pagination/connection.rb
+++ b/lib/graphql/pagination/connection.rb
@@ -45,6 +45,9 @@ module GraphQL
         end
       end
 
+      # @return [Hash<Symbol => Object>] The field arguments from the field that returned this connection
+      attr_reader :arguments
+
       # @param items [Object] some unpaginated collection item, like an `Array` or `ActiveRecord::Relation`
       # @param context [Query::Context]
       # @param parent [Object] The object this collection belongs to
@@ -52,8 +55,9 @@ module GraphQL
       # @param after [String, nil] A cursor for pagination, if the client provided one
       # @param last [Integer, nil] Limit parameter from the client, if provided
       # @param before [String, nil] A cursor for pagination, if the client provided one.
+      # @param arguments [Hash] The arguments to the field that returned the collection wrapped by this connection
       # @param max_page_size [Integer, nil] A configured value to cap the result size. Applied as `first` if neither first or last are given.
-      def initialize(items, parent: nil, field: nil, context: nil, first: nil, after: nil, max_page_size: :not_given, last: nil, before: nil, edge_class: nil)
+      def initialize(items, parent: nil, field: nil, context: nil, first: nil, after: nil, max_page_size: :not_given, last: nil, before: nil, edge_class: nil, arguments: nil)
         @items = items
         @parent = parent
         @context = context
@@ -62,6 +66,7 @@ module GraphQL
         @after_value = after
         @last_value = last
         @before_value = before
+        @arguments = arguments
         @edge_class = edge_class || self.class::Edge
         # This is only true if the object was _initialized_ with an override
         # or if one is assigned later.

--- a/lib/graphql/pagination/connection.rb
+++ b/lib/graphql/pagination/connection.rb
@@ -46,7 +46,7 @@ module GraphQL
       end
 
       # @return [Hash<Symbol => Object>] The field arguments from the field that returned this connection
-      attr_reader :arguments
+      attr_accessor :arguments
 
       # @param items [Object] some unpaginated collection item, like an `Array` or `ActiveRecord::Relation`
       # @param context [Query::Context]

--- a/lib/graphql/pagination/connections.rb
+++ b/lib/graphql/pagination/connections.rb
@@ -84,6 +84,7 @@ module GraphQL
           after: arguments[:after],
           last: arguments[:last],
           before: arguments[:before],
+          arguments: arguments,
           edge_class: edge_class_for_field(field),
         )
       end

--- a/lib/graphql/schema/field/connection_extension.rb
+++ b/lib/graphql/schema/field/connection_extension.rb
@@ -42,6 +42,7 @@ module GraphQL
               value.after_value ||= original_arguments[:after]
               value.last_value ||= original_arguments[:last]
               value.before_value ||= original_arguments[:before]
+              value.arguments ||= original_arguments
               value.field ||= field
               if field.has_max_page_size? && !value.has_max_page_size_override?
                 value.max_page_size = field.max_page_size

--- a/spec/graphql/schema/field/connection_extension_spec.rb
+++ b/spec/graphql/schema/field/connection_extension_spec.rb
@@ -4,12 +4,29 @@ require "spec_helper"
 describe GraphQL::Schema::Field::ConnectionExtension do
   class ConnectionShortcutSchema < GraphQL::Schema
     class ShortcutResolveExtension < GraphQL::Schema::FieldExtension
-      def resolve(**rest)
-        ["a", "b", "c", "d", "e"]
+      def resolve(arguments:, **rest)
+        collection = ["a", "b", "c", "d", "e"]
+        if (filter = arguments[:starting_with])
+          collection.select! { |x| x.start_with?(filter) }
+        end
+        collection
       end
     end
+
+    class CustomStringConnection < GraphQL::Types::Relay::BaseConnection
+      edge_type(GraphQL::Types::String.edge_type)
+      field :argument_data, [String], null: false
+
+      def argument_data
+        [object.arguments.class.name, *object.arguments.keys.map(&:inspect)]
+      end
+    end
+
     class Query < GraphQL::Schema::Object
-      field :names, GraphQL::Types::String.connection_type, null: false, extensions: [ShortcutResolveExtension]
+      field :names, CustomStringConnection, null: false, extensions: [ShortcutResolveExtension] do
+        argument :starting_with, String, required: false
+      end
+
       def names
         raise "This should never be called"
       end
@@ -21,5 +38,12 @@ describe GraphQL::Schema::Field::ConnectionExtension do
   it "implements connection handling even when resolve is shortcutted" do
     res = ConnectionShortcutSchema.execute("{ names(first: 2) { nodes } }")
     assert_equal ["a", "b"], res["data"]["names"]["nodes"]
+  end
+
+  it "assigns arguments to the connection instance" do
+    res = ConnectionShortcutSchema.execute("{ names(first: 2, startingWith: \"a\") { nodes argumentData } }")
+    assert_equal ["a"], res["data"]["names"]["nodes"]
+    # This come through as symbols
+    assert_equal ["Hash", ":first", ":starting_with"], res["data"]["names"]["argumentData"]
   end
 end


### PR DESCRIPTION
Fixes https://github.com/rmosolgo/graphql-ruby/issues/3359

(And makes new connections work like old ones)