### PR TITLE
Add support for `within` to `NumericalityValidator`.

### DIFF
--- a/lib/graphql/schema/validator/numericality_validator.rb
+++ b/lib/graphql/schema/validator/numericality_validator.rb
@@ -24,12 +24,13 @@ module GraphQL
         # @param other_than [Integer]
         # @param odd [Boolean]
         # @param even [Boolean]
+        # @param within [Range]
         # @param message [String] used for all validation failures
         def initialize(
             greater_than: nil, greater_than_or_equal_to: nil,
             less_than: nil, less_than_or_equal_to: nil,
             equal_to: nil, other_than: nil,
-            odd: nil, even: nil,
+            odd: nil, even: nil, within: nil,
             message: "%{validated} must be %{comparison} %{target}",
             **default_options
           )
@@ -42,6 +43,7 @@ module GraphQL
           @other_than = other_than
           @odd = odd
           @even = even
+          @within = within
           @message = message
           super(**default_options)
         end
@@ -63,6 +65,8 @@ module GraphQL
             (partial_format(@message, { comparison: "even", target: "" })).strip
           elsif @odd && !value.odd?
             (partial_format(@message, { comparison: "odd", target: "" })).strip
+          elsif @within && !@within.include?(value)
+            partial_format(@message, { comparison: "within", target: @within })
           end
         end
       end

--- a/spec/graphql/schema/validator/numericality_validator_spec.rb
+++ b/spec/graphql/schema/validator/numericality_validator_spec.rb
@@ -53,6 +53,15 @@ describe GraphQL::Schema::Validator::NumericalityValidator do
         { query: "{ validated(value: 9) }", result: nil, error_messages: ["value must be something other than 9"] },
       ]
     },
+    {
+      config: { within: 1..5, allow_null: true },
+      cases: [
+        { query: "{ validated(value: 1) }", result: 1, error_messages: [] },
+        { query: "{ validated(value: 5) }", result: 5, error_messages: [] },
+        { query: "{ validated(value: 0) }", result: nil, error_messages: ["value must be within 1..5"] },
+        { query: "{ validated(value: 6) }", result: nil, error_messages: ["value must be within 1..5"] },
+      ]
+    },
   ]
 
   build_tests(:numericality, Integer, expectations)


### PR DESCRIPTION
Resolves #3634.