### PR TITLE
Ruby 3: Don't pass empty hash as kwargs

### DIFF
--- a/lib/graphql/define/instance_definable.rb
+++ b/lib/graphql/define/instance_definable.rb
@@ -76,7 +76,7 @@ ERR
             # Apply definition from `define(...)` kwargs
             defn.define_keywords.each do |keyword, value|
               # Don't splat string hashes, which blows up on Rubies before 2.7
-              if value.is_a?(Hash) && value.each_key.all? { |k| k.is_a?(Symbol) }
+              if value.is_a?(Hash) && !value.empty? && value.each_key.all? { |k| k.is_a?(Symbol) }
                 defn_proxy.public_send(keyword, **value)
               else
                 defn_proxy.public_send(keyword, value)


### PR DESCRIPTION
## Problem description

When dynamically generating a schema via `GraphQL::Schema.define` while running Ruby 3, we encountered an error like thiis

```
12:16:29 GraphQL::Schema::InvalidTypeError: Query is invalid: field "api_user_coupon" arguments must be a hash of {String => GraphQL::Argument}, not a NilClass (nil)
12:16:29 /mnt/vol/tmp/bundler/pull-request/ruby/3.0.0/gems/graphql-1.12.12/lib/graphql/schema/traversal.rb:223:in `validate_type'
12:16:29 /mnt/vol/tmp/bundler/pull-request/ruby/3.0.0/gems/graphql-1.12.12/lib/graphql/schema/traversal.rb:142:in `visit'
12:16:29 /mnt/vol/tmp/bundler/pull-request/ruby/3.0.0/gems/graphql-1.12.12/lib/graphql/schema/traversal.rb:128:in `block in visit'
12:16:29 /mnt/vol/tmp/bundler/pull-request/ruby/3.0.0/gems/graphql-1.12.12/lib/graphql/schema/traversal.rb:128:in `each'
12:16:29 /mnt/vol/tmp/bundler/pull-request/ruby/3.0.0/gems/graphql-1.12.12/lib/graphql/schema/traversal.rb:128:in `visit'
12:16:29 /mnt/vol/tmp/bundler/pull-request/ruby/3.0.0/gems/graphql-1.12.12/lib/graphql/schema/traversal.rb:47:in `initialize'
12:16:29 /mnt/vol/tmp/bundler/pull-request/ruby/3.0.0/gems/graphql-1.12.12/lib/graphql/schema.rb:1828:in `new'
12:16:29 /mnt/vol/tmp/bundler/pull-request/ruby/3.0.0/gems/graphql-1.12.12/lib/graphql/schema.rb:1828:in `rebuild_artifacts'
12:16:29 /mnt/vol/tmp/bundler/pull-request/ruby/3.0.0/gems/graphql-1.12.12/lib/graphql/schema.rb:402:in `types'
12:16:29 /mnt/vol/tmp/bundler/pull-request/ruby/3.0.0/gems/graphql-1.12.12/lib/graphql/schema/validation.rb:157:in `block in module:Rules'
12:16:29 /mnt/vol/tmp/bundler/pull-request/ruby/3.0.0/gems/graphql-1.12.12/lib/graphql/schema/validation.rb:20:in `block (2 levels) in validate'
12:16:29 /mnt/vol/tmp/bundler/pull-request/ruby/3.0.0/gems/graphql-1.12.12/lib/graphql/schema/validation.rb:19:in `each'
12:16:29 /mnt/vol/tmp/bundler/pull-request/ruby/3.0.0/gems/graphql-1.12.12/lib/graphql/schema/validation.rb:19:in `block in validate'
12:16:29 /mnt/vol/tmp/bundler/pull-request/ruby/3.0.0/gems/graphql-1.12.12/lib/graphql/schema/validation.rb:17:in `each'
12:16:29 /mnt/vol/tmp/bundler/pull-request/ruby/3.0.0/gems/graphql-1.12.12/lib/graphql/schema/validation.rb:17:in `validate'
12:16:29 /mnt/vol/tmp/bundler/pull-request/ruby/3.0.0/gems/graphql-1.12.12/lib/graphql/schema.rb:363:in `deprecated_define'
12:16:29 /mnt/vol/tmp/bundler/pull-request/ruby/3.0.0/gems/graphql-1.12.12/lib/graphql/define/instance_definable.rb:155:in `deprecated_define'
12:16:29 /mnt/vol/tmp/bundler/pull-request/ruby/3.0.0/gems/graphql-1.12.12/lib/graphql/define/instance_definable.rb:19:in `define'
```

## Cause

This issue apparently occurs when dynamically defining a field without any arguments in Ruby 3 (this worked without issue for Ruby 2.7 and earlier).

In this case, an empty hash is being passed to the `method_missing` of `DefinedObjectProxy` when attempting to define the `arguments` on a `GraphQL::Field` as being an empty hash `{}`.:

https://github.com/rmosolgo/graphql-ruby/blob/bace1e4027900fc8779a5c2fd393ff6456046cea/lib/graphql/define/defined_object_proxy.rb#L36-L46

This then calls

https://github.com/rmosolgo/graphql-ruby/blob/bace1e4027900fc8779a5c2fd393ff6456046cea/lib/graphql/define/instance_definable.rb#L223-L238

which then just calls the accessor for `arguments` on `GraphQL::Field`. Note, also, the comment on `AssignAttribute#call`

```
        # Even though we're just using the first value here,
        # We have to add a splat here to use `ruby2_keywords`,
        # so that it will accept a `[{}]` input from the caller.
```

This is a clue to the solution, to be described below.

### Explanation

In Ruby 2.7 (using [ruby2_keywords](https://github.com/ruby/ruby2_keywords)), this is not a problem because the empty hash is retained as just an empty hash when the splatted hash is further passed in a method as `*args`. Here's a minimal Ruby example:

```ruby
# Ruby 2.7
✦ ❯ irb
irb(main):001:1* class A
irb(main):002:2*   def m(*args)
irb(main):003:2*     p args
irb(main):004:1*   end
irb(main):005:1*   ruby2_keywords :m
irb(main):006:0> end
=> nil
irb(main):008:0> A.new.m(**{})
[{}]
=> [{}]
```

[In Ruby 3, the behaviour of splatting a hash argument into keyword arguments changed](https://eregon.me/blog/2019/11/10/the-delegation-challenge-of-ruby27.html). In this particular case, after splatting with `**` the hash disappears and then interpreted as just `[]` when passed through `*args`. Here's a minimal example in Ruby:

```ruby
# Ruby 3
❯ irb
irb(main):001:1* class A
irb(main):002:2*   def m(*args)
irb(main):003:2*     p args
irb(main):004:1*   end
irb(main):005:1*   ruby2_keywords :m
irb(main):006:0> end
=> nil
irb(main):007:0> A.new.m(**{})
[]
```

This empty array is used in `AssignAttribute#call`

https://github.com/rmosolgo/graphql-ruby/blob/bace1e4027900fc8779a5c2fd393ff6456046cea/lib/graphql/define/instance_definable.rb#L234

Which is why `arguments` is assigned as `nil` rather than `{}`, despite being called as `arguments = {}` at the very top.

## Solution

The approach I'm suggesting in this PR is to avoid splatting an emptyHash into keyword arguments. This will be compatible with all versions of Ruby.