### PR TITLE
Don't decorate connections when loading from introspection responses

### DIFF
--- a/lib/graphql/schema/loader.rb
+++ b/lib/graphql/schema/loader.rb
@@ -169,6 +169,12 @@ module GraphQL
         def build_fields(type_defn, fields, type_resolver)
           loader = self
           fields.each do |field_hash|
+            unwrapped_field_hash = field_hash
+            while (of_type = unwrapped_field_hash["ofType"])
+              unwrapped_field_hash = of_type
+            end
+            type_name = unwrapped_field_hash["name"]
+
             type_defn.field(
               field_hash["name"],
               type: type_resolver.call(field_hash["type"]),
@@ -176,6 +182,8 @@ module GraphQL
               deprecation_reason: field_hash["deprecationReason"],
               null: true,
               camelize: false,
+              connection_extension: nil,
+              connection: type_name.end_with?("Connection"),
             ) do
               if field_hash["args"].any?
                 loader.build_arguments(self, field_hash["args"], type_resolver)

--- a/spec/integration/rails/graphql/schema_spec.rb
+++ b/spec/integration/rails/graphql/schema_spec.rb
@@ -190,10 +190,16 @@ type Query {
 
   describe ".from_introspection" do
     let(:schema) {
+      # This type would easily be mistaken for a connection... but it's not one.
+      db_connection = Class.new(GraphQL::Schema::Object) do
+        graphql_name "DatabaseConnection"
+        field :name, String, null: false
+      end
 
       query_root = Class.new(GraphQL::Schema::Object) do
         graphql_name 'Query'
         field :str, String, null: true
+        field :db, db_connection, null: false, connection: false
       end
 
       Class.new(GraphQL::Schema) do


### PR DESCRIPTION
fixes #3463

It's _possible_ that this could break some uses, but it's hard to imagine why someone would depend on `.from_introspection` returning a schema that _didn't_ match the one whose JSON was loaded!