### PR TITLE
Add use GraphQL::Execution::Errors to the error handling documentation

### DIFF
--- a/guides/errors/error_handling.md
+++ b/guides/errors/error_handling.md
@@ -19,6 +19,7 @@ Handlers are added with `rescue_from` configurations in the schema:
 ```ruby
 class MySchema < GraphQL::Schema
   # ...
+  use GraphQL::Execution::Errors
 
   rescue_from(ActiveRecord::RecordNotFound) do |err, obj, args, ctx, field|
     # Raise a graphql-friendly error with a custom message


### PR DESCRIPTION
I was trying to use the `rescue_from` method and it didn't work. I looked at the PR that introduce this, and you need to add the `GraphQL::Execution::Errors` to the schema. I think it would be nice to have it in the documentation's example.