### PR TITLE
Fix serialize for single key hash

### DIFF
--- a/lib/graphql/subscriptions/serialize.rb
+++ b/lib/graphql/subscriptions/serialize.rb
@@ -71,6 +71,9 @@ module GraphQL
               when OPEN_STRUCT_KEY
                 ostruct_values = load_value(value[OPEN_STRUCT_KEY])
                 OpenStruct.new(ostruct_values)
+              else
+                key = value.keys.first
+                { key => load_value(value[key]) }
               end
             else
               loaded_h = {}

--- a/spec/graphql/subscriptions/serialize_spec.rb
+++ b/spec/graphql/subscriptions/serialize_spec.rb
@@ -64,4 +64,11 @@ describe GraphQL::Subscriptions::Serialize do
     reloaded = serialize_load(serialized)
     assert_equal os, reloaded, "It reloads #{os.inspect} from #{serialized.inspect}"
   end
+
+  it "can deserialize single key hash" do
+    os = { 'a' => 1 }
+    serialized = os.to_json
+    reloaded = serialize_load(serialized)
+    assert_equal os, reloaded
+  end
 end


### PR DESCRIPTION
This fixes #3425. 

Not sure about the tests. In order to create the error condition, we must not use `serialize_dump`, as this appends additional keys, so I just use `to_json` instead :shrug: 