### PR TITLE
Update validation_errors documentation string

### DIFF
--- a/lib/graphql/query/validation_pipeline.rb
+++ b/lib/graphql/query/validation_pipeline.rb
@@ -36,7 +36,7 @@ module GraphQL
         @valid
       end
 
-      # @return [Array<GraphQL::StaticValidation::Error >] Static validation errors for the query string
+      # @return [Array<GraphQL::StaticValidation::Error, GraphQL::Query::VariableValidationError>] Static validation errors for the query string
       def validation_errors
         ensure_has_validated
         @validation_errors

--- a/lib/graphql/subscriptions/broadcast_analyzer.rb
+++ b/lib/graphql/subscriptions/broadcast_analyzer.rb
@@ -35,9 +35,6 @@ module GraphQL
           pt = @query.possible_types(current_type)
           pt.each do |object_type|
             ot_field = @query.get_field(object_type, current_field.graphql_name)
-            if !ot_field
-              binding.pry
-            end
             # Inherited fields would be exactly the same object;
             # only check fields that are overrides of the inherited one
             if ot_field && ot_field != current_field


### PR DESCRIPTION
Updates documentation to reflect `validation_errors` can include `GraphQL::Query::VariableValidationError` due to variable validation. https://github.com/rmosolgo/graphql-ruby/blob/46cae92e6e87be8adade48e5a5004843bab8c48f/lib/graphql/query/validation_pipeline.rb#L80

Additionally removes a `binding.pry` statement that I assume was not meant to be included in `master`.