### PR TITLE
Add option for connection class level configuration of nodes_field

### DIFF
--- a/lib/graphql/types/relay/connection_behaviors.rb
+++ b/lib/graphql/types/relay/connection_behaviors.rb
@@ -11,6 +11,7 @@ module GraphQL
           child_class.extend(ClassMethods)
           child_class.extend(Relay::DefaultRelay)
           child_class.default_relay(true)
+          child_class.nodes_field(true)
           child_class.node_nullable(true)
           child_class.edges_nullable(true)
           child_class.edge_nullable(true)
@@ -34,7 +35,7 @@ module GraphQL
           # It's called when you subclass this base connection, trying to use the
           # class name to set defaults. You can call it again in the class definition
           # to override the default (or provide a value, if the default lookup failed).
-          def edge_type(edge_type_class, edge_class: GraphQL::Relay::Edge, node_type: edge_type_class.node_type, nodes_field: true, node_nullable: self.node_nullable, edges_nullable: self.edges_nullable, edge_nullable: self.edge_nullable)
+          def edge_type(edge_type_class, edge_class: GraphQL::Relay::Edge, node_type: edge_type_class.node_type, nodes_field: self.nodes_field, node_nullable: self.node_nullable, edges_nullable: self.edges_nullable, edge_nullable: self.edge_nullable)
             # Set this connection's graphql name
             node_type_name = node_type.graphql_name
 
@@ -93,8 +94,8 @@ module GraphQL
             else
               @edges_nullable ||= new_value
             end
-          end     
-          
+          end
+
           # Set the default `edge_nullable` for this class and its child classes. (Defaults to `true`.)
           # Use `edge_nullable(false)` in your base class to make non-null `edge` fields.
           def edge_nullable(new_value = nil)
@@ -103,7 +104,17 @@ module GraphQL
             else
               @edge_nullable ||= new_value
             end
-          end               
+          end
+
+          # Set the default `nodes_field` for this class and its child classes. (Defaults to `true`.)
+          # Use `nodes_field(false)` in your base class to prevent adding of a nodes field.
+          def nodes_field(new_value = nil)
+            if new_value.nil?
+              defined?(@nodes_field) ? @nodes_field : superclass.nodes_field
+            else
+              @nodes_field = new_value
+            end
+          end
 
           private
 

--- a/lib/graphql/types/relay/connection_behaviors.rb
+++ b/lib/graphql/types/relay/connection_behaviors.rb
@@ -11,7 +11,7 @@ module GraphQL
           child_class.extend(ClassMethods)
           child_class.extend(Relay::DefaultRelay)
           child_class.default_relay(true)
-          child_class.nodes_field(true)
+          child_class.has_nodes_field(true)
           child_class.node_nullable(true)
           child_class.edges_nullable(true)
           child_class.edge_nullable(true)
@@ -35,7 +35,7 @@ module GraphQL
           # It's called when you subclass this base connection, trying to use the
           # class name to set defaults. You can call it again in the class definition
           # to override the default (or provide a value, if the default lookup failed).
-          def edge_type(edge_type_class, edge_class: GraphQL::Relay::Edge, node_type: edge_type_class.node_type, nodes_field: self.nodes_field, node_nullable: self.node_nullable, edges_nullable: self.edges_nullable, edge_nullable: self.edge_nullable)
+          def edge_type(edge_type_class, edge_class: GraphQL::Relay::Edge, node_type: edge_type_class.node_type, nodes_field: self.has_nodes_field, node_nullable: self.node_nullable, edges_nullable: self.edges_nullable, edge_nullable: self.edge_nullable)
             # Set this connection's graphql name
             node_type_name = node_type.graphql_name
 
@@ -108,9 +108,9 @@ module GraphQL
 
           # Set the default `nodes_field` for this class and its child classes. (Defaults to `true`.)
           # Use `nodes_field(false)` in your base class to prevent adding of a nodes field.
-          def nodes_field(new_value = nil)
+          def has_nodes_field(new_value = nil)
             if new_value.nil?
-              defined?(@nodes_field) ? @nodes_field : superclass.nodes_field
+              defined?(@nodes_field) ? @nodes_field : superclass.has_nodes_field
             else
               @nodes_field = new_value
             end

--- a/spec/graphql/types/relay/base_connection_spec.rb
+++ b/spec/graphql/types/relay/base_connection_spec.rb
@@ -26,7 +26,7 @@ describe GraphQL::Types::Relay::BaseConnection do
     end
 
     class NoNodesFieldClassOverrideConnectionType < GraphQL::Types::Relay::BaseConnection
-      nodes_field(false)
+      has_nodes_field(false)
     end
 
     class Schema < GraphQL::Schema
@@ -73,6 +73,6 @@ describe GraphQL::Types::Relay::BaseConnection do
   end
 
   it "supports class-level nodes_field config" do
-    assert_equal false, NonNullAbleNodeDummy::NoNodesFieldClassOverrideConnectionType.nodes_field
+    assert_equal false, NonNullAbleNodeDummy::NoNodesFieldClassOverrideConnectionType.has_nodes_field
   end
 end

--- a/spec/graphql/types/relay/base_connection_spec.rb
+++ b/spec/graphql/types/relay/base_connection_spec.rb
@@ -19,6 +19,10 @@ describe GraphQL::Types::Relay::BaseConnection do
       field :connection, NonNullableNodeEdgeConnectionType, null: false
     end
 
+    class NoNodesFieldClassOverrideConnectionType < GraphQL::Types::Relay::BaseConnection
+      nodes_field(false)
+    end
+
     class Schema < GraphQL::Schema
       query Query
     end
@@ -54,5 +58,9 @@ describe GraphQL::Types::Relay::BaseConnection do
 
     refute type.connection_type.fields["nodes"].connection?
     refute type.connection_type.fields["edges"].type.unwrap.fields["node"].connection?
+  end
+
+  it "supports class-level nodes_field config" do
+    assert_equal false, NonNullAbleNodeDummy::NoNodesFieldClassOverrideConnectionType.nodes_field
   end
 end


### PR DESCRIPTION
This adds the option to set `nodes_field(false)` in your connection classes(base classes) to make this configurable at the class level.