### PR TITLE
Errors: reliably pick the most specific handler

### DIFF
--- a/lib/graphql/execution/errors.rb
+++ b/lib/graphql/execution/errors.rb
@@ -18,21 +18,83 @@ module GraphQL
     #
     class Errors
       def self.use(schema)
-        if schema.plugins.any? { |(plugin, kwargs)| plugin == self }
-          definition_line = caller(2, 1).first
-          GraphQL::Deprecation.warn("GraphQL::Execution::Errors is now installed by default, remove `use GraphQL::Execution::Errors` from #{definition_line}")
-        end
-        schema.error_handler = self.new(schema)
+        definition_line = caller(2, 1).first
+        GraphQL::Deprecation.warn("GraphQL::Execution::Errors is now installed by default, remove `use GraphQL::Execution::Errors` from #{definition_line}")
       end
+
+      NEW_HANDLER_HASH = ->(h, k) {
+        h[k] = {
+          class: k,
+          handler: nil,
+          subclass_handlers: Hash.new(&NEW_HANDLER_HASH),
+         }
+      }
 
       def initialize(schema)
         @schema = schema
+        @handlers = {
+          class: nil,
+          handler: nil,
+          subclass_handlers: Hash.new(&NEW_HANDLER_HASH),
+        }
       end
 
-      class NullErrorHandler
-        def self.with_error_handling(_ctx)
-          yield
+      # @api private
+      def each_rescue
+        handlers = @handlers.values
+        while (handler = handlers.shift) do
+          yield(handler[:class], handler[:handler])
+          handlers.concat(handler[:subclass_handlers].values)
         end
+      end
+
+      # Register this handler, updating the
+      # internal handler index to maintain least-to-most specific.
+      #
+      # @param error_class [Class<Exception>]
+      # @param error_handler [Proc]
+      # @return [void]
+      def rescue_from(error_class, error_handler)
+        subclasses_handlers = {}
+        this_level_subclasses = []
+        # During this traversal, do two things:
+        # - Identify any already-registered subclasses of this error class
+        #   and gather them up to be inserted _under_ this class
+        # - Find the point in the index where this handler should be inserted
+        #   (That is, _under_ any superclasses, or at top-level, if there are no superclasses registered)
+        handlers = @handlers[:subclass_handlers]
+        while (handlers) do
+          this_level_subclasses.clear
+          # First, identify already-loaded handlers that belong
+          # _under_ this one. (That is, they're handlers
+          # for subclasses of `error_class`.)
+          handlers.each do |err_class, handler|
+            if err_class < error_class
+              subclasses_handlers[err_class] = handler
+              this_level_subclasses << err_class
+            end
+          end
+          # Any handlers that we'll be moving, delete them from this point in the index
+          this_level_subclasses.each do |err_class|
+            handlers.delete(err_class)
+          end
+
+          # See if any keys in this hash are superclasses of this new class:
+          next_index_point = handlers.find { |err_class, handler| error_class < err_class }
+          if next_index_point
+            handlers = next_index_point[1][:subclass_handlers]
+          else
+            # this new handler doesn't belong to any sub-handlers,
+            # so insert it in the current set of `handlers`
+            break
+          end
+        end
+        # Having found the point at which to insert this handler,
+        # register it and merge any subclass handlers back in at this point.
+        this_class_handlers = handlers[error_class]
+        this_class_handlers[:handler] = error_handler
+        this_class_handlers[:subclass_handlers].merge!(subclasses_handlers)
+        nil
       end
 
       # Call the given block with the schema's configured error handlers.
@@ -44,8 +106,7 @@ module GraphQL
       def with_error_handling(ctx)
         yield
       rescue StandardError => err
-        rescues = ctx.schema.rescues
-        _err_class, handler = rescues.find { |err_class, handler| err.is_a?(err_class) }
+        handler = find_handler_for(err.class)
         if handler
           runtime_info = ctx.namespace(:interpreter) || {}
           obj = runtime_info[:current_object]
@@ -57,6 +118,43 @@ module GraphQL
           handler.call(err, obj, args, ctx, field)
         else
           raise err
+        end
+      end
+
+      # @return [Proc, nil] The handler for `error_class`, if one was registered on this schema or inherited
+      def find_handler_for(error_class)
+        handlers = @handlers[:subclass_handlers]
+        handler = nil
+        while (handlers) do
+          _err_class, next_handler = handlers.find { |err_class, handler| error_class <= err_class }
+          if next_handler
+            handlers = next_handler[:subclass_handlers]
+            handler = next_handler
+          else
+            # Don't reassign `handler` --
+            # let the previous assignment carry over outside this block.
+            break
+          end
+        end
+
+        # check for a handler from a parent class:
+        if @schema.superclass.respond_to?(:error_handler) && (parent_errors = @schema.superclass.error_handler)
+          parent_handler = parent_errors.find_handler_for(error_class)
+        end
+
+        # If the inherited handler is more specific than the one defined here,
+        # use it.
+        # If it's a tie (or there is no parent handler), use the one defined here.
+        # If there's an inherited one, but not one defined here, use the inherited one.
+        # Otherwise, there's no handler for this error, return `nil`.
+        if parent_handler && handler && parent_handler[:class] < handler[:class]
+          parent_handler[:handler]
+        elsif handler
+          handler[:handler]
+        elsif parent_handler
+          parent_handler[:handler]
+        else
+          nil
         end
       end
     end

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -46,7 +46,6 @@ describe GraphQL::Schema do
         multiplex_analyzer Object.new
         rescue_from(StandardError) { }
         use GraphQL::Backtrace
-        self.error_handler = Object.new
       end
     end
 
@@ -71,10 +70,8 @@ describe GraphQL::Schema do
       assert_equal base_schema.tracers, schema.tracers
       assert_equal base_schema.query_analyzers, schema.query_analyzers
       assert_equal base_schema.multiplex_analyzers, schema.multiplex_analyzers
-      assert_equal base_schema.rescues, schema.rescues
       assert_equal base_schema.disable_introspection_entry_points?, schema.disable_introspection_entry_points?
-      assert_equal [GraphQL::Execution::Errors, GraphQL::Pagination::Connections, GraphQL::Backtrace], schema.plugins.map(&:first)
-      assert_equal base_schema.error_handler, schema.error_handler
+      assert_equal [GraphQL::Pagination::Connections, GraphQL::Backtrace], schema.plugins.map(&:first)
     end
 
     it "can override configuration from its superclass" do
@@ -125,8 +122,6 @@ describe GraphQL::Schema do
       schema.use(GraphQL::Execution::Interpreter)
       schema.rescue_from(GraphQL::ExecutionError)
       schema.tracer(GraphQL::Tracing::NewRelicTracing)
-      error_handler = Object.new
-      schema.error_handler = error_handler
 
       assert_equal query, schema.query
       assert_equal mutation, schema.mutation
@@ -144,11 +139,9 @@ describe GraphQL::Schema do
       assert_equal schema.directives, GraphQL::Schema.default_directives.merge(DummyFeature1.graphql_name => DummyFeature1, DummyFeature2.graphql_name => DummyFeature2)
       assert_equal base_schema.query_analyzers + [query_analyzer], schema.query_analyzers
       assert_equal base_schema.multiplex_analyzers + [multiplex_analyzer], schema.multiplex_analyzers
-      assert_equal [GraphQL::Execution::Errors, GraphQL::Pagination::Connections, GraphQL::Backtrace, GraphQL::Execution::Interpreter], schema.plugins.map(&:first)
-      assert_equal [GraphQL::ExecutionError, StandardError], schema.rescues.keys.sort_by(&:name)
+      assert_equal [GraphQL::Pagination::Connections, GraphQL::Backtrace, GraphQL::Execution::Interpreter], schema.plugins.map(&:first)
       assert_equal [GraphQL::Tracing::DataDogTracing, GraphQL::Backtrace::Tracer], base_schema.tracers
       assert_equal [GraphQL::Tracing::DataDogTracing, GraphQL::Backtrace::Tracer, GraphQL::Tracing::NewRelicTracing], schema.tracers
-      assert_equal error_handler, schema.error_handler
     end
   end
 


### PR DESCRIPTION
Both the previous implementation, and, afaict, graphql-errors, use order-dependent algorithms for matching a handler to an error. So, an error subclass might match a superclass, depending on how the underlying data structures are constructed. 

This can cause incompatibilities in migrating from graphql-errors in cases where, previously, handlers were ordered to match specificity, but graphql-ruby builds the underlying structures differently (and matches them differently). This implementation makes the behavior deterministic based on class hierarchy: an error will be matched to the _most specific_ handler registered for it on a schema class (or a parent class of the schema class). 
