### PR TITLE
feat(graphql-ruby-client): support graphql-ws and GraphiQL for Subscription over ActionCable

### DIFF
--- a/guides/javascript_client/apollo_subscriptions.md
+++ b/guides/javascript_client/apollo_subscriptions.md
@@ -22,7 +22,7 @@ GraphQL-Ruby's JavaScript client includes four kinds of support for Apollo Clien
 
 ## Apollo 2
 
-Apollo 2 is supported by implementing Apollo Links.
+Apollo 2 is supported by implementing [Apollo Links](https://www.apollographql.com/docs/react/api/link/introduction/).
 
 ## Apollo 2 -- Pusher
 

--- a/guides/javascript_client/graphql_ws_and_graphiql_subscription.md
+++ b/guides/javascript_client/graphql_ws_and_graphiql_subscription.md
@@ -1,0 +1,48 @@
+---
+layout: guide
+doc_stub: false
+search: true
+section: JavaScript Client
+title: graphql-ws and GraphiQL Subscription
+desc: GraphQL subscriptions with graphql-ws client, like GraphiQL
+index: 4
+---
+
+GraphQL-Ruby's JavaScript client includes 1 kind of support for [`graphql-ws`][graphql-ws], which is used by [GraphiQL][graphiql]:
+
+- [ActionCable](#actioncable)
+
+## ActionCable
+
+`graphql-ruby-client` includes support for subscriptions when integrating [`graphql-ws`][graphql-ws] and [`@rails/actioncable][[rails-actioncable-client-side-component]].
+
+To use it with GraphiQL:
+
+```js
+import * as React from 'react';
+import ReactDOM from 'react-dom';
+import { GraphiQL } from 'graphiql';
+import { createGraphiQLFetcher } from '@graphiql/toolkit';
+import ActionCableGraphqlWsClient from 'graphql-ruby-client/subscriptions/ActionCableGraphqlWsClient';
+import { createConsumer } from '@rails/actioncable';
+
+const cable = createConsumer()
+const url = 'https://myschema.com/graphql';
+
+const wsClient = new ActionCableGraphqlWsClient({
+  cable
+  // channelName: "GraphqlChannel" // Default
+})
+
+const fetcher = createGraphiQLFetcher({
+  wsClient
+});
+
+export const App = () => <GraphiQL fetcher={fetcher} />;
+
+ReactDOM.render(document.getElementByID('graphiql'), <App />);
+```
+
+[graphql-ws]: https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md
+[graphiql]: https://github.com/graphql/graphiql
+[rails-actioncable-client-side-component]: https://guides.rubyonrails.org/action_cable_overview.html#client-side-components

--- a/javascript_client/package.json
+++ b/javascript_client/package.json
@@ -22,6 +22,7 @@
     "@types/zen-observable": "^0.8.2",
     "ably": "1.2.6",
     "graphql": "^15.0.0",
+    "graphql-ws": "^5.5.5",
     "jest": "^25.0.0",
     "nock": "^11.0.0",
     "pako": "^2.0.3",
@@ -41,7 +42,8 @@
   },
   "peerDependencies": {
     "@apollo/client": "^3.3.6",
-    "graphql": "^14.3.1 || ^15.0.0"
+    "graphql": "^14.3.1 || ^15.0.0",
+    "graphql-ws": "^5.5.5"
   },
   "prettier": {
     "semi": false,

--- a/javascript_client/src/subscriptions/ActionCableGraphqlWsClient.ts
+++ b/javascript_client/src/subscriptions/ActionCableGraphqlWsClient.ts
@@ -1,23 +1,18 @@
 import ActionCable from 'actioncable'
+import assert from 'assert'
 import GraphqlWs from 'graphql-ws'
+import { ActionCableUtil } from '../utils/ActionCableUtil'
 import GraphqlWsClient from './GraphqlWsClient'
 
-/**
- * Create a Relay Modern-compatible subscription handler.
- *
- * @param {ActionCable.Consumer} cable - An ActionCable consumer from `.createConsumer`
- * @param {String} channelName - ActionCable Channel name. Defaults to "GraphqlChannel"
- * @param {OperationStoreClient} operations - A generated OperationStoreClient for graphql-pro's OperationStore
- * @return {Function}
- */
-interface ActionCableGraphqlWsClientOptions {
+export interface ActionCableGraphqlWsClientOptions {
+  /** An ActionCable consumer from `.createConsumer` */
   cable: ActionCable.Cable
+  /** ActionCable Channel name. Defaults to "GraphqlChannel" */
   channelName: string
+  /** A generated OperationStoreClient for graphql-pro's OperationStore */
   operations?: { getOperationId: Function}
   // connectionParams: ConnectionParams
 }
-
-const getChannelId = () => Math.round(Date.now() + Math.random() * 100000).toString(16) // TODO: extract
 
 interface ChannelNameWithParams extends ActionCable.ChannelNameWithParams {
   channel: string
@@ -26,8 +21,9 @@ interface ChannelNameWithParams extends ActionCable.ChannelNameWithParams {
 
 class ActionCableGraphqlWsClient extends GraphqlWsClient {
   cable: ActionCable.Cable
-  actionCableChannel: ActionCable.Channel
+  channel: ActionCable.Channel
   cleanup: () => void
+  sink?: GraphqlWs.Sink
   // operations // TODO:
 
   constructor(options: ActionCableGraphqlWsClientOptions) {
@@ -36,40 +32,40 @@ class ActionCableGraphqlWsClient extends GraphqlWsClient {
     this.cable = options.cable
     const channelNameWithParams: ChannelNameWithParams = {
       channel: options.channelName || 'GraphqlChannel',
-      channelId: getChannelId()
+      channelId: ActionCableUtil.getUniqueChannelId()
     }
 
-    this.actionCableChannel = this.cable.subscriptions.create(channelNameWithParams, {
-      connected: this._action_cable_connected,
-      disconnected: this._action_cable_disconnected,
-      received: this._action_cable_received
-    })
-    this.cleanup = () => { /* TODO */}
+    this.channel = this.cable.subscriptions.create(channelNameWithParams, {
+      connected: this.action_cable_connected.bind(this),
+      disconnected: this.action_cable_disconnected.bind(this),
+      received: this.action_cable_received.bind(this)
+    })// TODO: support connectionParams like `ActionCableLink.ts` ?
+    this.cleanup = () => {
+      this.channel.unsubscribe()
+    }
   }
 
-  on(event: GraphqlWs.Event) {
-    switch (event) {
-      case 'connecting':
-        break
-      case 'opened':
-        break
-      case 'connected':
-        break
-      case 'ping':
-        break
-      case 'pong':
-        break
-      case 'message':
-        break
-      case 'closed':
-        break
-      case 'error':
-        break
-    }
-    return () => {}
-  }
+  // TODO: Should we do anything with `event` here ?
+  on(_event: GraphqlWs.Event) { return () => {} }
 
   subscribe(payload: GraphqlWs.SubscribePayload, sink: GraphqlWs.Sink) {
+    this.sink = sink
+    const {
+      operationName,
+      query,
+      variables,
+    } = payload
+
+    const channelParams = {
+      variables,
+      operationName,
+      query
+    }
+
+    this.channel.perform('execute', channelParams)
+    // TODO: Why another 'send' in `createActionCableHandler` ?
+    // this.channel.perform('send', channelParams)
+
     return this.cleanup
   }
 
@@ -77,20 +73,22 @@ class ActionCableGraphqlWsClient extends GraphqlWsClient {
     return this.cleanup()
   }
 
-  _connect() {
+  private action_cable_connected() {}
 
-  }
+  private action_cable_disconnected() {}
 
-  _action_cable_connected() {
-    // TODO
-  }
+  private action_cable_received(payload: any) {
+    assert.ok(this.sink) // subscribe() should have been called first, right ?
+    const result = payload.result
 
-  _action_cable_disconnected() {
-    // TODO
-  }
-
-  _action_cable_received() {
-    // TODO
+    if (result?.errors) {
+      this.sink.error(result.errors)
+    } else if (result) {
+      this.sink.next(result)
+    }
+    if (!payload.more) {
+      this.sink.complete()
+    }
   }
 }
 

--- a/javascript_client/src/subscriptions/ActionCableGraphqlWsClient.ts
+++ b/javascript_client/src/subscriptions/ActionCableGraphqlWsClient.ts
@@ -1,0 +1,97 @@
+import ActionCable from 'actioncable'
+import GraphqlWs from 'graphql-ws'
+import GraphqlWsClient from './GraphqlWsClient'
+
+/**
+ * Create a Relay Modern-compatible subscription handler.
+ *
+ * @param {ActionCable.Consumer} cable - An ActionCable consumer from `.createConsumer`
+ * @param {String} channelName - ActionCable Channel name. Defaults to "GraphqlChannel"
+ * @param {OperationStoreClient} operations - A generated OperationStoreClient for graphql-pro's OperationStore
+ * @return {Function}
+ */
+interface ActionCableGraphqlWsClientOptions {
+  cable: ActionCable.Cable
+  channelName: string
+  operations?: { getOperationId: Function}
+  // connectionParams: ConnectionParams
+}
+
+const getChannelId = () => Math.round(Date.now() + Math.random() * 100000).toString(16) // TODO: extract
+
+interface ChannelNameWithParams extends ActionCable.ChannelNameWithParams {
+  channel: string
+  channelId: string
+}
+
+class ActionCableGraphqlWsClient extends GraphqlWsClient {
+  cable: ActionCable.Cable
+  actionCableChannel: ActionCable.Channel
+  cleanup: () => void
+  // operations // TODO:
+
+  constructor(options: ActionCableGraphqlWsClientOptions) {
+    super()
+
+    this.cable = options.cable
+    const channelNameWithParams: ChannelNameWithParams = {
+      channel: options.channelName || 'GraphqlChannel',
+      channelId: getChannelId()
+    }
+
+    this.actionCableChannel = this.cable.subscriptions.create(channelNameWithParams, {
+      connected: this._action_cable_connected,
+      disconnected: this._action_cable_disconnected,
+      received: this._action_cable_received
+    })
+    this.cleanup = () => { /* TODO */}
+  }
+
+  on(event: GraphqlWs.Event) {
+    switch (event) {
+      case 'connecting':
+        break
+      case 'opened':
+        break
+      case 'connected':
+        break
+      case 'ping':
+        break
+      case 'pong':
+        break
+      case 'message':
+        break
+      case 'closed':
+        break
+      case 'error':
+        break
+    }
+    return () => {}
+  }
+
+  subscribe(payload: GraphqlWs.SubscribePayload, sink: GraphqlWs.Sink) {
+    return this.cleanup
+  }
+
+  dispose() {
+    return this.cleanup()
+  }
+
+  _connect() {
+
+  }
+
+  _action_cable_connected() {
+    // TODO
+  }
+
+  _action_cable_disconnected() {
+    // TODO
+  }
+
+  _action_cable_received() {
+    // TODO
+  }
+}
+
+export default ActionCableGraphqlWsClient

--- a/javascript_client/src/subscriptions/ActionCableLink.ts
+++ b/javascript_client/src/subscriptions/ActionCableLink.ts
@@ -1,6 +1,7 @@
 import { ApolloLink, Observable, FetchResult, Operation, NextLink } from "@apollo/client/core"
 import { Cable } from "actioncable"
 import { print } from "graphql"
+import { ActionCableUtil } from "../utils/ActionCableUtil"
 
 type RequestResult = FetchResult<{ [key: string]: any; }, Record<string, any>, Record<string, any>>
 type ConnectionParams = object | ((operation: Operation) => object)
@@ -25,7 +26,7 @@ class ActionCableLink extends ApolloLink {
   // instead, it sends the request to ActionCable.
   request(operation: Operation, _next: NextLink): Observable<RequestResult> {
     return new Observable((observer) => {
-      var channelId = Math.round(Date.now() + Math.random() * 100000).toString(16)
+      var channelId = ActionCableUtil.getUniqueChannelId()
       var actionName = this.actionName
       var connectionParams = (typeof this.connectionParams === "function") ?
         this.connectionParams(operation) : this.connectionParams

--- a/javascript_client/src/subscriptions/ActionCableLink.ts
+++ b/javascript_client/src/subscriptions/ActionCableLink.ts
@@ -17,7 +17,7 @@ class ActionCableLink extends ApolloLink {
   }) {
     super()
     this.cable = options.cable
-    this.channelName = options.channelName || "GraphqlChannel"
+    this.channelName = options.channelName || ActionCableUtil.DEFAULT_CHANNEL
     this.actionName = options.actionName || "execute"
     this.connectionParams = options.connectionParams || {}
   }

--- a/javascript_client/src/subscriptions/ActionCableSubscriber.ts
+++ b/javascript_client/src/subscriptions/ActionCableSubscriber.ts
@@ -31,7 +31,7 @@ class ActionCableSubscriber {
     var networkInterface = this._networkInterface
     var channelId = ActionCableUtil.getUniqueChannelId()
     var channel = this._cable.subscriptions.create({
-      channel: "GraphqlChannel",
+      channel: ActionCableUtil.DEFAULT_CHANNEL,
       channelId: channelId,
     }, {
       // After connecting, send the data over ActionCable

--- a/javascript_client/src/subscriptions/ActionCableSubscriber.ts
+++ b/javascript_client/src/subscriptions/ActionCableSubscriber.ts
@@ -1,6 +1,7 @@
 import printer from "graphql/language/printer"
 import registry from "./registry"
 import { Cable } from "actioncable"
+import { ActionCableUtil } from "../utils/ActionCableUtil"
 
 interface ApolloNetworkInterface {
   applyMiddlewares: Function
@@ -28,8 +29,7 @@ class ActionCableSubscriber {
   */
   subscribe(request: any, handler: any) {
     var networkInterface = this._networkInterface
-    // unique-ish
-    var channelId = Math.round(Date.now() + Math.random() * 100000).toString(16)
+    var channelId = ActionCableUtil.getUniqueChannelId()
     var channel = this._cable.subscriptions.create({
       channel: "GraphqlChannel",
       channelId: channelId,

--- a/javascript_client/src/subscriptions/GraphqlWsClient.ts
+++ b/javascript_client/src/subscriptions/GraphqlWsClient.ts
@@ -1,0 +1,21 @@
+import GraphqlWs from 'graphql-ws'
+
+class GraphqlWsClient implements GraphqlWs.Client {
+  on(event: GraphqlWs.Event) {
+    return () => {
+      console.error('Subclass responsibility')
+    }
+  }
+
+  subscribe(payload: GraphqlWs.SubscribePayload, sink: GraphqlWs.Sink) {
+    return () => {
+      console.error('Subclass responsibility')
+    }
+  }
+
+  dispose() {
+    console.error('Subclass responsibility')
+  }
+}
+
+export default GraphqlWsClient

--- a/javascript_client/src/subscriptions/GraphqlWsClient.ts
+++ b/javascript_client/src/subscriptions/GraphqlWsClient.ts
@@ -1,16 +1,14 @@
 import GraphqlWs from 'graphql-ws'
 
 class GraphqlWsClient implements GraphqlWs.Client {
-  on(event: GraphqlWs.Event) {
-    return () => {
-      console.error('Subclass responsibility')
-    }
+  on(_event: GraphqlWs.Event) {
+    console.error('Subclass responsibility')
+    return () => {}
   }
 
-  subscribe(payload: GraphqlWs.SubscribePayload, sink: GraphqlWs.Sink) {
-    return () => {
-      console.error('Subclass responsibility')
-    }
+  subscribe(_payload: GraphqlWs.SubscribePayload, _sink: GraphqlWs.Sink) {
+    console.error('Subclass responsibility')
+    return () => {}
   }
 
   dispose() {

--- a/javascript_client/src/subscriptions/__tests__/ActionCableGraphqlWsClientTest.ts
+++ b/javascript_client/src/subscriptions/__tests__/ActionCableGraphqlWsClientTest.ts
@@ -1,0 +1,129 @@
+import { Cable  } from "actioncable"
+import { Sink, SubscribePayload } from "graphql-ws"
+import ActionCableGraphqlWsClient, { ActionCableGraphqlWsClientOptions } from "../ActionCableGraphqlWsClient"
+
+describe("ActionCableGraphqlWsClient", () => {
+  let log: any[]
+  let cable: any
+  let cableReceived: Function
+  let options: ActionCableGraphqlWsClientOptions
+  let query: string
+  let subscribePayload: SubscribePayload
+  let sink: Sink
+
+  beforeEach(() => {
+    log = []
+    cable = {
+      subscriptions: {
+        create: function(channelName: string | object, options: {connected: Function, received: Function}) {
+          let channel = channelName
+          let params = typeof channel === "object" ? channel : { channel }
+          let alreadyConnected = false
+          cableReceived = options.received
+          let subscription = Object.assign(
+            Object.create({
+              perform: function(actionName: string, options: object) {
+                log.push(["cable perform", { actionName: actionName, options: options }])
+              },
+              unsubscribe: function() {
+                log.push(["cable unsubscribe"])
+              }
+            }),
+            { params },
+            options
+          )
+
+          subscription.connected = subscription.connected.bind(subscription)
+          let received = subscription.received
+          subscription.received = function(data: any) {
+            if (!alreadyConnected) {
+              alreadyConnected = true
+              subscription.connected()
+            }
+            received(data)
+          }
+          subscription.__proto__.unsubscribe = subscription.__proto__.unsubscribe.bind(subscription)
+          return subscription
+        }
+      }
+    }
+    options = {
+      cable: (cable as unknown) as Cable,
+      channelName: 'GraphQLChannel',
+      operations: undefined
+    }
+
+    query = "subscription { foo { bar } }"
+
+    subscribePayload = {
+      operationName: 'myOperationName',
+      variables: { a: 1 },
+      query: query
+    }
+
+    sink = {
+      next(value) {
+        log.push(["sink next", value])
+      },
+      error(error) {
+        log.push(["sink error", error])
+      },
+      complete() {
+        log.push(["sink complete"])
+      }
+    }
+  })
+
+  it("delegates to the cable", () => {
+    const client = new ActionCableGraphqlWsClient(options)
+
+    client.subscribe(subscribePayload, sink)
+    cableReceived({ result: { data: null }, more: true })
+    cableReceived({ result: { data: "data 1" }, more: true })
+    cableReceived({ result: { data: "data 2" }, more: false })
+
+    expect(log).toEqual([
+      [
+        "cable perform",
+        {
+          actionName: "execute",
+          options: {
+            operationName: "myOperationName",
+            query: "subscription { foo { bar } }",
+            variables: { a: 1 }
+          }
+        }
+      ],
+      ["sink next", { data: null} ],
+      ["sink next", { data: "data 1"} ],
+      ["sink next", { data: "data 2"} ],
+      ["sink complete"],
+    ])
+  })
+
+  it("delegates a manual unsubscribe to the cable", () => {
+    const client = new ActionCableGraphqlWsClient(options)
+
+    client.subscribe(subscribePayload, sink)
+    cableReceived({ result: { data: null }, more: true })
+    cableReceived({ result: { data: "data 1" }, more: true })
+    client.dispose()
+
+    expect(log).toEqual([
+      [
+        "cable perform",
+        {
+          actionName: "execute",
+          options: {
+            operationName: "myOperationName",
+            query: "subscription { foo { bar } }",
+            variables: { a: 1 }
+          }
+        }
+      ],
+      ["sink next", { data: null }],
+      ["sink next", { data: "data 1" }],
+      ["cable unsubscribe"]
+    ])
+  })
+})

--- a/javascript_client/src/subscriptions/createActionCableHandler.ts
+++ b/javascript_client/src/subscriptions/createActionCableHandler.ts
@@ -1,4 +1,5 @@
 import { Cable } from "actioncable"
+import { ActionCableUtil } from "../utils/ActionCableUtil"
 
 /**
  * Create a Relay Modern-compatible subscription handler.
@@ -14,8 +15,7 @@ interface ActionCableHandlerOptions {
 
 function createActionCableHandler(options: ActionCableHandlerOptions) {
   return function (operation: { text: string, name: string}, variables: object, _cacheConfig: object, observer: {onError: Function, onNext: Function, onCompleted: Function}) {
-    // unique-ish
-    var channelId = Math.round(Date.now() + Math.random() * 100000).toString(16)
+    var channelId = ActionCableUtil.getUniqueChannelId()
     var cable = options.cable
     var operations = options.operations
 

--- a/javascript_client/src/subscriptions/createActionCableHandler.ts
+++ b/javascript_client/src/subscriptions/createActionCableHandler.ts
@@ -21,7 +21,7 @@ function createActionCableHandler(options: ActionCableHandlerOptions) {
 
     // Register the subscription by subscribing to the channel
     const channel = cable.subscriptions.create({
-      channel: "GraphqlChannel",
+      channel: ActionCableUtil.DEFAULT_CHANNEL,
       channelId: channelId,
     }, {
       connected: function() {

--- a/javascript_client/src/subscriptions/registry.ts
+++ b/javascript_client/src/subscriptions/registry.ts
@@ -3,7 +3,7 @@ interface ApolloSubscription {
 }
 
 // State management for subscriptions.
-// Used to add subscriptions to an Apollo network intrface.
+// Used to add subscriptions to an Apollo network interface.
 class ApolloSubscriptionRegistry {
   // Apollo expects unique ids to reference each subscription,
   // here's a simple incrementing ID generator which starts at 1

--- a/javascript_client/src/utils/ActionCableUtil.ts
+++ b/javascript_client/src/utils/ActionCableUtil.ts
@@ -1,0 +1,8 @@
+export class ActionCableUtil {
+  /**
+   * Generate a unique-ish random string suitable as part of ActionCable channel identifier
+   *
+   * @returns String unique-ish random string
+   */
+  static getUniqueChannelId = (): string => Math.round(Date.now() + Math.random() * 100000).toString(16)
+}

--- a/javascript_client/src/utils/ActionCableUtil.ts
+++ b/javascript_client/src/utils/ActionCableUtil.ts
@@ -5,4 +5,9 @@ export class ActionCableUtil {
    * @returns String unique-ish random string
    */
   static getUniqueChannelId = (): string => Math.round(Date.now() + Math.random() * 100000).toString(16)
+
+  /**
+   * Default ActionCable channel name
+   */
+  static DEFAULT_CHANNEL = "GraphqlChannel"
 }


### PR DESCRIPTION
(Probably cloud help) close https://github.com/rmosolgo/graphiql-rails/issues/90, #2658 

`graphql-ruby` already has client side support for [Apollo Subscription](https://graphql-ruby.org/javascript_client/apollo_subscriptions.html) and [Relay Subscription](https://graphql-ruby.org/javascript_client/relay_subscriptions.html), but GraphiQL (thus [`graphiql-rails`](https://github.com/rmosolgo/graphiql-rails)) seems to [use `graphql-ws` under the hood](https://github.com/graphql/graphiql/blob/2ee5a45b4d8059179c7b56fc9c05c6a916208c3d/packages/graphiql-toolkit/src/create-fetcher/types.ts#L84-L88) therefore [Subscription is not supported in `/graphiql`](https://github.com/rmosolgo/graphql-ruby/commit/df88a44e4f2cbb00c08005dbede869cd1fd81212#diff-a1ea5af1a78917fa653eff83d9ae72180fabd3d9cf616f14dd1871739963cd73R132).

This draft PR aims to support [`graphql-ws` client](https://github.com/enisdenjo/graphql-ws#use-the-client) like [Apollo Subscription](https://graphql-ruby.org/javascript_client/apollo_subscriptions.html) and [Relay Subscription](https://graphql-ruby.org/javascript_client/relay_subscriptions.html) did, hoping to make Subscription works for GraphiQL client.


## Progress

- [x] javascript client interface
- [x] basic implementation
- [x] unit test
- [ ] testing with with GraphiQL or `graphql-ws`
