### PR TITLE
Suggest using rails/globalid for object identification

### DIFF
--- a/guides/schema/object_identification.md
+++ b/guides/schema/object_identification.md
@@ -51,6 +51,22 @@ class MySchema < GraphQL::Schema
 end
 ```
 
+You could also use the [`GlobalID`](https://github.com/rails/globalid) gem (included in Ruby on Rails since v4.2) to achieve this:
+
+```ruby
+class MySchema < GraphQL::Schema
+  def self.id_from_object(object, type_definition, query_ctx)
+    # Generates a URI like `gid://myproject/User/1` base64-encoded.
+    object.to_gid.to_param
+  end
+
+  def self.object_from_id(id, query_ctx)
+    # Finds the object using the base64-encoded URI.
+    GlobalID.find(id)
+  end
+end
+```
+
 ### Node interface
 
 One requirement for Relay's object management is implementing the `"Node"` interface.


### PR DESCRIPTION
I'm doing this in one application of mine and it's been working great. Comes out-of-the-box with Rails >= 4.2.
It's not encrypted, but one could use the signed version if that's desirable (much longer string though):

```
> signed = object.to_sgid.to_param
"BAh7CEkiCGdpZAY6BkVUSSIWR2lkOi8vYXBpL0FkbWluLzQGOwBUSSIMcHVycG9zZQY7AFRJIgxkZWZhdWx0BjsAVEkiD2V4cGlyZXNfYXQGOwBUSSIdMjAyMS0xMC0yOVQxNjo0OTozNy45ODdaBjsAVA==--e37d30ef25344e027994dbc198598e159b9b9646"

> GlobalID::Locator.locate_signed(signed)
```