### PR TITLE
Recommend NO_UPDATE instead of :no_update to skip subscription updates

### DIFF
--- a/guides/subscriptions/subscription_classes.md
+++ b/guides/subscriptions/subscription_classes.md
@@ -278,20 +278,20 @@ After a client has registered a subscription, the application may trigger subscr
 
 - Unsubscribe the client with `unsubscribe`
 - Return a value with `super` (which returns `object`) or by returning a different value.
-- Return `:no_update` to skip this update
+- Return `NO_UPDATE` to skip this update
 
 ### Skipping subscription updates
 
 (__Note__: only supported when using the new {% internal_link "Interpreter runtime", "/queries/interpreter#installation" %})
 
-Perhaps you don't want to send updates to a certain subscriber. For example, if someone leaves a comment, you might want to push the new comment to _other_ subscribers, but not the commenter, who already has that comment data. You can accomplish this by returning `:no_update`.
+Perhaps you don't want to send updates to a certain subscriber. For example, if someone leaves a comment, you might want to push the new comment to _other_ subscribers, but not the commenter, who already has that comment data. You can accomplish this by returning `NO_UPDATE`.
 
 ```ruby
 class Subscriptions::CommentWasAdded < Subscriptions::BaseSubscription
   def update(post_id:)
     comment = object # #<Comment ...>
     if comment.author == context[:viewer]
-      :no_update
+      NO_UPDATE
     else
       # Continue updating this client, since it's not the commenter
       super

--- a/lib/graphql/schema/subscription.rb
+++ b/lib/graphql/schema/subscription.rb
@@ -14,7 +14,7 @@ module GraphQL
     class Subscription < GraphQL::Schema::Resolver
       extend GraphQL::Schema::Resolver::HasPayloadType
       extend GraphQL::Schema::Member::HasFields
-
+      NO_UPDATE = :no_update
       # The generated payload type is required; If there's no payload,
       # propagate null.
       null false
@@ -68,7 +68,7 @@ module GraphQL
       # Wrap the user-provided `#update` hook
       def resolve_update(**args)
         ret_val = args.any? ? update(**args) : update
-        if ret_val == :no_update
+        if ret_val == NO_UPDATE
           context.namespace(:subscriptions)[:no_update] = true
           context.skip
         else
@@ -77,7 +77,7 @@ module GraphQL
       end
 
       # The default implementation returns the root object.
-      # Override it to return `:no_update` if you want to
+      # Override it to return {NO_UPDATE} if you want to
       # skip updates sometimes. Or override it to return a different object.
       def update(args = {})
         object
@@ -122,7 +122,7 @@ module GraphQL
       # In that implementation, only `.trigger` calls with _exact matches_ result in updates to subscribers.
       #
       # To implement a filtered stream-type subscription flow, override this method to return a string with field name and subscription scope.
-      # Then, implement {#update} to compare its arguments to the current `object` and return `:no_update` when an
+      # Then, implement {#update} to compare its arguments to the current `object` and return {NO_UPDATE} when an
       # update should be filtered out.
       #
       # @see {#update} for how to skip updates when an event comes with a matching topic.

--- a/spec/graphql/schema/subscription_spec.rb
+++ b/spec/graphql/schema/subscription_spec.rb
@@ -60,7 +60,7 @@ describe GraphQL::Schema::Subscription do
         if context[:viewer] == user
           # don't update for one's own toots.
           # (IRL it would make more sense to implement this in `#subscribe`)
-          :no_update
+          NO_UPDATE
         else
           # This assumes that trigger object can fulfill `{toot:, user:}`,
           # for testing that the default implementation is `return object`
@@ -379,7 +379,7 @@ describe GraphQL::Schema::Subscription do
       assert_equal [{"handle" => "eileencodes"}, {"handle" => "tenderlove"}], update["data"]["usersJoined"]["users"]
     end
 
-    it "skips the update if `:no_update` is returned, but updates other subscribers" do
+    it "skips the update if `NO_UPDATE` is returned, but updates other subscribers" do
       query_str = <<-GRAPHQL
       subscription {
         tootWasTooted(handle: "matz") {
@@ -401,7 +401,7 @@ describe GraphQL::Schema::Subscription do
       assert_equal "Merry Christmas, here's a new Ruby version", mailbox1.first["data"]["tootWasTooted"]["toot"]["body"]
       # But not matz:
       assert_equal [], mailbox2
-      # `:no_update` doesn't cause an unsubscribe
+      # `NO_UPDATE` doesn't cause an unsubscribe
       assert_equal 2, in_memory_subscription_count
     end
 

--- a/spec/graphql/subscriptions_spec.rb
+++ b/spec/graphql/subscriptions_spec.rb
@@ -144,7 +144,7 @@ class ClassBasedInMemoryBackend < InMemoryBackend
 
     def update(channel: nil)
       if channel && object.channel != channel
-        :no_update
+        NO_UPDATE
       else
         super
       end


### PR DESCRIPTION
The _value_ is still `:no_update`, for compatibility, but using a constant will make typos more obvious.

fixes #3615

Only merge this _right_ before releasing the gem, so that the docs don't recommend the wrong thing.