### PR TITLE
Update wording of the `max_page_size` option to include database limit

### DIFF
--- a/guides/pagination/using_connections.md
+++ b/guides/pagination/using_connections.md
@@ -62,7 +62,7 @@ This way, you can handle this _particular_ `relation` with custom code.
 
 ## Max Page Size
 
-You can apply `max_page_size` to limit the number of items returned, regardless of what the client requests.
+You can apply `max_page_size` to limit the number of items returned and queried from the database, regardless of what the client requests.
 
 - __For the whole schema__, you can add it to your schema definition:
 


### PR DESCRIPTION
Not sure how you'd prefer the wording, but would like a call out that specifies that the database query is also limited, as I (and presumably others) had assumed that it would just limit the returned data but still hit the database for a large list of items.

Is related to #3576 