### PR TITLE
Store additional details in select static validation errors

### DIFF
--- a/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb
+++ b/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb
@@ -41,7 +41,9 @@ module GraphQL
               error_options = {
                 nodes: parent,
                 type: kind_of_node,
-                argument: node.name
+                argument: node.name,
+                argument_defn: arg_defn,
+                value: node.value
               }
               if coerce_extensions
                 error_options[:coerce_extensions] = coerce_extensions

--- a/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb
+++ b/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb
@@ -41,8 +41,8 @@ module GraphQL
               error_options = {
                 nodes: parent,
                 type: kind_of_node,
-                argument: node.name,
-                argument_defn: arg_defn,
+                argument_name: node.name,
+                argument: arg_defn,
                 value: node.value
               }
               if coerce_extensions

--- a/lib/graphql/static_validation/rules/argument_literals_are_compatible_error.rb
+++ b/lib/graphql/static_validation/rules/argument_literals_are_compatible_error.rb
@@ -7,13 +7,13 @@ module GraphQL
       attr_reader :argument
       attr_reader :value
 
-      def initialize(message, path: nil, nodes: [], type:, argument: nil, extensions: nil, coerce_extensions: nil, argument_defn: nil, value: nil)
+      def initialize(message, path: nil, nodes: [], type:, argument_name: nil, extensions: nil, coerce_extensions: nil, argument: nil, value: nil)
         super(message, path: path, nodes: nodes)
         @type_name = type
-        @argument_name = argument
+        @argument_name = argument_name
         @extensions = extensions
         @coerce_extensions = coerce_extensions
-        @argument = argument_defn
+        @argument = argument
         @value = value
       end
 

--- a/lib/graphql/static_validation/rules/argument_literals_are_compatible_error.rb
+++ b/lib/graphql/static_validation/rules/argument_literals_are_compatible_error.rb
@@ -4,13 +4,17 @@ module GraphQL
     class ArgumentLiteralsAreCompatibleError < StaticValidation::Error
       attr_reader :type_name
       attr_reader :argument_name
+      attr_reader :argument
+      attr_reader :value
 
-      def initialize(message, path: nil, nodes: [], type:, argument: nil, extensions: nil, coerce_extensions: nil)
+      def initialize(message, path: nil, nodes: [], type:, argument: nil, extensions: nil, coerce_extensions: nil, argument_defn: nil, value: nil)
         super(message, path: path, nodes: nodes)
         @type_name = type
         @argument_name = argument
         @extensions = extensions
         @coerce_extensions = coerce_extensions
+        @argument = argument_defn
+        @value = value
       end
 
       # A hash representation of this Message

--- a/lib/graphql/static_validation/rules/arguments_are_defined.rb
+++ b/lib/graphql/static_validation/rules/arguments_are_defined.rb
@@ -15,8 +15,8 @@ module GraphQL
             nodes: node,
             name: error_arg_name,
             type: kind_of_node,
-            argument: node.name,
-            parent_defn: parent_defn
+            argument_name: node.name,
+            parent: parent_defn
           ))
         else
           # Some other weird error

--- a/lib/graphql/static_validation/rules/arguments_are_defined.rb
+++ b/lib/graphql/static_validation/rules/arguments_are_defined.rb
@@ -15,7 +15,8 @@ module GraphQL
             nodes: node,
             name: error_arg_name,
             type: kind_of_node,
-            argument: node.name
+            argument: node.name,
+            parent_defn: parent_defn
           ))
         else
           # Some other weird error

--- a/lib/graphql/static_validation/rules/arguments_are_defined_error.rb
+++ b/lib/graphql/static_validation/rules/arguments_are_defined_error.rb
@@ -5,12 +5,14 @@ module GraphQL
       attr_reader :name
       attr_reader :type_name
       attr_reader :argument_name
+      attr_reader :parent
 
-      def initialize(message, path: nil, nodes: [], name:, type:, argument:)
+      def initialize(message, path: nil, nodes: [], name:, type:, argument:, parent_defn:)
         super(message, path: path, nodes: nodes)
         @name = name
         @type_name = type
         @argument_name = argument
+        @parent = parent_defn
       end
 
       # A hash representation of this Message

--- a/lib/graphql/static_validation/rules/arguments_are_defined_error.rb
+++ b/lib/graphql/static_validation/rules/arguments_are_defined_error.rb
@@ -7,12 +7,12 @@ module GraphQL
       attr_reader :argument_name
       attr_reader :parent
 
-      def initialize(message, path: nil, nodes: [], name:, type:, argument:, parent_defn:)
+      def initialize(message, path: nil, nodes: [], name:, type:, argument_name:, parent:)
         super(message, path: path, nodes: nodes)
         @name = name
         @type_name = type
-        @argument_name = argument
-        @parent = parent_defn
+        @argument_name = argument_name
+        @parent = parent
       end
 
       # A hash representation of this Message


### PR DESCRIPTION
## Objective

Ability to analyze static validation errors that can be caused due to scheme member visibility. Where possible, the analysis would look at the corresponding type definitions of related schema members (argument, enum type, enum value, field, input object, interface, mutation, object, union).

Related to [#3365 - AST Analysis on invalid queries?](https://github.com/rmosolgo/graphql-ruby/issues/3365)

The following errors would be considered for this purpose:
- `GraphQL::StaticValidation::ArgumentLiteralsAreCompatibleError`
- `GraphQL::StaticValidation::ArgumentsAreDefinedError`
- `GraphQL::StaticValidation::FieldsAreDefinedOnTypeError`
- `GraphQL::StaticValidation::FragmentTypesExistError`
- `GraphQL::Query::VariableValidationError`

## Problem

A couple static validation errors do not currently contain enough information to try and locate a schema member's definition when it exists but is hidden. While processing the static validation rules, we already lookup such definitions though the warden in order to determine if an error should be raised, and we can include the definition's reference as part of error (but not sent as part of the response to a client).

#### `ArgumentsAreDefinedError`

The existing arguments do not provide enough detail to locate the specific argument's type definition (if it even exists) from among all arguments belong to directives, fields, and input objects. We have a string value of the arguments name, but not a good sense of its surroundings.

#### `ArgumentLiteralsAreCompatibleError`

Similar to `ArgumentsAreDefinedError`, we are missing enough detail to locate the specific argument's type definition. Additionally, if the argument's expected type is an unwrapped enum, we would want to try and match the provided value (currently missing) to one of the possible enum values to check its visibility.