### PR TITLE
Runtime directives on fragments

### DIFF
--- a/benchmark/run.rb
+++ b/benchmark/run.rb
@@ -3,7 +3,7 @@ TESTING_INTERPRETER = true
 require "graphql"
 require "jazz"
 require "benchmark/ips"
-require "ruby-prof"
+require "stackprof"
 require "memory_profiler"
 require "graphql/batch"
 
@@ -46,15 +46,11 @@ module GraphQLBenchmark
     SCHEMA.execute(document: DOCUMENT)
     # CARD_SCHEMA.validate(ABSTRACT_FRAGMENTS)
     res = nil
-    result = RubyProf.profile do
+    result = StackProf.run(mode: :wall) do
       # CARD_SCHEMA.validate(ABSTRACT_FRAGMENTS)
       res = SCHEMA.execute(document: DOCUMENT)
     end
-    # printer = RubyProf::FlatPrinter.new(result)
-    # printer = RubyProf::GraphHtmlPrinter.new(result)
-    printer = RubyProf::FlatPrinterWithLineNumbers.new(result)
-
-    printer.print(STDOUT, {})
+    StackProf::Report.new(result).print_text
   end
 
   # Adapted from https://github.com/rmosolgo/graphql-ruby/issues/861
@@ -67,13 +63,10 @@ module GraphQLBenchmark
       }
     end
 
-    result = RubyProf.profile do
+    result = StackProf.run(mode: :wall) do
       schema.execute(document: document)
     end
-    printer = RubyProf::FlatPrinter.new(result)
-    # printer = RubyProf::GraphHtmlPrinter.new(result)
-    # printer = RubyProf::FlatPrinterWithLineNumbers.new(result)
-    printer.print(STDOUT, {})
+    StackProf::Report.new(result).print_text
 
     report = MemoryProfiler.report do
       schema.execute(document: document)

--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "racc", "~> 1.4"
   s.add_development_dependency "rake", "~> 12"
   s.add_development_dependency "rubocop", "0.68" # for Ruby 2.2 enforcement
+  s.add_development_dependency "stackprof"
   # required for upgrader
   s.add_development_dependency "parser"
   # website stuff

--- a/guides/type_definitions/directives.md
+++ b/guides/type_definitions/directives.md
@@ -77,7 +77,7 @@ query {
 Directive classes may implement the following class methods to interact with the runtime:
 
 - `def self.include?(obj, args, ctx)`: If this hook returns `false`, the nodes flagged by this directive will be skipped at runtime.
-- `def self.resolve(obj, args, ctx)`: Wraps the resolution of flagged nodes. Resolution is passed as a __block__, so `yield` will continue resolution. The return value of this method will be treated as the return value of the flagged field.
+- `def self.resolve(obj, args, ctx)`: Wraps the resolution of flagged nodes. Resolution is passed as a __block__, so `yield` will continue resolution.
 
 Looking for a runtime hook that isn't listed here? {% open_an_issue "New directive hook: @something", "<!-- Describe how the directive would be used and then how you might implement it --> " %} to start the conversation!
 

--- a/lib/graphql/dataloader.rb
+++ b/lib/graphql/dataloader.rb
@@ -77,6 +77,17 @@ module GraphQL
       nil
     end
 
+    # Use a self-contained queue for the work in the block.
+    def run_contained
+      prev_queue = @pending_jobs
+      @pending_jobs = []
+      res = yield
+      run
+      res
+    ensure
+      @pending_jobs = prev_queue
+    end
+
     # @api private Move along, move along
     def run
       # At a high level, the algorithm is:
@@ -224,16 +235,16 @@ module GraphQL
     #
     # @see https://github.com/rmosolgo/graphql-ruby/issues/3449
     def spawn_fiber
-      fiber_locals = {} 
+      fiber_locals = {}
 
       Thread.current.keys.each do |fiber_var_key|
         fiber_locals[fiber_var_key] = Thread.current[fiber_var_key]
-      end 
+      end
 
-      Fiber.new do 
+      Fiber.new do
         fiber_locals.each { |k, v| Thread.current[k] = v }
         yield
-      end 
+      end
     end
   end
 end

--- a/lib/graphql/dataloader.rb
+++ b/lib/graphql/dataloader.rb
@@ -78,7 +78,7 @@ module GraphQL
     end
 
     # Use a self-contained queue for the work in the block.
-    def run_contained
+    def run_isolated
       prev_queue = @pending_jobs
       @pending_jobs = []
       res = yield

--- a/lib/graphql/dataloader.rb
+++ b/lib/graphql/dataloader.rb
@@ -81,7 +81,11 @@ module GraphQL
     def run_isolated
       prev_queue = @pending_jobs
       @pending_jobs = []
-      res = yield
+      res = nil
+      # Make sure the block is inside a Fiber, so it can `Fiber.yield`
+      append_job {
+        res = yield
+      }
       run
       res
     ensure

--- a/lib/graphql/dataloader/null_dataloader.rb
+++ b/lib/graphql/dataloader/null_dataloader.rb
@@ -10,7 +10,7 @@ module GraphQL
       # These are all no-ops because code was
       # executed sychronously.
       def run; end
-      def run_contained; yield; end
+      def run_isolated; yield; end
       def yield; end
 
       def append_job

--- a/lib/graphql/dataloader/null_dataloader.rb
+++ b/lib/graphql/dataloader/null_dataloader.rb
@@ -10,6 +10,7 @@ module GraphQL
       # These are all no-ops because code was
       # executed sychronously.
       def run; end
+      def run_contained; yield; end
       def yield; end
 
       def append_job

--- a/lib/graphql/execution/interpreter/arguments_cache.rb
+++ b/lib/graphql/execution/interpreter/arguments_cache.rb
@@ -28,11 +28,12 @@ module GraphQL
         end
 
         def fetch(ast_node, argument_owner, parent_object)
-          @storage[ast_node][argument_owner][parent_object]
           # If any jobs were enqueued, run them now,
           # since this might have been called outside of execution.
           # (The jobs are responsible for updating `result` in-place.)
-          @dataloader.run
+          @dataloader.run_contained do
+            @storage[ast_node][argument_owner][parent_object]
+          end
           # Ack, the _hash_ is updated, but the key is eventually
           # overridden with an immutable arguments instance.
           # The first call queues up the job,

--- a/lib/graphql/execution/interpreter/arguments_cache.rb
+++ b/lib/graphql/execution/interpreter/arguments_cache.rb
@@ -31,7 +31,7 @@ module GraphQL
           # If any jobs were enqueued, run them now,
           # since this might have been called outside of execution.
           # (The jobs are responsible for updating `result` in-place.)
-          @dataloader.run_contained do
+          @dataloader.run_isolated do
             @storage[ast_node][argument_owner][parent_object]
           end
           # Ack, the _hash_ is updated, but the key is eventually

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -629,7 +629,7 @@ module GraphQL
             if !dir_defn.is_a?(Class)
               dir_defn = dir_defn.type_class || raise("Only class-based directives are supported (not `@#{dir_node.name}`)")
             end
-            dir_args = arguments(nil, dir_defn, dir_node).keyword_arguments
+            dir_args = arguments(nil, dir_defn, dir_node)
             dir_defn.resolve(object, dir_args, context) do
               run_directive(object, ast_node, idx + 1, &block)
             end
@@ -640,7 +640,7 @@ module GraphQL
         def directives_include?(node, graphql_object, parent_type)
           node.directives.each do |dir_node|
             dir_defn = schema.directives.fetch(dir_node.name).type_class || raise("Only class-based directives are supported (not #{dir_node.name.inspect})")
-            args = arguments(graphql_object, dir_defn, dir_node).keyword_arguments
+            args = arguments(graphql_object, dir_defn, dir_node)
             if !dir_defn.include?(graphql_object, args, context)
               return false
             end

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -17,6 +17,15 @@ module GraphQL
 
         class GraphQLResultHash < Hash
           include GraphQLResult
+
+          attr_accessor :graphql_merged_into
+
+          def []=(key, value)
+            if (t = @graphql_merged_into)
+              t[key] = value
+            end
+            super
+          end
         end
 
         class GraphQLResultArray < Array
@@ -135,6 +144,7 @@ module GraphQL
               end
             end
           end
+          from_result.graphql_merged_into = into_result
           nil
         end
 

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -757,10 +757,10 @@ describe GraphQL::Dataloader do
       assert_equal({ d: 4 }, result)
 
       dl.run_isolated {
-        r1 = dl.with(RunIsolated::CountSource).request(1)
-        r2 = dl.with(RunIsolated::CountSource).request(2)
+        _r1 = dl.with(RunIsolated::CountSource).request(1)
+        _r2 = dl.with(RunIsolated::CountSource).request(2)
         r3 = dl.with(RunIsolated::CountSource).request(3)
-        # This is going to Fiber.yield
+        # This is going to `Fiber.yield`
         result[:e] = r3.load
       }
 

--- a/spec/graphql/schema/directive_spec.rb
+++ b/spec/graphql/schema/directive_spec.rb
@@ -93,7 +93,6 @@ Use `locations(OBJECT)` to update this directive's definition, or remove it from
 
         ctx[:count_fields] ||= Hash.new { |h, k| h[k] = [] }
         field_count = result.is_a?(Hash) ? result.size : 1
-        p [path, field_count, result]
         ctx[:count_fields][path] << field_count
         nil # this does nothing
       end
@@ -146,7 +145,6 @@ Use `locations(OBJECT)` to update this directive's definition, or remove it from
   end
 
   describe "runtime directives" do
-    focus
     it "works with fragment spreads, inline fragments, and fields" do
       query_str = <<-GRAPHQL
       {

--- a/spec/graphql/schema/directive_spec.rb
+++ b/spec/graphql/schema/directive_spec.rb
@@ -88,7 +88,7 @@ Use `locations(OBJECT)` to update this directive's definition, or remove it from
       def self.resolve(obj, args, ctx)
         path = ctx[:current_path]
         result = nil
-        ctx.dataloader.run_contained do
+        ctx.dataloader.run_isolated do
           result = yield
           GraphQL::Execution::Interpreter::Resolve.resolve_all([result], ctx.dataloader)
         end


### PR DESCRIPTION
Oops, runtime directives on fragment spreads and inline fragments were never actually implemented. 

It turns out to be pretty tricky because it requires these changes: 

- Gathering selections to run should be scoped by AST, _if_ the fragments at hand have runtime directives that affect execution (eg, not `@include(if: true)`) 
- Then, those selections should be run with some degree of isolation. TBD: how much isolation? Anyways, the whole point of `@defer` is to send the whole sub-tree after-the-fact, so it's got to be executed on its own.
- Then, (I guess _depending_?), the sub-tree should be merged back to the main result, so that the result can contain the whole query. (This doesn't apply to `@defer`, but one can imagine a runtime that _doesn't_ split the result tree.) 

Doing this for synchronous execution was easy enough, but once promises and dataloader get involved, 🤯 


TODO: 

- [x] DRY some code?  (I did my best, anyways.)