### PR TITLE
Remove reference to defunct slack instance and use discord invite link instead

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,6 @@ I also sell [GraphQL::Pro](https://graphql.pro) which provides several features 
 
 ## Getting Involved
 
-- __Say hi & ask questions__ in the [#ruby channel on Slack](https://graphql-slack.herokuapp.com/) or [on Twitter](https://twitter.com/rmosolgo)!
+- __Say hi & ask questions__ in the #graphql-ruby channel on [Discord](https://discord.com/invite/xud7bH9) or [on Twitter](https://twitter.com/rmosolgo)!
 - __Report bugs__ by posting a description, full stack trace, and all relevant code in a  [GitHub issue](https://github.com/rmosolgo/graphql-ruby/issues).
 - __Start hacking__ with the [Development guide](https://graphql-ruby.org/development).


### PR DESCRIPTION
The slack link points to a slack instance that is no longer used, and a discord link is pinned at the top.  The slack link should no longer be used.