### PR TITLE
Make it so you can opt out of object authorization

### DIFF
--- a/spec/graphql/authorization_spec.rb
+++ b/spec/graphql/authorization_spec.rb
@@ -950,4 +950,54 @@ describe GraphQL::Authorization do
       refute res.key?("errors")
     end
   end
+
+  describe "overriding authorized_new" do
+    class AuthorizedNewOverrideSchema < GraphQL::Schema
+      class LogTracer
+        def trace(key, data)
+          if (c = data[:context]) || ((q = data[:query]) && (c = q.context))
+            c[:log] << key
+          end
+          yield
+        end
+      end
+
+      module CustomIntrospection
+        class DynamicFields < GraphQL::Introspection::DynamicFields
+          def self.authorized_new(obj, ctx)
+            new(obj, ctx)
+          end
+        end
+      end
+
+      class Query < GraphQL::Schema::Object
+        def self.authorized_new(obj, ctx)
+          new(obj, ctx)
+        end
+        field :int, Integer, null: false
+        def int; 1; end
+      end
+
+      query(Query)
+      introspection(CustomIntrospection)
+      tracer(LogTracer.new)
+    end
+
+    it "avoids calls to Object.authorized?" do
+      log = []
+      res = AuthorizedNewOverrideSchema.execute("{ __typename int }", context: { log: log })
+      assert_equal "Query", res["data"]["__typename"]
+      assert_equal 1, res["data"]["int"]
+      expected_log = [
+        "validate",
+        "analyze_query",
+        "execute_query",
+        "execute_field",
+        "execute_field",
+        "execute_query_lazy"
+      ]
+
+      assert_equal expected_log, log
+    end
+  end
 end


### PR DESCRIPTION
Fixes #3429 

I can't say I _recommend_ it, but if it's really adding up, this makes it possible (and tested) to override `Schema::Object.authorized_new` and bypass authorization. 

I also investigated an _option_ for disabling built-in authorization at runtime, but I found it put too much complexity in the code (https://github.com/rmosolgo/graphql-ruby/compare/skip-built-in-auth). 


Instead, this approach consolidates tracing and logic in `.authorized_new`, then tests to confirm that it can be overridden (including for `DynamicFields`, which implements `__typename`).

So, with this PR, you could opt out by adding: 

```ruby 
class Types::BaseObject 
  # Normally, GraphQL-Ruby calls `.authorized?` before initializing this, 
  # but we want to bypass that 
  def self.authorized_new(obj, ctx)
    new(obj, ctx)
  end 
end 
```

and 

```ruby 
class MySchema < GraphQL::Schema
  # Add a custom introspection module which will avoid `.authorized?` checks 
  # for __typename and __type(name: ...) fields
  module Introspection 
     class DynamicFields < GraphQL::Introspection::DynamicFields 
       def self.authorized_new(obj, ctx)
         new(obj, ctx)
       end 
     end 
   end 
   
   introspection(Introspection)
   
   # ... 
 end 
 ```