### PR TITLE
Support NO_UPDATE in ActionCable subscriptions

### DIFF
--- a/lib/graphql/subscriptions/action_cable_subscriptions.rb
+++ b/lib/graphql/subscriptions/action_cable_subscriptions.rb
@@ -170,10 +170,12 @@ module GraphQL
               first_subscription_id = first_event.context.fetch(:subscription_id)
               object ||= load_action_cable_message(message, first_event.context)
               result = execute_update(first_subscription_id, first_event, object)
-              # Having calculated the result _once_, send the same payload to all subscribers
-              events.each do |event|
-                subscription_id = event.context.fetch(:subscription_id)
-                deliver(subscription_id, result)
+              if !result.nil?
+                # Having calculated the result _once_, send the same payload to all subscribers
+                events.each do |event|
+                  subscription_id = event.context.fetch(:subscription_id)
+                  deliver(subscription_id, result)
+                end
               end
             end
           end

--- a/spec/graphql/subscriptions/action_cable_subscriptions_spec.rb
+++ b/spec/graphql/subscriptions/action_cable_subscriptions_spec.rb
@@ -86,8 +86,21 @@ describe GraphQL::Subscriptions::ActionCableSubscriptions do
       field :text, String, null: false
     end
 
+    class EvenCounter < GraphQL::Schema::Subscription
+      field :count, Integer, null: false
+
+      def update
+        if object[:count].even?
+          object
+        else
+          NO_UPDATE
+        end
+      end
+    end
+
     class Subscription < GraphQL::Schema::Object
       field :news_flash, subscription: NewsFlash
+      field :even_counter, subscription: EvenCounter
     end
 
     query(Query)
@@ -200,6 +213,22 @@ describe GraphQL::Subscriptions::ActionCableSubscriptions do
       "graphql-event:other::newsFlash:",
     ]
     assert_equal expected_streams, MockActionCable.mock_stream_names
+  end
+
+  it "supports no_update" do
+    mock_channel = MockActionCable.get_mock_channel
+    ctx = { channel: mock_channel }
+    ActionCableTestSchema.execute("subscription { evenCounter { count } }", context: ctx)
+
+    1.upto(4) do |c|
+      ActionCableTestSchema.subscriptions.trigger(:even_counter, {}, {count: c})
+    end
+
+    expected_messages = [
+      subscription_update("evenCounter" => { "count" => 2 }),
+      subscription_update("evenCounter" => { "count" => 4 }),
+    ]
+    assert_equal expected_messages, mock_channel.mock_broadcasted_messages
   end
 
   it "handles `execute_update` for a missing subscription ID" do


### PR DESCRIPTION
Looks like this may be the fix for #3189 and similar empty subscription updates I'm seeing in my application.

Applies the same pattern to `ActionCableSubscriptions` as `Subscriptions`, which just checks if `execute_update` returns `nil` and skips the delivery. See https://github.com/rmosolgo/graphql-ruby/blob/bace1e4027900fc8779a5c2fd393ff6456046cea/lib/graphql/subscriptions.rb#L141-L146

Given this is a subclass, I'm guessing there's a better way to rely on the superclass behavior and ensure all subclasses inherit this important feature. Open to suggestions.