### PR TITLE
Add support of query location for directive

### DIFF
--- a/spec/graphql/schema/directive/query_level_directive_spec.rb
+++ b/spec/graphql/schema/directive/query_level_directive_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe "Query level Directive" do
+  class QueryDirectiveSchema < GraphQL::Schema
+    class InitInt < GraphQL::Schema::Directive
+      locations(GraphQL::Schema::Directive::QUERY)
+      argument(:val, Integer, "Initial integer value.", required: true)
+
+      def self.resolve(obj, args, ctx)
+        ctx[:int] = args[:val]
+        yield
+      end
+    end
+
+    class Query < GraphQL::Schema::Object
+      field :int, Integer, null: false
+
+      def int
+        context[:int] ||= 0
+        context[:int] += 1
+      end
+    end
+
+    directive(InitInt)
+    query(Query)
+  end
+
+  it "returns an error if directive is not on the query level" do
+    str = 'query TestDirective {
+      int1: int @initInt(val: 10)
+      int2: int
+    }
+    '
+
+    res = QueryDirectiveSchema.execute(str)
+
+    expected_errors = [
+      {
+        "message" => "'@initInt' can't be applied to fields (allowed: queries)",
+        "locations" => [{ "line" => 2, "column" => 17 }],
+        "path" => ["query TestDirective", "int1"],
+        "extensions" => { "code" => "directiveCannotBeApplied", "targetName" => "fields", "name" => "initInt" }
+      }
+    ]
+    assert_equal(expected_errors, res["errors"])
+  end
+
+  it "runs on the query level" do
+    str = 'query TestDirective @initInt(val: 10) {
+      int1: int
+      int2: int
+    }
+    '
+
+    res = QueryDirectiveSchema.execute(str)
+    assert_equal({ "int1" => 11, "int2" => 12 }, res["data"])
+  end
+end


### PR DESCRIPTION
# Context
I was working on change which would benefit from having a directive working on a `query` level.
Turns out `graphql-ruby` doesn't support directives on this level.
This PRs fixes this issue.

# How do we make this change
We are able to reuse the code created for directives which use `resolve` method to alter query execution. Best example would be `Transform` directive. It uses `resolve` method and can be attached to field.
Following it as an example I was able to wrap the entry point of query interpretation (`GraphQL::Execution::Interpreter::Runtime#run_eager`) and wrap it in `resolve_with_directives` method.

`resolve_with_directives` method doesn't have any idea of what type of `node` it is working on, so it works on `field` level for `Transform` and can work on the whole query level as well.
It also supports having more than one directive attached to a query and will correctly execute all of them.

# Example usage
```Ruby
class QueryDirectiveSchema < GraphQL::Schema
   class InitInt < GraphQL::Schema::Directive
      locations(GraphQL::Schema::Directive::QUERY)
      argument(:val, Integer, "Initial integer value.", required: true)

      def self.resolve(obj, args, ctx)
         ctx[:int] = args[:val]
         yield
       end
    end

    class Query < GraphQL::Schema::Object
      field :int, Integer, null: false

      def int
        context[:int] ||= 0
        context[:int] += 1
      end
    end

    directive(InitInt)
    query(Query)
  end
```