### PR TITLE
Fix typo for Subscription#subscribe documentation

### DIFF
--- a/lib/graphql/schema/subscription.rb
+++ b/lib/graphql/schema/subscription.rb
@@ -58,11 +58,9 @@ module GraphQL
         end
       end
 
-      # Default implementation returns the root object.
+      # The default implementation returns nothing on subscribe.
       # Override it to return an object or
-      # `:no_response` to return nothing.
-      #
-      # The default is `:no_response`.
+      # `:no_response` to (explicitly) return nothing.
       def subscribe(args = {})
         :no_response
       end


### PR DESCRIPTION
> #&nbsp;Default implementation returns the root object.
> ...
> def subscribe

- `Subscription#update` returns root object by default
- `Subscription#subscribe` returns :no_response by default

Therefore this line seems to be a typo.