### PR TITLE
Assert that query is a string on GraphQL::Query#initialize

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -117,6 +117,10 @@ module GraphQL
         raise ArgumentError, "Query should only be provided a query string or a document, not both."
       end
 
+      if @query_string && !@query_string.is_a?(String)
+        raise ArgumentError, "Query string argument should be a String, got #{@query_string.class.name} instead."
+      end
+
       # A two-layer cache of type resolution:
       # { abstract_type => { value => resolved_type } }
       @resolved_types_cache = Hash.new do |h1, k1|

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -86,6 +86,22 @@ describe GraphQL::Query do
     end
   end
 
+  describe "when passed a query_string with an invalid type" do
+    it "returns an error to the client" do
+      assert_raises(ArgumentError) {
+        GraphQL::Query.new(schema, {"default" => "{ fromSource(source: COW) { id } }"})
+      }
+    end
+  end
+
+  describe "when passed a query with an invalid type" do
+    it "returns an error to the client" do
+      assert_raises(ArgumentError) {
+        GraphQL::Query.new(schema, query: {"default" => "{ fromSource(source: COW) { id } }"})
+      }
+    end
+  end
+
   describe "#operation_name" do
     describe "when provided" do
       let(:query_string) { <<-GRAPHQL


### PR DESCRIPTION
This commit aims to solve the issue #3619 - providing a query argument of an incorrect type would yield a `NoMethodError` due to the incorrect type argument to be allowed through to the lexer (which assumes it to be a string).

As this parameter is, more often than not, feed from an external source (e.g. a web request), this commit assumes a more defensive approach and ensures that when the `GraphQL::Query` is initialised, the query string is indeed of the correct type (a string).

As discussed in the issue, an `ArgumentError` is raised when a type mismatch is identified.

----

I've actually just received an error notification due to this issue. I think I'll end up addressing it at a different layer (perform the input validation/coercion at the controller layer). Regardless I tried to make the gem a bit more defensive in this regard - it's my first contribution, do let me know if there's a better place to perform the assertion and/or I'm missing some kind of test. 😄 