### PR TITLE
Avoid refining String when not necessary

### DIFF
--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -57,22 +57,26 @@ module GraphQL
   end
 
   # Support Ruby 2.2 by implementing `-"str"`. If we drop 2.2 support, we can remove this backport.
-  module StringDedupBackport
-    refine String do
-      def -@
-        if frozen?
-          self
-        else
-          self.dup.freeze
+  if !String.method_defined?(:-@)
+    module StringDedupBackport
+      refine String do
+        def -@
+          if frozen?
+            self
+          else
+            self.dup.freeze
+          end
         end
       end
     end
   end
 
-  module StringMatchBackport
-    refine String do
-      def match?(pattern)
-        self =~ pattern
+  if !String.method_defined?(:match?)
+    module StringMatchBackport
+      refine String do
+        def match?(pattern)
+          self =~ pattern
+        end
       end
     end
   end


### PR DESCRIPTION
Refinements have a very significant performance overhead. The simple fact of refining a method, even if the refinement is never used will make calls to that method 40% slower.

On rarely called methods in doesn't matter that much, but graphql-ruby refine some common String methods, so any project including the gem suffer from a significant performance penalty.

See this benchmark for more details: https://gist.github.com/casperisfine/1c46f05cccfa945cd156f445f0d3d6fa