### PR TITLE
Fix Subscriptions::Serialize incorrectly parsing time zone

### DIFF
--- a/lib/graphql/subscriptions/serialize.rb
+++ b/lib/graphql/subscriptions/serialize.rb
@@ -9,7 +9,7 @@ module GraphQL
       SYMBOL_KEY = "__sym__"
       SYMBOL_KEYS_KEY = "__sym_keys__"
       TIMESTAMP_KEY = "__timestamp__"
-      TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S.%N%Z" # eg '2020-01-01 23:59:59.123456789+05:00'
+      TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S.%N%z" # eg '2020-01-01 23:59:59.123456789+05:00'
       OPEN_STRUCT_KEY = "__ostruct__"
 
       module_function


### PR DESCRIPTION
Running spec/graphql/subscriptions/serialize_spec.rb locally will fail due to the difference on time zone offset.

![subscriptions/serialize_spec.rb fail on a UTC+8 machine](https://user-images.githubusercontent.com/12410942/138541887-7b1d4423-e191-4e5d-9018-9ee9cfcf78c2.png)

However, since my machine has a `+0800` timezone, It bugs me where `-0600` is coming from.
So I tried the serialization operation manualy and realized the test is actually catching a bug:

| Before | <img width="865" alt="before" src="https://user-images.githubusercontent.com/12410942/138542863-bdfc56e3-2c30-4215-92eb-8221422193a7.png"> |
| --- | --- |
| After | <img width="857" alt="after" src="https://user-images.githubusercontent.com/12410942/138542867-78191948-789b-4494-ad3e-7a2726255688.png"> |

<!-- <img width="790" alt="demo" src="https://user-images.githubusercontent.com/12410942/138542667-c0f0af79-a4c7-479b-b213-6323b9ba9596.png"> -->

Comparing [`Time.strptime`](https://ruby-doc.org/stdlib-2.4.1/libdoc/time/rdoc/Time.html#method-c-strptime) and [the existing comment](https://github.com/rmosolgo/graphql-ruby/pull/3667/commits/4c5affa6a55260d4a03d4f681c9f05f28ae4e9a8#diff-631e7bc3445ffd7314b998c99723c663cb418f6f29e7fdb466a16e24d24d04ccR12), I believe `%z` should be used instead of `%Z`
<img width="999" alt="image" src="https://user-images.githubusercontent.com/12410942/138542685-bc7f2458-8ad8-4060-96e3-25b04e1fa0f5.png">
