### PR TITLE
Make PusherLink pass its other event handlers along

### DIFF
--- a/javascript_client/src/subscriptions/PusherLink.ts
+++ b/javascript_client/src/subscriptions/PusherLink.ts
@@ -101,7 +101,7 @@ class PusherLink extends ApolloLink {
           observer.next(data)
           observer.complete()
         }
-      }})
+      }, error: observer.error, complete: observer.complete})
       // Return an object that will unsubscribe _if_ the query was a subscription.
       return {
         closed: false,


### PR DESCRIPTION
Fixes #3638 

Oops, this method _received_ error and complete handlers but didn't pass them along. I updated it to do so. The other links seem to work differently, so it wasn't obvious to me that they needed the same changes. 

