### PR TITLE
Deprecate .graphql_definition

### DIFF
--- a/lib/graphql/base_type.rb
+++ b/lib/graphql/base_type.rb
@@ -41,7 +41,9 @@ module GraphQL
     alias :graphql_name :name
     # Future-compatible alias
     # @see {GraphQL::SchemaMember}
-    alias :graphql_definition :itself
+    def graphql_definition(silence_deprecation_warning: false)
+      itself
+    end
 
     def type_class
       metadata[:type_class]
@@ -194,7 +196,7 @@ module GraphQL
         resolve_related_type(Object.const_get(type_arg))
       else
         if type_arg.respond_to?(:graphql_definition)
-          type_arg.graphql_definition
+          type_arg.graphql_definition(silence_deprecation_warning: true)
         else
           type_arg
         end

--- a/lib/graphql/boolean_type.rb
+++ b/lib/graphql/boolean_type.rb
@@ -1,2 +1,2 @@
 # frozen_string_literal: true
-GraphQL::BOOLEAN_TYPE = GraphQL::Types::Boolean.graphql_definition
+GraphQL::BOOLEAN_TYPE = GraphQL::Types::Boolean.graphql_definition(silence_deprecation_warning: true)

--- a/lib/graphql/directive/deprecated_directive.rb
+++ b/lib/graphql/directive/deprecated_directive.rb
@@ -1,2 +1,2 @@
 # frozen_string_literal: true
-GraphQL::Directive::DeprecatedDirective = GraphQL::Schema::Directive::Deprecated.graphql_definition
+GraphQL::Directive::DeprecatedDirective = GraphQL::Schema::Directive::Deprecated.graphql_definition(silence_deprecation_warning: true)

--- a/lib/graphql/directive/include_directive.rb
+++ b/lib/graphql/directive/include_directive.rb
@@ -1,2 +1,2 @@
 # frozen_string_literal: true
-GraphQL::Directive::IncludeDirective = GraphQL::Schema::Directive::Include.graphql_definition
+GraphQL::Directive::IncludeDirective = GraphQL::Schema::Directive::Include.graphql_definition(silence_deprecation_warning: true)

--- a/lib/graphql/directive/skip_directive.rb
+++ b/lib/graphql/directive/skip_directive.rb
@@ -1,2 +1,2 @@
 # frozen_string_literal: true
-GraphQL::Directive::SkipDirective = GraphQL::Schema::Directive::Skip.graphql_definition
+GraphQL::Directive::SkipDirective = GraphQL::Schema::Directive::Skip.graphql_definition(silence_deprecation_warning: true)

--- a/lib/graphql/float_type.rb
+++ b/lib/graphql/float_type.rb
@@ -1,2 +1,2 @@
 # frozen_string_literal: true
-GraphQL::FLOAT_TYPE = GraphQL::Types::Float.graphql_definition
+GraphQL::FLOAT_TYPE = GraphQL::Types::Float.graphql_definition(silence_deprecation_warning: true)

--- a/lib/graphql/id_type.rb
+++ b/lib/graphql/id_type.rb
@@ -1,2 +1,2 @@
 # frozen_string_literal: true
-GraphQL::ID_TYPE = GraphQL::Types::ID.graphql_definition
+GraphQL::ID_TYPE = GraphQL::Types::ID.graphql_definition(silence_deprecation_warning: true)

--- a/lib/graphql/int_type.rb
+++ b/lib/graphql/int_type.rb
@@ -1,2 +1,2 @@
 # frozen_string_literal: true
-GraphQL::INT_TYPE = GraphQL::Types::Int.graphql_definition
+GraphQL::INT_TYPE = GraphQL::Types::Int.graphql_definition(silence_deprecation_warning: true)

--- a/lib/graphql/relay/global_id_resolve.rb
+++ b/lib/graphql/relay/global_id_resolve.rb
@@ -10,7 +10,7 @@ module GraphQL
         if obj.is_a?(GraphQL::Schema::Object)
           obj = obj.object
         end
-        type = @type.respond_to?(:graphql_definition) ? @type.graphql_definition : @type
+        type = @type.respond_to?(:graphql_definition) ? @type.graphql_definition(silence_deprecation_warning: true) : @type
         ctx.query.schema.id_from_object(obj, type, ctx)
       end
     end

--- a/lib/graphql/relay/page_info.rb
+++ b/lib/graphql/relay/page_info.rb
@@ -2,6 +2,6 @@
 module GraphQL
   module Relay
     # Wrap a Connection and expose its page info
-    PageInfo = GraphQL::Types::Relay::PageInfo.graphql_definition
+    PageInfo = GraphQL::Types::Relay::PageInfo.graphql_definition(silence_deprecation_warning: true)
   end
 end

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -140,7 +140,7 @@ module GraphQL
           type_defn.mutation = mutation
           type_defn.ast_node = ast_node
           all_argument_definitions.each do |arg|
-            type_defn.arguments[arg.graphql_definition.name] = arg.graphql_definition # rubocop:disable Development/ContextIsPassedCop -- legacy-related
+            type_defn.arguments[arg.graphql_definition(silence_deprecation_warning: true).name] = arg.graphql_definition(silence_deprecation_warning: true) # rubocop:disable Development/ContextIsPassedCop -- legacy-related
           end
           # Make a reference to a classic-style Arguments class
           self.arguments_class = GraphQL::Query::Arguments.construct_arguments_class(type_defn)

--- a/lib/graphql/schema/interface.rb
+++ b/lib/graphql/schema/interface.rb
@@ -108,7 +108,7 @@ module GraphQL
           type_defn.type_membership_class = self.type_membership_class
           type_defn.ast_node = ast_node
           fields.each do |field_name, field_inst| # rubocop:disable Development/ContextIsPassedCop -- legacy-related
-            field_defn = field_inst.graphql_definition
+            field_defn = field_inst.graphql_definition(silence_deprecation_warning: true)
             type_defn.fields[field_defn.name] = field_defn # rubocop:disable Development/ContextIsPassedCop -- legacy-related
           end
           type_defn.metadata[:type_class] = self

--- a/lib/graphql/schema/list.rb
+++ b/lib/graphql/schema/list.rb
@@ -9,7 +9,7 @@ module GraphQL
       include Schema::Member::ValidatesInput
 
       def to_graphql
-        @of_type.graphql_definition.to_list_type
+        @of_type.graphql_definition(silence_deprecation_warning: true).to_list_type
       end
 
       # @return [GraphQL::TypeKinds::LIST]

--- a/lib/graphql/schema/member/cached_graphql_definition.rb
+++ b/lib/graphql/schema/member/cached_graphql_definition.rb
@@ -11,8 +11,15 @@ module GraphQL
         # A cached result of {.to_graphql}.
         # It's cached here so that user-overridden {.to_graphql} implementations
         # are also cached
-        def graphql_definition
-          @graphql_definition ||= to_graphql
+        def graphql_definition(silence_deprecation_warning: false)
+          @graphql_definition ||= begin
+            unless silence_deprecation_warning
+              message = "Legacy `.graphql_definition` objects are deprecated and will be removed in GraphQL-Ruby 2.0. Use a class-based definition instead."
+              caller_message = "\n\nCalled on #{self.inspect} from:\n #{caller(1, 25).map { |l| "  #{l}" }.join("\n")}"
+              GraphQL::Deprecation.warn(message + caller_message)
+            end
+            to_graphql
+          end
         end
 
         # This is for a common interface with .define-based types

--- a/lib/graphql/schema/non_null.rb
+++ b/lib/graphql/schema/non_null.rb
@@ -9,7 +9,7 @@ module GraphQL
       include Schema::Member::ValidatesInput
 
       def to_graphql
-        @of_type.graphql_definition.to_non_null_type
+        @of_type.graphql_definition(silence_deprecation_warning: true).to_non_null_type
       end
 
        # @return [GraphQL::TypeKinds::NON_NULL]

--- a/lib/graphql/schema/traversal.rb
+++ b/lib/graphql/schema/traversal.rb
@@ -173,7 +173,7 @@ Some late-bound types couldn't be resolved:
           end
         when Class
           if member.respond_to?(:graphql_definition)
-            graphql_member = member.graphql_definition
+            graphql_member = member.graphql_definition(silence_deprecation_warning: true)
             visit(schema, graphql_member, context_description)
           else
             raise GraphQL::Schema::InvalidTypeError.new("Unexpected traversal member: #{member} (#{member.class.name})")

--- a/lib/graphql/string_type.rb
+++ b/lib/graphql/string_type.rb
@@ -1,2 +1,2 @@
 # frozen_string_literal: true
-GraphQL::STRING_TYPE = GraphQL::Types::String.graphql_definition
+GraphQL::STRING_TYPE = GraphQL::Types::String.graphql_definition(silence_deprecation_warning: true)

--- a/spec/graphql/execution/typecast_spec.rb
+++ b/spec/graphql/execution/typecast_spec.rb
@@ -8,36 +8,36 @@ describe GraphQL::Execution::Typecast do
     end
 
     it "counts the same type as a subtype" do
-      assert subtype?(Dummy::Milk.graphql_definition, Dummy::Milk.graphql_definition)
-      assert !subtype?(Dummy::Milk.graphql_definition, Dummy::Cheese.graphql_definition)
-      assert subtype?(Dummy::Milk.graphql_definition.to_list_type.to_non_null_type, Dummy::Milk.graphql_definition.to_list_type.to_non_null_type)
+      assert subtype?(Dummy::Milk.graphql_definition(silence_deprecation_warning: true), Dummy::Milk.graphql_definition(silence_deprecation_warning: true))
+      assert !subtype?(Dummy::Milk.graphql_definition(silence_deprecation_warning: true), Dummy::Cheese.graphql_definition(silence_deprecation_warning: true))
+      assert subtype?(Dummy::Milk.graphql_definition(silence_deprecation_warning: true).to_list_type.to_non_null_type, Dummy::Milk.graphql_definition(silence_deprecation_warning: true).to_list_type.to_non_null_type)
     end
 
     it "counts member types as subtypes" do
-      assert subtype?(Dummy::Edible.graphql_definition, Dummy::Cheese.graphql_definition)
-      assert subtype?(Dummy::Edible.graphql_definition, Dummy::Milk.graphql_definition)
-      assert subtype?(Dummy::DairyProduct.graphql_definition, Dummy::Milk.graphql_definition)
-      assert subtype?(Dummy::DairyProduct.graphql_definition, Dummy::Cheese.graphql_definition)
+      assert subtype?(Dummy::Edible.graphql_definition(silence_deprecation_warning: true), Dummy::Cheese.graphql_definition(silence_deprecation_warning: true))
+      assert subtype?(Dummy::Edible.graphql_definition(silence_deprecation_warning: true), Dummy::Milk.graphql_definition(silence_deprecation_warning: true))
+      assert subtype?(Dummy::DairyProduct.graphql_definition(silence_deprecation_warning: true), Dummy::Milk.graphql_definition(silence_deprecation_warning: true))
+      assert subtype?(Dummy::DairyProduct.graphql_definition(silence_deprecation_warning: true), Dummy::Cheese.graphql_definition(silence_deprecation_warning: true))
 
-      assert !subtype?(Dummy::DairyAppQuery.graphql_definition, Dummy::DairyProduct.graphql_definition)
-      assert !subtype?(Dummy::Cheese.graphql_definition, Dummy::DairyProduct.graphql_definition)
-      assert !subtype?(Dummy::Edible.graphql_definition, Dummy::DairyProduct.graphql_definition)
-      assert !subtype?(Dummy::Edible.graphql_definition, GraphQL::DEPRECATED_STRING_TYPE)
-      assert !subtype?(Dummy::Edible.graphql_definition, Dummy::DairyProductInput.graphql_definition)
+      assert !subtype?(Dummy::DairyAppQuery.graphql_definition(silence_deprecation_warning: true), Dummy::DairyProduct.graphql_definition(silence_deprecation_warning: true))
+      assert !subtype?(Dummy::Cheese.graphql_definition(silence_deprecation_warning: true), Dummy::DairyProduct.graphql_definition(silence_deprecation_warning: true))
+      assert !subtype?(Dummy::Edible.graphql_definition(silence_deprecation_warning: true), Dummy::DairyProduct.graphql_definition(silence_deprecation_warning: true))
+      assert !subtype?(Dummy::Edible.graphql_definition(silence_deprecation_warning: true), GraphQL::DEPRECATED_STRING_TYPE)
+      assert !subtype?(Dummy::Edible.graphql_definition(silence_deprecation_warning: true), Dummy::DairyProductInput.graphql_definition(silence_deprecation_warning: true))
     end
 
     it "counts lists as subtypes if their inner types are subtypes" do
-      assert subtype?(Dummy::Edible.graphql_definition.to_list_type, Dummy::Milk.graphql_definition.to_list_type)
-      assert subtype?(Dummy::DairyProduct.graphql_definition.to_list_type, Dummy::Milk.graphql_definition.to_list_type)
-      assert !subtype?(Dummy::Cheese.graphql_definition.to_list_type, Dummy::DairyProduct.graphql_definition.to_list_type)
-      assert !subtype?(Dummy::Edible.graphql_definition.to_list_type, Dummy::DairyProduct.graphql_definition.to_list_type)
-      assert !subtype?(Dummy::Edible.graphql_definition.to_list_type, GraphQL::DEPRECATED_STRING_TYPE.to_list_type)
+      assert subtype?(Dummy::Edible.graphql_definition(silence_deprecation_warning: true).to_list_type, Dummy::Milk.graphql_definition(silence_deprecation_warning: true).to_list_type)
+      assert subtype?(Dummy::DairyProduct.graphql_definition(silence_deprecation_warning: true).to_list_type, Dummy::Milk.graphql_definition(silence_deprecation_warning: true).to_list_type)
+      assert !subtype?(Dummy::Cheese.graphql_definition(silence_deprecation_warning: true).to_list_type, Dummy::DairyProduct.graphql_definition(silence_deprecation_warning: true).to_list_type)
+      assert !subtype?(Dummy::Edible.graphql_definition(silence_deprecation_warning: true).to_list_type, Dummy::DairyProduct.graphql_definition(silence_deprecation_warning: true).to_list_type)
+      assert !subtype?(Dummy::Edible.graphql_definition(silence_deprecation_warning: true).to_list_type, GraphQL::DEPRECATED_STRING_TYPE.to_list_type)
     end
 
     it "counts non-null types as subtypes of nullable parent types" do
-      assert subtype?(Dummy::Milk.graphql_definition, Dummy::Milk.graphql_definition.to_non_null_type)
-      assert subtype?(Dummy::Edible.graphql_definition, Dummy::Milk.graphql_definition.to_non_null_type)
-      assert subtype?(Dummy::Edible.graphql_definition.to_non_null_type, Dummy::Milk.graphql_definition.to_non_null_type)
+      assert subtype?(Dummy::Milk.graphql_definition(silence_deprecation_warning: true), Dummy::Milk.graphql_definition(silence_deprecation_warning: true).to_non_null_type)
+      assert subtype?(Dummy::Edible.graphql_definition(silence_deprecation_warning: true), Dummy::Milk.graphql_definition(silence_deprecation_warning: true).to_non_null_type)
+      assert subtype?(Dummy::Edible.graphql_definition(silence_deprecation_warning: true).to_non_null_type, Dummy::Milk.graphql_definition(silence_deprecation_warning: true).to_non_null_type)
       assert subtype?(
         GraphQL::DEPRECATED_STRING_TYPE.to_non_null_type.to_list_type,
         GraphQL::DEPRECATED_STRING_TYPE.to_non_null_type.to_list_type.to_non_null_type,

--- a/spec/graphql/schema/field_spec.rb
+++ b/spec/graphql/schema/field_spec.rb
@@ -20,7 +20,7 @@ describe GraphQL::Schema::Field do
     end
 
     it "uses the argument class" do
-      arg_defn = field.graphql_definition.arguments.values.first
+      arg_defn = field.graphql_definition(silence_deprecation_warning: true).arguments.values.first
       assert_equal :ok, arg_defn.metadata[:custom]
     end
 
@@ -34,11 +34,11 @@ describe GraphQL::Schema::Field do
     end
 
     it "attaches itself to its graphql_definition as type_class" do
-      assert_equal field, field.graphql_definition.metadata[:type_class]
+      assert_equal field, field.graphql_definition(silence_deprecation_warning: true).metadata[:type_class]
     end
 
     it "camelizes the field name, unless camelize: false" do
-      assert_equal 'inspectInput', field.graphql_definition.name
+      assert_equal 'inspectInput', field.graphql_definition(silence_deprecation_warning: true).name
       assert_equal 'inspectInput', field.name
 
       underscored_field = GraphQL::Schema::Field.from_options(:underscored_field, String, null: false, camelize: false, owner: nil) do
@@ -214,7 +214,7 @@ describe GraphQL::Schema::Field do
 
     describe "type" do
       it "tells the return type" do
-        assert_equal "[String!]!", field.type.graphql_definition.to_s
+        assert_equal "[String!]!", field.type.graphql_definition(silence_deprecation_warning: true).to_s
       end
 
       it "returns the type class" do

--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -704,7 +704,7 @@ describe GraphQL::Schema::InputObject do
 
       messages = []
       GraphQL::Deprecation.stub(:warn, ->(message) { messages << message; nil }) do
-        input_object.graphql_definition
+        input_object.graphql_definition(silence_deprecation_warning: true)
       end
       assert_equal [expected_warning], messages
     end
@@ -716,7 +716,7 @@ describe GraphQL::Schema::InputObject do
       end
 
       assert_output "", "" do
-        input_object.graphql_definition
+        input_object.graphql_definition(silence_deprecation_warning: true)
       end
     end
   end

--- a/spec/graphql/schema/interface_spec.rb
+++ b/spec/graphql/schema/interface_spec.rb
@@ -47,7 +47,7 @@ describe GraphQL::Schema::Interface do
       assert new_object_2.method_defined?(:id)
 
       # It gets an overridden description:
-      assert_equal "The ID !!!!!", new_object_2.graphql_definition.fields["id"].description
+      assert_equal "The ID !!!!!", new_object_2.graphql_definition(silence_deprecation_warning: true).fields["id"].description
     end
   end
 

--- a/spec/graphql/schema/loader_spec.rb
+++ b/spec/graphql/schema/loader_spec.rb
@@ -377,7 +377,7 @@ type Query {
               ]
             }
           }
-        }).graphql_definition
+        }).graphql_definition(silence_deprecation_warning: true)
       end
     end
 

--- a/spec/graphql/schema/member/accepts_definition_spec.rb
+++ b/spec/graphql/schema/member/accepts_definition_spec.rb
@@ -79,35 +79,35 @@ describe GraphQL::Schema::Member::AcceptsDefinition do
 
   it "passes along configs for types" do
     assert_equal [:a, 123], AcceptsDefinitionSchema::Option.metadata
-    assert_equal 123, AcceptsDefinitionSchema::Option.graphql_definition.metadata[:a]
+    assert_equal 123, AcceptsDefinitionSchema::Option.graphql_definition(silence_deprecation_warning: true).metadata[:a]
     assert_equal [:a, :abc], AcceptsDefinitionSchema::Query.metadata
-    assert_equal :abc, AcceptsDefinitionSchema::Query.graphql_definition.metadata[:a]
-    assert_equal :zyx, AcceptsDefinitionSchema::Query.graphql_definition.metadata[:xyz]
+    assert_equal :abc, AcceptsDefinitionSchema::Query.graphql_definition(silence_deprecation_warning: true).metadata[:a]
+    assert_equal :zyx, AcceptsDefinitionSchema::Query.graphql_definition(silence_deprecation_warning: true).metadata[:xyz]
 
     assert_equal [:z, 888], AcceptsDefinitionSchema::Thing.metadata
-    assert_equal 888, AcceptsDefinitionSchema::Thing.graphql_definition.metadata[:z]
-    assert_equal :bc, AcceptsDefinitionSchema::Thing.graphql_definition.metadata[:a]
+    assert_equal 888, AcceptsDefinitionSchema::Thing.graphql_definition(silence_deprecation_warning: true).metadata[:z]
+    assert_equal :bc, AcceptsDefinitionSchema::Thing.graphql_definition(silence_deprecation_warning: true).metadata[:a]
     # Interface inheritance
     assert_equal [:z, 888], AcceptsDefinitionSchema::Thing2.metadata
-    assert_equal 888, AcceptsDefinitionSchema::Thing2.graphql_definition.metadata[:z]
-    assert_equal :bc, AcceptsDefinitionSchema::Thing2.graphql_definition.metadata[:a]
+    assert_equal 888, AcceptsDefinitionSchema::Thing2.graphql_definition(silence_deprecation_warning: true).metadata[:z]
+    assert_equal :bc, AcceptsDefinitionSchema::Thing2.graphql_definition(silence_deprecation_warning: true).metadata[:a]
 
     # Object inheritance
-    assert_equal :aaa, AcceptsDefinitionSchema::SomeObject.graphql_definition.metadata[:a]
-    assert_equal :aaa, AcceptsDefinitionSchema::SomeObject2.graphql_definition.metadata[:a]
+    assert_equal :aaa, AcceptsDefinitionSchema::SomeObject.graphql_definition(silence_deprecation_warning: true).metadata[:a]
+    assert_equal :aaa, AcceptsDefinitionSchema::SomeObject2.graphql_definition(silence_deprecation_warning: true).metadata[:a]
   end
 
   it "passes along configs for fields and arguments" do
-    assert_equal :def, AcceptsDefinitionSchema.find("Query.option").graphql_definition.metadata[:a]
-    assert_equal :ghi, AcceptsDefinitionSchema.find("Query.option.value").graphql_definition.metadata[:a]
+    assert_equal :def, AcceptsDefinitionSchema.find("Query.option").graphql_definition(silence_deprecation_warning: true).metadata[:a]
+    assert_equal :ghi, AcceptsDefinitionSchema.find("Query.option.value").graphql_definition(silence_deprecation_warning: true).metadata[:a]
   end
 
   it "passes along configs for enum values" do
-    assert_equal 456, AcceptsDefinitionSchema.find("Option").graphql_definition.values["A"].metadata[:a]
-    assert_nil AcceptsDefinitionSchema.find("Option").graphql_definition.values["B"].metadata[:a]
+    assert_equal 456, AcceptsDefinitionSchema.find("Option").graphql_definition(silence_deprecation_warning: true).values["A"].metadata[:a]
+    assert_nil AcceptsDefinitionSchema.find("Option").graphql_definition(silence_deprecation_warning: true).values["B"].metadata[:a]
   end
 
   it "passes along configs for schemas" do
-    assert_equal 999, AcceptsDefinitionSchema.graphql_definition.metadata[:a]
+    assert_equal 999, AcceptsDefinitionSchema.graphql_definition(silence_deprecation_warning: true).metadata[:a]
   end
 end

--- a/spec/graphql/schema/relay_classic_mutation_spec.rb
+++ b/spec/graphql/schema/relay_classic_mutation_spec.rb
@@ -32,7 +32,7 @@ describe GraphQL::Schema::RelayClassicMutation do
         graphql_name "Test"
       end
       assert_equal mutation, mutation.input_type.mutation
-      assert_equal mutation, mutation.input_type.graphql_definition.mutation
+      assert_equal mutation, mutation.input_type.graphql_definition(silence_deprecation_warning: true).mutation
     end
   end
 

--- a/spec/support/error_bubbling_helpers.rb
+++ b/spec/support/error_bubbling_helpers.rb
@@ -9,13 +9,13 @@ module ErrorBubblingHelpers
       if schema.is_a?(Class)
         schema.error_bubbling(false)
       end
-      schema.graphql_definition.error_bubbling = false
+      schema.graphql_definition(silence_deprecation_warning: true).error_bubbling = false
       yield if block_given?
     ensure
       if schema.is_a?(Class)
         schema.error_bubbling(original_error_bubbling)
       end
-      schema.graphql_definition.error_bubbling = original_error_bubbling
+      schema.graphql_definition(silence_deprecation_warning: true).error_bubbling = original_error_bubbling
     end
   end
 
@@ -25,13 +25,13 @@ module ErrorBubblingHelpers
       if schema.is_a?(Class)
         schema.error_bubbling(true)
       end
-      schema.graphql_definition.error_bubbling = true
+      schema.graphql_definition(silence_deprecation_warning: true).error_bubbling = true
       yield if block_given?
     ensure
       if schema.is_a?(Class)
         schema.error_bubbling(original_error_bubbling)
       end
-      schema.graphql_definition.error_bubbling = original_error_bubbling
+      schema.graphql_definition(silence_deprecation_warning: true).error_bubbling = original_error_bubbling
     end
   end
 end


### PR DESCRIPTION
All the features that use this were _already_ deprecated (I think!) but there is some user code that calls this directly, so warn people that it's going away. 

Fixes #3736 