### PR TITLE
add class level config to allow for edge.node to be non-nullable

### DIFF
--- a/lib/graphql/types/relay/edge_behaviors.rb
+++ b/lib/graphql/types/relay/edge_behaviors.rb
@@ -8,6 +8,7 @@ module GraphQL
           child_class.description("An edge in a connection.")
           child_class.field(:cursor, String, null: false, description: "A cursor for use in pagination.")
           child_class.extend(ClassMethods)
+          child_class.node_nullable(true)
         end
 
         module ClassMethods
@@ -15,7 +16,7 @@ module GraphQL
           #
           # @param node_type [Class] A `Schema::Object` subclass
           # @param null [Boolean]
-          def node_type(node_type = nil, null: true)
+          def node_type(node_type = nil, null: self.node_nullable)
             if node_type
               @node_type = node_type
               # Add a default `node` field
@@ -34,6 +35,16 @@ module GraphQL
 
           def visible?(ctx)
             node_type.visible?(ctx)
+          end
+
+          # Set the default `node_nullable` for this class and its child classes. (Defaults to `true`.)
+          # Use `node_nullable(false)` in your base class to make non-null `node` field.
+          def node_nullable(new_value = nil)
+            if new_value.nil?
+              defined?(@node_nullable) ? @node_nullable : superclass.node_nullable
+            else
+              @node_nullable = new_value
+            end
           end
         end
       end

--- a/spec/graphql/types/relay/base_edge_spec.rb
+++ b/spec/graphql/types/relay/base_edge_spec.rb
@@ -11,6 +11,10 @@ describe GraphQL::Types::Relay::BaseEdge do
       node_type(NonNullableNode, null: false)
     end
 
+    class NonNullableNodeClassOverrideEdgeType < GraphQL::Types::Relay::BaseEdge
+      node_nullable(false)
+    end
+
     class NonNullableNodeEdgeConnectionType < GraphQL::Types::Relay::BaseConnection
       edge_type(NonNullableNodeEdgeType, nodes_field: false)
     end
@@ -31,5 +35,9 @@ describe GraphQL::Types::Relay::BaseEdge do
     node_field = edge_type["fields"].find { |f| f["name"] == "node" }
     assert_equal "NON_NULL", node_field["type"]["kind"]
     assert_equal "NonNullableNode", node_field["type"]["ofType"]["name"]
+  end
+
+  it "supports class-level node_nullable config" do
+    assert_equal false, NonNullableDummy::NonNullableNodeClassOverrideEdgeType.node_nullable
   end
 end


### PR DESCRIPTION
This adds the option to set `node_nullable(false)` in your edge classes(base edge classes) to make this configurable at the class level.