### PR TITLE
Update schema testing documentation

### DIFF
--- a/guides/testing/schema_structure.md
+++ b/guides/testing/schema_structure.md
@@ -43,10 +43,7 @@ namespace :graphql do
         puts '⏳  Validating queries...'
         puts "\n"
 
-        validator = GraphQL::StaticValidation::Validator.new(schema: schema)
-        results = queries
-                    .map { |query| query = GraphQL::Query.new(schema, query) }
-                    .map { |query| validator.validate(query) }
+        results = queries.map { |query| schema.validate(query) }
         errors = results
                    .select { |result| result[:errors].present? }
                    .map { |result| result[:errors] }

--- a/guides/testing/schema_structure.md
+++ b/guides/testing/schema_structure.md
@@ -32,7 +32,7 @@ namespace :graphql do
   namespace :queries do
     desc 'Validates GraphQL queries against the current schema'
     task validate: [:environment] do
-      queries_file = 'test/fixtures/files/queries.json
+      queries_file = 'test/fixtures/files/queries.json'
       queries = Oj.load(File.read(queries_file))
 
       Validate.run_validate(queries, MySchema)

--- a/guides/testing/schema_structure.md
+++ b/guides/testing/schema_structure.md
@@ -25,4 +25,50 @@ You can read about this approach in ["Tracking Schema Changes with GraphQL-Ruby"
 
 ## Automatically check for breaking changes
 
-You can use [GraphQL::SchemaComparator](https://github.com/xuorig/graphql-schema_comparator) to check for breaking changes during development or CI.
+You can use [GraphQL::SchemaComparator](https://github.com/xuorig/graphql-schema_comparator) to check for breaking changes during development or CI. If you maintain a dump of queries that typically run against your server, you may also utilize `GraphQL::StaticValidation` to validate these queries directly. A Rake task such as the one below can be used to identify changes that are incompatible with existing queries.
+
+```ruby
+namespace :graphql do
+  namespace :queries do
+    desc 'Validates GraphQL queries against the current schema'
+    task validate: [:environment] do
+      queries_file = 'test/fixtures/files/queries.json
+      queries = Oj.load(File.read(queries_file))
+
+      Validate.run_validate(queries, MySchema)
+    end
+
+    module Validate
+      def self.run_validate(queries, schema)
+        puts '⏳  Validating queries...'
+        puts "\n"
+
+        validator = GraphQL::StaticValidation::Validator.new(schema: schema)
+        results = queries
+                    .map { |query| query = GraphQL::Query.new(schema, query) }
+                    .map { |query| validator.validate(query) }
+        errors = results
+                   .select { |result| result[:errors].present? }
+                   .map { |result| result[:errors] }
+                   .flatten
+
+        if errors.empty?
+          puts '✅  All queries are valid'
+        else
+          print_errors(errors)
+        end
+      end
+
+      def self.print_errors(errors)
+        puts 'Detected the following errors:'
+        puts "\n"
+
+        errors.each do |error|
+          path = error.path.join(', ')
+          puts "❌  #{path}: #{error.message}"
+        end
+      end
+    end
+  end
+end
+```

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -1293,6 +1293,13 @@ module GraphQL
         end
       end
 
+      def validate(query)
+        validator = GraphQL::StaticValidation::Validator.new(schema: self)
+        query = GraphQL::Query.new(self, query)
+        result = validator.validate(query, timeout: validate_timeout)
+        result[:errors]
+      end
+
       attr_writer :max_complexity
 
       def max_complexity(max_complexity = nil)

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -358,4 +358,26 @@ describe GraphQL::Schema do
       assert_equal expected_message, err.message
     end
   end
+
+  describe 'validate' do
+    let(:schema) { Dummy::Schema}
+
+    describe 'validate' do
+      it 'validates valid query ' do
+        query = "query sample { root }"
+
+        errors = schema.validate(query)
+
+        assert_empty errors
+      end
+
+      it 'validates invalid query ' do
+        query = "query sample { invalid }"
+
+        errors = schema.validate(query)
+
+        assert_equal(1, errors.size)
+      end
+    end
+  end
 end


### PR DESCRIPTION
For products where the GraphQL server serves one specific frontend, query dumps that list queries that are typically executed can be helpful. `GraphQL::SchemaComparator` lists changes that are breaking in theory, but using `StaticValidation` and aforementioned query dumps, we can get certainty when it comes to which fields can safely be changed or removed.

This PR updates the existing schema structure testing documentation to describe a simple Rake task that can be used to validate queries directly against a Schema. 

What do you think?