### PR TITLE
Connections: fix logic when boolean attributes are false

### DIFF
--- a/lib/graphql/types/relay/connection_behaviors.rb
+++ b/lib/graphql/types/relay/connection_behaviors.rb
@@ -79,9 +79,9 @@ module GraphQL
           # Use `node_nullable(false)` in your base class to make non-null `node` and `nodes` fields.
           def node_nullable(new_value = nil)
             if new_value.nil?
-              @node_nullable || superclass.node_nullable
+              defined?(@node_nullable) ? @node_nullable : superclass.node_nullable
             else
-              @node_nullable ||= new_value
+              @node_nullable = new_value
             end
           end
 
@@ -89,21 +89,21 @@ module GraphQL
           # Use `edges_nullable(false)` in your base class to make non-null `edges` fields.
           def edges_nullable(new_value = nil)
             if new_value.nil?
-              @edges_nullable || superclass.edges_nullable
+              defined?(@edges_nullable) ? @edges_nullable : superclass.edges_nullable
             else
-              @edges_nullable ||= new_value
+              @edges_nullable = new_value
             end
-          end     
-          
+          end
+
           # Set the default `edge_nullable` for this class and its child classes. (Defaults to `true`.)
           # Use `edge_nullable(false)` in your base class to make non-null `edge` fields.
           def edge_nullable(new_value = nil)
             if new_value.nil?
-              @edge_nullable || superclass.edge_nullable
+              defined?(@edge_nullable) ? @edge_nullable : superclass.edge_nullable
             else
-              @edge_nullable ||= new_value
+              @edge_nullable = new_value
             end
-          end               
+          end
 
           private
 

--- a/spec/graphql/types/relay/base_connection_spec.rb
+++ b/spec/graphql/types/relay/base_connection_spec.rb
@@ -15,6 +15,12 @@ describe GraphQL::Types::Relay::BaseConnection do
       edge_type(NodeEdgeType, node_nullable: false, edges_nullable: false, edge_nullable: false)
     end
 
+    class NonNullableEdgeClassOverrideConnectionType < GraphQL::Types::Relay::BaseConnection
+      edges_nullable(false)
+      edge_nullable(false)
+      node_nullable(false)
+    end
+
     class Query < GraphQL::Schema::Object
       field :connection, NonNullableNodeEdgeConnectionType, null: false
     end
@@ -37,14 +43,20 @@ describe GraphQL::Types::Relay::BaseConnection do
     connection_type = res["data"]["__schema"]["types"].find { |t| t["name"] == "NonNullableNodeEdgeConnection" }
     edges_field = connection_type["fields"].find { |f| f["name"] == "edges" }
     assert_equal "NON_NULL",edges_field["type"]["kind"]
-  end  
+  end
+
+  it "supports class-level edges_nullable config" do
+    assert_equal false, NonNullAbleNodeDummy::NonNullableEdgeClassOverrideConnectionType.edges_nullable
+    assert_equal false, NonNullAbleNodeDummy::NonNullableEdgeClassOverrideConnectionType.edge_nullable
+    assert_equal false, NonNullAbleNodeDummy::NonNullableEdgeClassOverrideConnectionType.node_nullable
+  end
 
   it "edge_nullable option is works" do
     res = NonNullAbleNodeDummy::Schema.execute(GraphQL::Introspection::INTROSPECTION_QUERY)
     connection_type = res["data"]["__schema"]["types"].find { |t| t["name"] == "NonNullableNodeEdgeConnection" }
     edges_field = connection_type["fields"].find { |f| f["name"] == "edges" }
     assert_equal "NON_NULL",edges_field["type"]["ofType"]["ofType"]["kind"]
-  end    
+  end
 
   it "never treats nodes like a connection" do
     type = Class.new(GraphQL::Schema::Object) do


### PR DESCRIPTION
Oops, these assignments and reads didn't actually work when the values were `false`, since `false` fails the `||` check.