### PR TITLE
Makes the test useful.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,11 @@
 name: CI Suite
 on:
-  push
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
 
 jobs:
   lint:

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -622,15 +622,8 @@ describe GraphQL::Execution::Interpreter do
   end
 
   describe "GraphQL::ExecutionErrors from non-null list fields" do
-    module ListErrorTest
-      class BaseField < GraphQL::Schema::Field
-        def authorized?(*)
-          raise GraphQL::ExecutionError, "#{name} is not authorized"
-        end
-      end
-
+    module ListValueErrorTest
       class Thing < GraphQL::Schema::Object
-        field_class BaseField
         field :title, String, null: false
       end
 
@@ -638,7 +631,7 @@ describe GraphQL::Execution::Interpreter do
         field :things, [Thing], null: false
 
         def things
-          [{title: "a"}, {title: "b"}, {title: "c"}]
+          [{title: nil}, {title: "b"}, {title: "c"}]
         end
       end
 
@@ -647,9 +640,36 @@ describe GraphQL::Execution::Interpreter do
       end
     end
 
-    it "returns only 1 error" do
-      res = ListErrorTest::Schema.execute("{ things { title } }")
+    it "returns 1 error" do
+      res = ListValueErrorTest::Schema.execute("{ things { title } }")
+
       assert_equal 1, res["errors"].size
+      assert_equal "Cannot return null for non-nullable field Thing.title", res["errors"].first["message"]
+    end
+
+    module ListErrorTest
+      class Thing < GraphQL::Schema::Object
+        field :title, String, null: false
+      end
+
+      class Query < GraphQL::Schema::Object
+        field :things, [Thing], null: false
+
+        def things
+          [nil, {title: "b"}, {title: "c"}]
+        end
+      end
+
+      class Schema < GraphQL::Schema
+        query Query
+      end
+    end
+
+    it "returns 1 error" do
+      res = ListErrorTest::Schema.execute("{ things { title } }")
+
+      assert_equal 1, res["errors"].size
+      assert_equal "Cannot return null for non-nullable field Query.things", res["errors"].first["message"]
     end
   end
 end


### PR DESCRIPTION
This spec was introduced here https://github.com/rmosolgo/graphql-ruby/pull/3505, so I think, the Null stuff should be tested here, right? Before an unauthorized was the error reason …