### PR TITLE
Fix find_handler_for method

### DIFF
--- a/lib/graphql/execution/errors.rb
+++ b/lib/graphql/execution/errors.rb
@@ -115,7 +115,7 @@ module GraphQL
           if obj.is_a?(GraphQL::Schema::Object)
             obj = obj.object
           end
-          handler.call(err, obj, args, ctx, field)
+          handler[:handler].call(err, obj, args, ctx, field)
         else
           raise err
         end
@@ -148,11 +148,11 @@ module GraphQL
         # If there's an inherited one, but not one defined here, use the inherited one.
         # Otherwise, there's no handler for this error, return `nil`.
         if parent_handler && handler && parent_handler[:class] < handler[:class]
-          parent_handler[:handler]
+          parent_handler
         elsif handler
-          handler[:handler]
+          handler
         elsif parent_handler
-          parent_handler[:handler]
+          parent_handler
         else
           nil
         end


### PR DESCRIPTION
parent_handler will be assigned the result of find_handler_for method.
https://github.com/rmosolgo/graphql-ruby/blob/ba3a0ceb7b61182270406fb61e98621afadb30ba/lib/graphql/execution/errors.rb#L142


Since the parent_handler expects a hash object with :handler and :class as keys, find_handler_for method must maintain that interface
https://github.com/rmosolgo/graphql-ruby/blob/ba3a0ceb7b61182270406fb61e98621afadb30ba/lib/graphql/execution/errors.rb#L150