### PR TITLE
Fix lazy skips

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -517,6 +517,15 @@ module GraphQL
               end
               continue_value(path, next_value, parent_type, field, is_non_null, ast_node, result_name, selection_result)
             elsif GraphQL::Execution::Execute::SKIP == value
+              # It's possible a lazy was already written here
+              case selection_result
+              when Hash
+                selection_result.delete(result_name)
+              when Array
+                selection_result.delete_at(result_name)
+              else
+                raise "Invariant: unexpected result class #{selection_result.class} (#{selection_result.inspect})"
+              end
               HALT
             else
               # What could this actually _be_? Anyhow,

--- a/lib/graphql/execution/lazy.rb
+++ b/lib/graphql/execution/lazy.rb
@@ -48,7 +48,11 @@ module GraphQL
           end
         end
 
-        if @value.is_a?(StandardError)
+        # `SKIP` was made into a subclass of `GraphQL::Error` to improve runtime performance
+        # (fewer clauses in a hot `case` block), but now it requires special handling here.
+        # I think it's still worth it for the performance win, but if the number of special
+        # cases grows, then maybe it's worth rethinking somehow.
+        if @value.is_a?(StandardError) && @value != GraphQL::Execution::Execute::SKIP
           raise @value
         else
           @value

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -587,21 +587,19 @@ describe GraphQL::Execution::Interpreter do
       lazy_resolve Proc, :call
     end
 
-    focus
     it "skips properly" do
       res = LazySkipSchema.execute("{ skip }")
       assert_equal({}, res["data"])
       refute res.key?("errors")
-      # This failed on 1.12.10, too
-      # res = LazySkipSchema.execute("{ lazySkip }")
-      # pp res
-      # assert_equal({}, res["data"])
-      # refute res.key?("errors")
 
-      res = LazySkipSchema.execute("subscription { nothing { nothing } }")
-      pp res
+      res = LazySkipSchema.execute("{ lazySkip }")
       assert_equal({}, res["data"])
       refute res.key?("errors")
+
+      res = LazySkipSchema.execute("subscription { nothing { nothing } }")
+      assert_equal({}, res["data"])
+      refute res.key?("errors")
+      # Make sure an update works properly
       LazySkipSchema.subscriptions.trigger(:nothing, {}, :nothing_at_all)
       key, updates = LazySkipSchema.subscriptions.deliveries.first
       assert_equal "nothing_at_all", updates[0]["data"]["nothing"]["nothing"]

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -616,7 +616,7 @@ describe GraphQL::Execution::Interpreter do
       refute res.key?("errors")
       # Make sure an update works properly
       LazySkipSchema.subscriptions.trigger(:nothing, {}, :nothing_at_all)
-      key, updates = LazySkipSchema.subscriptions.deliveries.first
+      _key, updates = LazySkipSchema.subscriptions.deliveries.first
       assert_equal "nothing_at_all", updates[0]["data"]["nothing"]["nothing"]
     end
   end


### PR DESCRIPTION
Fixes #3511 

The list-with-skips thing didn't work on old versions, either. Maybe it's overkill to include it here 🤔 

The perf looks about the same as master: 

```
Warming up --------------------------------------
Querying for 1000 objects
                         1.000  i/100ms
Calculating -------------------------------------
Querying for 1000 objects
                          4.822  (± 0.0%) i/s -     25.000  in   5.185050s
```