### PR TITLE
Properly call schema.unauthorized_field for unauthorized resolvers

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -608,8 +608,7 @@ module GraphQL
             if is_authorized
               public_send_field(object, args, ctx)
             else
-              err = GraphQL::UnauthorizedFieldError.new(object: application_object, type: object.class, context: ctx, field: self)
-              ctx.schema.unauthorized_field(err)
+              raise GraphQL::UnauthorizedFieldError.new(object: application_object, type: object.class, context: ctx, field: self)
             end
           end
         rescue GraphQL::UnauthorizedFieldError => err

--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -28,7 +28,7 @@ module GraphQL
       include Schema::Member::HasPath
       extend Schema::Member::HasPath
 
-      # @param object [Object] the initialize object, pass to {Query.initialize} as `root_value`
+      # @param object [Object] The application object that this field is being resolved on
       # @param context [GraphQL::Query::Context]
       # @param field [GraphQL::Schema::Field]
       def initialize(object:, context:, field:)
@@ -110,7 +110,7 @@ module GraphQL
                     public_send(self.class.resolve_method)
                   end
                 else
-                  nil
+                  raise GraphQL::UnauthorizedFieldError.new(context: context, object: object, type: field.owner, field: field)
                 end
               end
             end

--- a/spec/graphql/schema/subscription_spec.rb
+++ b/spec/graphql/schema/subscription_spec.rb
@@ -41,7 +41,8 @@ describe GraphQL::Schema::Subscription do
       # Can't subscribe to private users
       def authorized?(user:, path:, query:)
         if user[:private]
-          raise GraphQL::ExecutionError, "Can't subscribe to private user (#{path})"
+          context[:last_path] = path
+          false
         else
           true
         end
@@ -133,6 +134,11 @@ describe GraphQL::Schema::Subscription do
 
     def self.object_from_id(id, ctx)
       USERS[id]
+    end
+
+    def self.unauthorized_field(err)
+      path = err.context[:last_path]
+      raise GraphQL::ExecutionError, "Can't subscribe to private user (#{path})"
     end
 
 


### PR DESCRIPTION
Previously, when a resolver's `def authorized?` hook returned false, the resolver returned `nil`. But the schema's `.unauthorized_field` hook should have been called instead, as when any other field is unauthorized. 

Now, whenever `def authorized?` returns false in a mutation, subscription, or other resolver, the error is routed to `def self.unauthorized_field(err)` in the Schema class (which calls `def self.unauthorized_object(error)` by default). 

Fixes #3390 
Fixes #2048