### PR TITLE
Fix test with invalid default value

### DIFF
--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -487,7 +487,7 @@ describe GraphQL::Schema::InputObject do
 
     it "works with empty objects" do
       res = Jazz::Schema.execute("{ defaultValueTest2 }")
-      assert_equal "Jazz::InspectableInput -> {}", res["data"]["defaultValueTest2"]
+      assert_equal "Jazz::FullyOptionalInput -> {}", res["data"]["defaultValueTest2"]
     end
 
     it "introspects in GraphQL language with enums" do

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -335,6 +335,10 @@ module Jazz
     argument :int_value, Int, required: true
   end
 
+  class FullyOptionalInput < GraphQL::Schema::InputObject
+    argument :optional_value, String, required: false
+  end
+
   class InspectableInput < GraphQL::Schema::InputObject
     argument :ensemble_id, ID, required: false, loads: Ensemble
     argument :string_value, String, required: true, description: "Test description kwarg"
@@ -547,7 +551,7 @@ module Jazz
     end
 
     field :default_value_test_2, String, null: false, resolver_method: :default_value_test do
-      argument :arg_with_default, InspectableInput, required: false, default_value: {}
+      argument :arg_with_default, FullyOptionalInput, required: false, default_value: {}
     end
 
     field :complex_hash_key, String, null: false, hash_key: :'foo bar/fizz-buzz'


### PR DESCRIPTION
`InspectableInput` has a required argument, so this test was technically
invalid. I discovered this while trying to add validation for default
values. Replace it with a new fully optional input type in this test.

Extracted as the first stand-alone mergeable piece of #3448.

@rmosolgo 