### PR TITLE
Subscriptions broadcast: only call deserialization once

### DIFF
--- a/lib/graphql/subscriptions/action_cable_subscriptions.rb
+++ b/lib/graphql/subscriptions/action_cable_subscriptions.rb
@@ -96,7 +96,6 @@ module GraphQL
         @action_cable_coder = action_cable_coder
         @serializer = serializer
         @transmit_ns = namespace
-        @decoded_messages = {}
         super
       end
 
@@ -148,13 +147,14 @@ module GraphQL
         topic = initial_event.topic
         channel.stream_from(stream_event_name(initial_event), coder: @action_cable_coder) do |message|
           events_by_fingerprint = @events[topic]
+          object = nil
           events_by_fingerprint.each do |_fingerprint, events|
             if events.any? && events.first == initial_event
               # The fingerprint has told us that this response should be shared by all subscribers,
               # so just run it once, then deliver the result to every subscriber
               first_event = events.first
               first_subscription_id = first_event.context.fetch(:subscription_id)
-              object = decode_message(message)
+              object ||= @serializer.load(message)
               result = execute_update(first_subscription_id, first_event, object)
               # Having calculated the result _once_, send the same payload to all subscribers
               events.each do |event|
@@ -211,11 +211,6 @@ module GraphQL
 
       def stream_event_name(event)
         [EVENT_PREFIX, @transmit_ns, event.topic].join
-      end
-
-      # cache message in case the same message is sent to events with different fingerprints
-      def decode_message(message)
-        @decoded_messages[message] ||= @serializer.load(message)
       end
     end
   end


### PR DESCRIPTION
Fixes #3426

- Call `@serializer.load` only for the `initial_event` for the broadcastable subscriptions
- For non-broadcastable subscriptions cache serialization based on the message, so the same message is only serialized once.
