### PR TITLE
Remove extend GraphQL::Subscriptions::SubscriptionRoot from docs

### DIFF
--- a/guides/subscriptions/subscription_type.md
+++ b/guides/subscriptions/subscription_type.md
@@ -40,9 +40,6 @@ To add subscriptions to your system, define an `ObjectType` named `Subscription`
 ```ruby
 # app/graphql/types/subscription_type.rb
 class Types::SubscriptionType < GraphQL::Schema::Object
-  # If you're using the interpreter, also add:
-  extend GraphQL::Subscriptions::SubscriptionRoot
-
   field :post_was_published, subscription: Subscriptions::PostWasPublished
   # ...
 end


### PR DESCRIPTION
Looks like we don't need it anymore—everyone is on the Interpreter nowdays and this `extend` is added by default and we [warn](https://github.com/rmosolgo/graphql-ruby/blob/master/lib/graphql/subscriptions/subscription_root.rb#L9) when user does it.