### PR TITLE
Support extras: [:parent]

### DIFF
--- a/guides/fields/introduction.md
+++ b/guides/fields/introduction.md
@@ -194,6 +194,7 @@ A few `extras` are available:
 - `lookahead` (see {% internal_link "Lookahead", "/queries/lookahead" %})
 - `execution_errors`, whose `#add(err_or_msg)` method should be used for adding errors
 - `argument_details` (Intepreter only), an instance of {{ "GraphQL::Execution::Interpreter::Arguments" | api_doc }} with argument metadata
+- `parent` (the previous `object` in the query)
 - Custom extras, see below
 
 To inject them into your field method, first, add the `extras:` option to the field definition:


### PR DESCRIPTION
This was available in the old runtime and can be supported without much trouble. Fixes https://github.com/rmosolgo/graphql-ruby/issues/3641

cc @digitalmoksha, want to give this branch a try and see if it works for you? 

```ruby 
gem "graphql", github: "rmosolgo/graphql-ruby", ref: "extras-parent"
```
