### PR TITLE
Call def self.load_.... on Input objects to load arguments, separate loading from authorization

### DIFF
--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -302,21 +302,23 @@ module GraphQL
               if type.list?
                 loaded_values = custom_value.each_with_index.map { |custom_val, idx|
                   id = coerced_value[idx]
-                  load_method_owner.authorize_application_object(self, loads, id, context, custom_val)
+                  load_method_owner.authorize_application_object(self, id, context, custom_val)
                 }
                 context.schema.after_any_lazies(loaded_values, &:itself)
               else
-                load_method_owner.authorize_application_object(self, loads, coerced_value, context, custom_loaded_value)
+                load_method_owner.authorize_application_object(self, coerced_value, context, custom_loaded_value)
               end
             else
               custom_value
             end
           end
-        elsif loads && type.list?
-          loaded_values = coerced_value.map { |val| load_method_owner.load_and_authorize_application_object(self, loads, val, context) }
-          context.schema.after_any_lazies(loaded_values, &:itself)
         elsif loads
-          load_method_owner.load_and_authorize_application_object(self, loads, coerced_value, context)
+          if type.list?
+            loaded_values = coerced_value.map { |val| load_method_owner.load_and_authorize_application_object(self, val, context) }
+            context.schema.after_any_lazies(loaded_values, &:itself)
+          else
+            load_method_owner.load_and_authorize_application_object(self, coerced_value, context)
+          end
         else
           coerced_value
         end

--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -263,7 +263,6 @@ module GraphQL
         # If this isn't lazy, then the block returns eagerly and assigns the result here
         # If it _is_ lazy, then we write the lazy to the hash, then update it later
         argument_values[arg_key] = context.schema.after_lazy(coerced_value) do |resolved_coerced_value|
-          # TODO this should probably be inside after_lazy
           if loads && !from_resolver?
             arg_load_method = "load_#{keyword}"
             loaded_value = if owner.respond_to?(arg_load_method)

--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -262,7 +262,14 @@ module GraphQL
 
         # TODO this should probably be inside after_lazy
         if loads && !from_resolver?
-          loaded_value = if type.list?
+          arg_load_method = "load_#{keyword}"
+          loaded_value = if owner.respond_to?(arg_load_method)
+            if owner.is_a?(Class)
+              owner.public_send(arg_load_method, coerced_value, context)
+            else
+              owner.public_send(arg_load_method, coerced_value)
+            end
+          elsif type.list?
             loaded_values = coerced_value.map { |val| owner.load_application_object(self, loads, val, context) }
             context.schema.after_any_lazies(loaded_values) { |result| result }
           else

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -40,11 +40,7 @@ module GraphQL
             # With the interpreter, it's done during `coerce_arguments`
             if loads && !arg_defn.from_resolver? && !context.interpreter?
               value = @ruby_style_hash[ruby_kwargs_key]
-              loaded_value = if arg_defn.type.list?
-                value.map { |val| load_application_object(arg_defn, val, context) }
-              else
-                load_application_object(arg_defn, value, context)
-              end
+              loaded_value = arg_defn.load_and_authorize_value(self, value, context)
               maybe_lazies << context.schema.after_lazy(loaded_value) do |loaded_value|
                 overwrite_argument(ruby_kwargs_key, loaded_value)
               end

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -41,9 +41,9 @@ module GraphQL
             if loads && !arg_defn.from_resolver? && !context.interpreter?
               value = @ruby_style_hash[ruby_kwargs_key]
               loaded_value = if arg_defn.type.list?
-                value.map { |val| load_application_object(arg_defn, loads, val, context) }
+                value.map { |val| load_application_object(arg_defn, val, context) }
               else
-                load_application_object(arg_defn, loads, value, context)
+                load_application_object(arg_defn, value, context)
               end
               maybe_lazies << context.schema.after_lazy(loaded_value) do |loaded_value|
                 overwrite_argument(ruby_kwargs_key, loaded_value)

--- a/lib/graphql/schema/member/has_arguments.rb
+++ b/lib/graphql/schema/member/has_arguments.rb
@@ -225,7 +225,15 @@ module GraphQL
             if id.nil?
               return nil
             end
-            loaded_application_object = object_from_id(lookup_as_type, id, context)
+            object_from_id(lookup_as_type, id, context)
+          end
+
+          def load_and_authorize_application_object(argument, lookup_as_type, id, context)
+            loaded_application_object = load_application_object(argument, lookup_as_type, id, context)
+            authorize_application_object(argument, lookup_as_type, id, context, loaded_application_object)
+          end
+
+          def authorize_application_object(argument, lookup_as_type, id, context, loaded_application_object)
             context.schema.after_lazy(loaded_application_object) do |application_object|
               if application_object.nil?
                 err = GraphQL::LoadApplicationObjectFailedError.new(argument: argument, id: id, object: application_object)

--- a/lib/graphql/schema/member/has_arguments.rb
+++ b/lib/graphql/schema/member/has_arguments.rb
@@ -233,6 +233,7 @@ module GraphQL
             authorize_application_object(argument, lookup_as_type, id, context, loaded_application_object)
           end
 
+          # TODO refactor away lookup_as_type ?
           def authorize_application_object(argument, lookup_as_type, id, context, loaded_application_object)
             context.schema.after_lazy(loaded_application_object) do |application_object|
               if application_object.nil?

--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -40,7 +40,6 @@ module GraphQL
         self.class.arguments.each do |name, arg|
           @arguments_by_keyword[arg.keyword] = arg
         end
-        @arguments_loads_as_type = self.class.arguments_loads_as_type
         @prepared_arguments = nil
       end
 
@@ -338,18 +337,9 @@ module GraphQL
         # also add some preparation hook methods which will be used for this argument
         # @see {GraphQL::Schema::Argument#initialize} for the signature
         def argument(*args, **kwargs, &block)
-          loads = kwargs[:loads]
           # Use `from_resolver: true` to short-circuit the InputObject's own `loads:` implementation
           # so that we can support `#load_{x}` methods below.
-          arg_defn = super(*args, from_resolver: true, **kwargs)
-          own_arguments_loads_as_type[arg_defn.keyword] = loads if loads
-          arg_defn
-        end
-
-        # @api private
-        def arguments_loads_as_type
-          inherited_lookups = superclass.respond_to?(:arguments_loads_as_type) ? superclass.arguments_loads_as_type : {}
-          inherited_lookups.merge(own_arguments_loads_as_type)
+          super(*args, from_resolver: true, **kwargs)
         end
 
         # Registers new extension
@@ -384,10 +374,6 @@ module GraphQL
 
         def own_extensions
           @own_extensions
-        end
-
-        def own_arguments_loads_as_type
-          @own_arguments_loads_as_type ||= {}
         end
       end
     end


### PR DESCRIPTION
Fixes https://github.com/rmosolgo/graphql-ruby/issues/3680
Fixes #3685 

TODO: 

- [x] Review this code again. I hacked to make it work on resolvers and input objects both (and, technically, directives), but it's not good yet. 