### PR TITLE
Rescue StandardError on graphql controller.

### DIFF
--- a/lib/generators/graphql/templates/graphql_controller.erb
+++ b/lib/generators/graphql/templates/graphql_controller.erb
@@ -15,9 +15,9 @@ class GraphqlController < ApplicationController
     }
     result = <%= schema_name %>.execute(query, variables: variables, context: context, operation_name: operation_name)
     render json: result
-  rescue => e
+  rescue StandardError => e
     raise e unless Rails.env.development?
-    handle_error_in_development e
+    handle_error_in_development(e)
   end
 
   private


### PR DESCRIPTION
This PR intends to improve the error handling in the generated controller, since rescuing all exceptions may cause some issues.