### PR TITLE
Reduce interpreter overhead

### DIFF
--- a/lib/graphql/execution/interpreter/resolve.rb
+++ b/lib/graphql/execution/interpreter/resolve.rb
@@ -34,13 +34,14 @@ module GraphQL
           next_results = []
           while results.any?
             result_value = results.shift
-            if result_value.is_a?(Hash)
+            case result_value
+            when Hash
               results.concat(result_value.values)
               next
-            elsif result_value.is_a?(Array)
+            when Array
               results.concat(result_value)
               next
-            elsif result_value.is_a?(Lazy)
+            when Lazy
               loaded_value = result_value.value
               if loaded_value.is_a?(Lazy)
                 # Since this field returned another lazy,

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -136,7 +136,7 @@ describe GraphQL::Execution::Interpreter do
         base_ctx_value = context[key]
         interpreter_ctx_value = context.namespace(:interpreter)[key]
         if base_ctx_value != interpreter_ctx_value
-          raise "Context mismatch for #{key} -> #{base_ctx_value} / intepreter: #{interpreter_ctx_value}"
+          raise "Context mismatch for #{key.inspect} -> #{base_ctx_value.inspect} / intepreter: #{interpreter_ctx_value.inspect}"
         else
           base_ctx_value
         end


### PR DESCRIPTION
Trying to improve #3345 

- Remove overhead by detecting interpreter context keys at read instead of `Context#[]=` at runtime
  - If people are using these keys for other purposes, this could break -- should i take care to preserve compat here?
- refactor set_type_at_path to set_non_null_at_path, only set it when nonnull is true