### PR TITLE
Add example of nullable options to Types::Relay::BaseConnection

### DIFF
--- a/guides/type_definitions/extensions.md
+++ b/guides/type_definitions/extensions.md
@@ -123,6 +123,14 @@ For example, you can create a custom connection:
 
 ```ruby
 class Types::MyCustomConnection < GraphQL::Types::Relay::BaseConnection
+  # BaseConnection has these nullable configurations
+  # and the nodes field by default, but you can change
+  # these options if you want
+  edges_nullable(true)
+  edge_nullable(true)
+  node_nullable(true)
+  has_nodes_field(true)
+
   field :total_count, Integer, null: false
 
   def total_count

--- a/lib/graphql/types/relay/base_connection.rb
+++ b/lib/graphql/types/relay/base_connection.rb
@@ -24,6 +24,10 @@ module GraphQL
       #   end
       #   class Types::PostConnection < Types::BaseConnection
       #     edge_type(Types::PostEdge)
+      #     edges_nullable(true)
+      #     edge_nullable(true)
+      #     node_nullable(true)
+      #     has_nodes_field(true)
       #   end
       #
       # @see Relay::BaseEdge for edge types


### PR DESCRIPTION
Add to docs of GraphQL::Types::Relay::BaseConnection the new options to customize nullable options and presence of nodes field.