### PR TITLE
get full sub-query for a field to proxy to external API

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -354,6 +354,10 @@ module GraphQL
           finished_jobs = 0
           enqueued_jobs = gathered_selections.size
           gathered_selections.each do |result_name, field_ast_nodes_or_ast_node|
+            if @context[:current_object].show_current_query
+              @context[:current_query] = field_ast_nodes_or_ast_node.to_query_string
+            end
+
             @dataloader.append_job {
               evaluate_selection(
                 path, result_name, field_ast_nodes_or_ast_node, scoped_context, owner_object, owner_type, is_eager_selection, selections_result, parent_object

--- a/lib/graphql/schema/member/base_dsl_methods.rb
+++ b/lib/graphql/schema/member/base_dsl_methods.rb
@@ -54,6 +54,21 @@ module GraphQL
           end
         end
 
+        # Whether or not :current_query should be available.
+        # Call this method to provide a new show_current_query; OR
+        # call it without an argument to get the show_current_query
+        # @param new_show_current_query [Boolean]
+        # @return [Boolean]
+        def show_current_query(new_show_current_query = nil)
+          if new_show_current_query
+            @show_current_query = new_show_current_query
+          elsif defined?(@show_current_query)
+            @show_current_query
+          else
+            nil
+          end
+        end
+
         # This pushes some configurations _down_ the inheritance tree,
         # in order to prevent repetitive lookups at runtime.
         module ConfigurationExtension


### PR DESCRIPTION
## Use case
In order to proxy a top-level query 1:1 to a remote API, there currently is not a great solution. In https://github.com/rmosolgo/graphql-ruby/issues/1812, [graphql-remote_loader](https://github.com/d12/graphql-remote_loader) was suggested as a potential solution, but it is a bit verbose as it is on a field-by-field basis and it also doesn't seem to have the capabilities to proxy through a sub-query.

Say for example, we have a query:
```
user(id: 1) {
  name
  address
}
search(term: "ski resorts") {
  results
}
```

And we want to proxy the user query to a user API:
```ruby
def user(id:)
  # The only query string accessible seems to be the full one with user and search
  UserAPI.query(context.query.query_string)
end
```

Then the only way with current functionality is to send the entire query through or do some manual manipulation on it to properly get it proxied.

## Potential solution
If each individual resolver had access to the sub-query that is specific to it via an interface such as `context[:current_query]`, then in the example, we could have access to the user-specific sub-query that we could pass through to the UserAPI:
```
user(id: 1) {
  name
  address
}
```
I assume this can potentially cause a performance hit, if so then this could be behind a flag defined on the field, such as `show_current_query`. If performance is not a concern, then that portion is unnecessary.