### PR TITLE
Fix validating input object arguments on runtime directives

### DIFF
--- a/lib/graphql/static_validation/rules/required_input_object_attributes_are_present.rb
+++ b/lib/graphql/static_validation/rules/required_input_object_attributes_are_present.rb
@@ -23,7 +23,7 @@ module GraphQL
         defn = if arg_defn && arg_defn.type.unwrap.kind.input_object?
           arg_defn.type.unwrap
         else
-          context.field_definition
+          context.directive_definition || context.field_definition
         end
 
         parent_type = context.warden.get_argument(defn, parent_name(parent, defn))

--- a/spec/graphql/schema/directive/query_level_directive_spec.rb
+++ b/spec/graphql/schema/directive/query_level_directive_spec.rb
@@ -3,12 +3,16 @@ require "spec_helper"
 
 describe "Query level Directive" do
   class QueryDirectiveSchema < GraphQL::Schema
+    class DirectiveInput < GraphQL::Schema::InputObject
+      argument :val, Integer, required: true
+    end
     class InitInt < GraphQL::Schema::Directive
       locations(GraphQL::Schema::Directive::QUERY)
-      argument(:val, Integer, "Initial integer value.", required: true)
+      argument(:val, Integer, "Initial integer value.", required: false)
+      argument(:input, DirectiveInput, required: false)
 
       def self.resolve(obj, args, ctx)
-        ctx[:int] = args[:val]
+        ctx[:int] = args[:val] || args[:input][:val] || 0
         yield
       end
     end
@@ -55,5 +59,24 @@ describe "Query level Directive" do
 
     res = QueryDirectiveSchema.execute(str)
     assert_equal({ "int1" => 11, "int2" => 12 }, res["data"])
+  end
+
+  it "works with input object arguments" do
+    str = 'query TestDirective @initInt(input: { val: 12 }) {
+      int1: int
+      int2: int
+    }
+    '
+
+    res = QueryDirectiveSchema.execute(str)
+    assert_equal({ "int1" => 13, "int2" => 14 }, res["data"])
+
+    error_str = 'query TestDirective @initInt(input: {val: "abc"}) {
+      int1: int
+      int2: int
+    }
+    '
+    error_res = QueryDirectiveSchema.execute(error_str)
+    assert_equal(["Argument 'val' on InputObject 'DirectiveInput' has an invalid value (\"abc\"). Expected type 'Int!'."], error_res["errors"].map { |e| e["message"] })
   end
 end


### PR DESCRIPTION
Fixes #3483 

Oops, I suspect that this code path (runtime directive with input object argument) was just _never_ tested. There was no way for this code to lookup an argument definition on a directive.

