### PR TITLE
Improve the message when a field returns an invalid enum value

### DIFF
--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "racc", "~> 1.4"
   s.add_development_dependency "rake", "~> 12"
   s.add_development_dependency "rubocop", "0.68" # for Ruby 2.2 enforcement
-  s.add_development_dependency "stackprof"
   # required for upgrader
   s.add_development_dependency "parser"
   # website stuff

--- a/spec/graphql/schema/enum_spec.rb
+++ b/spec/graphql/schema/enum_spec.rb
@@ -111,10 +111,18 @@ describe GraphQL::Schema::Enum do
       assert_equal("DONKEY", enum.coerce_isolated_result(:donkey))
     end
 
-    it "raises when a result value can't be coerced" do
-      assert_raises(GraphQL::EnumType::UnresolvedValueError) {
+    it "raises a helpful error when a result value can't be coerced" do
+      err = assert_raises(GraphQL::EnumType::UnresolvedValueError) {
+        enum.coerce_result(:nonsense, OpenStruct.new(current_path: ["thing", 0, "name"], current_field: OpenStruct.new(path: "Thing.name")))
+      }
+      expected_context_message = "`Thing.name` returned `:nonsense` at `thing.0.name`, but this isn't a valid value for `DairyAnimal`. Update the field or resolver to return one of `DairyAnimal`'s values instead."
+      assert_equal expected_context_message, err.message
+
+      err2 = assert_raises(GraphQL::EnumType::UnresolvedValueError) {
         enum.coerce_isolated_result(:nonsense)
       }
+      expected_isolated_message = "`:nonsense` was returned for `DairyAnimal`, but this isn't a valid value for `DairyAnimal`. Update the field or resolver to return one of `DairyAnimal`'s values instead."
+      assert_equal expected_isolated_message, err2.message
     end
 
     describe "resolving with a warden" do


### PR DESCRIPTION
To improve debugging situations like https://github.com/rmosolgo/graphql-ruby/issues/3506