### PR TITLE
Transform GraphQL-related objects to plain Hashes and Arrays before returning them

### DIFF
--- a/lib/graphql/backtrace/table.rb
+++ b/lib/graphql/backtrace/table.rb
@@ -144,7 +144,7 @@ module GraphQL
       end
 
       def value_at(runtime, path)
-        response = runtime.response
+        response = runtime.final_result
         path.each do |key|
           if response && (response = response[key])
             next

--- a/lib/graphql/execution/interpreter.rb
+++ b/lib/graphql/execution/interpreter.rb
@@ -18,7 +18,7 @@ module GraphQL
       def execute(_operation, _root_type, query)
         runtime = evaluate(query)
         sync_lazies(query: query)
-        runtime.response
+        runtime.final_result
       end
 
       def self.use(schema_class)
@@ -56,7 +56,7 @@ module GraphQL
 
       def self.finish_query(query, _multiplex)
         {
-          "data" => query.context.namespace(:interpreter)[:runtime].response
+          "data" => query.context.namespace(:interpreter)[:runtime].final_result
         }
       end
 
@@ -87,7 +87,7 @@ module GraphQL
         final_values = queries.map do |query|
           runtime = query.context.namespace(:interpreter)[:runtime]
           # it might not be present if the query has an error
-          runtime ? runtime.response : nil
+          runtime ? runtime.final_result : nil
         end
         final_values.compact!
         tracer.trace("execute_query_lazy", {multiplex: multiplex, query: query}) do

--- a/lib/graphql/execution/interpreter/resolve.rb
+++ b/lib/graphql/execution/interpreter/resolve.rb
@@ -34,7 +34,10 @@ module GraphQL
           next_results = []
           while results.any?
             result_value = results.shift
-            if result_value.is_a?(Hash)
+            if result_value.is_a?(Runtime::GraphQLResultHash) || result_value.is_a?(Hash)
+              results.concat(result_value.values)
+              next
+            elsif result_value.is_a?(Runtime::GraphQLResultArray)
               results.concat(result_value.values)
               next
             elsif result_value.is_a?(Array)
@@ -46,7 +49,8 @@ module GraphQL
                 # Since this field returned another lazy,
                 # add it to the same queue
                 results << loaded_value
-              elsif loaded_value.is_a?(Hash) || loaded_value.is_a?(Array)
+              elsif loaded_value.is_a?(Runtime::GraphQLResultHash) || loaded_value.is_a?(Runtime::GraphQLResultArray) ||
+                  loaded_value.is_a?(Hash) || loaded_value.is_a?(Array)
                 # Add these values in wholesale --
                 # they might be modified by later work in the dataloader.
                 next_results << loaded_value

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -10,8 +10,6 @@ module GraphQL
       class Runtime
 
         module GraphQLResult
-          # These methods are private concerns of GraphQL-Ruby,
-          # they aren't guaranteed to continue working in the future.
           attr_accessor :graphql_dead, :graphql_parent, :graphql_result_name
           # Although these are used by only one of the Result classes,
           # it's handy to have the methods implemented on both (even though they just return `nil`)
@@ -21,6 +19,7 @@ module GraphQL
           # @return [nil, true]
           attr_accessor :graphql_non_null_list_items
 
+          # @return [Hash] Plain-Ruby result data (`@graphql_metadata` contains Result wrapper objects)
           attr_accessor :graphql_result_data
         end
 

--- a/lib/graphql/schema/directive/transform.rb
+++ b/lib/graphql/schema/directive/transform.rb
@@ -39,7 +39,7 @@ module GraphQL
           transform_name = arguments[:by]
           if TRANSFORMS.include?(transform_name) && return_value.respond_to?(transform_name)
             return_value = return_value.public_send(transform_name)
-            response = context.namespace(:interpreter)[:runtime].response
+            response = context.namespace(:interpreter)[:runtime].final_result
             *keys, last = path
             keys.each do |key|
               if response && (response = response[key])

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -454,6 +454,9 @@ describe GraphQL::Execution::Interpreter do
       assert_equal nil, res["data"]["findMany"][1]
       assert_equal nil, res["data"]["findMany"][2]
       assert_equal false, res.key?("errors")
+
+      assert_equal Hash, res["data"].class
+      assert_equal Array, res["data"]["findMany"].class
     end
 
     it "works with union lists that have members of different kinds, with different nullabilities" do

--- a/spec/graphql/schema/directive_spec.rb
+++ b/spec/graphql/schema/directive_spec.rb
@@ -94,7 +94,7 @@ Use `locations(OBJECT)` to update this directive's definition, or remove it from
         end
 
         ctx[:count_fields] ||= Hash.new { |h, k| h[k] = [] }
-        field_count = result.is_a?(Hash) ? result.size : 1
+        field_count = result.respond_to?(:graphql_result_data) ? result.graphql_result_data.size : 1
         ctx[:count_fields][path] << field_count
         nil # this does nothing
       end


### PR DESCRIPTION
This is not an awesome implementation, but it addresses the incompatibility described in #3516 

It adds a slow deep-copy step to all responses. I'm not sure how else to solve the problem: one data structure is used to collect values at runtime, while another value must be returned at the end. 

A couple other approaches I considered very briefly: 

- Using refinements instead of extending built-ins. I think it _would_ actually work here, since all the uses are in the same scope. But I have doubts about the performance, even on CRuby. And I don't think JRuby supports them at all, IIRC. 
- Each GraphQL* result class keeps another "plain" data structure in an instance variable, and replays all modifications onto it. It seems error-prone and hard to maintain. The other problem is, the "plain" object would have to check if incoming values are actually GraphQL* result objects, and store their "plain" data objects if so. Ick. 

Running `rake bench:profile_large_result`, I see an 8.5% slowdown on this branch.

cc @eapache 