### PR TITLE
Stop returning invalid null errors to clients

### DIFF
--- a/guides/errors/type_errors.md
+++ b/guides/errors/type_errors.md
@@ -10,10 +10,11 @@ index: 3
 
 The GraphQL specification _requires_ certain assumptions to hold true when executing a query. However, it's possible that some code would violate that assumption, resulting in a type error.
 
-Here are two type errors that you can customize in GraphQL-Ruby:
+Here are some type errors that you can customize in GraphQL-Ruby:
 
 - A field with `null: false` returned `nil`
 - A field returned a value as a union or interface, but that value couldn't be resolved to a member of that union or interface.
+- A built-in scalar received an out-of-bounds or wrongly-encoded value from a client or from the application
 
 You can specify behavior in these cases by defining a {{ "Schema.type_error" | api_doc }} hook:
 
@@ -27,9 +28,11 @@ end
 
 It is called with an instance of {{ "GraphQL::UnresolvedTypeError" | api_doc }} or {{ "GraphQL::InvalidNullError" | api_doc }} and the query context (a {{ "GraphQL::Query::Context" |  api_doc }}).
 
-If you don't specify a hook, you get the default behavior:
+If you don't specify a hook, you get the default behavior ({{ "GraphQL::Schema::DefaultTypeResolve" | api_doc }}):
 
-- Unexpected `nil`s add an error the response's `"errors"` key
-- Unresolved Union / Interface types raise {{ "GraphQL::UnresolvedTypeError" | api_doc }}
-
+- Unresolved Union / Interface types raise {{ "GraphQL::UnresolvedTypeError" | api_doc }} and halt the query
+- Application-returned strings that aren't in UTF-8 encoding raise {{ "GraphQL::StringEncodingError" | api_doc }}s and halt the query
+- Application-returned integers beyond the GraphQL specification's limit raise {{ "GraphQL::IntegerEncodingError" | api_doc }}s and halt the query
+- Client-provided integers beyond the GraphQL specification's limit pass {{ "GraphQL::IntegerDecodingError" | api_docs }}s to this method, and they're replaced with `nil`
+- An application-returned `nil` for a field configured with `null: false` passes a {{ "GraphQL::InvalidNullError" | api_doc }} to this method, but it's silently ignored
 An object that fails type resolution is treated as `nil`.

--- a/guides/errors/type_errors.md
+++ b/guides/errors/type_errors.md
@@ -35,4 +35,5 @@ If you don't specify a hook, you get the default behavior ({{ "GraphQL::Schema::
 - Application-returned integers beyond the GraphQL specification's limit raise {{ "GraphQL::IntegerEncodingError" | api_doc }}s and halt the query
 - Client-provided integers beyond the GraphQL specification's limit pass {{ "GraphQL::IntegerDecodingError" | api_docs }}s to this method, and they're replaced with `nil`
 - An application-returned `nil` for a field configured with `null: false` passes a {{ "GraphQL::InvalidNullError" | api_doc }} to this method, but it's silently ignored
+
 An object that fails type resolution is treated as `nil`.

--- a/lib/graphql/schema/default_type_error.rb
+++ b/lib/graphql/schema/default_type_error.rb
@@ -4,11 +4,12 @@ module GraphQL
     module DefaultTypeError
       def self.call(type_error, ctx)
         case type_error
-        when GraphQL::InvalidNullError
-          ctx.errors << type_error
+        when GraphQL::InvalidNullError, GraphQL::IntegerDecodingError
+          nil
         when GraphQL::UnresolvedTypeError, GraphQL::StringEncodingError, GraphQL::IntegerEncodingError
           raise type_error
-        when GraphQL::IntegerDecodingError
+        else
+          # The library doesn't send any other errors this way...
           nil
         end
       end

--- a/spec/graphql/execution/errors_spec.rb
+++ b/spec/graphql/execution/errors_spec.rb
@@ -172,6 +172,14 @@ describe "GraphQL::Execution::Errors" do
     def self.resolve_type(type, obj, ctx)
       Thing
     end
+
+    def self.type_error(err, ctx)
+      if err.is_a?(GraphQL::InvalidNullError)
+        ctx.errors << err
+      else
+        super
+      end
+    end
   end
 
   class ErrorsTestSchemaWithoutInterpreter < GraphQL::Schema
@@ -183,6 +191,14 @@ describe "GraphQL::Execution::Errors" do
     end
 
     query(Query)
+
+    def self.type_error(err, ctx)
+      if err.is_a?(GraphQL::InvalidNullError)
+        ctx.errors << err
+      else
+        super
+      end
+    end
   end
 
   describe "rescue_from handling" do

--- a/spec/graphql/non_null_type_spec.rb
+++ b/spec/graphql/non_null_type_spec.rb
@@ -7,7 +7,7 @@ describe GraphQL::NonNullType do
       query_string = %|{ cow { name cantBeNullButIs } }|
       result = Dummy::Schema.execute(query_string)
       assert_equal({"cow" => nil }, result["data"])
-      assert_equal([{"message"=>"Cannot return null for non-nullable field Cow.cantBeNullButIs"}], result["errors"])
+      assert_equal([{"message"=>"Failed null on Cow.cantBeNullButIs"}], result["errors"])
     end
 
     it "propagates the null up to the next nullable field" do
@@ -26,7 +26,7 @@ describe GraphQL::NonNullType do
       |
       result = Dummy::Schema.execute(query_string)
       assert_equal(nil, result["data"])
-      assert_equal([{"message"=>"Cannot return null for non-nullable field DeepNonNull.nonNullInt"}], result["errors"])
+      refute result.key?("errors")
     end
 
     describe "when type_error is configured to raise an error" do

--- a/spec/graphql/query/executor_spec.rb
+++ b/spec/graphql/query/executor_spec.rb
@@ -147,7 +147,7 @@ describe GraphQL::Query::Executor do
           "data" => { "cow" => nil },
           "errors" => [
             {
-              "message" => "Cannot return null for non-nullable field Cow.cantBeNullButIs"
+              "message" => "Failed null on Cow.cantBeNullButIs"
             }
           ]
         }

--- a/spec/graphql/subscriptions_spec.rb
+++ b/spec/graphql/subscriptions_spec.rb
@@ -106,7 +106,16 @@ end
 class ClassBasedInMemoryBackend < InMemoryBackend
   class Payload < GraphQL::Schema::Object
     field :str, String, null: false
+
+    def str
+      object.str || raise(GraphQL::ExecutionError, "Invalid null #{__method__}")
+    end
+
     field :int, Integer, null: false
+
+    def int
+      object.int || raise(GraphQL::ExecutionError, "Invalid null #{__method__}")
+    end
   end
 
   class PayloadType < GraphQL::Schema::Enum
@@ -236,6 +245,10 @@ class FromDefinitionInMemoryBackend < InMemoryBackend
       "event" => DEFAULT_SUBSCRIPTION_RESOLVE,
       "eventSubscription" => ->(o,a,c) { nil },
       "failedEvent" => ->(o,a,c) { raise GraphQL::ExecutionError.new("unauthorized") },
+    },
+    "Payload" => {
+      "str" => ->(obj, args, ctx) { obj.str || raise(GraphQL::ExecutionError.new("invalid null str")) },
+      "int" => ->(obj, args, ctx) { obj.int || raise(GraphQL::ExecutionError.new("invalid null int")) },
     },
   }
   Schema = GraphQL::Schema.from_definition(SchemaDefinition, default_resolve: Resolvers, using: {InMemoryBackend::Subscriptions => { extra: 123 }})

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -526,6 +526,9 @@ module Dummy
     def self.type_error(err, ctx)
       if err.is_a?(GraphQL::IntegerEncodingError) && err.integer_value == 99**99
         MAGIC_INT_COERCE_VALUE
+      elsif err.is_a?(GraphQL::InvalidNullError) && err.field.graphql_name == "cantBeNullButIs"
+        ctx.errors << GraphQL::ExecutionError.new("Failed null on #{err.field.path}")
+        nil
       else
         super
       end

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -945,6 +945,14 @@ module Jazz
     use GraphQL::Dataloader
 
     use MetadataPlugin, value: "xyz"
+
+    def self.type_error(err, ctx)
+      if err.is_a?(GraphQL::InvalidNullError)
+        ctx.errors << err
+      else
+        super
+      end
+    end
   end
 
   class SchemaWithoutIntrospection < GraphQL::Schema

--- a/spec/support/lazy_helpers.rb
+++ b/spec/support/lazy_helpers.rb
@@ -179,6 +179,14 @@ module LazyHelpers
         super
       end
     end
+
+    def self.type_error(err, ctx)
+      if err.is_a?(GraphQL::InvalidNullError)
+        ctx.errors << err
+      else
+        super
+      end
+    end
   end
 
   def run_query(query_str, **rest)


### PR DESCRIPTION
This is a breaking change of sorts. Previously, if a field with `null: false` recieved `nil` from its resolver, it would add an entry to the query's `"errors"` set. 

However, this was useless: it did the client no good, since they couldn't fix the error. Also, if this happened in production, it wasn't treated like an exception, so it didn't show up in bug trackers anyways. 

Might as well remove this implementation detail from the client experience.

------

### Update 

I'm not sure this is the right change to make. Here's the spec: 

>  If the result of resolving a field is null (either because the function to resolve the field returned null or because a field error was raised), and that field is of a Non-Null type, then a field error is raised. The error must be added to the "errors" list in the response.

It says that there _should_ be a client error in this case. It's not intuitive to me. Maybe the thing to do is generate a better example in the schema from Rails generators.