### PR TITLE
Optimize ActiveRecordRelationConnection#has_next_page

### DIFF
--- a/lib/graphql/pagination/active_record_relation_connection.rb
+++ b/lib/graphql/pagination/active_record_relation_connection.rb
@@ -5,6 +5,26 @@ module GraphQL
   module Pagination
     # Customizes `RelationConnection` to work with `ActiveRecord::Relation`s.
     class ActiveRecordRelationConnection < Pagination::RelationConnection
+      def has_next_page
+        if @has_next_page.nil?
+          @has_next_page = if before_offset && before_offset > 0
+            true
+          elsif first
+            if @nodes && @nodes.count < first
+              false
+            else
+              initial_offset = sliced_nodes.offset_value || 0
+              sliced_nodes.offset(initial_offset + first).exists?
+            end
+          else
+            false
+          end
+        end
+        @has_next_page
+      end
+
+      private
+
       def relation_count(relation)
         int_or_hash = if relation.respond_to?(:unscope)
           relation.unscope(:order).count(:all)

--- a/lib/graphql/pagination/active_record_relation_connection.rb
+++ b/lib/graphql/pagination/active_record_relation_connection.rb
@@ -5,25 +5,12 @@ module GraphQL
   module Pagination
     # Customizes `RelationConnection` to work with `ActiveRecord::Relation`s.
     class ActiveRecordRelationConnection < Pagination::RelationConnection
-      def has_next_page
-        if @has_next_page.nil?
-          @has_next_page = if before_offset && before_offset > 0
-            true
-          elsif first
-            if @nodes && @nodes.count < first
-              false
-            else
-              initial_offset = sliced_nodes.offset_value || 0
-              sliced_nodes.offset(initial_offset + first).exists?
-            end
-          else
-            false
-          end
-        end
-        @has_next_page
-      end
-
       private
+
+      def relation_larger_than(relation, size)
+        initial_offset = relation.offset_value || 0
+        relation.offset(initial_offset + size).exists?
+      end
 
       def relation_count(relation)
         int_or_hash = if relation.respond_to?(:unscope)

--- a/lib/graphql/pagination/relation_connection.rb
+++ b/lib/graphql/pagination/relation_connection.rb
@@ -35,7 +35,7 @@ module GraphQL
             if @nodes && @nodes.count < first
               false
             else
-              relation_count(set_limit(sliced_nodes, first + 1)) == first + 1
+              relation_larger_than(sliced_nodes, first)
             end
           else
             false
@@ -52,6 +52,13 @@ module GraphQL
       end
 
       private
+
+      # @param relation [Object] A database query object
+      # @param size [Integer] The value against which we check the relation size
+      # @return [Boolean] True if the number of items in this relation is larger than `size`
+      def relation_larger_than(relation, size)
+        relation_count(set_limit(relation, size + 1)) == size + 1
+      end
 
       # @param relation [Object] A database query object
       # @return [Integer, nil] The offset value, or nil if there isn't one

--- a/spec/graphql/pagination/active_record_relation_connection_spec.rb
+++ b/spec/graphql/pagination/active_record_relation_connection_spec.rb
@@ -62,7 +62,7 @@ if testing_rails?
       assert_equal true, results["data"]["items"]["pageInfo"]["hasNextPage"]
       assert_equal false, results["data"]["items"]["pageInfo"]["hasPreviousPage"]
       assert_equal 1, log.split("\n").size, "It runs only one query"
-      assert_equal 1, log.scan("SELECT 1 AS").size, "It's an exist query (#{log.inspect})"
+      assert_equal 1, log.squeeze.scan("SELECT 1 AS").size, "It's an exist query (#{log.inspect})"
 
       log = with_active_record_log do
         results = schema.execute("{

--- a/spec/graphql/pagination/active_record_relation_connection_spec.rb
+++ b/spec/graphql/pagination/active_record_relation_connection_spec.rb
@@ -62,7 +62,7 @@ if testing_rails?
       assert_equal true, results["data"]["items"]["pageInfo"]["hasNextPage"]
       assert_equal false, results["data"]["items"]["pageInfo"]["hasPreviousPage"]
       assert_equal 1, log.split("\n").size, "It runs only one query"
-      assert_equal 1, log.scan("COUNT(").size, "It's a count query (#{log.inspect})"
+      assert_equal 1, log.scan("SELECT 1 AS").size, "It's an exist query (#{log.inspect})"
 
       log = with_active_record_log do
         results = schema.execute("{


### PR DESCRIPTION
Optimizes the ActiveRecordRelationConnection#has_next_page method by using `exists?` instead of a full count statement.

Fixes #3401.