### PR TITLE
Skip extras[:irep_node] in the interpreter

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -246,11 +246,17 @@ module GraphQL
                   # Use this flag to tell Interpreter::Arguments to add itself
                   # to the keyword args hash _before_ freezing everything.
                   extra_args[:argument_details] = :__arguments_add_self
+                when :irep_node
+                  # This is used by `__typename` in order to support the legacy runtime,
+                  # but it has no use here (and it's always `nil`).
+                  # Stop adding it here to avoid the overhead of `.merge_extras` below.
                 else
                   extra_args[extra] = field_defn.fetch_extra(extra, context)
                 end
               end
-              resolved_arguments = resolved_arguments.merge_extras(extra_args)
+              if extra_args.any?
+                resolved_arguments = resolved_arguments.merge_extras(extra_args)
+              end
               resolved_arguments.keyword_arguments
             end
 


### PR DESCRIPTION
I noticed this overhead while profiling #3429 , that `__typename` would call `.merge_extras`, even though it didn't _use_ extras. We can reduce this overhead. It's possible that this would "break" code for people whose resolvers _require_ `irep_node: nil` to be passed because they use `extras [:irep_node]` even though they use the new runtime. There are two options here: 

- Remove that extra, since it's meaningless in this context 
- Provide a default value in the method that expects it (eg `def resolve(irep_node: nil)`), so that Ruby doesn't :boom: when it isn't provided. 



<details>
<summary> <b>Before</b> benchmark</summary>
<p>

```
~/code/graphql-ruby % stackprof stackprof.out
==================================
  Mode: cpu(10)
  Samples: 97 (0.00% miss rate)
  GC: 1 (1.03%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
        89  (91.8%)          19  (19.6%)     GraphQL::Tracing::Traceable#trace
        10  (10.3%)          10  (10.3%)     GraphQL::Execution::Interpreter::Arguments#initialize
        18  (18.6%)           8   (8.2%)     GraphQL::Execution::Interpreter::Arguments#merge_extras
        61  (62.9%)           5   (5.2%)     GraphQL::Execution::Interpreter::Runtime#evaluate_selection
         4   (4.1%)           4   (4.1%)     GraphQL::Schema::Member::CachedGraphQLDefinition#initialize_copy
         3   (3.1%)           3   (3.1%)     GraphQL::StaticValidation::RequiredArgumentsArePresent#assert_required_args
         3   (3.1%)           3   (3.1%)     GraphQL::Schema.connections
         3   (3.1%)           3   (3.1%)     GraphQL::Execution::Interpreter::HashResponse#write
         3   (3.1%)           3   (3.1%)     GraphQL::Query#initialize
        93  (95.9%)           3   (3.1%)     CustomTracing#platform_trace
         2   (2.1%)           2   (2.1%)     String#unpack
         2   (2.1%)           2   (2.1%)     GraphQL::Language::Parser#next_token
         2   (2.1%)           2   (2.1%)     GraphQL::InvalidNullError.subclass_for
        59  (60.8%)           2   (2.1%)     GraphQL::Execution::Interpreter::Runtime#evaluate_selection_with_args
         2   (2.1%)           2   (2.1%)     GraphQL::Query::Context#[]=
         2   (2.1%)           2   (2.1%)     GraphQL::Execution::Interpreter::Resolve.resolve
         1   (1.0%)           1   (1.0%)     GraphQL::StaticValidation::DefinitionDependencies#dependency_map
         1   (1.0%)           1   (1.0%)     GraphQL::Language::Nodes::OperationDefinition#initialize_node
         1   (1.0%)           1   (1.0%)     GraphQL::Pagination::Connections#all_wrappers
         2   (2.1%)           1   (1.0%)     GraphQL::StaticValidation::FragmentSpreadsArePossible#initialize
         1   (1.0%)           1   (1.0%)     GraphQL::Schema::Member::BaseDSLMethods#introspection
         3   (3.1%)           1   (1.0%)     GraphQL::Schema::Field#type
         1   (1.0%)           1   (1.0%)     GraphQL::Pagination::Connection#first
         1   (1.0%)           1   (1.0%)     GraphQL::Language::Nodes::Field#children
         1   (1.0%)           1   (1.0%)     GraphQL::NonNullType#initialize
         1   (1.0%)           1   (1.0%)     (sweeping)
         1   (1.0%)           1   (1.0%)     GraphQL::Schema::Object.own_interface_type_memberships
         1   (1.0%)           1   (1.0%)     GraphQL::StaticValidation::VariableUsagesAreAllowed#initialize
         1   (1.0%)           1   (1.0%)     GraphQL::Schema.query
         1   (1.0%)           1   (1.0%)     GraphQL::Language::Parser#_reduce_33
```

</p>
</details>

<details>
<summary> <b>After</b> benchmark </summary>

<p>

```
~/code/graphql-ruby % stackprof stackprof.out
==================================
  Mode: cpu(10)
  Samples: 84 (2.33% miss rate)
  GC: 0 (0.00%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
        79  (94.0%)          22  (26.2%)     GraphQL::Tracing::Traceable#trace
         6   (7.1%)           6   (7.1%)     GraphQL::Schema::Member::CachedGraphQLDefinition#initialize_copy
        47  (56.0%)           5   (6.0%)     GraphQL::Execution::Interpreter::Runtime#evaluate_selection
         4   (4.8%)           4   (4.8%)     GraphQL::Execution::Interpreter::Runtime#gather_selections
         3   (3.6%)           3   (3.6%)     GraphQL::Query::Context#[]=
         3   (3.6%)           3   (3.6%)     GraphQL::Pagination::Connection#initialize
        82  (97.6%)           3   (3.6%)     CustomTracing#platform_trace
         3   (3.6%)           3   (3.6%)     GraphQL::Schema::Warden#visible?
         3   (3.6%)           3   (3.6%)     GraphQL::Schema::Member::HasFields#get_field
         2   (2.4%)           2   (2.4%)     GraphQL::Language::Parser#next_token
         5   (6.0%)           2   (2.4%)     GraphQL::Schema::Warden#read_through
         2   (2.4%)           2   (2.4%)     GraphQL::Schema::Object.inherited
         2   (2.4%)           2   (2.4%)     GraphQL::Schema.query
         2   (2.4%)           2   (2.4%)     GraphQL::StaticValidation::ValidationContext#schema
         1   (1.2%)           1   (1.2%)     GraphQL::Query::Context#initialize
         1   (1.2%)           1   (1.2%)     GraphQL::Schema::FindInheritedValue#find_inherited_value
         1   (1.2%)           1   (1.2%)     String#unpack
         1   (1.2%)           1   (1.2%)     GraphQL::Language::Token#initialize
         1   (1.2%)           1   (1.2%)     Array#pack
         2   (2.4%)           1   (1.2%)     GraphQL::Language::Parser#make_node
         1   (1.2%)           1   (1.2%)     GraphQL::Language::Nodes::Field#initialize_node
         3   (3.6%)           1   (1.2%)     GraphQL::StaticValidation::VariablesAreUsedAndDefined#initialize
         1   (1.2%)           1   (1.2%)     GraphQL::StaticValidation::BaseVisitor::ContextMethods#type_definition
        10  (11.9%)           1   (1.2%)     GraphQL::Schema::IntrospectionSystem#initialize
         1   (1.2%)           1   (1.2%)     GraphQL::Schema::Enum.inherited
         1   (1.2%)           1   (1.2%)     GraphQL::NonNullType#initialize
         3   (3.6%)           1   (1.2%)     GraphQL::Schema::Field#type
         1   (1.2%)           1   (1.2%)     GraphQL::ListType#initialize
         1   (1.2%)           1   (1.2%)     GraphQL::Language::Nodes::Field#children
         1   (1.2%)           1   (1.2%)     GraphQL::Tracing::PlatformTracing#cached_platform_key
```

</p>
</details>