### PR TITLE
Properly detect input objects for authorization

### DIFF
--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -151,7 +151,7 @@ module GraphQL
             input_obj_arg = input_obj_arg.type_class
             # TODO: this skips input objects whose values were alread replaced with application objects.
             # See: https://github.com/rmosolgo/graphql-ruby/issues/2633
-            if value.respond_to?(:key?) && value.key?(input_obj_arg.keyword) && !input_obj_arg.authorized?(obj, value[input_obj_arg.keyword], ctx)
+            if value.is_a?(InputObject) && value.key?(input_obj_arg.keyword) && !input_obj_arg.authorized?(obj, value[input_obj_arg.keyword], ctx)
               return false
             end
           end


### PR DESCRIPTION
Instead of assuming any object responding to `.key?` is a hash, use `.has_key?` instead, which is less likely to conflict with some application object method name.

Fixes #3604