### PR TITLE
Fix some dead marking and detection

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -380,7 +380,6 @@ module GraphQL
                 value.ast_node ||= ast_node
                 context.errors << value
                 set_result(selection_result, result_name, nil)
-                selection_result.graphql_dead = true
               end
               HALT
             elsif value.is_a?(GraphQL::UnauthorizedError)
@@ -600,7 +599,7 @@ module GraphQL
             if eager
               lazy.value
             else
-              result[result_name] = lazy
+              set_result(result, result_name, lazy)
               lazy
             end
           else


### PR DESCRIPTION
Fixes #3504 

TODO: 

-  ~~Investigate marking the parent as dead. Is it in the spec?~~

    I didn't check the spec, but I'm going to keep this behavior because: 
    
      - It's how it used to work 
      - It makes it _look_ like the first error halts subsequent execution (but I think it actually _continues_ under the hood, but never updates the result, since it's dead)
- [x] Migrate the test from #3504 into a test 