### PR TITLE
Remove @client fields before syncing

### DIFF
--- a/javascript_client/src/__tests__/__snapshots__/syncTest.ts.snap
+++ b/javascript_client/src/__tests__/__snapshots__/syncTest.ts.snap
@@ -269,9 +269,7 @@ exports[`sync operations Relay support Uses Apollo Android OperationOutput JSON 
 Array [
   Object {
     "alias": "aba626ea9bdf465954e89e5590eb2c1a",
-    "body": "mutation RemoveTodoMutation(
-  $input: RemoveTodoInput!
-) {
+    "body": "mutation RemoveTodoMutation($input: RemoveTodoInput!) {
   removeTodo(input: $input) {
     deletedTodoId
     user {
@@ -285,9 +283,7 @@ Array [
   },
   Object {
     "alias": "67c2bc8aa3185a209d6651b4feb63c04",
-    "body": "query appQuery(
-  $userId: String
-) {
+    "body": "query appQuery($userId: String) {
   user(id: $userId) {
     ...TodoApp_user
     id
@@ -362,9 +358,7 @@ fragment Todo_user on User {
   },
   Object {
     "alias": "db9904c31d91416f21d45fe3d153884c",
-    "body": "mutation MarkAllTodosMutation(
-  $input: MarkAllTodosInput!
-) {
+    "body": "mutation MarkAllTodosMutation($input: MarkAllTodosInput!) {
   markAllTodos(input: $input) {
     changedTodos {
       id
@@ -380,9 +374,7 @@ fragment Todo_user on User {
   },
   Object {
     "alias": "2eb8c9941fdb3117fdbc08d15fab62d0",
-    "body": "mutation AddTodoMutation(
-  $input: AddTodoInput!
-) {
+    "body": "mutation AddTodoMutation($input: AddTodoInput!) {
   addTodo(input: $input) {
     todoEdge {
       __typename
@@ -403,9 +395,7 @@ fragment Todo_user on User {
   },
   Object {
     "alias": "d970fd7dbf118794415dec7324d463e3",
-    "body": "mutation RenameTodoMutation(
-  $input: RenameTodoInput!
-) {
+    "body": "mutation RenameTodoMutation($input: RenameTodoInput!) {
   renameTodo(input: $input) {
     todo {
       id
@@ -417,9 +407,7 @@ fragment Todo_user on User {
   },
   Object {
     "alias": "a49217db31a8be3f4107763b957d5fca",
-    "body": "mutation RemoveCompletedTodosMutation(
-  $input: RemoveCompletedTodosInput!
-) {
+    "body": "mutation RemoveCompletedTodosMutation($input: RemoveCompletedTodosInput!) {
   removeCompletedTodos(input: $input) {
     deletedTodoIds
     user {
@@ -433,9 +421,7 @@ fragment Todo_user on User {
   },
   Object {
     "alias": "d7dda774dcfa32fe0d9661e01cac9a4a",
-    "body": "mutation ChangeTodoStatusMutation(
-  $input: ChangeTodoStatusInput!
-) {
+    "body": "mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
   changeTodoStatus(input: $input) {
     todo {
       id
@@ -461,7 +447,8 @@ Array [
     __typename
     name
   }
-}",
+}
+",
     "name": "UpdateSomething",
   },
   Object {
@@ -470,9 +457,11 @@ Array [
   helloWorld
   ...MoreFields
 }
+
 fragment MoreFields on Query {
   __typename
-}",
+}
+",
     "name": "getHelloWorld",
   },
 ]

--- a/javascript_client/src/__tests__/apolloExample/gen/output.json
+++ b/javascript_client/src/__tests__/apolloExample/gen/output.json
@@ -11,7 +11,7 @@
 					"type": "String!"
 				}
 			],
-			"source": "mutation UpdateSomething($name: String!) {\n  updateSomething(name: $name) {\n    __typename\n    name\n  }\n}",
+			"source": "mutation UpdateSomething($name: String!) {\n  updateSomething(name: $name) {\n    __typename\n    name\n  somethingElse @client\n }\n}",
 			"fields": [
 				{
 					"responseName": "updateSomething",

--- a/javascript_client/src/__tests__/example-apollo-android-operation-output.json
+++ b/javascript_client/src/__tests__/example-apollo-android-operation-output.json
@@ -1,7 +1,7 @@
 {
   "aba626ea9bdf465954e89e5590eb2c1a": {
     "name": "RemoveTodoMutation",
-    "source": "mutation RemoveTodoMutation(\n  $input: RemoveTodoInput!\n) {\n  removeTodo(input: $input) {\n    deletedTodoId\n    user {\n      completedCount\n      totalCount\n      id\n    }\n  }\n}\n"
+    "source": "mutation RemoveTodoMutation(\n  $input: RemoveTodoInput!\n) {\n  removeTodo(input: $input) {\n    deletedTodoId\n    user {\n      completedCount\n      totalCount\n      thing @client\n      id\n    }\n  }\n}\n"
   },
   "67c2bc8aa3185a209d6651b4feb63c04": {
     "name": "appQuery",

--- a/javascript_client/src/sync/__tests__/removeClientFieldsTest.ts
+++ b/javascript_client/src/sync/__tests__/removeClientFieldsTest.ts
@@ -1,0 +1,19 @@
+import { removeClientFieldsFromString } from "../removeClientFields"
+
+
+describe("removing @client fields", () => {
+  function normalizeString(str: string) {
+    return str.replace(/\s+/g, " ").trim()
+  }
+
+  it("returns a string without any fields with @client", () => {
+    var newString = removeClientFieldsFromString("{ f1 f2 @client { a b } f3 { a b @client } }")
+    var expectedString = "{ f1 f3 { a } }"
+    expect(normalizeString(newString)).toEqual(expectedString)
+  })
+  it("leaves other strings unchanged", () => {
+    var originalString = "{ f1 f2 @other { a b } f3 { a b @notClient } }"
+    var newString = removeClientFieldsFromString(originalString)
+    expect(normalizeString(newString)).toEqual(originalString)
+  })
+})

--- a/javascript_client/src/sync/index.ts
+++ b/javascript_client/src/sync/index.ts
@@ -1,7 +1,9 @@
 import sendPayload from "./sendPayload"
+
 import { generateClientCode, gatherOperations, ClientOperation } from "./generateClient"
 import Logger from "./logger"
 import fs from "fs"
+import { removeClientFieldsFromString } from "./removeClientFields"
 
 interface SyncOptions {
   path?: string,
@@ -83,8 +85,9 @@ function sync(options: SyncOptions) {
     // Structure is { operationId => { "name" => "...", "source" => "query { ... } " } }
     for (var operationId in apolloAndroidOutput) {
       operationData = apolloAndroidOutput[operationId]
+      let bodyWithoutClientFields = removeClientFieldsFromString(operationData.source)
       payload.operations.push({
-        body: operationData.source,
+        body: bodyWithoutClientFields,
         alias: operationId,
       })
     }
@@ -93,10 +96,11 @@ function sync(options: SyncOptions) {
     const jsonText = fs.readFileSync(options.apolloCodegenJsonOutput).toString()
     const jsonData = JSON.parse(jsonText)
     jsonData.operations.map(function(operation: {operationId: string, operationName: string, sourceWithFragments: string}) {
+      const bodyWithoutClientFields = removeClientFieldsFromString(operation.sourceWithFragments)
       payload.operations.push({
         alias: operation.operationId,
         name: operation.operationName,
-        body: operation.sourceWithFragments,
+        body: bodyWithoutClientFields,
       })
     })
   } else {

--- a/javascript_client/src/sync/prepareIsolatedFiles.ts
+++ b/javascript_client/src/sync/prepareIsolatedFiles.ts
@@ -1,7 +1,7 @@
 import fs from "fs"
 import {parse, visit, print, OperationDefinitionNode} from "graphql"
 import {addTypenameIfAbsent} from "./addTypenameToSelectionSet"
-
+import { removeClientFields } from "./removeClientFields"
 
 /**
  * Read a bunch of GraphQL files and treat them as islands.
@@ -33,6 +33,7 @@ function prepareIsolatedFiles(filenames: string[], addTypename: boolean) {
       }
     }
     ast = visit(ast, visitor)
+    ast = removeClientFields(ast)
 
     return {
       // populate alias later, when hashFunc is available

--- a/javascript_client/src/sync/prepareProject.ts
+++ b/javascript_client/src/sync/prepareProject.ts
@@ -1,6 +1,7 @@
 import { addTypenameIfAbsent } from "./addTypenameToSelectionSet";
 import fs from "fs"
 import {parse, visit, print, OperationDefinitionNode, FragmentDefinitionNode, FragmentSpreadNode, DocumentNode} from "graphql"
+import { removeClientFields } from "./removeClientFields";
 
 /**
  * Take a whole bunch of GraphQL in one big string
@@ -68,7 +69,7 @@ function prepareProject(filenames: string[], addTypename: boolean) {
 
   // Find the dependencies, build the accumulator
   ast = visit(ast, visitor)
-
+  ast = removeClientFields(ast)
   // For each operation, build a separate document of that operation and its deps
   // then print the new document to a string
   var operations = allOperationNames.map(function(operationName) {

--- a/javascript_client/src/sync/removeClientFields.ts
+++ b/javascript_client/src/sync/removeClientFields.ts
@@ -1,0 +1,31 @@
+import { visit, ASTNode, FieldNode, parse, print } from "graphql"
+
+
+function removeIfClient(node: FieldNode): undefined | null {
+  const clientDirective = node.directives?.find((directiveNode) => { return directiveNode.name.value == "client" })
+  if (clientDirective) {
+    return null
+  } else {
+    return undefined
+  }
+}
+
+function removeClientFields(node: ASTNode) {
+  var visitor = {
+    Field: {
+      leave: removeIfClient,
+    }
+  }
+  return visit(node, visitor)
+}
+
+function removeClientFieldsFromString(body: string): string {
+  const ast = parse(body)
+  const newAst = removeClientFields(ast)
+  return print(newAst)
+}
+
+export {
+  removeClientFields,
+  removeClientFieldsFromString
+}


### PR DESCRIPTION
Oops, if you're using Apollo's client fields (https://www.apollographql.com/docs/react/local-state/managing-state-with-field-policies/#querying), then `sync` won't work right, because those fields don't exist on the server. So, strip them out before sending the operation to `sync`. (Then, when the server runs the operation by ID, it will execute the operation _without_ `@client` fields.)