### PR TITLE
Remove suggestion to use deprecated functionality

### DIFF
--- a/guides/queries/ast_analysis.md
+++ b/guides/queries/ast_analysis.md
@@ -16,11 +16,10 @@ The primitive for analysis is {{ "GraphQL::Analysis::AST::Analyzer" | api_doc }}
 
 ### Using Analyzers
 
-Query analyzers are added to the schema with `query_analyzer`; however, to use the new analysis engine, you must opt in by using `use GraphQL::Analysis::AST`, for example:
+Query analyzers are added to the schema with `query_analyzer`, for example:
 
 ```ruby
 class MySchema < GraphQL::Schema
-  use GraphQL::Analysis::AST
   query_analyzer MyQueryAnalyzer
 end
 ```


### PR DESCRIPTION
This is now the default, it is no longer necessary to `use GraphQL::Analysis::AST` per https://github.com/rmosolgo/graphql-ruby/blob/5c3a8ec6f45319f40cb59f2ffb5961bb1071aa80/lib/graphql/analysis/ast.rb#L18