### PR TITLE
use validation_max_errors in validation pipeline

### DIFF
--- a/lib/graphql/query/validation_pipeline.rb
+++ b/lib/graphql/query/validation_pipeline.rb
@@ -72,7 +72,7 @@ module GraphQL
         elsif @operation_name_error
           @validation_errors << @operation_name_error
         else
-          validation_result = @schema.static_validator.validate(@query, validate: @validate, timeout: @schema.validate_timeout)
+          validation_result = @schema.static_validator.validate(@query, validate: @validate, timeout: @schema.validate_timeout, max_errors: @schema.validate_max_errors)
           @validation_errors.concat(validation_result[:errors])
           @internal_representation = validation_result[:irep]
 

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -45,7 +45,6 @@ describe GraphQL::Query do
   it "applies the max validation errors config" do
     limited_schema = Class.new(schema) { validate_max_errors(2) }
     res = limited_schema.execute("{ a b c d }")
-    pp res
     assert_equal 2, res["errors"].size
     refute res.key?("data")
   end

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -42,6 +42,14 @@ describe GraphQL::Query do
   )}
   let(:result) { query.result }
 
+  it "applies the max validation errors config" do
+    limited_schema = Class.new(schema) { validate_max_errors(2) }
+    res = limited_schema.execute("{ a b c d }")
+    pp res
+    assert_equal 2, res["errors"].size
+    refute res.key?("data")
+  end
+
   describe "when passed both a query string and a document" do
     it "returns an error to the client when query kwarg is used" do
       assert_raises ArgumentError do


### PR DESCRIPTION
This is a follow-up to https://github.com/rmosolgo/graphql-ruby/pull/3675

That PR introduced the ability to limit static validation errors.
Unfortunately, I forgot to hook it up to the validation pipeline 😿 

Anyway, this follow-up PR does just that.