### PR TITLE
configure a custom printer from the schema

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -270,7 +270,7 @@ module GraphQL
     # @return [String, nil] Returns nil if the query is invalid.
     def sanitized_query_string(inline_variables: true)
       with_prepared_ast {
-        GraphQL::Language::SanitizedPrinter.new(self, inline_variables: inline_variables).sanitized_query_string
+        schema.sanitized_printer.new(self, inline_variables: inline_variables).sanitized_query_string
       }
     end
 

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -1631,6 +1631,14 @@ module GraphQL
         find_inherited_value(:multiplex_analyzers, EMPTY_ARRAY) + own_multiplex_analyzers
       end
 
+      def sanitized_printer(new_sanitized_printer = nil)
+        if new_sanitized_printer
+          @own_sanitized_printer = new_sanitized_printer
+        else
+          @own_sanitized_printer || GraphQL::Language::SanitizedPrinter
+        end
+      end
+
       # Execute a query on itself.
       # @see {Query#initialize} for arguments.
       # @return [Hash] query result, ready to be serialized as JSON


### PR DESCRIPTION
[It is recommended that the redact condition be customized in a subclass that inherits from SanitizedPrinter](https://github.com/rmosolgo/graphql-ruby/blob/master/lib/graphql/language/sanitized_printer.rb#L62-L63).

However, we cannot use custom SanitizedPrinter in Query#sanitized_query_string because it does not provide a way to set a custom SanitizedPrinter in the schema.
to use a custom SanitizedPrinter, you need to create a Query object, which is very inconvenient.

This PullRequest implements a way to set a custom SanitizedPrinter from the schema so that custom SanitizedPrinter can be used with Query#sanitized_query_string.

