### PR TITLE
ActionCable subscriptions: close channel when unsubscribing from server

### DIFF
--- a/lib/graphql/subscriptions/action_cable_subscriptions.rb
+++ b/lib/graphql/subscriptions/action_cable_subscriptions.rb
@@ -216,6 +216,8 @@ module GraphQL
       # The channel was closed, forget about it.
       def delete_subscription(subscription_id)
         query = @subscriptions.delete(subscription_id)
+        # In case this came from the server, tell the client to unsubscribe:
+        @action_cable.server.broadcast(stream_subscription_name(subscription_id), { more: false })
         # This can be `nil` when `.trigger` happens inside an unsubscribed ActionCable channel,
         # see https://github.com/rmosolgo/graphql-ruby/issues/2478
         if query

--- a/spec/dummy/app/assets/javascripts/application.js
+++ b/spec/dummy/app/assets/javascripts/application.js
@@ -42,7 +42,12 @@
           },
           received: function(data) {
             console.log("received", query, variables, data)
-            receivedCallback(data)
+            if (data.more) {
+              receivedCallback(data)
+            } else {
+              this.unsubscribe()
+              App.logToBody("Remaining ActionCable subscriptions: " + App.cable.subscriptions.subscriptions.length)
+            }
           }
         }
       ),
@@ -53,5 +58,13 @@
         this.subscription.unsubscribe()
       },
     }
+  }
+
+  // Add `text` to the HTML body, for debugging
+  App.logToBody = function(text) {
+    var bodyLog = document.getElementById("body-log")
+    var logEntry = document.createElement("p")
+    logEntry.innerText = text
+    bodyLog.appendChild(logEntry)
   }
 }).call(this);

--- a/spec/dummy/app/channels/graphql_channel.rb
+++ b/spec/dummy/app/channels/graphql_channel.rb
@@ -12,11 +12,18 @@ class GraphqlChannel < ActionCable::Channel::Base
   end
 
   class CounterIncremented < GraphQL::Schema::Subscription
-    @@call_count = 0
+    def self.reset_call_count
+      @@call_count = 0
+    end
+
+    reset_call_count
 
     field :new_value, Integer, null: false
 
     def update
+      if object && object.value == "server-unsubscribe"
+        unsubscribe
+      end
       result = {
         new_value: @@call_count += 1
       }

--- a/spec/dummy/app/views/pages/show.html
+++ b/spec/dummy/app/views/pages/show.html
@@ -19,6 +19,7 @@
 <ul id="fingerprint-updates-1">
 </ul>
 <button onClick="triggerWithFingerprint('1')">Trigger with fingerprint 1</button>
+<button onClick="serverSideUnsubscribeWithFingerprint('1')">Server-side unsubscribe with fingerprint 1</button>
 <button onClick="unsubscribeWithFingerprint('1')">Unsubscribe with fingerprint 1</button>
 
 <br>
@@ -32,14 +33,6 @@
 <div id="body-log">
 </div>
 <script>
-
-// Add `text` to the HTML body, for debugging
-function logToBody(text) {
-  var bodyLog = document.getElementById("body-log")
-  var logEntry = document.createElement("p")
-  logEntry.innerText = text
-  bodyLog.appendChild(logEntry)
-}
 
 function appendItem(parentId, text) {
   var list = document.getElementById(parentId)
@@ -76,7 +69,7 @@ var val2 = 1
 
 var fingerprintSubscriptions = {}
 function subscribeWithFingerprint(key) {
-  logToBody("subscribing to " + key)
+  App.logToBody("subscribing to " + key)
   if (!fingerprintSubscriptions[key]) {
     fingerprintSubscriptions[key] = []
   }
@@ -85,7 +78,7 @@ function subscribeWithFingerprint(key) {
     query: "subscription fingerprint" + key + " { counterIncremented { newValue } }",
     variables: {},
     received: function(data) {
-      logToBody("received from " + key + " " + JSON.stringify(data))
+      App.logToBody("received from " + key + " " + JSON.stringify(data))
 
       if (data.result.data.counterIncremented) {
         appendItem("fingerprint-updates-" + key, "update-" + newSub.number + "-value-" + data.result.data.counterIncremented.newValue)
@@ -99,15 +92,31 @@ function subscribeWithFingerprint(key) {
 }
 
 function triggerWithFingerprint(key) {
-  logToBody("triggering " + key)
-  var sub = fingerprintSubscriptions[key][0]
-  sub.trigger({field: "counterIncremented", arguments: {}, value: null})
+  App.logToBody("triggering " + key)
+  var subs = fingerprintSubscriptions[key]
+  var sub = subs && subs[0]
+  sub && sub.trigger({field: "counterIncremented", arguments: {}, value: null})
 }
 
 function unsubscribeWithFingerprint(key) {
-  fingerprintSubscriptions[key].forEach(function(sub) {
+  var subs = fingerprintSubscriptions[key]
+  subs && subs.forEach(function(sub) {
     sub.unsubscribe()
   })
   fingerprintSubscriptions[key] = []
 }
+
+function serverSideUnsubscribeWithFingerprint(key) {
+  App.logToBody("server-side unsubscribing " + key)
+  var subs = fingerprintSubscriptions[key]
+  if (subs) {
+    var sub = subs[0]
+    if (sub) {
+      sub.trigger({field: "counterIncremented", arguments: {}, value: "server-unsubscribe"})
+      // Assume it's removed:
+      subs.shift()
+    }
+  }
+}
+
 </script>


### PR DESCRIPTION
The server should send `more: false` when the server closes a connection. It turns out this is already _expected_ by the client code: 

https://github.com/rmosolgo/graphql-ruby/blob/e936d7110f54d64bfa5de996736f3afff3af7eec/javascript_client/src/subscriptions/ActionCableLink.ts#L53-L55

https://github.com/rmosolgo/graphql-ruby/blob/e936d7110f54d64bfa5de996736f3afff3af7eec/javascript_client/src/subscriptions/ActionCableSubscriber.ts#L61-L63

https://github.com/rmosolgo/graphql-ruby/blob/e936d7110f54d64bfa5de996736f3afff3af7eec/javascript_client/src/subscriptions/createActionCableHandler.ts#L57-L60
It was just never sent. Now it is :+1: 

fixes #3650