### PR TITLE
Add multi-tenant support for subscriptions

### DIFF
--- a/guides/subscriptions/multi_tenant.md
+++ b/guides/subscriptions/multi_tenant.md
@@ -79,12 +79,12 @@ For __deserializing ActionCable messages__, provide a `serializer:` object that 
 ```ruby
 class MultiTenantSerializer
   def self.dump(obj)
-    GraphQL::Subscriptions::Serializer.dump(obj)
+    GraphQL::Subscriptions::Serialize.dump(obj)
   end
 
   def self.load(string, context)
     MultiTenancy.select_tenant(context[:tenant]) do
-      GraphQL::Subscriptions::Serializer.load(string)
+      GraphQL::Subscriptions::Serialize.load(string)
     end
   end
 end

--- a/guides/subscriptions/multi_tenant.md
+++ b/guides/subscriptions/multi_tenant.md
@@ -1,0 +1,119 @@
+---
+layout: guide
+doc_stub: false
+search: true
+section: Subscriptions
+title: Multi-Tenant
+desc: Switching tenants in GraphQL Subscription execution
+index: 8
+---
+
+In a multi-tenant system, data from many different accounts is stored on the same server. (An account might be an organization, a customer, a namespace, a domain, etc -- these are all _tenants_.) Gems like [Apartment](https://github.com/influitive/apartment) assist with this arrangement, but it can also be implemented in the application. Here are a few considerations for this architecture when using GraphQL subscriptions.
+
+#### Tenant-based `subscription_scope`
+
+When subscriptions are delivered, {% internal_link "`subscription_scope`",  "subscriptions/subscription_classes#scope" %} is one element used to route data to the right subscriber. In short, it's the _implicit_ identifier for the receiver. In a multi-tenant architecture, `subscription_scope` should reference the context key that names the tenant, for example:
+
+```ruby
+class BudgetWasApproved < GraphQL::Schema::Subscription
+  subscription_scope :tenant # This would work with `context[:tenant] => "acme-corp"`
+  # ...
+end
+
+# Include the scope when `.trigger`ing:
+BudgetSchema.subscriptions.trigger(:budget_was_approved, {}, { ... }, scope: "acme-corp")
+```
+
+
+Alternatively, `subscription_scope` might name something that _belongs_ to the tenant:
+
+```ruby
+class BudgetWasApproved < GraphQL::Schema::Subcription
+  subscription_scope :project_id # This would work with `context[:project_id] = 1234`
+end
+
+# Include the scope when `.trigger`ing:
+BudgetSchema.subscriptions.trigger(:budget_was_approved, {}, { ... }, scope: 1234)
+```
+
+As long as `project_id` is unique among _all_ tenants, that would work fine too. But _some_ scope is required so that subscriptions can be disambiguated between tenants.
+
+#### Choosing a tenant for execution
+
+There are a few places where subscriptions might need to load data:
+
+- When building the payload for the subscription (fetching data to prepare the result)
+- `ActionCableSubscriptions`: when deserializing the JSON string broadcasted by `ActionCable`
+- `PusherSubscriptions` and `AblySubscriptions`: when deserializing query context
+
+Each of these operations will need to select the right tenant in order to load data properly.
+
+For __building the payload__, use a {% internal_link "Tracer", "queries/tracing" %}:
+
+```ruby
+class TenantSelectionTracer
+  def self.trace(event, data)
+    case event
+    when "execute_multiplex" # this is the top-level, umbrella event
+      context = data[:multiplex].queries.first.context # This assumes that all queries in a multiplex have the same tenant
+      MultiTenancy.select_tenant(context[:tenant]) do
+      # ^^ your multi-tenancy implementation here
+        yield
+      end
+    else
+      yield
+    end
+  end
+end
+
+# ...
+class MySchema < GraphQL::Schema
+  tracer(TenantSelectionTracer)
+end
+```
+
+The tracer above will use `context[:tenant]` to select a tenant for the duration of execution for _all_ queries, mutations, and subscriptions.
+
+For __deserializing ActionCable messages__, provide a `serializer:` object that implements `.dump(obj)` and `.load(string, context)`:
+
+```ruby
+class MultiTenantSerializer
+  def self.dump(obj)
+    GraphQL::Subscriptions::Serializer.dump(obj)
+  end
+
+  def self.load(string, context)
+    MultiTenancy.select_tenant(context[:tenant]) do
+      GraphQL::Subscriptions::Serializer.load(string)
+    end
+  end
+end
+
+# ...
+class MySchema < GraphQL::Schema
+  # ...
+  use GraphQL::Subscriptions::ActionCableSubscriptions, serializer: MultiTenantSerializer
+end
+```
+
+The implementation above will use the built-in serialization algorithms, but it will do so _in the context of_ the selected tenant.
+
+For __loading query context in Pusher and Ably__, add tenant selection to your `load_context` method, if required:
+
+```ruby
+class CustomSubscriptions < GraphQL::Pro::PusherSubscriptions # or `GraphQL::Pro::AblySubscriptions`
+  def dump_context(ctx)
+    JSON.dump(ctx.to_h)
+  end
+
+  def load_context(ctx_string)
+    ctx_data = JSON.parse(ctx_string)
+    MultiTenancy.select_tenant(ctx_data["tenant"]) do
+      # Build a symbol-keyed hash, loading objects from the database if necessary
+      # to use a `context: ...`
+    end
+  end
+end
+```
+
+With that approach, the selected tenant will be active when building the context hash, in case any objects need to be loaded from the database.

--- a/guides/subscriptions/multi_tenant.md
+++ b/guides/subscriptions/multi_tenant.md
@@ -10,6 +10,20 @@ index: 8
 
 In a multi-tenant system, data from many different accounts is stored on the same server. (An account might be an organization, a customer, a namespace, a domain, etc -- these are all _tenants_.) Gems like [Apartment](https://github.com/influitive/apartment) assist with this arrangement, but it can also be implemented in the application. Here are a few considerations for this architecture when using GraphQL subscriptions.
 
+#### Add Tenant to `context`
+
+All the approaches below will use `context[:tenant]` to identify the tenant during GraphQL execution, so make sure to assign it before executing a query:
+
+```ruby
+context = {
+  viewer: current_user,
+  tenant: current_user.tenant,
+  # ...
+}
+
+MySchema.execute(query_str, context: context, ...)
+```
+
 #### Tenant-based `subscription_scope`
 
 When subscriptions are delivered, {% internal_link "`subscription_scope`",  "subscriptions/subscription_classes#scope" %} is one element used to route data to the right subscriber. In short, it's the _implicit_ identifier for the receiver. In a multi-tenant architecture, `subscription_scope` should reference the context key that names the tenant, for example:

--- a/guides/subscriptions/overview.md
+++ b/guides/subscriptions/overview.md
@@ -47,3 +47,7 @@ Read more in the {% internal_link "Implementation guide", "subscriptions/impleme
 ### Broadcasts
 
 By default, the subscription implementations listed above handle each subscription in total isolation. However, this behavior can be optimized by setting up broadcasts. Read more in the {% internal_link "Broadcast guide", "subscriptions/broadcast" %}.
+
+### Multi-Tenant
+
+See the {% internal_link "Multi-tenant guide", "subscriptions/multi_tenant" %} for supporting multi-tenancy in GraphQL subscriptions.

--- a/spec/graphql/subscriptions/action_cable_subscriptions_spec.rb
+++ b/spec/graphql/subscriptions/action_cable_subscriptions_spec.rb
@@ -155,4 +155,134 @@ describe GraphQL::Subscriptions::ActionCableSubscriptions do
     res = ActionCableTestSchema.subscriptions.execute_update("nonsense-id", {}, {})
     assert_nil res
   end
+
+  if defined?(GlobalID)
+    class MultiTenantSchema < GraphQL::Schema
+      module Data
+        class Player
+          include GlobalID::Identification
+
+          attr_reader :name, :id
+
+          def initialize(id, name)
+            @id = id
+            @name = name
+          end
+
+          def self.find(id)
+            Data.find(id)
+          end
+        end
+
+        OBJECTS_BY_TENANT = {
+          "tenant-1" => { 1 => Player.new(1, "player-1") },
+          "tenant-2" => { 2 => Player.new(2, "player-2") },
+        }
+
+        def self.find(id)
+          if @current_tenant
+            id = id.to_i # It's stringified by GlobalId
+            @current_tenant[id] || raise("Didn't find `#{id.inspect}` in #{@current_tenant}")
+          else
+            raise("Use .switch to pick a tenant first")
+          end
+        end
+
+        def self.switch(tenant)
+          @current_tenant = OBJECTS_BY_TENANT.fetch(tenant)
+          yield
+        ensure
+          @current_tenant = nil
+        end
+      end
+
+      class Player < GraphQL::Schema::Object
+        field :name, String, null: false
+      end
+
+      class PointScored < GraphQL::Schema::Subscription
+        field :score, Int, null: false
+        field :player, Player, null: false
+        subscription_scope :tenant
+
+        def update
+          {
+            score: object[:score],
+            player: object[:player] || Data.find(object[:player_id])
+          }
+        end
+      end
+
+      class Subscription < GraphQL::Schema::Object
+        field :point_scored, subscription: PointScored
+      end
+
+      class TenantTracer
+        def self.trace(event, data)
+          case event
+          when "execute_multiplex"
+            tenant = data[:multiplex].queries.first.context[:tenant]
+            Data.switch(tenant) do
+              yield
+            end
+          else
+            yield
+          end
+        end
+      end
+
+      query(Player)
+      subscription(Subscription)
+      tracer(TenantTracer)
+
+      module Serialize
+        def self.load(message, ctx)
+          Data.switch(ctx[:tenant]) do
+            GraphQL::Subscriptions::Serialize.load(message)
+          end
+        end
+
+        def self.dump(obj)
+          GraphQL::Subscriptions::Serialize.dump(obj)
+        end
+      end
+
+      use GraphQL::Subscriptions::ActionCableSubscriptions,
+        action_cable: MockActionCable,
+        action_cable_coder: JSON,
+        serializer: Serialize
+    end
+
+    it "works with multi-tenant architecture" do
+      mock_channel_1 = MockActionCable.get_mock_channel
+      ctx_1 = { channel: mock_channel_1, tenant: "tenant-1" }
+      MultiTenantSchema.execute("subscription { pointScored { score player { name } } }", context: ctx_1)
+
+      mock_channel_2 = MockActionCable.get_mock_channel
+      ctx_2 = { channel: mock_channel_2, tenant: "tenant-2" }
+      MultiTenantSchema.execute("subscription { pointScored { score player { name } } }", context: ctx_2)
+      # This will use the `.find` in `def update`:
+      MultiTenantSchema.subscriptions.trigger(:point_scored, {}, { score: 5, player_id: 1 }, scope: "tenant-1")
+      # This will use GlobalId in `Serialize`:
+      MultiTenantSchema.subscriptions.trigger(:point_scored, {}, { score: 3, player: MultiTenantSchema::Data::Player.new(2, nil) }, scope: "tenant-2")
+
+
+      expected_msg_1 = subscription_update({
+        "pointScored" => {
+          "score" => 5,
+          "player" => { "name" => "player-1" },
+        }
+      })
+
+      expected_msg_2 = subscription_update({
+        "pointScored" => {
+          "score" => 3,
+          "player" => { "name" => "player-2" }
+        },
+      })
+
+      assert_equal [expected_msg_1], mock_channel_1.mock_broadcasted_messages
+      assert_equal [expected_msg_2], mock_channel_2.mock_broadcasted_messages
+    end
+  end
 end


### PR DESCRIPTION
This came up in https://github.com/rmosolgo/graphql-ruby/issues/2444 and again, recently, by email, so I thought I'd explore proper support for it. 

Here, I've added a test case for multi-tenant subscription updates with ActionCable and a brief guide describing the considerations.