### PR TITLE
Add support for lazy loading descriptions on all definitions

### DIFF
--- a/lib/graphql/argument.rb
+++ b/lib/graphql/argument.rb
@@ -5,7 +5,7 @@ module GraphQL
     include GraphQL::Define::InstanceDefinable
     accepts_definitions :name, :type, :description, :default_value, :as, :prepare, :method_access, :deprecation_reason
     attr_reader :default_value
-    attr_accessor :description, :name, :as, :deprecation_reason
+    attr_accessor :name, :as, :deprecation_reason
     attr_accessor :ast_node
     attr_accessor :method_access
     alias :graphql_name :name
@@ -84,6 +84,17 @@ module GraphQL
     def type_class
       metadata[:type_class]
     end
+
+    attr_writer :description
+
+    # @return [String, nil] The client-facing description of this field
+    def description
+      if @description.is_a?(Proc)
+        @description = @description.call
+      end
+      @description
+    end
+
 
     NO_DEFAULT_VALUE = Object.new
     # @api private

--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -52,8 +52,15 @@ module GraphQL
       @name = name
     end
 
+    attr_writer :description
+
     # @return [String, nil] a description for this type
-    attr_accessor :description
+    def description
+      if @description.is_a?(Proc)
+        @description = @description.call
+      end
+      @description
+    end
 
     # @return [Boolean] Is this type a predefined introspection type?
     def introspection?

--- a/lib/graphql/field.rb
+++ b/lib/graphql/field.rb
@@ -43,8 +43,15 @@ module GraphQL
     attr_reader :name
     alias :graphql_name :name
 
+    attr_writer :description
+
     # @return [String, nil] The client-facing description of this field
-    attr_accessor :description
+    def description
+      if @description.is_a?(Proc)
+        @description = @description.call
+      end
+      @description
+    end
 
     # @return [String, nil] The client-facing reason why this field is deprecated (if present, the field is deprecated)
     attr_accessor :deprecation_reason

--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -308,7 +308,14 @@ module GraphQL
 
       class DirectiveDefinition < AbstractNode
         include DefinitionNode
-        attr_reader :description
+
+        def description
+          if @description.is_a?(Proc)
+            @description = @description.call
+          end
+          @description
+        end
+
         scalar_methods :name
         children_methods(
           locations: Nodes::DirectiveLocation,
@@ -546,7 +553,14 @@ module GraphQL
 
       class ScalarTypeDefinition < AbstractNode
         include DefinitionNode
-        attr_reader :description
+
+        def description
+          if @description.is_a?(Proc)
+            @description = @description.call
+          end
+          @description
+        end
+
         scalar_methods :name
         children_methods({
           directives: GraphQL::Language::Nodes::Directive,
@@ -564,7 +578,14 @@ module GraphQL
 
       class InputValueDefinition < AbstractNode
         include DefinitionNode
-        attr_reader :description
+
+        def description
+          if @description.is_a?(Proc)
+            @description = @description.call
+          end
+          @description
+        end
+
         scalar_methods :name, :type, :default_value
         children_methods({
           directives: GraphQL::Language::Nodes::Directive,
@@ -574,7 +595,14 @@ module GraphQL
 
       class FieldDefinition < AbstractNode
         include DefinitionNode
-        attr_reader :description
+
+        def description
+          if @description.is_a?(Proc)
+            @description = @description.call
+          end
+          @description
+        end
+
         scalar_methods :name, :type
         children_methods({
           directives: GraphQL::Language::Nodes::Directive,
@@ -595,7 +623,14 @@ module GraphQL
 
       class ObjectTypeDefinition < AbstractNode
         include DefinitionNode
-        attr_reader :description
+
+        def description
+          if @description.is_a?(Proc)
+            @description = @description.call
+          end
+          @description
+        end
+
         scalar_methods :name, :interfaces
         children_methods({
           directives: GraphQL::Language::Nodes::Directive,
@@ -615,7 +650,14 @@ module GraphQL
 
       class InterfaceTypeDefinition < AbstractNode
         include DefinitionNode
-        attr_reader :description
+
+        def description
+          if @description.is_a?(Proc)
+            @description = @description.call
+          end
+          @description
+        end
+
         scalar_methods :name
         children_methods({
           directives: GraphQL::Language::Nodes::Directive,
@@ -635,7 +677,16 @@ module GraphQL
 
       class UnionTypeDefinition < AbstractNode
         include DefinitionNode
-        attr_reader :description, :types
+        # @return [String, nil] The client-facing description of this field
+
+        def description
+          if @description.is_a?(Proc)
+            @description = @description.call
+          end
+          @description
+        end
+
+        attr_reader :types
         scalar_methods :name
         children_methods({
           directives: GraphQL::Language::Nodes::Directive,
@@ -654,7 +705,14 @@ module GraphQL
 
       class EnumValueDefinition < AbstractNode
         include DefinitionNode
-        attr_reader :description
+
+        def description
+          if @description.is_a?(Proc)
+            @description = @description.call
+          end
+          @description
+        end
+
         scalar_methods :name
         children_methods({
           directives: GraphQL::Language::Nodes::Directive,
@@ -664,7 +722,14 @@ module GraphQL
 
       class EnumTypeDefinition < AbstractNode
         include DefinitionNode
-        attr_reader :description
+
+        def description
+          if @description.is_a?(Proc)
+            @description = @description.call
+          end
+          @description
+        end
+
         scalar_methods :name
         children_methods({
           directives: GraphQL::Language::Nodes::Directive,
@@ -684,7 +749,14 @@ module GraphQL
 
       class InputObjectTypeDefinition < AbstractNode
         include DefinitionNode
-        attr_reader :description
+
+        def description
+          if @description.is_a?(Proc)
+            @description = @description.call
+          end
+          @description
+        end
+
         scalar_methods :name
         children_methods({
           directives: GraphQL::Language::Nodes::Directive,

--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -101,6 +101,9 @@ module GraphQL
         if text
           @description = text
         else
+          if @description.is_a?(Proc)
+            @description = @description.call
+          end
           @description
         end
       end

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -336,6 +336,9 @@ module GraphQL
         if text
           @description = text
         else
+          if @description.is_a?(Proc)
+            @description = @description.call
+          end
           @description
         end
       end

--- a/lib/graphql/schema/member/base_dsl_methods.rb
+++ b/lib/graphql/schema/member/base_dsl_methods.rb
@@ -48,6 +48,9 @@ module GraphQL
           if new_description
             @description = new_description
           elsif defined?(@description)
+            if @description.is_a?(Proc)
+              @description = @description.call
+            end
             @description
           else
             nil

--- a/spec/graphql/schema/object_spec.rb
+++ b/spec/graphql/schema/object_spec.rb
@@ -65,7 +65,19 @@ describe GraphQL::Schema::Object do
       assert_equal "NewSubclass", new_subclass_2.graphql_name
       assert_equal object_class.description, new_subclass_2.description
     end
-
+    
+    it "allows a lambda for descriptions" do
+      # Manually assign a name since `.name` isn't populated for dynamic classes
+      new_subclass_1 = Class.new(object_class) do
+        graphql_name "NewSubclass"
+        TYPE = "musicians"
+        description -> { "A group of #{TYPE} playing together"}
+      end
+      new_subclass_2 = Class.new(new_subclass_1)
+      assert_equal "NewSubclass", new_subclass_1.graphql_name
+      assert_equal "NewSubclass", new_subclass_2.graphql_name
+      assert_equal object_class.description, new_subclass_2.description
+    end
     it "implements visibility constrained interface when context is private" do
       found_interfaces = object_class.interfaces({ private: true })
       assert_equal 5, found_interfaces.count


### PR DESCRIPTION
By handling the  when it's called, we can save constant lookups during application loading for lazy loading, for eagerloading this presents no change