### PR TITLE
Try using a class ivar instead of a class variable to fix truffleruby build

### DIFF
--- a/spec/support/appoptics.rb
+++ b/spec/support/appoptics.rb
@@ -24,19 +24,22 @@ module AppOpticsAPM
   end
 
   module Config
-    @@config = {}
+    class << self
+      def [](key)
+        config[key.to_sym]
+      end
 
-    def self.[](key)
-      @@config[key.to_sym]
-    end
+      def []=(key, value)
+        config[key.to_sym] = value
+      end
 
-    def self.[]=(key, value)
-      key = key.to_sym
-      @@config[key] = value
-    end
+      def clear
+        config.clear
+      end
 
-    def self.clear
-      @@config = {}
+      def config
+        @config ||= {}
+      end
     end
   end
 


### PR DESCRIPTION
It seemed to be choking on `@@config`: 

```

Error:
GraphQL::Tracing::AppOpticsTracing#test_0001_calls AppOpticsAPM::SDK.trace with names and kvs:
NameError: uninitialized class variable @@config in AppOpticsAPM::Config
Did you mean?  @@config
    /home/runner/work/graphql-ruby/graphql-ruby/spec/support/appoptics.rb:30:in `[]'
    /home/runner/work/graphql-ruby/graphql-ruby/lib/graphql/tracing/appoptics_tracing.rb:72:in `gql_config'
    /home/runner/work/graphql-ruby/graphql-ruby/lib/graphql/tracing/appoptics_tracing.rb:43:in `platform_trace'
    /home/runner/work/graphql-ruby/graphql-ruby/lib/graphql/tracing/platform_tracing.rb:25:in `trace'
    /home/runner/work/graphql-ruby/graphql-ruby/lib/graphql/tracing.rb:83:in `call_tracers'
    /home/runner/work/graphql-ruby/graphql-ruby/lib/graphql/tracing.rb:67:in `trace'
    /home/runner/work/graphql-ruby/graphql-ruby/lib/graphql/execution/multiplex.rb:60:in `run_queries'
    /home/runner/work/graphql-ruby/graphql-ruby/lib/graphql/execution/multiplex.rb:50:in `run_all'
    /home/runner/work/graphql-ruby/graphql-ruby/lib/graphql/schema.rb:1682:in `multiplex'
    /home/runner/work/graphql-ruby/graphql-ruby/lib/graphql/schema.rb:1653:in `execute'
    /home/runner/work/graphql-ruby/graphql-ruby/spec/graphql/tracing/appoptics_tracing_spec.rb:74:in `test_0001_calls AppOpticsAPM::SDK.trace with names and kvs'

Error:
GraphQL::Tracing::AppOpticsTracing#test_0002_uses type + field keys:
NameError: uninitialized class variable @@config in AppOpticsAPM::Config
Did you mean?  @@config
    /home/runner/work/graphql-ruby/graphql-ruby/spec/support/appoptics.rb:30:in `[]'
    /home/runner/work/graphql-ruby/graphql-ruby/lib/graphql/tracing/appoptics_tracing.rb:72:in `gql_config'
    /home/runner/work/graphql-ruby/graphql-ruby/lib/graphql/tracing/appoptics_tracing.rb:43:in `platform_trace'
    /home/runner/work/graphql-ruby/graphql-ruby/lib/graphql/tracing/platform_tracing.rb:25:in `trace'
    /home/runner/work/graphql-ruby/graphql-ruby/lib/graphql/tracing.rb:83:in `call_tracers'
    /home/runner/work/graphql-ruby/graphql-ruby/lib/graphql/tracing.rb:67:in `trace'
    /home/runner/work/graphql-ruby/graphql-ruby/lib/graphql/execution/multiplex.rb:60:in `run_queries'
    /home/runner/work/graphql-ruby/graphql-ruby/lib/graphql/execution/multiplex.rb:50:in `run_all'
    /home/runner/work/graphql-ruby/graphql-ruby/lib/graphql/schema.rb:1682:in `multiplex'
    /home/runner/work/graphql-ruby/graphql-ruby/lib/graphql/schema.rb:1653:in `execute'
    /home/runner/work/graphql-ruby/graphql-ruby/spec/graphql/tracing/appoptics_tracing_spec.rb:93:in `test_0002_uses type + field keys'

Failure:
GraphQL::Tracing::AppOpticsTracing#test_0004_should not barf, when appoptics is present but not loaded [/home/runner/work/graphql-ruby/graphql-ruby/spec/graphql/tracing/appoptics_tracing_spec.rb:124]
Minitest::Assertion: failed: It raised 'uninitialized class variable @@config in AppOpticsAPM::Config' when AppOpticsAPM is not loaded.

Error:
GraphQL::Tracing::AppOpticsTracing#test_0006_should not create traces when disabled:
NoMethodError: undefined method `[]=' for nil:NilClass
    /home/runner/work/graphql-ruby/graphql-ruby/spec/graphql/tracing/appoptics_tracing_spec.rb:140:in `test_0006_should not create traces when disabled'
```

Anyhow, class variables are basically _always_ the wrong thing...