### PR TITLE
Backtrace array fix

### DIFF
--- a/lib/graphql/backtrace/tracer.rb
+++ b/lib/graphql/backtrace/tracer.rb
@@ -22,7 +22,7 @@ module GraphQL
         when "execute_field", "execute_field_lazy"
           query = metadata[:query] || raise(ArgumentError, "Add `legacy: true` to use GraphQL::Backtrace without the interpreter runtime.")
           multiplex = query.multiplex
-          push_key = metadata[:path].reject { |i| i.is_a?(Integer) }
+          push_key = metadata[:path]
           parent_frame = multiplex.context[:graphql_backtrace_contexts][push_key[0..-2]]
 
           if parent_frame.is_a?(GraphQL::Query)


### PR DESCRIPTION
Fixes #3538

Honestly, I don't know why integers were getting kicked out here. It was added back in https://github.com/rmosolgo/graphql-ruby/pull/3275/files#diff-7ba264b85d9b3b0cf7e63d1f6d7af371e94b5eb43042de2e835990282456f1baR26, when I updated Backtrace to work with the interpreter. 

Why would it just now have started failing?

cc @eapache 