### PR TITLE
Fix a typo in Field Resolution document

### DIFF
--- a/guides/fields/introduction.md
+++ b/guides/fields/introduction.md
@@ -81,7 +81,7 @@ Fields with a `deprecation_reason:` will appear as "deprecated" in GraphiQL.
 
 ### Field Resolution
 
-In general, fields return Ruby values corresponding to their GraphQL return types. For example, a field with the return type `String` should return a Ruby string, and a field with the return type `[User!]!` should return a Ruby array with zero or more `User` objects in it.
+In general, fields return Ruby values corresponding to their GraphQL return types. For example, a field with the return type `String` should return a Ruby string, and a field with the return type `[User!]!` should return a Ruby array with one or more `User` objects in it.
 
 By default, fields return values by:
 


### PR DESCRIPTION
https://graphql-ruby.org/fields/introduction.html

<img width="1142" alt="CleanShot 2021-05-12 at 23 18 41@2x" src="https://user-images.githubusercontent.com/1000669/117990759-6a8cec80-b378-11eb-8f87-c6bb2a573f11.png">

`[User!]!` should return array with 1 or more `User`s.