### PR TITLE
Suggest @rails/actioncable package for Rails 6

### DIFF
--- a/guides/javascript_client/apollo_subscriptions.md
+++ b/guides/javascript_client/apollo_subscriptions.md
@@ -147,10 +147,10 @@ import { ApolloLink } from 'apollo-link';
 import { ApolloClient } from 'apollo-client';
 import { HttpLink } from 'apollo-link-http';
 import { InMemoryCache } from 'apollo-cache-inmemory';
-import ActionCable from 'actioncable';
+import { createConsumer } from '@rails/actioncable';
 import ActionCableLink from 'graphql-ruby-client/subscriptions/ActionCableLink';
 
-const cable = ActionCable.createConsumer()
+const cable = createConsumer()
 
 const httpLink = new HttpLink({
   uri: '/graphql',
@@ -174,6 +174,8 @@ const client = new ApolloClient({
   cache: new InMemoryCache()
 });
 ```
+
+Note that for Rails 5, the ActionCable client package is `actioncable`, not `@rails/actioncable`.
 
 ## Apollo 1
 
@@ -228,7 +230,7 @@ For example:
 
 ```js
 // Load ActionCable and create a consumer
-var ActionCable = require('actioncable')
+var ActionCable = require('@rails/actioncable')
 var cable = ActionCable.createConsumer()
 window.cable = cable
 


### PR DESCRIPTION
We had issues with our subscriptions after following the guide, because the back end is running Action Cable 6 but the front end was running Action Cable 5. The client package [got renamed to `@rails/actioncable`](https://github.com/rails/rails/pull/34905) in Rails 6.