### PR TITLE
Fix when field max_page_size override is nil

### DIFF
--- a/lib/graphql/pagination/connections.rb
+++ b/lib/graphql/pagination/connections.rb
@@ -79,7 +79,7 @@ module GraphQL
           context: context,
           parent: parent,
           field: field,
-          max_page_size: field.max_page_size || context.schema.default_max_page_size,
+          max_page_size: field.has_max_page_size? ? field.max_page_size : context.schema.default_max_page_size,
           first: arguments[:first],
           after: arguments[:after],
           last: arguments[:last],

--- a/spec/graphql/pagination/connections_spec.rb
+++ b/spec/graphql/pagination/connections_spec.rb
@@ -35,7 +35,7 @@ describe GraphQL::Pagination::Connections do
   end
 
   it "returns connections by class, using inherited mappings and local overrides" do
-    field_defn = OpenStruct.new(max_page_size: 10, type: GraphQL::Types::Relay::BaseConnection)
+    field_defn = OpenStruct.new(has_max_page_size?: true, max_page_size: 10, type: GraphQL::Types::Relay::BaseConnection)
 
     set_wrapper = schema.connections.wrap(field_defn, nil, Set.new([1,2,3]), {}, nil)
     assert_instance_of SetConnection, set_wrapper
@@ -114,10 +114,43 @@ describe GraphQL::Pagination::Connections do
 
   it "lets unrelated NoMethodErrors bubble up" do
     err = assert_raises NoMethodError do
-      pp ConnectionErrorTestSchema.execute("{ things2 { name } }")
+      ConnectionErrorTestSchema.execute("{ things2 { name } }")
     end
 
     assert_includes err.message, "undefined method `no_such_method' for <BadThing!>"
+  end
+
+  it "uses a field's `max_page_size: nil` configuration" do
+    user_type = Class.new(GraphQL::Schema::Object) do
+      graphql_name 'User'
+      field :name, String, null: false
+    end
+
+    query_type = Class.new(GraphQL::Schema::Object) do
+      graphql_name 'Query'
+      field :users, user_type.connection_type, null: true, max_page_size: nil
+      def users
+        [{ name: 'Yoda' }, { name: 'Anakin' }, { name: 'Obi Wan' }]
+      end
+    end
+
+    schema = Class.new(GraphQL::Schema) do
+      # This value should be overriden by `max_page_size: nil` in the field definition above
+      default_max_page_size 2
+      query(query_type)
+    end
+
+    res = schema.execute(<<~GRAPHQL).to_h
+      {
+        users {
+          nodes {
+            name
+          }
+        }
+      }
+    GRAPHQL
+
+    assert_equal ["Yoda", "Anakin", "Obi Wan"], res['data']['users']['nodes'].map { |node| node['name'] }
   end
 
   class SingleNewConnectionSchema < GraphQL::Schema

--- a/spec/graphql/pagination/connections_spec.rb
+++ b/spec/graphql/pagination/connections_spec.rb
@@ -140,7 +140,7 @@ describe GraphQL::Pagination::Connections do
       query(query_type)
     end
 
-    res = schema.execute(<<~GRAPHQL).to_h
+    res = schema.execute(<<-GRAPHQL).to_h
       {
         users {
           nodes {


### PR DESCRIPTION
Fixes https://github.com/rmosolgo/graphql-ruby/issues/2840

Derp, `x || y` is not going to work when you _want_ `x`'s value of `nil` 🤦 