### PR TITLE
Make sure documents are valid after removing client fields

### DIFF
--- a/javascript_client/src/__tests__/__snapshots__/syncTest.ts.snap
+++ b/javascript_client/src/__tests__/__snapshots__/syncTest.ts.snap
@@ -283,7 +283,9 @@ Array [
   },
   Object {
     "alias": "67c2bc8aa3185a209d6651b4feb63c04",
-    "body": "query appQuery($userId: String) {
+    "body": "query appQuery(
+  $userId: String
+) {
   user(id: $userId) {
     ...TodoApp_user
     id
@@ -358,7 +360,9 @@ fragment Todo_user on User {
   },
   Object {
     "alias": "db9904c31d91416f21d45fe3d153884c",
-    "body": "mutation MarkAllTodosMutation($input: MarkAllTodosInput!) {
+    "body": "mutation MarkAllTodosMutation(
+  $input: MarkAllTodosInput!
+) {
   markAllTodos(input: $input) {
     changedTodos {
       id
@@ -374,7 +378,9 @@ fragment Todo_user on User {
   },
   Object {
     "alias": "2eb8c9941fdb3117fdbc08d15fab62d0",
-    "body": "mutation AddTodoMutation($input: AddTodoInput!) {
+    "body": "mutation AddTodoMutation(
+  $input: AddTodoInput!
+) {
   addTodo(input: $input) {
     todoEdge {
       __typename
@@ -395,7 +401,9 @@ fragment Todo_user on User {
   },
   Object {
     "alias": "d970fd7dbf118794415dec7324d463e3",
-    "body": "mutation RenameTodoMutation($input: RenameTodoInput!) {
+    "body": "mutation RenameTodoMutation(
+  $input: RenameTodoInput!
+) {
   renameTodo(input: $input) {
     todo {
       id
@@ -407,7 +415,9 @@ fragment Todo_user on User {
   },
   Object {
     "alias": "a49217db31a8be3f4107763b957d5fca",
-    "body": "mutation RemoveCompletedTodosMutation($input: RemoveCompletedTodosInput!) {
+    "body": "mutation RemoveCompletedTodosMutation(
+  $input: RemoveCompletedTodosInput!
+) {
   removeCompletedTodos(input: $input) {
     deletedTodoIds
     user {
@@ -421,7 +431,9 @@ fragment Todo_user on User {
   },
   Object {
     "alias": "d7dda774dcfa32fe0d9661e01cac9a4a",
-    "body": "mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
+    "body": "mutation ChangeTodoStatusMutation(
+  $input: ChangeTodoStatusInput!
+) {
   changeTodoStatus(input: $input) {
     todo {
       id
@@ -447,8 +459,7 @@ Array [
     __typename
     name
   }
-}
-",
+}",
     "name": "UpdateSomething",
   },
   Object {
@@ -457,11 +468,9 @@ Array [
   helloWorld
   ...MoreFields
 }
-
 fragment MoreFields on Query {
   __typename
-}
-",
+}",
     "name": "getHelloWorld",
   },
 ]

--- a/javascript_client/src/sync/__tests__/removeClientFieldsTest.ts
+++ b/javascript_client/src/sync/__tests__/removeClientFieldsTest.ts
@@ -11,9 +11,92 @@ describe("removing @client fields", () => {
     var expectedString = "{ f1 f3 { a } }"
     expect(normalizeString(newString)).toEqual(expectedString)
   })
+
   it("leaves other strings unchanged", () => {
     var originalString = "{ f1 f2 @other { a b } f3 { a b @notClient } }"
     var newString = removeClientFieldsFromString(originalString)
     expect(normalizeString(newString)).toEqual(originalString)
+  })
+
+  it("removes references to fragments that contain all client fields", () => {
+    var originalString = `
+    {
+      f1
+      ...Fragment1
+      ... on Query {
+        f3
+        ...Fragment2
+      }
+      ...Fragment3
+    }
+
+    fragment Fragment1 on Query {
+      f2 @client
+      f3
+      ...Fragment2
+    }
+
+    fragment Fragment2 on Query {
+      f4 @client
+      f5 @client
+      f6 @client {
+        f7
+        f8
+      }
+    }
+
+    fragment Fragment3 on Query {
+      ...Fragment2
+    }
+    `
+
+    var expectedString = `
+    {
+      f1
+      ...Fragment1
+      ... on Query {
+        f3
+      }
+    }
+
+    fragment Fragment1 on Query {
+      f3
+    }
+    `
+
+    var newString = removeClientFieldsFromString(originalString)
+    expect(normalizeString(newString)).toEqual(normalizeString(expectedString))
+  })
+
+  it("removes now-unused variables", () => {
+    var newString = removeClientFieldsFromString("query($thing: ID!){ f1 f2(thing: $thing) @client }")
+    var expectedString = "{ f1 }"
+    expect(normalizeString(newString)).toEqual(expectedString)
+  })
+
+  it("removes fragments that are spread inside client fields", () => {
+    // from https://github.com/apollographql/apollo-client/pull/6892/
+    var originalString = `
+    query Simple {
+      networkField
+      field @client {
+        ...ClientFragment
+      }
+    }
+    fragment ClientFragment on Thing {
+      ...NestedFragment
+    }
+    fragment NestedFragment on Thing {
+      otherField
+      bar
+    }`
+    var expectedString = `
+    query Simple {
+      networkField
+    }
+    `
+
+    var newString = removeClientFieldsFromString(originalString)
+    expect(normalizeString(newString)).toEqual(normalizeString(expectedString))
   })
 })

--- a/javascript_client/src/sync/removeClientFields.ts
+++ b/javascript_client/src/sync/removeClientFields.ts
@@ -1,28 +1,120 @@
-import { visit, ASTNode, FieldNode, parse, print } from "graphql"
+import { parse, DocumentNode, VariableDefinitionNode, print, visit } from "graphql"
 
+function removeClientFields(node: DocumentNode) {
+  // Deleting fields can create invalid documents:
+  // - If variables were used by those fields (or their subfields), then their definitions are invalid
+  // - If a fragment contained only deleted fields, it is now empty and therefore invalid and should be deleted
+  // - If a fragment spread names a deleted fragment, it is now invalid
+  // - If a client field contained a fragment spread and it's deleted, then a fragment may be left unspread
 
-function removeIfClient(node: FieldNode): undefined | null {
-  const clientDirective = node.directives?.find((directiveNode) => { return directiveNode.name.value == "client" })
-  if (clientDirective) {
-    return null
-  } else {
-    return undefined
-  }
-}
+  let anythingWasRemoved = false
+  const usedVariables: string[] = []
+  let definedFragments: string[] = []
+  let spreadFragments: string[] = []
 
-function removeClientFields(node: ASTNode) {
-  var visitor = {
+  // First pass: remove as much as possible, even if the document is left invalid.
+  // - remove fields that have @client
+  // - remove fragment definitions that become empty
+  let newDoc = visit(node, {
     Field: {
-      leave: removeIfClient,
+      enter: (node) => {
+        if (node.directives && node.directives.some((d) => { return d.name.value === "client" })) {
+          anythingWasRemoved = true
+          // Delete this node
+          return null
+        } else {
+          return undefined
+        }
+      }
+    },
+    // FragmentSpread: ... Don't do this now, because we might find some in Fragment Definitions that are deleted later.
+    FragmentDefinition: {
+      leave: (node) => {
+        if (node.selectionSet.selections.length == 0) {
+          // All the fields in this fragment were removed
+          return null
+        } else {
+          definedFragments.push(node.name.value)
+          return undefined
+        }
+      }
+    },
+    FragmentSpread: {
+      enter: (node) => {
+        spreadFragments.push(node.name.value)
+      }
+    },
+    Variable: {
+      enter: (node, _key, parent) => {
+        if ((parent as VariableDefinitionNode).kind !== 'VariableDefinition') {
+          // This will only find variables that are used _after_ `@client` fields are deleted.
+          // (If `@client` fields are deleted, then their arguments aren't visited)
+          usedVariables.push(node.name.value)
+        }
+      },
+    },
+  })
+
+  if (anythingWasRemoved) {
+    // At this point, we can remove variables that aren't used.
+    newDoc = visit(newDoc, {
+      VariableDefinition: {
+        enter: (node) => {
+          if (!usedVariables.includes(node.variable.name.value)) {
+            return null
+          } else {
+            return undefined
+          }
+        }
+      },
+    })
+
+    // Then, remove spreads of empty fragment definitions as long as we keep finding them
+    // Also remove definitions of fragments that aren't spread anymore
+    while (anythingWasRemoved) {
+      let previouslyDefinedFragments = definedFragments
+      let previouslySpreadFragments = spreadFragments
+      definedFragments = []
+      spreadFragments = []
+      anythingWasRemoved = false
+      newDoc = visit(newDoc, {
+        FragmentSpread: {
+          enter: (node) => {
+            if (!previouslyDefinedFragments.includes(node.name.value)) {
+              anythingWasRemoved = true
+              return null
+            } else {
+              spreadFragments.push(node.name.value)
+              return undefined
+            }
+          }
+        },
+        FragmentDefinition: {
+          enter: (node) => {
+            if (node.selectionSet.selections.length == 0 || !previouslySpreadFragments.includes(node.name.value)) {
+              anythingWasRemoved = true
+              return null
+            } else {
+              definedFragments.push(node.name.value)
+              return undefined
+            }
+          }
+        }
+      })
     }
   }
-  return visit(node, visitor)
+
+  return newDoc
 }
 
 function removeClientFieldsFromString(body: string): string {
-  const ast = parse(body)
-  const newAst = removeClientFields(ast)
-  return print(newAst)
+  if (body.includes("@client")) {
+    const ast = parse(body)
+    const newAst = removeClientFields(ast)
+    return print(newAst)
+  } else {
+    return body
+  }
 }
 
 export {


### PR DESCRIPTION
I considered using `removeDirectivesFromDocument` from Apollo Client (https://github.com/apollographql/apollo-client/blob/d470c964db46728d8a5dfc63990859c550fa1656/src/utilities/graphql/transform.ts#L94), but I found that: 

- It didn't remove empty fragment definitions (apparently Apollo _does_ somewhere along the line though, because they're removed by the time they go over the wire) 
- It has unfixed bugs: https://github.com/apollographql/apollo-client/pull/6892 

So I rolled my own based on the examples there. 