### PR TITLE
Add an after-define hook to field extensions

### DIFF
--- a/guides/type_definitions/field_extensions.md
+++ b/guides/type_definitions/field_extensions.md
@@ -48,6 +48,8 @@ end
 
 This way, an extension can encapsulate a behavior requiring several configuration options.
 
+### TODO document after-hook
+
 ### Modifying field execution
 
 Extensions have two hooks that wrap field resolution. Since GraphQL-Ruby supports deferred execution, these hooks _might not_ be called back-to-back.

--- a/guides/type_definitions/field_extensions.md
+++ b/guides/type_definitions/field_extensions.md
@@ -48,7 +48,19 @@ end
 
 This way, an extension can encapsulate a behavior requiring several configuration options.
 
-### TODO document after-hook
+### Adding default argument configurations
+
+Extensions may provide _default_ argument configurations which are applied if the field doesn't define the argument for itself. The configuration is passed to {{ Schema::FieldExtension.default_argument | api_doc }}. For example, to define a `:query` argument if the field doesn't already have one:
+
+```ruby
+class SearchableExtension < GraphQL::Schema::FieldExtension
+  # Any field which uses this extension and _doesn't_ define
+  # its own `:query` argument will get an argument configured with this:
+  default_argument(:query, String, required: false, description: "A search query")
+end
+```
+
+Additionally, extensions may implement `def after_define` which is called _after_ the field's `do .. . end` block. This is helpful when an extension should provide _default_ configurations without overriding anything in the field definition.
 
 ### Modifying field execution
 

--- a/guides/type_definitions/field_extensions.md
+++ b/guides/type_definitions/field_extensions.md
@@ -60,7 +60,7 @@ class SearchableExtension < GraphQL::Schema::FieldExtension
 end
 ```
 
-Additionally, extensions may implement `def after_define` which is called _after_ the field's `do .. . end` block. This is helpful when an extension should provide _default_ configurations without overriding anything in the field definition.
+Additionally, extensions may implement `def after_define` which is called _after_ the field's `do .. . end` block. This is helpful when an extension should provide _default_ configurations without overriding anything in the field definition. (When extensions are added by calling `field.extension(...)` on an already-defined field `def after_define` is called immediately.)
 
 ### Modifying field execution
 

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -323,7 +323,7 @@ module GraphQL
           end
         end
 
-        self.extensions.each { |ext| ext.apply_2; ext.freeze }
+        self.extensions.each(&:after_define_apply)
       end
 
       # If true, subscription updates with this field can be shared between viewers

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -322,6 +322,8 @@ module GraphQL
             instance_eval(&definition_block)
           end
         end
+
+        self.extensions.each { |ext| ext.apply_2; ext.freeze }
       end
 
       # If true, subscription updates with this field can be shared between viewers

--- a/lib/graphql/schema/field/connection_extension.rb
+++ b/lib/graphql/schema/field/connection_extension.rb
@@ -4,11 +4,21 @@ module GraphQL
   class Schema
     class Field
       class ConnectionExtension < GraphQL::Schema::FieldExtension
-        def apply
-          field.argument :after, "String", "Returns the elements in the list that come after the specified cursor.", required: false
-          field.argument :before, "String", "Returns the elements in the list that come before the specified cursor.", required: false
-          field.argument :first, "Int", "Returns the first _n_ elements from the list.", required: false
-          field.argument :last, "Int", "Returns the last _n_ elements from the list.", required: false
+        def apply_2
+          all_keywords = field.all_argument_definitions.map(&:keyword)
+          all_keywords.uniq!
+          if !all_keywords.include?(:after)
+            field.argument :after, "String", "Returns the elements in the list that come after the specified cursor.", required: false
+          end
+          if !all_keywords.include?(:before)
+            field.argument :before, "String", "Returns the elements in the list that come before the specified cursor.", required: false
+          end
+          if !all_keywords.include?(:first)
+            field.argument :first, "Int", "Returns the first _n_ elements from the list.", required: false
+          end
+          if !all_keywords.include?(:last)
+            field.argument :last, "Int", "Returns the last _n_ elements from the list.", required: false
+          end
         end
 
         # Remove pagination args before passing it to a user method

--- a/lib/graphql/schema/field/connection_extension.rb
+++ b/lib/graphql/schema/field/connection_extension.rb
@@ -4,30 +4,16 @@ module GraphQL
   class Schema
     class Field
       class ConnectionExtension < GraphQL::Schema::FieldExtension
-        def apply_2
-          all_keywords = field.all_argument_definitions.map(&:keyword)
-          all_keywords.uniq!
-          if !all_keywords.include?(:after)
-            field.argument :after, "String", "Returns the elements in the list that come after the specified cursor.", required: false
-          end
-          if !all_keywords.include?(:before)
-            field.argument :before, "String", "Returns the elements in the list that come before the specified cursor.", required: false
-          end
-          if !all_keywords.include?(:first)
-            field.argument :first, "Int", "Returns the first _n_ elements from the list.", required: false
-          end
-          if !all_keywords.include?(:last)
-            field.argument :last, "Int", "Returns the last _n_ elements from the list.", required: false
-          end
-        end
+        default_argument :after, "String", "Returns the elements in the list that come after the specified cursor.", required: false
+        default_argument :before, "String", "Returns the elements in the list that come before the specified cursor.", required: false
+        default_argument :first, "Int", "Returns the first _n_ elements from the list.", required: false
+        default_argument :last, "Int", "Returns the last _n_ elements from the list.", required: false
 
         # Remove pagination args before passing it to a user method
         def resolve(object:, arguments:, context:)
+          # Ruby 3.0 added `.except`, but we support Ruby 2:
           next_args = arguments.dup
-          next_args.delete(:first)
-          next_args.delete(:last)
-          next_args.delete(:before)
-          next_args.delete(:after)
+          added_default_arguments.each { |a| next_args.delete(a) }
           yield(object, next_args, arguments)
         end
 

--- a/lib/graphql/schema/field/connection_extension.rb
+++ b/lib/graphql/schema/field/connection_extension.rb
@@ -4,16 +4,20 @@ module GraphQL
   class Schema
     class Field
       class ConnectionExtension < GraphQL::Schema::FieldExtension
-        default_argument :after, "String", "Returns the elements in the list that come after the specified cursor.", required: false
-        default_argument :before, "String", "Returns the elements in the list that come before the specified cursor.", required: false
-        default_argument :first, "Int", "Returns the first _n_ elements from the list.", required: false
-        default_argument :last, "Int", "Returns the last _n_ elements from the list.", required: false
+        def apply
+          field.argument :after, "String", "Returns the elements in the list that come after the specified cursor.", required: false
+          field.argument :before, "String", "Returns the elements in the list that come before the specified cursor.", required: false
+          field.argument :first, "Int", "Returns the first _n_ elements from the list.", required: false
+          field.argument :last, "Int", "Returns the last _n_ elements from the list.", required: false
+        end
 
         # Remove pagination args before passing it to a user method
         def resolve(object:, arguments:, context:)
-          # Ruby 3.0 added `.except`, but we support Ruby 2:
           next_args = arguments.dup
-          added_default_arguments.each { |a| next_args.delete(a) }
+          next_args.delete(:first)
+          next_args.delete(:last)
+          next_args.delete(:before)
+          next_args.delete(:after)
           yield(object, next_args, arguments)
         end
 

--- a/lib/graphql/schema/field_extension.rb
+++ b/lib/graphql/schema/field_extension.rb
@@ -15,6 +15,9 @@ module GraphQL
       # @return [Object]
       attr_reader :options
 
+      # @return [Array<Symbol>, nil] `default_argument`s added, if any were added (otherwise, `nil`)
+      attr_reader :added_default_arguments
+
       # Called when the extension is mounted with `extension(name, options)`.
       # The instance will be frozen to avoid improper use of state during execution.
       # @param field [GraphQL::Schema::Field] The field where this extension was mounted
@@ -22,7 +25,30 @@ module GraphQL
       def initialize(field:, options:)
         @field = field
         @options = options || {}
+        @added_default_arguments = nil
         apply
+      end
+
+      class << self
+        # @return [Array(Array, Hash), nil] A list of default argument configs, or `nil` if there aren't any
+        def default_argument_configurations
+          args = superclass.respond_to?(:default_argument_configurations) ? superclass.default_argument_configurations : nil
+          if @own_default_argument_configurations
+            if args
+              args.concat(@own_default_argument_configurations)
+            else
+              args = @own_default_argument_configurations.dup
+            end
+          end
+          args
+        end
+
+        # @see Argument#initialize
+        # @see HasArguments#argument
+        def default_argument(*argument_args, **argument_kwargs)
+          configs = @own_default_argument_configurations ||= []
+          configs << [argument_args, argument_kwargs]
+        end
       end
 
       # Called when this extension is attached to a field.
@@ -34,7 +60,26 @@ module GraphQL
       # Called after the field's definition block has been executed.
       # (Any arguments from the block are present on `field`)
       # @return [void]
-      def apply_2
+      def after_define
+      end
+
+      # @api private
+      def after_define_apply
+        after_define
+        if (configs = self.class.default_argument_configurations)
+          existing_keywords = field.all_argument_definitions.map(&:keyword)
+          existing_keywords.uniq!
+          @added_default_arguments = []
+          configs.each do |config|
+            argument_args, argument_kwargs = config
+            arg_name = argument_args[0]
+            if !existing_keywords.include?(arg_name)
+              @added_default_arguments << arg_name
+              field.argument(*argument_args, **argument_kwargs)
+            end
+          end
+        end
+        freeze
       end
 
       # Called before resolving {#field}. It should either:

--- a/lib/graphql/schema/field_extension.rb
+++ b/lib/graphql/schema/field_extension.rb
@@ -16,20 +16,25 @@ module GraphQL
       attr_reader :options
 
       # Called when the extension is mounted with `extension(name, options)`.
-      # The instance is frozen to avoid improper use of state during execution.
+      # The instance will be frozen to avoid improper use of state during execution.
       # @param field [GraphQL::Schema::Field] The field where this extension was mounted
       # @param options [Object] The second argument to `extension`, or `{}` if nothing was passed.
       def initialize(field:, options:)
         @field = field
         @options = options || {}
         apply
-        freeze
       end
 
       # Called when this extension is attached to a field.
       # The field definition may be extended during this method.
       # @return [void]
       def apply
+      end
+
+      # Called after the field's definition block has been executed.
+      # (Any arguments from the block are present on `field`)
+      # @return [void]
+      def apply_2
       end
 
       # Called before resolving {#field}. It should either:

--- a/spec/graphql/introspection/type_type_spec.rb
+++ b/spec/graphql/introspection/type_type_spec.rb
@@ -224,7 +224,7 @@ describe GraphQL::Introspection::TypeType do
       field_result = type_result["fields"].find { |f| f["name"] == "bases" }
       all_arg_names = ["after", "before", "first", "last", "nameIncludes", "complexOrder"]
       returned_arg_names = field_result["args"].map { |a| a["name"] }
-      assert_equal all_arg_names, returned_arg_names
+      assert_equal all_arg_names.sort, returned_arg_names.sort
     end
   end
 end

--- a/spec/graphql/schema/field/connection_extension_spec.rb
+++ b/spec/graphql/schema/field/connection_extension_spec.rb
@@ -18,7 +18,7 @@ describe GraphQL::Schema::Field::ConnectionExtension do
       field :argument_data, [String], null: false
 
       def argument_data
-        [object.arguments.class.name, *object.arguments.keys.map(&:inspect)]
+        [object.arguments.class.name, *object.arguments.keys.map(&:inspect).sort]
       end
     end
 

--- a/spec/graphql/schema/field_extension_spec.rb
+++ b/spec/graphql/schema/field_extension_spec.rb
@@ -298,4 +298,28 @@ describe GraphQL::Schema::FieldExtension do
       assert ext.frozen?
     end
   end
+
+  describe ".default_argument" do
+    class DefaultArgumentThing < GraphQL::Schema::Object
+      class DefaultArgumentExtension < GraphQL::Schema::FieldExtension
+        default_argument :query, String, required: false
+      end
+
+      field :search_1, String, extensions: [DefaultArgumentExtension]
+
+      field :search_2, String, extensions: [DefaultArgumentExtension] do
+        argument :query, String, required: true
+      end
+    end
+
+    it "adds an argument if one wasn't given in the definition block" do
+      search_1 = DefaultArgumentThing.get_field("search1")
+      assert_equal [:query], search_1.extensions.first.added_default_arguments
+      assert_equal GraphQL::Types::String, search_1.get_argument("query").type
+
+      search_2 = DefaultArgumentThing.get_field("search2")
+      assert_equal [], search_2.extensions.first.added_default_arguments
+      assert_equal GraphQL::Types::String.to_non_null_type, search_2.get_argument("query").type
+    end
+  end
 end

--- a/spec/graphql/schema/field_extension_spec.rb
+++ b/spec/graphql/schema/field_extension_spec.rb
@@ -308,7 +308,7 @@ describe GraphQL::Schema::FieldExtension do
       field :search_1, String, extensions: [DefaultArgumentExtension]
 
       field :search_2, String, extensions: [DefaultArgumentExtension] do
-        argument :query, String, required: true
+        argument :query, String
       end
     end
 


### PR DESCRIPTION
This would allow field extensions to define arguments on fields _without_ overriding something from the field's definition block. 

cc @cocoahero 

TODO: 

- [x] Name 
- [x] Docs
- [x] Remove breaking change to ConnectionExtension