### PR TITLE
Validate argument defaults

### DIFF
--- a/lib/graphql/introspection/input_value_type.rb
+++ b/lib/graphql/introspection/input_value_type.rb
@@ -19,7 +19,7 @@ module GraphQL
 
       def default_value
         if @object.default_value?
-          value = @object.default_value
+          value = @object.default_value(@context)
           if value.nil?
             'null'
           else

--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -148,7 +148,7 @@ module GraphQL
       def authorized?(**inputs)
         self.class.arguments.each_value do |argument|
           arg_keyword = argument.keyword
-          if inputs.key?(arg_keyword) && !(arg_value = inputs[arg_keyword]).nil? && (arg_value != argument.default_value)
+          if inputs.key?(arg_keyword) && !(arg_value = inputs[arg_keyword]).nil? && (arg_value != argument.default_value(context))
             arg_auth, err = argument.authorized?(self, arg_value, context)
             if !arg_auth
               return arg_auth, err

--- a/spec/graphql/schema/argument_spec.rb
+++ b/spec/graphql/schema/argument_spec.rb
@@ -211,6 +211,13 @@ describe GraphQL::Schema::Argument do
     end
   end
 
+  it 'validates the type of the default value' do
+    arg = GraphQL::Schema::Argument.new("my_arg", GraphQL::Types::Int, required: true, owner: nil, default_value: :some_symbol)
+    assert_raises(StandardError) do
+      arg.default_value
+    end
+  end
+
   describe 'loads' do
     it "loads input object arguments" do
       query_str = <<-GRAPHQL


### PR DESCRIPTION
I'm not sure how I feel about this solution:
- it's as lazy as possible to avoid late-bound types, which it does in
the test cases we've got right now, but I don't think there's any
guarantee?
- it's so lazy it might just trigger during the first query execution
rather than during schema boot, which seems bad and also leads to a
random exception being raised because we have no good error-handling in
this path
- it's not cachable because it's context-dependent so it adds some small
overhead of revalidation on every access of default_value

@rmosolgo @benjie this technically addresses #3248 and supersedes #3448 but... oof.