### PR TITLE
Fix non-null connection fields to only return one non-null error

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -369,6 +369,7 @@ module GraphQL
 
         # @return [void]
         def evaluate_selection(path, result_name, field_ast_nodes_or_ast_node, scoped_context, owner_object, owner_type, is_eager_field, selections_result) # rubocop:disable Metrics/ParameterLists
+          return if dead_result?(selections_result)
           # As a performance optimization, the hash key will be a `Node` if
           # there's only one selection of the field. But if there are multiple
           # selections of the field, it will be an Array of nodes

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -649,6 +649,7 @@ describe GraphQL::Execution::Interpreter do
         connection_type_class BaseConnection
         edge_type_class BaseEdge
         field :title, String, null: false
+        field :body, String, null: false
       end
 
       class Query < GraphQL::Schema::Object
@@ -656,6 +657,15 @@ describe GraphQL::Execution::Interpreter do
 
         def things
           [{title: "a"}, {title: "b"}, {title: "c"}]
+        end
+
+        field :thing, Thing, null: false
+
+        def thing
+          {
+            title: "a",
+            body: "b",
+          }
         end
       end
 
@@ -670,6 +680,10 @@ describe GraphQL::Execution::Interpreter do
       assert_equal 1, res.context[:authorized_calls]
 
       res = ConnectionErrorTest::Schema.execute("{ things { edges { node { title } } } }")
+      assert_equal 1, res["errors"].size
+      assert_equal 1, res.context[:authorized_calls]
+
+      res = ConnectionErrorTest::Schema.execute("{ thing { title body } }")
       assert_equal 1, res["errors"].size
       assert_equal 1, res.context[:authorized_calls]
     end


### PR DESCRIPTION
This puts the behavior _back_ to how it was in 1.12.10

Also, stop resolving lists when they become dead.

Fixes https://github.com/rmosolgo/graphql-ruby/issues/3504#issuecomment-908825696 