### PR TITLE
Fix parent dead marking

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -490,9 +490,7 @@ module GraphQL
                 @response = nil
               else
                 set_result(parent, name_in_parent, nil)
-                # This is odd, but it's how it used to work. Even if `parent` _would_ accept
-                # a `nil`, it's marked dead. TODO: check the spec, is there a reason for this?
-                parent.graphql_dead = true
+                selection_result.graphql_dead = true
               end
             else
               selection_result[result_name] = value


### PR DESCRIPTION
fixes https://github.com/rmosolgo/graphql-ruby/issues/3536

Oops, there was some suspicious bits in the new runtime code. They were a misunderstanding of _this_ old code:

https://github.com/rmosolgo/graphql-ruby/blob/a9a7373a1fbf91cbcc10a1385cc4cf8c2af8254d/lib/graphql/execution/interpreter/runtime.rb#L587-L591

In that context: 

- `path` includes the names of "parent" fields ("above" this one) and _this_ field name
- `propagate_path` removes the _field name_ from the path, marking the result object as dead

But I migrated it to this: 

https://github.com/rmosolgo/graphql-ruby/blob/eb58d269ffac694ecbc2147e238d61d54c5fd0e2/lib/graphql/execution/interpreter/runtime.rb#L473-L476

My misunderstanding was about how the field name (`result_name` above) fits in. In fact, `selection_result` in the new code was _already_ equivalent to `propagate_path` in the old code -- it was the object which would _contain_ the result. In the new code, `result_name` was the same as `path[-1]` in the old code. 

So the fix was to mark `selection_result` as dead, instead.