### PR TITLE
Improve field conflict error messages

### DIFF
--- a/lib/graphql/static_validation/error.rb
+++ b/lib/graphql/static_validation/error.rb
@@ -32,8 +32,10 @@ module GraphQL
 
       private
 
+      attr_reader :nodes
+
       def locations
-        @nodes.map do |node|
+        nodes.map do |node|
           h = {"line" => node.line, "column" => node.col}
           h["filename"] = node.filename if node.filename
           h

--- a/lib/graphql/static_validation/rules/fields_will_merge.rb
+++ b/lib/graphql/static_validation/rules/fields_will_merge.rb
@@ -20,16 +20,38 @@ module GraphQL
       end
 
       def on_operation_definition(node, _parent)
-        conflicts_within_selection_set(node, type_definition)
+        setting_errors { conflicts_within_selection_set(node, type_definition) }
         super
       end
 
       def on_field(node, _parent)
-        conflicts_within_selection_set(node, type_definition)
+        setting_errors { conflicts_within_selection_set(node, type_definition) }
         super
       end
 
       private
+
+      def field_conflicts
+        @field_conflicts ||= Hash.new do |errors, field|
+          errors[field] = GraphQL::StaticValidation::FieldsWillMergeError.new(kind: :field, field_name: field)
+        end
+      end
+
+      def arg_conflicts
+        @arg_conflicts ||= Hash.new do |errors, field|
+          errors[field] = GraphQL::StaticValidation::FieldsWillMergeError.new(kind: :argument, field_name: field)
+        end
+      end
+
+      def setting_errors
+        @field_conflicts = nil
+        @arg_conflicts = nil
+
+        yield
+
+        field_conflicts.each_value { |error| add_error(error) }
+        arg_conflicts.each_value { |error| add_error(error) }
+      end
 
       def conflicts_within_selection_set(node, parent_type)
         return if parent_type.nil?
@@ -191,28 +213,17 @@ module GraphQL
 
         if !are_mutually_exclusive
           if node1.name != node2.name
-            errored_nodes = [node1.name, node2.name].sort.join(" or ")
-            msg = "Field '#{response_key}' has a field conflict: #{errored_nodes}?"
-            add_error(GraphQL::StaticValidation::FieldsWillMergeError.new(
-              msg,
-              nodes: [node1, node2],
-              path: [],
-              field_name: response_key,
-              conflicts: errored_nodes
-            ))
+            conflict = field_conflicts[response_key]
+
+            conflict.add_conflict(node1, node1.name)
+            conflict.add_conflict(node2, node2.name)
           end
 
           if !same_arguments?(node1, node2)
-            args = [serialize_field_args(node1), serialize_field_args(node2)]
-            conflicts = args.map { |arg| GraphQL::Language.serialize(arg) }.join(" or ")
-            msg = "Field '#{response_key}' has an argument conflict: #{conflicts}?"
-            add_error(GraphQL::StaticValidation::FieldsWillMergeError.new(
-              msg,
-              nodes: [node1, node2],
-              path: [],
-              field_name: response_key,
-              conflicts: conflicts
-            ))
+            conflict = arg_conflicts[response_key]
+
+            conflict.add_conflict(node1, GraphQL::Language.serialize(serialize_field_args(node1)))
+            conflict.add_conflict(node2, GraphQL::Language.serialize(serialize_field_args(node2)))
           end
         end
 

--- a/lib/graphql/static_validation/rules/fields_will_merge_error.rb
+++ b/lib/graphql/static_validation/rules/fields_will_merge_error.rb
@@ -3,12 +3,33 @@ module GraphQL
   module StaticValidation
     class FieldsWillMergeError < StaticValidation::Error
       attr_reader :field_name
-      attr_reader :conflicts
+      attr_reader :kind
 
-      def initialize(message, path: nil, nodes: [], field_name:, conflicts:)
-        super(message, path: path, nodes: nodes)
+      def initialize(kind:, field_name:)
+        super(nil)
+
         @field_name = field_name
-        @conflicts = conflicts
+        @kind = kind
+        @conflicts = []
+      end
+
+      def message
+        "Field '#{field_name}' has #{kind == :argument ? 'an' : 'a'} #{kind} conflict: #{conflicts}?"
+      end
+
+      def path
+        []
+      end
+
+      def conflicts
+        @conflicts.join(' or ')
+      end
+
+      def add_conflict(node, conflict_str)
+        return if nodes.include?(node)
+
+        @nodes << node
+        @conflicts << conflict_str
       end
 
       # A hash representation of this Message

--- a/lib/graphql/static_validation/validation_context.rb
+++ b/lib/graphql/static_validation/validation_context.rb
@@ -15,7 +15,8 @@ module GraphQL
       extend Forwardable
 
       attr_reader :query, :errors, :visitor,
-        :on_dependency_resolve_handlers
+        :on_dependency_resolve_handlers,
+        :max_errors
 
       def_delegators :@query, :schema, :document, :fragments, :operations, :warden
 


### PR DESCRIPTION
Following the merge of https://github.com/rmosolgo/graphql-ruby/pull/3690, we have a good general solution for excessive validation error messages.

However, we may still want to improve the field-conflict error messages, since these are confusing, and include every pair-wise combination of conflicting values. A simpler representation is a list of all conflicting values, as implemented here.

Short-circuiting behavior is preserved, honoring the `validation_max_errors` configuration.

