### PR TITLE
Fixes returning a RawValue as part of a list

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -277,10 +277,7 @@ module GraphQL
               end
               after_lazy(app_result, owner: owner_type, field: field_defn, path: next_path, ast_node: ast_node, scoped_context: context.scoped_context, owner_object: object, arguments: kwarg_arguments) do |inner_result|
                 continue_value = continue_value(next_path, inner_result, owner_type, field_defn, return_type.non_null?, ast_node)
-                if RawValue === continue_value
-                  # Write raw value directly to the response without resolving nested objects
-                  write_in_response(next_path, continue_value.resolve)
-                elsif HALT != continue_value
+                if HALT != continue_value
                   continue_field(next_path, continue_value, owner_type, field_defn, return_type, ast_node, next_selections, false, object, kwarg_arguments)
                 end
               end
@@ -331,6 +328,10 @@ module GraphQL
 
             continue_value(path, next_value, parent_type, field, is_non_null, ast_node)
           elsif GraphQL::Execution::Execute::SKIP == value
+            HALT
+          elsif value.is_a?(GraphQL::Execution::Interpreter::RawValue)
+            # Write raw value directly to the response without resolving nested objects
+            write_in_response(path, value.resolve)
             HALT
           else
             value

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -171,6 +171,12 @@ describe GraphQL::Execution::Interpreter do
         raw_value(sym: "RAW", name: "Raw expansion", always_cached_value: 42)
       end
 
+      field :expansion_mixed, [Expansion], null: false
+
+      def expansion_mixed
+        expansions + [expansion_raw]
+      end
+
       field :expansions, [Expansion], null: false
       def expansions
         EXPANSIONS
@@ -508,6 +514,23 @@ describe GraphQL::Execution::Interpreter do
   end
 
   describe "returning raw values" do
+    it "returns raw value" do
+      query_str = <<-GRAPHQL
+      {
+        expansionRaw {
+          name
+          sym
+          alwaysCachedValue
+        }
+      }
+      GRAPHQL
+
+      res = InterpreterTest::Schema.execute(query_str)
+      assert_equal({ sym: "RAW", name: "Raw expansion", always_cached_value: 42 }, res["data"]["expansionRaw"])
+    end
+  end
+
+  describe "returning raw values and resolved fields" do
     it "returns raw value" do
       query_str = <<-GRAPHQL
       {


### PR DESCRIPTION
Moved the `RawValue` check into `continue_value` so it returns the direct `RawValue` and `HALT`s rather than continuing down the tree.

This allows using partial fragments to return a list, like this:

```ruby
def resolver
  query = Something.where(other_thing_id: object.id, status: ['submitted', 'in-progress', 'completed'])

  query.map { |something| cache_fragment(something) }
end
```

Fixes #3402