### PR TITLE
Add a method to access all enum values without filtering

### DIFF
--- a/lib/graphql/schema/enum.rb
+++ b/lib/graphql/schema/enum.rb
@@ -84,6 +84,25 @@ module GraphQL
           visible_values
         end
 
+        # @return [Array<Schema::EnumValue>] An unfiltered list of all definitions
+        def all_enum_value_definitions
+          all_defns = if superclass.respond_to?(:all_enum_value_definitions)
+            superclass.all_enum_value_definitions
+          else
+            []
+          end
+
+          @own_values && @own_values.each do |_key, value|
+            if value.is_a?(Array)
+              all_defns.concat(value)
+            else
+              all_defns << value
+            end
+          end
+
+          all_defns
+        end
+
         # @return [Hash<String => GraphQL::Schema::EnumValue>] Possible values of this enum, keyed by name.
         def values(context = GraphQL::Query::NullContext)
           enum_values(context).each_with_object({}) { |val, obj| obj[val.graphql_name] = val }

--- a/lib/graphql/schema/enum_value.rb
+++ b/lib/graphql/schema/enum_value.rb
@@ -86,7 +86,7 @@ module GraphQL
       end
 
       def inspect
-        "#<#{self.class} #{path} #{description ? "(#{description.inspect})" : ""}>"
+        "#<#{self.class} #{path} @value=#{@value.inspect}#{description ? " @description=#{description.inspect}" : ""}>"
       end
 
       def visible?(_ctx); true; end

--- a/spec/graphql/schema/dynamic_members_spec.rb
+++ b/spec/graphql/schema/dynamic_members_spec.rb
@@ -1037,7 +1037,7 @@ GRAPHQL
       err = assert_raises GraphQL::Schema::DuplicateNamesError do
         enum_type.values({ allowed_for: 2 })
       end
-      expected_message ="Found two visible definitions for `DuplicateEnumValue.ONE`: #<DuplicateNames::BaseEnumValue DuplicateEnumValue.ONE (\"second definition\")>, #<DuplicateNames::BaseEnumValue DuplicateEnumValue.ONE (\"first definition\")>"
+      expected_message ="Found two visible definitions for `DuplicateEnumValue.ONE`: #<DuplicateNames::BaseEnumValue DuplicateEnumValue.ONE @value=\"ONE\" @description=\"second definition\">, #<DuplicateNames::BaseEnumValue DuplicateEnumValue.ONE @value=\"ONE\" @description=\"first definition\">"
       assert_equal expected_message, err.message
 
       # no get_value method ... yet ...

--- a/spec/graphql/schema/enum_spec.rb
+++ b/spec/graphql/schema/enum_spec.rb
@@ -92,6 +92,26 @@ describe GraphQL::Schema::Enum do
     end
   end
 
+  describe "multiple values with the same name" do
+    class MultipleNameTestEnum < GraphQL::Schema::Enum
+      value "A"
+      value "B", value: :a
+      value "B", value: :b
+    end
+
+    it "doesn't allow it from enum_values" do
+      err = assert_raises GraphQL::Schema::DuplicateNamesError do
+        MultipleNameTestEnum.enum_values
+      end
+      expected_message = "Found two visible definitions for `MultipleNameTestEnum.B`: #<GraphQL::Schema::EnumValue MultipleNameTestEnum.B @value=:a>, #<GraphQL::Schema::EnumValue MultipleNameTestEnum.B @value=:b>"
+      assert_equal expected_message, err.message
+    end
+
+    it "returns them all in all_enum_value_definitions" do
+      assert_equal 3, MultipleNameTestEnum.all_enum_value_definitions.size
+    end
+  end
+
   describe "legacy tests" do
     let(:enum) { Dummy::DairyAnimal }
 


### PR DESCRIPTION
This method isn't needed for runtime or even building schema caches, which I guess is why I missed it before. But it's handy for working with the schema.