### PR TITLE
Improve error message when client not setup for ActionCable Subscription

### DIFF
--- a/lib/graphql/subscriptions/action_cable_subscriptions.rb
+++ b/lib/graphql/subscriptions/action_cable_subscriptions.rb
@@ -128,7 +128,7 @@ module GraphQL
       # and re-evaluate the query locally.
       def write_subscription(query, events)
         unless (channel = query.context[:channel])
-          raise GraphQL::ExecutionError, "This GraphQL Subscription client does not support the transport protocol expected"\
+          raise GraphQL::Error, "This GraphQL Subscription client does not support the transport protocol expected"\
             "by the backend Subscription Server implementation (graphql-ruby ActionCableSubscriptions in this case)."\
             "Some official client implementation including Apollo (https://graphql-ruby.org/javascript_client/apollo_subscriptions.html), "\
             "Relay Modern (https://graphql-ruby.org/javascript_client/relay_subscriptions.html#actioncable)."\

--- a/spec/graphql/subscriptions/action_cable_subscriptions_spec.rb
+++ b/spec/graphql/subscriptions/action_cable_subscriptions_spec.rb
@@ -208,7 +208,7 @@ describe GraphQL::Subscriptions::ActionCableSubscriptions do
   end
 
   it "raise ExecutionError for a missing context.channel" do
-    error = assert_raises GraphQL::ExecutionError do
+    error = assert_raises GraphQL::Error do
       ActionCableTestSchema.execute("subscription { newsFlash { text } }", context: {})
     end
     assert_includes error.message, "This GraphQL Subscription client does not support the transport protocol expected"


### PR DESCRIPTION
fix #3412 according to https://github.com/rmosolgo/graphql-ruby/issues/3412#issuecomment-931469905

The current error message from the perspective of a client is something like `500 Internal Server Error: KeyError` (#3412) or `key not found: :channel` (#2585)

Any suggestion about the (hopefully informative) error message is welcome!