### PR TITLE
[Documentation] Update action cable subscription setup docs

### DIFF
--- a/lib/graphql/subscriptions/action_cable_subscriptions.rb
+++ b/lib/graphql/subscriptions/action_cable_subscriptions.rb
@@ -34,12 +34,12 @@ module GraphQL
     #         channel: self,
     #       }
     #
-    #       result = MySchema.execute({
+    #       result = MySchema.execute(
     #         query: query,
     #         context: context,
     #         variables: variables,
     #         operation_name: operation_name
-    #       })
+    #       )
     #
     #       payload = {
     #         result: result.to_h,


### PR DESCRIPTION
Ruby's behavior around keyword arguments changed in Ruby 3.0. This change updates the action cable subscriptions example to account for those changes.

This was previously found in #3310 