### PR TITLE
Support duck typing in type definitions

### DIFF
--- a/lib/graphql/schema/member/build_type.rb
+++ b/lib/graphql/schema/member/build_type.rb
@@ -82,6 +82,11 @@ module GraphQL
             parse_type(type_expr.call, null: true)
           when false
             raise ArgumentError, "Received `false` instead of a type, maybe a `!` should be replaced with `null: true` (for fields) or `required: true` (for arguments)"
+          else
+            # Perhaps it's a non-module object that still defines a GraphQL definition.
+            if type_expr.respond_to?(:graphql_definition)
+              type_expr
+            end
           end
 
           if return_type.nil?

--- a/spec/graphql/schema/member/build_type_spec.rb
+++ b/spec/graphql/schema/member/build_type_spec.rb
@@ -27,6 +27,10 @@ describe GraphQL::Schema::Member::BuildType do
       assert_equal Jazz::BaseObject, GraphQL::Schema::Member::BuildType.parse_type(Jazz::BaseObject, null: true)
     end
 
+    it "resolves an object type from a dynamically defined scalar" do
+      assert_equal Jazz::Key["A"], GraphQL::Schema::Member::BuildType.parse_type(Jazz::Key["A"], null: true)
+    end
+
     it "resolves an object type from a string" do
       assert_equal Jazz::BaseObject, GraphQL::Schema::Member::BuildType.parse_type("Jazz::BaseObject", null: true)
     end

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -293,6 +293,23 @@ module Jazz
     def self.coerce_result(val, ctx)
       val.to_notation
     end
+
+    def self.[](required_root)
+      KeyWithRootRequirement.new(required_root)
+    end
+  end
+
+  class KeyWithRootRequirement < Struct.new(:required_root)
+    def coerse_input(val, ctx)
+      key = Key.coerse_input(val, ctx)
+      return nil unless key.root == required_root
+      key
+    end
+
+    def self.coerce_result(val, ctx)
+      return nil unless val.root == required_root
+      Key.coerce_result(val, ctx)
+    end
   end
 
   class Musician < BaseObject


### PR DESCRIPTION
# Motivation

I ran into a scenario where I want to be able to write this:

```ruby
argument :foo_id, Types::GID["Foo"]
```

`Types::GID` is a custom Scalar we've defined that parses a String into a Global Id ([`URI::GID`](https://github.com/rails/globalid). We want to enforce that it had a specific `model_name`. That is, `gid://App/Foo/123` would be accepted, but not `gid://App/Bar/123`.

We used the `[]` operator on `Types::GID` to return a new Scalar type that defines a specialized `coerce_input` which perform the validation. Using the current API, we were forced to use a dynamically defined class.

<details><summary>Example using dynamically-defined Scalar sub-classes</summary>

```ruby
class GID < BaseScalar
  graphql_name "GID"
  description "A Global ID for a model."

  @class_cache = {}
  class << self
    # Returns a new Scalar class that requires GIDs with a specific model_name.
    # @param [String] expected_model_name
    # @return [Class]
    def [](expected_model_name)
      @class_cache[expected_model_name.to_sym] ||= begin
        name = "#{GID.name.demodulize}_#{expected_model_name}"

        klass = Class.new(self) do
          @expected_model_name = expected_model_name

          # @param [String, Integer] value The input value to parse into a GID
          # @return [URI::GID, nil]
          def self.coerce_input(value, _)
            GIDParser.parse(value, expected_model_name: @expected_model_name)
          rescue GIDParser::UnexpectedModelName
            raise GraphQL::CoercionError, "Expected a GID with the model_name '#{@expected_model_name}'"
          rescue ArgumentError
            handle_coercion_error(value)
          end
        end

        GID.const_set(name, klass) # This sets the klass' name.

        klass.graphql_name(name)
        klass.description(<<~DESC)
          A Global ID for a #{expected_model_name} model. E.g. gid://AppName/#{expected_model_name}/123
        DESC

        klass
      end
    end

    # @param [String, Integer] value The input value to parse into a URI::GID
    # @return [URI::GID, nil]
    def coerce_input(value, _)
      GIDParser.parse(value, expected_model_name: @expected_model_name)
    rescue ArgumentError
      handle_coercion_error(value)
    end

    # @param [String, URI::GID] value the value to coerce into a result
    # @return [String]
    def coerce_result(value, _)
      case value
      when String then value
      when URI::GID then value.encode
      else raise ArgumentError
      end
    rescue ArgumentError
      handle_coercion_error(value)
    end

    def handle_coercion_error(value)
      raise GraphQL::CoercionError, "invalid GID '#{value}'"
    end
  end
end
```

</details>

We would have preferred to use a decorator pattern, which would require less meta-programming magic. But this wasn't possible, because the current library implementation requires the type to be a `Module`. This isn't a `Module`, but it responds to the same methods, so it seems reasonable that it should still be accepted.

<details><summary>Desired decorator-based approach</summary>

```ruby
# frozen_string_literal: true

class GID < BaseScalar
  graphql_name "GID"
  description "A Global ID for a model."

  class GIDWithModelRequirement < Struct.new(:expected_model_name)
    # @param [String, Integer] value The input value to parse into a GID
    # @return [URI::GID, nil]
    def coerce_input(value, _)
      GIDParser.parse(value, expected_model_name: @expected_model_name)
    rescue GIDParser::UnexpectedModelName
      raise GraphQL::CoercionError, "Expected a GID with the model_name '#{@expected_model_name}'"
    rescue ArgumentError
      handle_coercion_error(value)
    end
  end

  class << self
    # Returns a new Scalar class that requires GIDs with a specific model_name.
    # @param [String] expected_model_name
    # @return [Class]
    def [](expected_model_name)
      # TODO: figure out how to set graphql_name and description
      GIDWithModelRequirement.new(expected_model_name)
    end

    # @param [String, Integer] value The input value to parse into a URI::GID
    # @return [URI::GID, nil]
    def coerce_input(value, _)
      GIDParser.parse(value, expected_model_name: @expected_model_name)
    rescue ArgumentError
      handle_coercion_error(value)
    end

    # @param [String, URI::GID] value the value to coerce into a result
    # @return [String]
    def coerce_result(value, _)
      case value
      when String then value
      when URI::GID then value.encode
      else raise ArgumentError
      end
    rescue ArgumentError
      handle_coercion_error(value)
    end

    def handle_coercion_error(value)
      raise GraphQL::CoercionError, "invalid GID '#{value}'"
    end
  end
end
```

</details>

# Proposed solution

Accept a `type_expr`  of any type, so long as it respond to `graphql_definition`.