### PR TITLE
Add failing test for directives with input cycles

### DIFF
--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -122,6 +122,32 @@ type Word {
       assert_schema_and_compare_output(schema.chop)
     end
 
+    it 'can build a schema with directives whose inputs have a cycle' do
+      schema = <<-SCHEMA
+schema {
+  query: Hello
+}
+
+directive @foo(arg: InputA) on FIELD
+
+input InputA {
+  value: InputB
+}
+
+input InputB {
+  value: InputA
+}
+      SCHEMA
+
+      parsed_schema = GraphQL::Schema.from_definition(schema)
+      assert_equal ["deprecated", "foo", "include", "skip"], parsed_schema.directives.keys.sort
+      parsed_schema.directives.values.each do |dir_class|
+        assert dir_class < GraphQL::Schema::Directive
+      end
+
+      assert_schema_and_compare_output(schema.chop)
+    end
+
     it 'supports descriptions and definition_line' do
       schema = <<-SCHEMA
 schema {


### PR DESCRIPTION
It was noted in a comment in build_from_definition.rb that this might be
a problem. It is a problem (this test currently fails with
SystemStackError).

@rmosolgo this is incomplete right now given it's just a test and no actual fix, but I ran into this as part of digging around in https://github.com/rmosolgo/graphql-ruby/pull/3448.