### PR TITLE
fix(Lexer): resolved issue when rebuilding trimmed whitespace string

### DIFF
--- a/lib/graphql/language/block_string.rb
+++ b/lib/graphql/language/block_string.rb
@@ -55,7 +55,7 @@ module GraphQL
         end
 
         # Rebuild the string
-        lines.size > 1 ? lines.join("\n") : (lines.first || "")
+        lines.size > 1 ? lines.join("\n") : (lines.first || "".dup)
       end
 
       def self.print(str, indent: '')

--- a/lib/graphql/language/block_string.rb
+++ b/lib/graphql/language/block_string.rb
@@ -7,7 +7,7 @@ module GraphQL
       def self.trim_whitespace(str)
         # Early return for the most common cases:
         if str == ""
-          return ""
+          return "".dup
         elsif !(has_newline = str.include?("\n")) && !(str.start_with?(" "))
           return str
         end
@@ -55,7 +55,7 @@ module GraphQL
         end
 
         # Rebuild the string
-        lines.size > 1 ? lines.join("\n") : (lines.first || "")
+        lines.size > 1 ? lines.join("\n") : (lines.first || "".dup)
       end
 
       def self.print(str, indent: '')

--- a/lib/graphql/language/block_string.rb
+++ b/lib/graphql/language/block_string.rb
@@ -55,7 +55,7 @@ module GraphQL
         end
 
         # Rebuild the string
-        lines.size > 1 ? lines.join("\n") : (lines.first || "".dup)
+        lines.size > 1 ? lines.join("\n") : (lines.first || "")
       end
 
       def self.print(str, indent: '')

--- a/lib/graphql/language/lexer.rb
+++ b/lib/graphql/language/lexer.rb
@@ -1437,9 +1437,6 @@ meta[:col],
 meta[:previous_token],
 )
 else
-# As the string is modified in place below, duping the value will provide a non-frozen string to modify.
-# `GraphQL::Language::BlockString.trim_whitespace`, can return frozen strings.
-value = value.dup if value.frozen?
 replace_escaped_characters_in_place(value)
 
 if !value.valid_encoding?

--- a/lib/graphql/language/lexer.rb
+++ b/lib/graphql/language/lexer.rb
@@ -1437,6 +1437,9 @@ meta[:col],
 meta[:previous_token],
 )
 else
+# As the string is modified in place below, duping the value will provide a non-frozen string to modify.
+# `GraphQL::Language::BlockString.trim_whitespace`, can return frozen strings.
+value = value.dup if value.frozen?
 replace_escaped_characters_in_place(value)
 
 if !value.valid_encoding?

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -233,7 +233,7 @@ union U = Hello
       assert_equal 63, built_schema.types["U"].ast_node.definition_line
     end
 
-    it 'supports descriptions and definition_line' do
+    it 'handles empty type descriptions' do
       schema = <<-SCHEMA
 """
 """

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -233,6 +233,17 @@ union U = Hello
       assert_equal 63, built_schema.types["U"].ast_node.definition_line
     end
 
+    it 'supports descriptions and definition_line' do
+      schema = <<-SCHEMA
+"""
+"""
+type Query {
+  f1: Int
+}
+      SCHEMA
+      refute_nil GraphQL::Schema.from_definition(schema)
+    end
+
     it 'maintains built-in directives' do
       schema = <<-SCHEMA
 schema {


### PR DESCRIPTION
Fixes https://github.com/rmosolgo/graphql-ruby/issues/3740

When rebuilding an empty trimmed whitespace string, such as `"\n"`, which can occur when a type has an empty description, a frozen string is returned, causing in place substitution with gsub to fail when replacing escaped characters in place at [GraphQL::Language::Lexer.replace_escaped_characters_in_place](https://github.com/rmosolgo/graphql-ruby/blob/489267e0fb63651bef0579dd1ced839a9a6c2ebb/lib/graphql/language/lexer.rb#L1440).