### PR TITLE
Support server-filtered dynamic streams for subscription

### DIFF
--- a/lib/graphql/schema/subscription.rb
+++ b/lib/graphql/schema/subscription.rb
@@ -116,6 +116,22 @@ module GraphQL
         end
       end
 
+      # This is called during initial subscription to get a "name" for this subscription.
+      # Later, when `.trigger` is called, this will be called again to build another "name".
+      # Any subscribers with matching topic will begin the update flow.
+      #
+      # The default implementation creates a string using the field name, subscription scope, and argument keys and values.
+      # In that implementation, only `.trigger` calls with _exact matches_ result in updates to subscribers.
+      #
+      # To implement a filtered stream-type subscription flow, override this method to return a string with field name and subscription scope.
+      # Then, implement {#update} to compare its arguments to the current `object` and return `:no_update` when an
+      # update should be filtered out.
+      #
+      # @see {#update} for how to skip updates when an event comes with a matching topic.
+      # @param arguments [GraphQL::Execution::Interpreter::Arguments]
+      # @param field [GraphQL::Schema::Field]
+      # @param scope [Object, nil] A value corresponding to `.trigger(... scope:)` (for updates) or the `subscription_scope` found in `context` (for initial subscriptions).
+      # @return [String] An identifier corresponding to a stream of updates
       def self.topic_for(arguments:, field:, scope:)
         normalized_args = case arguments
         when GraphQL::Query::Arguments

--- a/lib/graphql/schema/subscription.rb
+++ b/lib/graphql/schema/subscription.rb
@@ -128,30 +128,12 @@ module GraphQL
       # update should be filtered out.
       #
       # @see {#update} for how to skip updates when an event comes with a matching topic.
-      # @param arguments [GraphQL::Execution::Interpreter::Arguments]
+      # @param arguments [Hash<String => Object>] The arguments for this topic, in GraphQL-style (camelized strings)
       # @param field [GraphQL::Schema::Field]
       # @param scope [Object, nil] A value corresponding to `.trigger(... scope:)` (for updates) or the `subscription_scope` found in `context` (for initial subscriptions).
       # @return [String] An identifier corresponding to a stream of updates
       def self.topic_for(arguments:, field:, scope:)
-        normalized_args = case arguments
-        when GraphQL::Query::Arguments
-          arguments
-        when Hash
-          if field.is_a?(GraphQL::Schema::Field)
-            Subscriptions::Event.stringify_args(field, arguments)
-          else
-            GraphQL::Query::LiteralInput.from_arguments(
-              arguments,
-              field,
-              nil,
-            )
-          end
-        else
-          raise ArgumentError, "Unexpected arguments: #{arguments}, must be Hash or GraphQL::Arguments"
-        end
-
-        sorted_h = Subscriptions::Event.stringify_args(field, normalized_args.to_h)
-        Subscriptions::Serialize.dump_recursive([scope, field.graphql_name, sorted_h])
+        Subscriptions::Serialize.dump_recursive([scope, field.graphql_name, arguments])
       end
 
       # Overriding Resolver#field_options to include subscription_scope

--- a/lib/graphql/subscriptions/event.rb
+++ b/lib/graphql/subscriptions/event.rb
@@ -29,26 +29,9 @@ module GraphQL
       end
 
       # @return [String] an identifier for this unit of subscription
-      def self.serialize(name, arguments, field, scope:)
-        normalized_args = case arguments
-        when GraphQL::Query::Arguments
-          arguments
-        when Hash
-          if field.is_a?(GraphQL::Schema::Field)
-            stringify_args(field, arguments)
-          else
-            GraphQL::Query::LiteralInput.from_arguments(
-              arguments,
-              field,
-              nil,
-            )
-          end
-        else
-          raise ArgumentError, "Unexpected arguments: #{arguments}, must be Hash or GraphQL::Arguments"
-        end
-
-        sorted_h = stringify_args(field, normalized_args.to_h)
-        Serialize.dump_recursive([scope, name, sorted_h])
+      def self.serialize(_name, arguments, field, scope:)
+        subscription = field.resolver || GraphQL::Schema::Subscription
+        subscription.topic_for(arguments: arguments, field: field, scope: scope)
       end
 
       # @return [String] a logical identifier for this event. (Stable when the query is broadcastable.)
@@ -68,7 +51,7 @@ module GraphQL
       end
 
       class << self
-        private
+        # TODO implement this another way?
         def stringify_args(arg_owner, args)
           case args
           when Hash

--- a/lib/graphql/subscriptions/event.rb
+++ b/lib/graphql/subscriptions/event.rb
@@ -31,7 +31,8 @@ module GraphQL
       # @return [String] an identifier for this unit of subscription
       def self.serialize(_name, arguments, field, scope:)
         subscription = field.resolver || GraphQL::Schema::Subscription
-        subscription.topic_for(arguments: arguments, field: field, scope: scope)
+        normalized_args = stringify_args(field, arguments.to_h)
+        subscription.topic_for(arguments: normalized_args, field: field, scope: scope)
       end
 
       # @return [String] a logical identifier for this event. (Stable when the query is broadcastable.)
@@ -51,7 +52,7 @@ module GraphQL
       end
 
       class << self
-        # TODO implement this another way?
+        private
         def stringify_args(arg_owner, args)
           case args
           when Hash

--- a/spec/graphql/subscriptions_spec.rb
+++ b/spec/graphql/subscriptions_spec.rb
@@ -66,8 +66,10 @@ class InMemoryBackend
       sub_ids_by_fp = @events[topic]
       sub_ids_by_fp.each do |fingerprint, sub_ids|
         result = execute_update(sub_ids.first, event, object)
-        sub_ids.each do |sub_id|
-          deliver(sub_id, result)
+        if !result.nil?
+          sub_ids.each do |sub_id|
+            deliver(sub_id, result)
+          end
         end
       end
     end
@@ -134,6 +136,25 @@ class ClassBasedInMemoryBackend < InMemoryBackend
     field :payload, Payload, null: true
   end
 
+  class FilteredStream < GraphQL::Schema::Subscription
+    subscription_scope :segment
+    argument :channel, Integer, required: false
+
+    field :message, String, null: false
+
+    def update(channel: nil)
+      if channel && object.channel != channel
+        :no_update
+      else
+        super
+      end
+    end
+
+    def self.topic_for(arguments:, field:, scope:)
+      "#{field.graphql_name}:#{scope}"
+    end
+  end
+
   class Subscription < GraphQL::Schema::Object
     field :payload, Payload, null: false do
       argument :id, ID, required: true
@@ -156,6 +177,8 @@ class ClassBasedInMemoryBackend < InMemoryBackend
     def failed_event(id:)
       raise GraphQL::ExecutionError.new("unauthorized")
     end
+
+    field :filtered_stream, subscription: FilteredStream
   end
 
   class Query < GraphQL::Schema::Object
@@ -293,6 +316,46 @@ describe GraphQL::Subscriptions do
           assert_equal({"str" => "Update", "int" => 1}, deliveries["1"][0]["data"]["firstPayload"])
           assert_equal({"str" => "Update", "int" => 2}, deliveries["2"][0]["data"]["firstPayload"])
           assert_equal({"str" => "Update", "int" => 3}, deliveries["1"][1]["data"]["firstPayload"])
+        end
+      end
+
+      if schema != FromDefinitionInMemoryBackend::Schema # No way to specify this when using IDL
+        it "supports filtering in the subscription class" do
+          query_str = "subscription($channel: Int) { filteredStream(channel: $channel) { message } }"
+
+          # Unfiltered:
+          schema.execute(query_str, context: { socket: "1", segment: "A" }, variables: {})
+          # Filtered:
+          schema.execute(query_str, context: { socket: "2", segment: "A" }, variables: { channel: 1 })
+          schema.execute(query_str, context: { socket: "3", segment: "A" }, variables: { channel: 2 })
+
+          # Another Subscription scope:
+          schema.execute(query_str, context: { socket: "4", segment: "B" }, variables: {})
+          schema.execute(query_str, context: { socket: "5", segment: "B" }, variables: { channel: 1 })
+
+          schema.subscriptions.trigger(:filtered_stream, {}, OpenStruct.new(channel: 1, message: "Message 1"), scope: "A")
+          schema.subscriptions.trigger(:filtered_stream, {}, OpenStruct.new(channel: 2, message: "Message 2"), scope: "A")
+          schema.subscriptions.trigger(:filtered_stream, {}, OpenStruct.new(channel: 3, message: "Message 3"), scope: "A")
+
+          # Unfiltered, received all updates:
+          assert_equal 3, deliveries["1"].size
+          # Only received updates that matched `channel`:
+          assert_equal 1, deliveries["2"].size
+          assert_equal 1, deliveries["3"].size
+          # Different segment, no updates:
+          assert_equal 0, deliveries["4"].size
+          assert_equal 0, deliveries["5"].size
+
+          schema.subscriptions.trigger(:filtered_stream, {}, OpenStruct.new(channel: 1, message: "Message 4"), scope: "B")
+          schema.subscriptions.trigger(:filtered_stream, {}, OpenStruct.new(channel: 2, message: "Message 5"), scope: "B")
+
+          # These should be unchanged because the later triggers had a different scope value:
+          assert_equal 3, deliveries["1"].size
+          assert_equal 1, deliveries["2"].size
+          assert_equal 1, deliveries["3"].size
+          # These received updates from the second set of triggers:
+          assert_equal 2, deliveries["4"].size
+          assert_equal 1, deliveries["5"].size
         end
       end
 

--- a/spec/graphql/subscriptions_spec.rb
+++ b/spec/graphql/subscriptions_spec.rb
@@ -319,7 +319,7 @@ describe GraphQL::Subscriptions do
         end
       end
 
-      if schema != FromDefinitionInMemoryBackend::Schema # No way to specify this when using IDL
+      if in_memory_backend_class != FromDefinitionInMemoryBackend # No way to specify this when using IDL
         it "supports filtering in the subscription class" do
           query_str = "subscription($channel: Int) { filteredStream(channel: $channel) { message } }"
 


### PR DESCRIPTION
Fixes #3588 

TODO:

- [x] Move a topic method into subscription classes
- [x] Test overriding the topic method and filtering with `#update`
- [x] Clean up argument serialization? Can't that use an existing method?