### PR TITLE
Revert alias changes

### DIFF
--- a/lib/graphql/argument.rb
+++ b/lib/graphql/argument.rb
@@ -8,7 +8,7 @@ module GraphQL
     attr_accessor :description, :name, :as, :deprecation_reason
     attr_accessor :ast_node
     attr_accessor :method_access
-    alias_method :graphql_name, :name
+    alias :graphql_name :name
 
     ensure_defined(:name, :description, :default_value, :type=, :type, :as, :expose_as, :prepare, :method_access, :deprecation_reason)
 

--- a/lib/graphql/backtrace.rb
+++ b/lib/graphql/backtrace.rb
@@ -40,7 +40,7 @@ module GraphQL
       @table.to_table
     end
 
-    alias_method :to_s, :inspect
+    alias :to_s :inspect
 
     def to_a
       @table.to_backtrace

--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -38,10 +38,10 @@ module GraphQL
     attr_reader :name
     # Future-compatible alias
     # @see {GraphQL::SchemaMember}
-    alias_method :graphql_name, :name
+    alias :graphql_name :name
     # Future-compatible alias
     # @see {GraphQL::SchemaMember}
-    alias_method :graphql_definition, :itself
+    alias :graphql_definition :itself
 
     def type_class
       metadata[:type_class]
@@ -117,8 +117,8 @@ module GraphQL
       name
     end
 
-    alias_method :inspect, :to_s
-    alias_method :to_type_signature, :to_s
+    alias :inspect :to_s
+    alias :to_type_signature :to_s
 
     def valid_isolated_input?(value)
       valid_input?(value, GraphQL::Query::NullContext)

--- a/lib/graphql/directive.rb
+++ b/lib/graphql/directive.rb
@@ -18,11 +18,11 @@ module GraphQL
 
     # Future-compatible alias
     # @see {GraphQL::SchemaMember}
-    alias_method :graphql_name, :name
+    alias :graphql_name :name
 
     # Future-compatible alias
     # @see {GraphQL::SchemaMember}
-    alias_method :graphql_definition, :itself
+    alias :graphql_definition :itself
 
     LOCATIONS = [
       QUERY =                  :QUERY,

--- a/lib/graphql/field.rb
+++ b/lib/graphql/field.rb
@@ -82,7 +82,7 @@ module GraphQL
 
     # Future-compatible alias
     # @see {GraphQL::SchemaMember}
-    alias_method :graphql_definition, :itself
+    alias :graphql_definition :itself
 
     # @return [Boolean]
     def connection?

--- a/lib/graphql/language/token.rb
+++ b/lib/graphql/language/token.rb
@@ -22,7 +22,7 @@ module GraphQL
         @prev_token = prev_token
       end
 
-      alias_method :to_s, :value
+      alias to_s value
       def to_i; @value.to_i; end
       def to_f; @value.to_f; end
 

--- a/lib/graphql/non_null_type.rb
+++ b/lib/graphql/non_null_type.rb
@@ -62,7 +62,7 @@ module GraphQL
       "#{of_type.to_s}!"
     end
     alias_method :inspect, :to_s
-    alias_method :to_type_signature, :to_s
+    alias :to_type_signature :to_s
 
     def non_null?
       true

--- a/lib/graphql/query/arguments.rb
+++ b/lib/graphql/query/arguments.rb
@@ -124,7 +124,7 @@ module GraphQL
         ruby_kwargs
       end
 
-      alias_method :to_hash, :to_kwargs
+      alias :to_hash :to_kwargs
 
       private
 

--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -13,7 +13,7 @@ module GraphQL
 
         # @return [Boolean] were any fields of this selection skipped?
         attr_reader :skipped
-        alias_method :skipped?, :skipped
+        alias :skipped? :skipped
 
         # @api private
         attr_writer :skipped
@@ -98,8 +98,8 @@ module GraphQL
           @context.add_error(err)
         end
 
-        alias_method :>>, :add
-        alias_method :push, :add
+        alias :>> :add
+        alias :push :add
       end
 
       include SharedMethods
@@ -215,7 +215,7 @@ module GraphQL
       def to_h
         @provided_values.merge(@scoped_context)
       end
-      alias_method :to_hash, :to_h
+      alias :to_hash :to_h
 
       def key?(key)
         @scoped_context.key?(key) || @provided_values.key?(key)
@@ -258,7 +258,7 @@ module GraphQL
         extend Forwardable
 
         attr_reader :irep_node, :field, :parent_type, :query, :schema, :parent, :key, :type
-        alias_method :selection, :irep_node
+        alias :selection :irep_node
 
         def initialize(context, key, irep_node, parent, object)
           @context = context

--- a/lib/graphql/relay/mutation.rb
+++ b/lib/graphql/relay/mutation.rb
@@ -26,8 +26,8 @@ module GraphQL
         :field, :result_class, :input_type
       )
       # For backwards compat, but do we need this separate API?
-      alias_method :return_fields, :fields
-      alias_method :input_fields, :arguments
+      alias :return_fields :fields
+      alias :input_fields :arguments
 
       def initialize
         GraphQL::Deprecation.warn "GraphQL::Relay::Mutation will be removed from GraphQL-Ruby 2.0, use GraphQL::Schema::RelayClassicMutation instead: https://graphql-ruby.org/mutations/mutation_classes"

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -354,7 +354,7 @@ module GraphQL
     end
 
     # For forwards-compatibility with Schema classes
-    alias_method :graphql_definition, :itself
+    alias :graphql_definition :itself
 
     def deprecated_define(**kwargs, &block)
       super
@@ -692,7 +692,7 @@ module GraphQL
     end
 
     # Can't delegate to `class`
-    alias_method :_schema_class, :class
+    alias :_schema_class :class
     def_delegators :_schema_class, :unauthorized_object, :unauthorized_field, :inaccessible_fields
     def_delegators :_schema_class, :directive
     def_delegators :_schema_class, :error_handler

--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -19,7 +19,7 @@ module GraphQL
 
       # @return [String] the GraphQL name for this argument, camelized unless `camelize: false` is provided
       attr_reader :name
-      alias_method :graphql_name, :name
+      alias :graphql_name :name
 
       # @return [GraphQL::Schema::Field, Class] The field or input object this argument belongs to
       attr_reader :owner

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -22,7 +22,7 @@ module GraphQL
 
       # @return [String] the GraphQL name for this field, camelized unless `camelize: false` is provided
       attr_reader :name
-      alias_method :graphql_name, :name
+      alias :graphql_name :name
 
       attr_writer :description
 
@@ -64,7 +64,7 @@ module GraphQL
         "#<#{self.class} #{path}#{arguments.any? ? "(...)" : ""}: #{type.to_type_signature}>"
       end
 
-      alias_method :mutation, :resolver
+      alias :mutation :resolver
 
       # @return [Boolean] Apply tracing to this field? (Default: skip scalars, this is the override value)
       attr_reader :trace

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -15,6 +15,7 @@ module GraphQL
       attr_reader :context
       # @return [GraphQL::Query::Arguments, GraphQL::Execution::Interpereter::Arguments] The underlying arguments instance
       attr_reader :arguments
+      alias :to_hash, :to_h
 
       # Ruby-like hash behaviors, read-only
       def_delegators :@ruby_style_hash, :keys, :values, :each, :map, :any?, :empty?
@@ -62,12 +63,12 @@ module GraphQL
         @maybe_lazies = maybe_lazies
       end
 
+
       def to_h
         @ruby_style_hash.reduce({}) do |h, (key, value)|
           h.merge!(key => unwrap_value(value))
         end
       end
-      alias to_hash to_h
 
       def prepare
         if context

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -63,10 +63,11 @@ module GraphQL
       end
 
       def to_h
-        unwrap_value(@ruby_style_hash)
+        @ruby_style_hash.reduce({}) do |h, (key, value)|
+          h.merge!(key => unwrap_value(value))
+        end
       end
-
-      alias_method :to_hash, :to_h
+      alias to_hash to_h
 
       def prepare
         if context

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -65,9 +65,7 @@ module GraphQL
 
 
       def to_h
-        @ruby_style_hash.reduce({}) do |h, (key, value)|
-          h.merge!(key => unwrap_value(value))
-        end
+        unwrap_value(@ruby_style_hash)
       end
 
       def prepare

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -15,7 +15,6 @@ module GraphQL
       attr_reader :context
       # @return [GraphQL::Query::Arguments, GraphQL::Execution::Interpereter::Arguments] The underlying arguments instance
       attr_reader :arguments
-      alias :to_hash, :to_h
 
       # Ruby-like hash behaviors, read-only
       def_delegators :@ruby_style_hash, :keys, :values, :each, :map, :any?, :empty?
@@ -66,6 +65,10 @@ module GraphQL
 
       def to_h
         unwrap_value(@ruby_style_hash)
+      end
+
+      def to_hash
+        to_h
       end
 
       def prepare

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -62,7 +62,6 @@ module GraphQL
         @maybe_lazies = maybe_lazies
       end
 
-
       def to_h
         unwrap_value(@ruby_style_hash)
       end
@@ -159,7 +158,6 @@ module GraphQL
 
         # @api private
         INVALID_OBJECT_MESSAGE = "Expected %{object} to be a key-value object responding to `to_h` or `to_unsafe_h`."
-
 
         def validate_non_null_input(input, ctx)
           result = GraphQL::Query::InputValidationResult.new

--- a/lib/graphql/schema/late_bound_type.rb
+++ b/lib/graphql/schema/late_bound_type.rb
@@ -6,7 +6,7 @@ module GraphQL
     # @api Private
     class LateBoundType
       attr_reader :name
-      alias_method :graphql_name, :name
+      alias :graphql_name :name
       def initialize(local_name)
         @name = local_name
       end
@@ -27,7 +27,7 @@ module GraphQL
         "#<LateBoundType @name=#{name}>"
       end
 
-      alias_method :to_s, :inspect
+      alias :to_s :inspect
     end
   end
 end

--- a/lib/graphql/schema/member/base_dsl_methods.rb
+++ b/lib/graphql/schema/member/base_dsl_methods.rb
@@ -99,7 +99,7 @@ module GraphQL
           raise GraphQL::RequiredImplementationMissingError
         end
 
-        alias_method :unwrap, :itself
+        alias :unwrap :itself
 
         # Creates the default name for a schema member.
         # The default name is the Ruby constant name,

--- a/lib/graphql/schema/resolver/has_payload_type.rb
+++ b/lib/graphql/schema/resolver/has_payload_type.rb
@@ -20,8 +20,8 @@ module GraphQL
           @payload_type ||= generate_payload_type
         end
 
-        alias_method :type, :payload_type
-        alias_method :type_expr, :payload_type
+        alias :type :payload_type
+        alias :type_expr :payload_type
 
         def field_class(new_class = nil)
           if new_class

--- a/lib/graphql/static_validation/rules/no_definitions_are_present.rb
+++ b/lib/graphql/static_validation/rules/no_definitions_are_present.rb
@@ -14,21 +14,21 @@ module GraphQL
         nil
       end
 
-      alias_method :on_directive_definition, :on_invalid_node
-      alias_method :on_schema_definition, :on_invalid_node
-      alias_method :on_scalar_type_definition, :on_invalid_node
-      alias_method :on_object_type_definition, :on_invalid_node
-      alias_method :on_input_object_type_definition, :on_invalid_node
-      alias_method :on_interface_type_definition, :on_invalid_node
-      alias_method :on_union_type_definition, :on_invalid_node
-      alias_method :on_enum_type_definition, :on_invalid_node
-      alias_method :on_schema_extension, :on_invalid_node
-      alias_method :on_scalar_type_extension, :on_invalid_node
-      alias_method :on_object_type_extension, :on_invalid_node
-      alias_method :on_input_object_type_extension, :on_invalid_node
-      alias_method :on_interface_type_extension, :on_invalid_node
-      alias_method :on_union_type_extension, :on_invalid_node
-      alias_method :on_enum_type_extension, :on_invalid_node
+      alias :on_directive_definition :on_invalid_node
+      alias :on_schema_definition :on_invalid_node
+      alias :on_scalar_type_definition :on_invalid_node
+      alias :on_object_type_definition :on_invalid_node
+      alias :on_input_object_type_definition :on_invalid_node
+      alias :on_interface_type_definition :on_invalid_node
+      alias :on_union_type_definition :on_invalid_node
+      alias :on_enum_type_definition :on_invalid_node
+      alias :on_schema_extension :on_invalid_node
+      alias :on_scalar_type_extension :on_invalid_node
+      alias :on_object_type_extension :on_invalid_node
+      alias :on_input_object_type_extension :on_invalid_node
+      alias :on_interface_type_extension :on_invalid_node
+      alias :on_union_type_extension :on_invalid_node
+      alias :on_enum_type_extension :on_invalid_node
 
       def on_document(node, parent)
         super


### PR DESCRIPTION
Ugh! `alias_method :to_hash, :to_h` made it so that if you override `def to_h`, it isn't picked up by `.to_hash`.

Since obviously I don't understand the difference between `alias_method` and `alias`, I'm reverting all these changes from #3524 