### PR TITLE
Tolerate null value for array argument in AST field usage

### DIFF
--- a/lib/graphql/analysis/ast/field_usage.rb
+++ b/lib/graphql/analysis/ast/field_usage.rb
@@ -37,7 +37,7 @@ module GraphQL
 
             if argument.definition.type.kind.input_object?
               extract_deprecated_arguments(argument.value.arguments.argument_values)
-            elsif argument.definition.type.list?
+            elsif argument.definition.type.list? && !argument.value.nil?
               argument
                 .value
                 .select { |value| value.respond_to?(:arguments) }

--- a/spec/graphql/analysis/ast/field_usage_spec.rb
+++ b/spec/graphql/analysis/ast/field_usage_spec.rb
@@ -138,6 +138,20 @@ describe GraphQL::Analysis::AST::FieldUsage do
     end
   end
 
+  describe "query with an array argument sent as null" do
+    let(:query_string) {%|
+      query {
+        searchDairy(product: null) {
+          __typename
+        }
+      }
+    |}
+
+    it "tolerates null for array argument" do
+      result
+    end
+  end
+
   describe "query with deprecated arguments nested in an argument" do
     let(:query_string) {%|
       query {


### PR DESCRIPTION
Avoid calling #select on a value that may be nil.

When upgrading from graphql 1.11.3 to 1.12.17, some of our application tests started failing with this error:

"NoMethodError: private method `select' called for nil:NilClass"

The tests in question were passing null as the value for an array argument, and it appears recent versions of graphql-ruby don't handle that case in the analyser.

Looks like this problem was introduced when deprecated argument tracking was introduced in commit:

[264443b1 track deprecated arguments alongside deprecated fields](https://github.com/rmosolgo/graphql-ruby/commit/264443b197d269b467ac070c173400c2bef44aa2)
