### PR TITLE
Documentation: Change `allow_nil` to the correct `allow_null`

### DIFF
--- a/guides/fields/validation.md
+++ b/guides/fields/validation.md
@@ -37,7 +37,7 @@ Validations can be provided with a keyword (`validates: { ... }`) or with a meth
 All the validators below accept the following options:
 
 - `allow_blank: true` will permit any input that responds to `.blank?` and returns true for it.
-- `allow_nil: true` will permit `nil` (bypassing the validation)
+- `allow_null: true` will permit `null` (from JS) and/or `nil` (from Ruby) (bypassing the validation)
 - `message: "..."` customizes the error message when the validation fails
 
 For example:


### PR DESCRIPTION
According to the docs (in section "Constructor Details"), `allow_null` is the name of the option accepted by all validators not `allow_nil`

(docs: https://graphql-ruby.org/api-doc/1.12.8/GraphQL/Schema/Validator.html)