### PR TITLE
Introspection support for deprecated directive arguments

### DIFF
--- a/lib/graphql/introspection.rb
+++ b/lib/graphql/introspection.rb
@@ -17,7 +17,7 @@ query IntrospectionQuery {
       name
       description
       locations
-      args {
+      args#{include_deprecated_args ? '(includeDeprecated: true)' : ''} {
         ...InputValue
       }
     }

--- a/lib/graphql/introspection/directive_type.rb
+++ b/lib/graphql/introspection/directive_type.rb
@@ -12,13 +12,17 @@ module GraphQL
       field :name, String, null: false, method: :graphql_name
       field :description, String, null: true
       field :locations, [GraphQL::Schema::LateBoundType.new("__DirectiveLocation")], null: false
-      field :args, [GraphQL::Schema::LateBoundType.new("__InputValue")], null: false
+      field :args, [GraphQL::Schema::LateBoundType.new("__InputValue")], null: false do
+        argument :include_deprecated, Boolean, required: false, default_value: false
+      end
       field :on_operation, Boolean, null: false, deprecation_reason: "Use `locations`.", method: :on_operation?
       field :on_fragment, Boolean, null: false, deprecation_reason: "Use `locations`.", method: :on_fragment?
       field :on_field, Boolean, null: false, deprecation_reason: "Use `locations`.", method: :on_field?
 
-      def args
-        @context.warden.arguments(@object)
+      def args(include_deprecated:)
+        args = @context.warden.arguments(@object)
+        args = args.reject(&:deprecation_reason) unless include_deprecated
+        args
       end
     end
   end

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -785,6 +785,8 @@ union Union = Concrete
 
     it 'supports @deprecated' do
       schema = <<-SCHEMA
+directive @directiveWithDeprecatedArg(deprecatedArg: Boolean @deprecated(reason: "Don't use me!")) on OBJECT
+
 enum MyEnum {
   OLD_VALUE @deprecated
   OTHER_VALUE @deprecated(reason: "Terrible reasons")

--- a/spec/graphql/schema/printer_spec.rb
+++ b/spec/graphql/schema/printer_spec.rb
@@ -152,7 +152,7 @@ skipping a field. Directives provide this by describing additional information
 to the executor.
 """
 type __Directive {
-  args: [__InputValue!]!
+  args(includeDeprecated: Boolean = false): [__InputValue!]!
   description: String
   locations: [__DirectiveLocation!]!
   name: String!
@@ -857,6 +857,8 @@ directive @a(a: Letter) on ENUM_VALUE
 directive @b(b: BInput) on ENUM_VALUE
 
 directive @customDirective on FIELD_DEFINITION
+
+directive @directiveWithDeprecatedArg(deprecatedArg: Boolean @deprecated(reason: "Don't use me!")) on OBJECT
 
 directive @intDir(a: Int!) on INPUT_FIELD_DEFINITION
 


### PR DESCRIPTION
Looks like I missed support for deprecated directive arguments in #3015. 🤦  This means graphql-js generated [introspection queries](https://github.com/graphql/graphql-js/blob/main/src/utilities/getIntrospectionQuery.js) with the `inputValueDeprecation: true` option don't work against graphql-ruby servers.