### PR TITLE
Copy parent thread local vars to dataloader fiber local vars

### DIFF
--- a/guides/dataloader/overview.md
+++ b/guides/dataloader/overview.md
@@ -33,8 +33,6 @@ At a high level, `GraphQL::Dataloader`'s usage of `Fiber` looks like this:
 - `GraphQL::Dataloader` takes the first paused Fiber and resumes it, causing the `GraphQL::Dataloader::Source` to execute its `#fetch(...)` call. That Fiber continues execution as far as it can.
 - Likewise, paused Fibers are resumed, causing GraphQL execution to continue, until all paused Fibers are evaluated completely.
 
-Since _all_ GraphQL execution is inside a Fiber, __`Thread.current[...]` won't be set__. Those assignments are _Fiber-local_, so each new Fiber has an _empty_ `Thread.current`. For `GraphQL::Dataloader`, use GraphQL-Ruby's `context` object to provide "current" values to a GraphQL query. Inside `#fetch(...)` methods, those values can be re-assigned to `Thread.current` if application code requires it.
-
 ## Getting Started
 
 To install {{ "GraphQL::Dataloader" | api_doc }}, add it to your schema with `use ...`, for example:

--- a/guides/dataloader/overview.md
+++ b/guides/dataloader/overview.md
@@ -33,6 +33,8 @@ At a high level, `GraphQL::Dataloader`'s usage of `Fiber` looks like this:
 - `GraphQL::Dataloader` takes the first paused Fiber and resumes it, causing the `GraphQL::Dataloader::Source` to execute its `#fetch(...)` call. That Fiber continues execution as far as it can.
 - Likewise, paused Fibers are resumed, causing GraphQL execution to continue, until all paused Fibers are evaluated completely.
 
+Whenever `GraphQL::Dataloader` creates a new `Fiber`, it copies each pair from `Thread.current[...]` and reassigns them inside the new `Fiber`.
+
 ## Getting Started
 
 To install {{ "GraphQL::Dataloader" | api_doc }}, add it to your schema with `use ...`, for example:


### PR DESCRIPTION
By default, Fibers have their own storage for `Thread#[]`, which is entirely separate from the parent `Thread#[]` storage. Many gems (such as RequestStore, MiniRacer, etc.) rely on thread local vars to keep track of execution context. Since Dataloader relies on `Fiber.new`, gems that rely on thread local storage cannot keep track of what's happening within the GraphQL execution context, causing unexpected behavior for users.

This PR implements the solution from https://github.com/rmosolgo/graphql-ruby/issues/3449#issuecomment-830409933 to copy thread locals vars to fiber local vars when using Dataloader.


see #3366
see #3449