### PR TITLE
When an underscore itself is passed, `camelize` method returns a string unchanged without any error

### DIFF
--- a/lib/graphql/schema/member/build_type.rb
+++ b/lib/graphql/schema/member/build_type.rb
@@ -124,6 +124,7 @@ module GraphQL
         end
 
         def camelize(string)
+          return string if string == '_'
           return string unless string.include?("_")
           camelized = string.split('_').map(&:capitalize).join
           camelized[0] = camelized[0].downcase

--- a/spec/graphql/schema/member/build_type_spec.rb
+++ b/spec/graphql/schema/member/build_type_spec.rb
@@ -60,4 +60,21 @@ describe GraphQL::Schema::Member::BuildType do
       assert_equal "T", GraphQL::Schema::Member::BuildType.to_type_name(list_req_t)
     end
   end
+
+  describe ".camelize" do
+    it "keeps a string that does not contain underscore intact" do
+      s = "graphQL"
+      assert_equal s, GraphQL::Schema::Member::BuildType.camelize(s)
+    end
+
+    it "keeps an underscore itself intact" do
+      s = "_"
+      assert_equal s, GraphQL::Schema::Member::BuildType.camelize(s)
+    end
+
+    it "converts a string that contains underscore into a camelized one" do
+      s = "graph_ql"
+      assert_equal "graphQl", GraphQL::Schema::Member::BuildType.camelize(s)
+    end
+  end
 end


### PR DESCRIPTION
This PR updates the behaviour of `camelize` method when `_` itself was provided.
It adds an additional check to return a string as it is when the string is `_`, while it used to give "undefined method `downcase' for nil:NilClass" in the existing code.
I also added a test for this method in [build_type_spec.rb](https://github.com/rmosolgo/graphql-ruby/blob/edd51927f71424bfeff54406ff29dbe0c2d01869/spec/graphql/schema/member/build_type_spec.rb), with a minimal set of conditional cases.

Before:
```$ bundle exec rake test TEST=spec/graphql/schema/member/build_type_spec.rb

# Running tests with run options --seed 6671:

.............E.

Finished tests in 0.002122s, 7068.8030 tests/s, 6597.5495 assertions/s.


Error:
GraphQL::Schema::Member::BuildType::.to_type_name::.camelize#test_0002_keeps an underscore
itself intact:
NoMethodError: undefined method `downcase' for nil:NilClass
    /Users/motorollerscalatron/codes/graphql-ruby/lib/graphql/schema/member/build_type.rb:129:in `ca
melize'
    /Users/motorollerscalatron/codes/graphql-ruby/spec/graphql/schema/member/build_type_spec.rb:71:i
n `block (4 levels) in <top (required)>'
:
:
```

After:
```
$ bundle exec rake test TEST=spec/graphql/schema/member/build_type_spec.rb

# Running tests with run options --seed 14368:

...............

Finished tests in 0.003566s, 4206.3937 tests/s, 4206.3937 assertions/s.


15 tests, 15 assertions, 0 failures, 0 errors, 0 skips
```
