### PR TITLE
Include a final newline in Schema.to_definition output

### DIFF
--- a/lib/graphql/schema/printer.rb
+++ b/lib/graphql/schema/printer.rb
@@ -4,37 +4,32 @@ module GraphQL
     # Used to convert your {GraphQL::Schema} to a GraphQL schema string
     #
     # @example print your schema to standard output (via helper)
-    #   MySchema = GraphQL::Schema.define(query: QueryType)
     #   puts GraphQL::Schema::Printer.print_schema(MySchema)
     #
     # @example print your schema to standard output
-    #   MySchema = GraphQL::Schema.define(query: QueryType)
     #   puts GraphQL::Schema::Printer.new(MySchema).print_schema
     #
     # @example print a single type to standard output
-    #   query_root = GraphQL::ObjectType.define do
-    #     name "Query"
+    #   class Types::Query < GraphQL::Schema::Object
     #     description "The query root of this schema"
     #
-    #     field :post do
-    #       type post_type
-    #       resolve ->(obj, args, ctx) { Post.find(args["id"]) }
-    #     end
+    #     field :post, Types::Post, null: true
     #   end
     #
-    #   post_type = GraphQL::ObjectType.define do
-    #     name "Post"
+    #   class Types::Post < GraphQL::Schema::Object
     #     description "A blog post"
     #
-    #     field :id, !types.ID
-    #     field :title, !types.String
-    #     field :body, !types.String
+    #     field :id, ID, null: false
+    #     field :title, String, null: false
+    #     field :body, String, null: false
     #   end
     #
-    #   MySchema = GraphQL::Schema.define(query: query_root)
+    #   class MySchema < GraphQL::Schema
+    #     query(Types::Query)
+    #   end
     #
     #   printer = GraphQL::Schema::Printer.new(MySchema)
-    #   puts printer.print_type(post_type)
+    #   puts printer.print_type(Types::Post)
     #
     class Printer < GraphQL::Language::Printer
       attr_reader :schema, :warden
@@ -87,7 +82,7 @@ module GraphQL
 
       # Return a GraphQL schema string for the defined types in the schema
       def print_schema
-        print(@document)
+        print(@document) + "\n"
       end
 
       def print_type(type)

--- a/spec/graphql/language/document_from_schema_definition_spec.rb
+++ b/spec/graphql/language/document_from_schema_definition_spec.rb
@@ -60,7 +60,7 @@ describe GraphQL::Language::DocumentFromSchemaDefinition do
     let(:expected_document) { GraphQL.parse(expected_idl) }
 
     describe "when schemas have enums and directives" do
-      let(:schema_idl) { <<-GRAPHQL.chomp
+      let(:schema_idl) { <<-GRAPHQL
 directive @locale(lang: LangEnum!) on FIELD
 
 directive @secret(top: Boolean = false) on FIELD_DEFINITION

--- a/spec/graphql/language/parser_spec.rb
+++ b/spec/graphql/language/parser_spec.rb
@@ -157,7 +157,7 @@ describe GraphQL::Language::Parser do
     schema = Dummy::Schema
     schema_string = GraphQL::Schema::Printer.print_schema(schema)
     document = subject.parse(schema_string)
-    assert_equal schema_string, document.to_query_string
+    assert_equal schema_string.chomp, document.to_query_string
   end
 
   describe "parse errors" do

--- a/spec/graphql/rake_task_spec.rb
+++ b/spec/graphql/rake_task_spec.rb
@@ -39,8 +39,8 @@ describe GraphQL::RakeTask do
       assert_equal(JSON.parse(expected_json), JSON.parse(dumped_json))
 
       dumped_idl = File.read("./schema.graphql")
-      expected_idl = rake_task_schema_defn.chomp
-      assert_equal(expected_idl + "\n", dumped_idl)
+      expected_idl = RakeTaskSchema.to_definition
+      assert_equal(expected_idl, dumped_idl, "The rake task output and #to_definition output match")
     end
   end
 

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -27,7 +27,7 @@ type HelloScalars {
 }
       SCHEMA
 
-      assert_schema_and_compare_output(schema.chop)
+      assert_schema_and_compare_output(schema)
     end
 
     it 'can build a schema with underscored names' do
@@ -41,7 +41,7 @@ type Query {
 }
       SCHEMA
 
-      assert_schema_and_compare_output(schema.chop)
+      assert_schema_and_compare_output(schema)
     end
 
     it 'can build a schema with default input object values' do
@@ -55,7 +55,7 @@ type Query {
 }
       SCHEMA
 
-      assert_schema_and_compare_output(schema.chop)
+      assert_schema_and_compare_output(schema)
     end
 
     it 'can build a schema with directives' do
@@ -119,7 +119,7 @@ type Word {
       assert_instance_of parsed_schema.directives["language"], au_revoir_directives.first
       assert_equal({ is: "fr" }, au_revoir_directives.first.arguments.keyword_arguments)
 
-      assert_schema_and_compare_output(schema.chop)
+      assert_schema_and_compare_output(schema)
     end
 
     it 'supports descriptions and definition_line' do
@@ -189,7 +189,7 @@ And a union
 union U = Hello
       SCHEMA
 
-      assert_schema_and_compare_output(schema.chop)
+      assert_schema_and_compare_output(schema)
 
       built_schema = GraphQL::Schema.from_definition(schema)
       # The schema's are the same since there's no description
@@ -307,7 +307,7 @@ type HelloScalars {
 }
       SCHEMA
 
-      assert_schema_and_compare_output(schema.chop)
+      assert_schema_and_compare_output(schema)
     end
 
     it 'supports recursive type' do
@@ -322,7 +322,7 @@ type Recurse {
 }
       SCHEMA
 
-      assert_schema_and_compare_output(schema.chop)
+      assert_schema_and_compare_output(schema)
     end
 
     it 'supports two types circular' do
@@ -342,7 +342,7 @@ type TypeTwo {
 }
       SCHEMA
 
-      assert_schema_and_compare_output(schema.chop)
+      assert_schema_and_compare_output(schema)
     end
 
     it 'supports single argument fields' do
@@ -360,7 +360,7 @@ type Hello {
 }
       SCHEMA
 
-      assert_schema_and_compare_output(schema.chop)
+      assert_schema_and_compare_output(schema)
     end
 
     it 'properly understands connections' do
@@ -474,7 +474,7 @@ type Type {
 }
       SCHEMA
 
-      built_schema = assert_schema_and_compare_output(schema.chop)
+      built_schema = assert_schema_and_compare_output(schema)
       obj = built_schema.types["Type"]
       refute obj.fields["organization"].connection?
       assert obj.fields["organizations"].connection?
@@ -491,7 +491,7 @@ type Hello {
 }
       SCHEMA
 
-      assert_schema_and_compare_output(schema.chop)
+      assert_schema_and_compare_output(schema)
     end
 
     it 'supports simple type with interface' do
@@ -509,7 +509,7 @@ interface WorldInterface {
 }
       SCHEMA
 
-      assert_schema_and_compare_output(schema.chop)
+      assert_schema_and_compare_output(schema)
     end
 
     it 'supports simple output enum' do
@@ -527,7 +527,7 @@ type OutputEnumRoot {
 }
       SCHEMA
 
-      assert_schema_and_compare_output(schema.chop)
+      assert_schema_and_compare_output(schema)
     end
 
     it 'supports simple input enum' do
@@ -545,7 +545,7 @@ type InputEnumRoot {
 }
       SCHEMA
 
-      assert_schema_and_compare_output(schema.chop)
+      assert_schema_and_compare_output(schema)
     end
 
     it 'supports multiple value enum' do
@@ -564,7 +564,7 @@ type OutputEnumRoot {
 }
       SCHEMA
 
-      assert_schema_and_compare_output(schema.chop)
+      assert_schema_and_compare_output(schema)
     end
 
     it 'supports simple union' do
@@ -584,7 +584,7 @@ type World {
 }
       SCHEMA
 
-      assert_schema_and_compare_output(schema.chop)
+      assert_schema_and_compare_output(schema)
     end
 
     it 'supports multiple union' do
@@ -608,7 +608,7 @@ type WorldTwo {
 }
       SCHEMA
 
-      assert_schema_and_compare_output(schema.chop)
+      assert_schema_and_compare_output(schema)
     end
 
     it 'supports redefining built-in scalars' do
@@ -624,7 +624,7 @@ type Root {
 }
       SCHEMA
 
-      built_schema = assert_schema_and_compare_output(schema.chop)
+      built_schema = assert_schema_and_compare_output(schema)
       id_scalar = built_schema.types["ID"]
       assert_equal true, id_scalar.valid_isolated_input?("123")
     end
@@ -642,7 +642,7 @@ type Root {
 }
       SCHEMA
 
-      built_schema = assert_schema_and_compare_output(schema.chop)
+      built_schema = assert_schema_and_compare_output(schema)
       custom_scalar = built_schema.types["CustomScalar"]
       assert_equal true, custom_scalar.valid_isolated_input?("anything")
       assert_equal true, custom_scalar.valid_isolated_input?(12345)
@@ -664,7 +664,7 @@ type Root {
 }
       SCHEMA
 
-      assert_schema_and_compare_output(schema.chop)
+      assert_schema_and_compare_output(schema)
     end
 
     it 'supports simple argument field with default value' do
@@ -685,7 +685,7 @@ type Hello {
 }
       SCHEMA
 
-      assert_schema_and_compare_output(schema.chop)
+      assert_schema_and_compare_output(schema)
     end
 
     it 'supports simple type with mutation' do
@@ -706,7 +706,7 @@ type Mutation {
 }
       SCHEMA
 
-      assert_schema_and_compare_output(schema.chop)
+      assert_schema_and_compare_output(schema)
     end
 
     it 'supports simple type with mutation and default values' do
@@ -725,7 +725,7 @@ type Query {
 }
       SCHEMA
 
-      assert_schema_and_compare_output(schema.chop)
+      assert_schema_and_compare_output(schema)
     end
 
     it 'supports simple type with subscription' do
@@ -746,7 +746,7 @@ type Subscription {
 }
       SCHEMA
 
-      assert_schema_and_compare_output(schema.chop)
+      assert_schema_and_compare_output(schema)
     end
 
     it 'supports unreferenced type implementing referenced interface' do
@@ -764,7 +764,7 @@ type Query {
 }
       SCHEMA
 
-      assert_schema_and_compare_output(schema.chop)
+      assert_schema_and_compare_output(schema)
     end
 
     it 'supports unreferenced type implementing referenced union' do
@@ -780,7 +780,7 @@ type Query {
 union Union = Concrete
       SCHEMA
 
-      assert_schema_and_compare_output(schema.chop)
+      assert_schema_and_compare_output(schema)
     end
 
     it 'supports @deprecated' do
@@ -806,7 +806,7 @@ type Query {
 }
       SCHEMA
 
-      assert_schema_and_compare_output(schema.chop)
+      assert_schema_and_compare_output(schema)
     end
 
     it "tracks original AST node" do
@@ -889,7 +889,7 @@ type HelloScalars {
         file.close
 
         built_schema = GraphQL::Schema.from_definition(file.path)
-        assert_equal schema.strip, GraphQL::Schema::Printer.print_schema(built_schema)
+        assert_equal schema, GraphQL::Schema::Printer.print_schema(built_schema)
       end
     end
   end
@@ -1395,7 +1395,7 @@ type ThingEdge {
 
       it "doesn't add arguments that aren't in the IDL" do
         schema = GraphQL::Schema.from_definition(schema_defn)
-        assert_equal schema_defn.chomp, schema.to_definition
+        assert_equal schema_defn, schema.to_definition
       end
     end
   end
@@ -1427,7 +1427,7 @@ type ThingEdge {
 
       assert_equal [], schema.orphan_types.map(&:graphql_name)
 
-      expected_definition = <<-GRAPHQL.chomp
+      expected_definition = <<-GRAPHQL
 interface Node {
   id: ID!
 }

--- a/spec/graphql/schema/loader_spec.rb
+++ b/spec/graphql/schema/loader_spec.rb
@@ -301,7 +301,7 @@ describe GraphQL::Schema::Loader do
     end
 
     it "works with underscored names" do
-      schema_sdl = <<-GRAPHQL.chomp
+      schema_sdl = <<-GRAPHQL
 type A_Type {
   f(argument_1: Int, argument_two: Int): Int
 }

--- a/spec/graphql/schema/printer_spec.rb
+++ b/spec/graphql/schema/printer_spec.rb
@@ -577,7 +577,7 @@ input Varied {
 }
 SCHEMA
 
-      assert_equal expected.chomp, GraphQL::Schema::Printer.print_schema(schema)
+      assert_equal expected, GraphQL::Schema::Printer.print_schema(schema)
     end
 
     it 'prints a schema without directives' do
@@ -595,7 +595,7 @@ SCHEMA
         query query_type
       end
 
-      expected = "type Query {\n  foobar: Int!\n}"
+      expected = "type Query {\n  foobar: Int!\n}\n"
       assert_equal expected, GraphQL::Schema::Printer.new(schema).print_schema
     end
   end
@@ -644,7 +644,7 @@ SCHEMA
     }
 
     context = { names: ["Query", "Post"] }
-    assert_equal expected.chomp, schema.to_definition(context: context, only: only_filter)
+    assert_equal expected, schema.to_definition(context: context, only: only_filter)
   end
 
 
@@ -740,7 +740,7 @@ SCHEMA
     }
 
     context = { names: ["Varied", "Image", "Sub"] }
-    assert_equal expected.chomp, schema.to_definition(context: context, except: except_filter)
+    assert_equal expected, schema.to_definition(context: context, except: except_filter)
   end
 
   describe "#print_type" do
@@ -847,7 +847,7 @@ SCHEMA
 
 
     str = GraphQL::Schema::Printer.print_schema TestPrintSchema
-    assert_equal "schema {\n  query: OddlyNamedQuery\n}\n\ntype OddlyNamedQuery {\n  int: Int!\n}", str
+    assert_equal "schema {\n  query: OddlyNamedQuery\n}\n\ntype OddlyNamedQuery {\n  int: Int!\n}\n", str
   end
 
   it "prints directives parsed from IDL" do
@@ -889,6 +889,6 @@ enum Thing {
     GRAPHQL
 
     schema = GraphQL::Schema.from_definition(input)
-    assert_equal input.chomp, GraphQL::Schema::Printer.print_schema(schema)
+    assert_equal input, GraphQL::Schema::Printer.print_schema(schema)
   end
 end

--- a/spec/integration/rails/graphql/schema_spec.rb
+++ b/spec/integration/rails/graphql/schema_spec.rb
@@ -177,7 +177,7 @@ type Query {
       SCHEMA
 
       built_schema = GraphQL::Schema.from_definition(schema)
-      assert_equal schema.chop, GraphQL::Schema::Printer.print_schema(built_schema)
+      assert_equal schema, GraphQL::Schema::Printer.print_schema(built_schema)
     end
 
     it "builds from a file" do


### PR DESCRIPTION
Fixes #3528 

As described there, the output of the rake task and the output of `MySchema.to_definition` should really _match_. And as described in #3480 , the file created by the rake task should really include a final newline. 

Given those two, `.to_definition` should also include a newline. People might have to add workarounds to accommodate this in their existing tooling, but on the whole, it sure seems like the _right_ thing to me. 