### PR TITLE
Fix recursive and duplicate stringify_args call

### DIFF
--- a/lib/graphql/subscriptions/event.rb
+++ b/lib/graphql/subscriptions/event.rb
@@ -35,7 +35,7 @@ module GraphQL
           arguments
         when Hash
           if field.is_a?(GraphQL::Schema::Field)
-            stringify_args(field, arguments)
+            arguments
           else
             GraphQL::Query::LiteralInput.from_arguments(
               arguments,
@@ -85,21 +85,21 @@ module GraphQL
                 arg_defn = get_arg_definition(arg_owner, normalized_arg_name)
               end
 
-              next_args[normalized_arg_name] = stringify_args(arg_defn.type, v)
+              next_args[normalized_arg_name] = stringify_args(arg_defn, v)
             end
             # Make sure they're deeply sorted
             next_args.sort.to_h
           when Array
             args.map { |a| stringify_args(arg_owner, a) }
           when GraphQL::Schema::InputObject
-            stringify_args(arg_owner, args.to_h)
+            stringify_args(args, args.to_h)
           else
             args
           end
         end
 
         def get_arg_definition(arg_owner, arg_name)
-          arg_owner.arguments[arg_name] || arg_owner.arguments.each_value.find { |v| v.keyword.to_s == arg_name }
+          arg_owner.arguments[arg_name] || arg_owner.arguments[arg_name.to_s]
         end
       end
     end


### PR DESCRIPTION
Fixes https://github.com/rmosolgo/graphql-ruby/issues/3525

Subscriptions fail when given an argument of type [CustomTypeHere!]!

Please see attached issue for more information on the problem

In the recursive stringify_args call it receives a `GraphQL::Schema::NonNull` as the `arg_owner` which does not have the arguments method that is called in `get_arg_definition`.

This patch is working for us on our project, but I am afraid I don't have full context over the guts/internals of this section of the code.

Just putting this up there to receive feedback and see what outside factors could be impacted by this change.
Todo:
- Write tests if this gets feedback from @rsmosolgo