### PR TITLE
Fix introspection visibility for directives

### DIFF
--- a/lib/graphql/introspection/schema_type.rb
+++ b/lib/graphql/introspection/schema_type.rb
@@ -31,7 +31,7 @@ module GraphQL
       end
 
       def directives
-        context.schema.directives.values
+        @context.warden.directives
       end
 
       private


### PR DESCRIPTION
https://github.com/rmosolgo/graphql-ruby/pull/3450 updated directives to respect visibility; however, it isn't respected in introspection. This PR fixes visibility for directives in introspection.

**Expected**
Directives returned during introspective respect visibility. 

**Actual**
Directives do not respect visibility and are always returned when defined. 

cc @eapache 