### PR TITLE
Fix introspection of default input objects

### DIFF
--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -226,8 +226,8 @@ module GraphQL
         # It's funny to think of a _result_ of an input object.
         # This is used for rendering the default value in introspection responses.
         def coerce_result(value, ctx)
-          # Allow the application to provide values as :symbols, and convert them to the strings
-          value = value.reduce({}) { |memo, (k, v)| memo[k.to_s] = v; memo }
+          # Allow the application to provide values as :snake_symbols, and convert them to the camelStrings
+          value = value.reduce({}) { |memo, (k, v)| memo[Member::BuildType.camelize(k.to_s)] = v; memo }
 
           result = {}
 

--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -493,18 +493,18 @@ describe GraphQL::Schema::InputObject do
     it "introspects in GraphQL language with enums" do
       class InputDefaultSchema < GraphQL::Schema
         class Letter < GraphQL::Schema::Enum
-          value "A"
-          value "B"
+          value "A", value: 1
+          value "B", value: 2
         end
 
         class InputObj < GraphQL::Schema::InputObject
-          argument :a, Letter, required: false
-          argument :b, Letter, required: false
+          argument :arg_a, Letter, required: false
+          argument :arg_b, Letter, required: false
         end
 
         class Query < GraphQL::Schema::Object
           field :i, Int, null: true do
-            argument :arg, InputObj, required: false, default_value: { a: "A", b: "B" }
+            argument :arg, InputObj, required: false, default_value: { arg_a: 1, arg_b: 2 }
           end
         end
 
@@ -524,7 +524,7 @@ describe GraphQL::Schema::InputObject do
         }
       }
       "
-      assert_equal "{a: A, b: B}", res["data"]["__type"]["fields"].first["args"].first["defaultValue"]
+      assert_equal "{argA: A, argB: B}", res["data"]["__type"]["fields"].first["args"].first["defaultValue"]
     end
   end
 


### PR DESCRIPTION
It seems that the intent was to allow default input object values to be
specified in snake_case, but we weren't camelCasing them on output which
was leading to issues (in introspection and also schema printing).

See e.g. `string_value` which is actually the default for an argument `stringValue` (because graphql-ruby automatically camelCases argument names at _definition time_), in
https://github.com/rmosolgo/graphql-ruby/blob/173ad1babed18d18b43f9988e5d409db4a3ca3b7/spec/support/jazz.rb#L543

Tweak an existing spec to cover this case (as well as the "enums
specifed as values not names" case), then add the missing call to
camelize.

@rmosolgo I'm not actually 100% sure if I'm interpreting the intention here properly. The code is obviously trivial/straightforward but maybe the intention was to force people to write their default values in camelCase and it's the Jazz schema that made a mistake?

This is a second stand-alone extraction from https://github.com/rmosolgo/graphql-ruby/pull/3448.

cc @benjie