### PR TITLE
Skip checking @mutation during authorization

### DIFF
--- a/lib/graphql/schema/member/base_dsl_methods.rb
+++ b/lib/graphql/schema/member/base_dsl_methods.rb
@@ -113,27 +113,15 @@ module GraphQL
         end
 
         def visible?(context)
-          if @mutation
-            @mutation.visible?(context)
-          else
-            true
-          end
+          true
         end
 
         def accessible?(context)
-          if @mutation
-            @mutation.accessible?(context)
-          else
-            true
-          end
+          true
         end
 
         def authorized?(object, context)
-          if @mutation
-            @mutation.authorized?(object, context)
-          else
-            true
-          end
+          true
         end
       end
     end


### PR DESCRIPTION
This ivar is assigned to payload types and input types that are generated for mutations. I don't think this check is useful because the mutation should be running its own authorization at runtime. (And evidently, it's not tested.) I can't think of any case this would be useful for!

(I noticed this while profiling #3429 and thought it could probably be simplified without any downside.)