### PR TITLE
Remove extra count query for hasNextPage when paginating

### DIFF
--- a/lib/graphql/pagination/relation_connection.rb
+++ b/lib/graphql/pagination/relation_connection.rb
@@ -32,7 +32,11 @@ module GraphQL
           @has_next_page = if before_offset && before_offset > 0
             true
           elsif first
-            relation_count(set_limit(sliced_nodes, first + 1)) == first + 1
+            if @nodes && @nodes.count < first
+              false
+            else
+              relation_count(set_limit(sliced_nodes, first + 1)) == first + 1
+            end
           else
             false
           end

--- a/spec/graphql/pagination/active_record_relation_connection_spec.rb
+++ b/spec/graphql/pagination/active_record_relation_connection_spec.rb
@@ -93,6 +93,22 @@ if testing_rails?
 
       log = with_active_record_log do
         results = schema.execute("{
+          items(first: 11, maxPageSizeOverride: 11) {
+            nodes {
+              __typename
+            }
+            pageInfo {
+              hasNextPage
+            }
+          }
+        }")
+      end
+      assert_equal ["Item"] * 10, results["data"]["items"]["nodes"].map { |i| i["__typename"] }
+      assert_equal 1, log.split("\n").size, "It runs only one query when less than total count is requested"
+      assert_equal 0, log.scan("COUNT(").size, "It runs no count query"
+
+      log = with_active_record_log do
+        results = schema.execute("{
           items(first: 3) {
             nodes {
               __typename
@@ -103,7 +119,6 @@ if testing_rails?
           }
         }")
       end
-
       # This currently runs one query to load the nodes, then another one to count _just beyond_ the nodes.
       # A better implementation would load `first + 1` nodes and use that to set `has_next_page`.
       assert_equal ["Item", "Item", "Item"], results["data"]["items"]["nodes"].map { |i| i["__typename"] }


### PR DESCRIPTION
This PR adds an optimization for an edge case (probably very common code path though) in pagination when querying for `hasNextPage`.

Currently, we get the value of `hasNextPage` by comparing the result of `count` query with limit `first + 1` with `first (query param) + 1`.

We can eliminate the `count` query in cases where nodes are already fetched and there's less than specified in `first` param.
