### PR TITLE
Require scope for subscription classes when  is configured

### DIFF
--- a/lib/graphql/schema/subscription.rb
+++ b/lib/graphql/schema/subscription.rb
@@ -103,14 +103,24 @@ module GraphQL
       # Call this method to provide a new subscription_scope; OR
       # call it without an argument to get the subscription_scope
       # @param new_scope [Symbol]
+      # @param optional [Boolean] If true, then don't require `scope:` to be provided to updates to this subscription.
       # @return [Symbol]
-      def self.subscription_scope(new_scope = READING_SCOPE)
+      def self.subscription_scope(new_scope = READING_SCOPE, optional: false)
         if new_scope != READING_SCOPE
           @subscription_scope = new_scope
+          @subscription_scope_optional = optional
         elsif defined?(@subscription_scope)
           @subscription_scope
         else
           find_inherited_value(:subscription_scope)
+        end
+      end
+
+      def self.subscription_scope_optional?
+        if defined?(@subscription_scope_optional)
+          @subscription_scope_optional
+        else
+          find_inherited_value(:subscription_scope_optional, false)
         end
       end
 

--- a/lib/graphql/subscriptions.rb
+++ b/lib/graphql/subscriptions.rb
@@ -16,6 +16,13 @@ module GraphQL
     class InvalidTriggerError < GraphQL::Error
     end
 
+    # Raised when either:
+    # - An initial subscription didn't have a value for `context[subscription_scope]`
+    # - Or, an update didn't pass `.trigger(..., scope:)`
+    # When raised, the initial subscription or update fails completely.
+    class SubscriptionScopeMissingError < GraphQL::Error
+    end
+
     # @see {Subscriptions#initialize} for options, concrete implementations may add options.
     def self.use(defn, options = {})
       schema = defn.is_a?(Class) ? defn : defn.target

--- a/spec/dummy/app/channels/graphql_channel.rb
+++ b/spec/dummy/app/channels/graphql_channel.rb
@@ -13,7 +13,6 @@ class GraphqlChannel < ActionCable::Channel::Base
 
   class CounterIncremented < GraphQL::Schema::Subscription
     @@call_count = 0
-    subscription_scope :subscriber_id
 
     field :new_value, Integer, null: false
 
@@ -21,7 +20,7 @@ class GraphqlChannel < ActionCable::Channel::Base
       result = {
         new_value: @@call_count += 1
       }
-      puts "  -> CounterIncremented#update(#{context[:subscriber_id]}): #{result}"
+      puts "  -> CounterIncremented#update: #{result}"
       result
     end
   end

--- a/spec/graphql/schema/subscription_spec.rb
+++ b/spec/graphql/schema/subscription_spec.rb
@@ -76,6 +76,10 @@ describe GraphQL::Schema::Subscription do
       field :user, User, null: false
     end
 
+    class DirectTootWasTootedWithOptionalScope < DirectTootWasTooted
+      subscription_scope :viewer, optional: true
+    end
+
     # Test initial response, which returns all users
     class UsersJoined < BaseSubscription
       class UsersJoinedManualPayload < GraphQL::Schema::Object
@@ -105,6 +109,7 @@ describe GraphQL::Schema::Subscription do
     class Subscription < GraphQL::Schema::Object
       field :toot_was_tooted, subscription: TootWasTooted, extras: [:path, :query]
       field :direct_toot_was_tooted, subscription: DirectTootWasTooted
+      field :direct_toot_was_tooted_with_optional_scope, subscription: DirectTootWasTootedWithOptionalScope
       field :users_joined, subscription: UsersJoined
       field :new_users_joined, subscription: NewUsersJoined
     end
@@ -127,9 +132,13 @@ describe GraphQL::Schema::Subscription do
     subscription(Subscription)
 
     rescue_from(StandardError) { |err, *rest|
-      err2 = RuntimeError.new("This should never happen: #{err.class}: #{err.message}")
-      err2.set_backtrace(err.backtrace)
-      raise err2
+      if err.is_a?(GraphQL::Subscriptions::SubscriptionScopeMissingError)
+        raise err
+      else
+        err2 = RuntimeError.new("This should never happen: #{err.class}: #{err.message}")
+        err2.set_backtrace(err.backtrace)
+        raise err2
+      end
     }
 
     def self.object_from_id(id, ctx)
@@ -484,6 +493,66 @@ describe GraphQL::Schema::Subscription do
       scoped_subscription = SubscriptionFieldSchema::get_field("Subscription", "directTootWasTooted")
 
       assert_equal :viewer, scoped_subscription.subscription_scope
+    end
+
+    it "requires subscription scope for subscribe and update by default" do
+      err = assert_raises GraphQL::Subscriptions::SubscriptionScopeMissingError do
+        exec_query <<-GRAPHQL
+          subscription {
+            directTootWasTooted {
+              toot { body }
+            }
+          }
+        GRAPHQL
+      end
+      expected_message = "Subscription.directTootWasTooted (SubscriptionFieldSchema::DirectTootWasTooted) requires a `scope:` value to trigger updates (Set `subscription_scope ..., optional: true` to disable this requirement)"
+      assert_equal expected_message, err.message
+      assert_equal 0, in_memory_subscription_count
+
+      res = exec_query <<-GRAPHQL, context: { viewer: :me }
+        subscription {
+          directTootWasTooted {
+            toot { body }
+          }
+        }
+      GRAPHQL
+      assert_equal 1, in_memory_subscription_count
+
+      obj = OpenStruct.new(toot: { body: "Hello from matz!" }, user: SubscriptionFieldSchema::USERS["matz"])
+      err = assert_raises GraphQL::Subscriptions::SubscriptionScopeMissingError do
+        SubscriptionFieldSchema.subscriptions.trigger(:direct_toot_was_tooted, {}, obj)
+      end
+      assert_equal expected_message, err.message
+    end
+
+    it "doesn't require subscription scope if `optional: true`" do
+      res = exec_query <<-GRAPHQL, context: { viewer: :me }
+        subscription {
+          directTootWasTootedWithOptionalScope {
+            toot { body }
+          }
+        }
+      GRAPHQL
+
+      res2 = exec_query <<-GRAPHQL
+        subscription {
+          directTootWasTootedWithOptionalScope {
+            toot { body }
+          }
+        }
+      GRAPHQL
+
+      assert_equal 2, in_memory_subscription_count
+
+      obj = OpenStruct.new(toot: { body: "Hello from matz!" }, user: SubscriptionFieldSchema::USERS["matz"])
+
+      SubscriptionFieldSchema.subscriptions.trigger(:direct_toot_was_tooted_with_optional_scope, {}, obj)
+      assert_equal 0, res.context[:subscription_mailbox].length
+      assert_equal 1, res2.context[:subscription_mailbox].length
+
+      SubscriptionFieldSchema.subscriptions.trigger(:direct_toot_was_tooted_with_optional_scope, {}, obj, scope: :me)
+      assert_equal 1, res.context[:subscription_mailbox].length
+      assert_equal 1, res2.context[:subscription_mailbox].length
     end
 
     it "provides a subscription scope that is used in execution" do

--- a/spec/graphql/schema/subscription_spec.rb
+++ b/spec/graphql/schema/subscription_spec.rb
@@ -509,7 +509,7 @@ describe GraphQL::Schema::Subscription do
       assert_equal expected_message, err.message
       assert_equal 0, in_memory_subscription_count
 
-      res = exec_query <<-GRAPHQL, context: { viewer: :me }
+      exec_query <<-GRAPHQL, context: { viewer: :me }
         subscription {
           directTootWasTooted {
             toot { body }


### PR DESCRIPTION
This is a _breaking change_ for graphql 1.13.0; to get the old behavior, add `optional: true` to any `subscription_scope ...` configurations in your schema. 

Now, if a Subscription class has a `subscription_scope`, it will be required for initial subscribe and subsequent updates, unless it's configured with `optional: true` (which falls back to the previous behavior, where `nil` is a valid subscription scope value).

Fixes #3209 