### PR TITLE
Add field_options for edges, node, and nodes fields

### DIFF
--- a/lib/graphql/types/relay/connection_behaviors.rb
+++ b/lib/graphql/types/relay/connection_behaviors.rb
@@ -35,7 +35,8 @@ module GraphQL
           # It's called when you subclass this base connection, trying to use the
           # class name to set defaults. You can call it again in the class definition
           # to override the default (or provide a value, if the default lookup failed).
-          def edge_type(edge_type_class, edge_class: GraphQL::Relay::Edge, node_type: edge_type_class.node_type, nodes_field: self.has_nodes_field, node_nullable: self.node_nullable, edges_nullable: self.edges_nullable, edge_nullable: self.edge_nullable)
+          # @param edges_field_options [Hash] Any extra keyword arguments to pass to the `field :edges, ...` configuration
+          def edge_type(edge_type_class, edge_class: GraphQL::Relay::Edge, node_type: edge_type_class.node_type, nodes_field: self.has_nodes_field, node_nullable: self.node_nullable, edges_nullable: self.edges_nullable, edge_nullable: self.edge_nullable, edges_field_options: nil)
             # Set this connection's graphql name
             node_type_name = node_type.graphql_name
 
@@ -43,11 +44,20 @@ module GraphQL
             @edge_type = edge_type_class
             @edge_class = edge_class
 
-            field :edges, [edge_type_class, null: edge_nullable],
+            field_options = {
+              name: :edges,
+              type: [edge_type_class, null: edge_nullable],
               null: edges_nullable,
               description: "A list of edges.",
               legacy_edge_class: edge_class, # This is used by the old runtime only, for EdgesInstrumentation
-              connection: false
+              connection: false,
+            }
+
+            if edges_field_options
+              field_options.merge!(edges_field_options)
+            end
+
+            field(**field_options)
 
             define_nodes_field(node_nullable) if nodes_field
 

--- a/lib/graphql/types/relay/edge_behaviors.rb
+++ b/lib/graphql/types/relay/edge_behaviors.rb
@@ -16,22 +16,22 @@ module GraphQL
           #
           # @param node_type [Class] A `Schema::Object` subclass
           # @param null [Boolean]
-          # @param node_field_options [Hash] Any extra arguments to pass to the `field :node` configuration
-          def node_type(node_type = nil, null: self.node_nullable, node_field_options: nil)
+          # @param field_options [Hash] Any extra arguments to pass to the `field :node` configuration
+          def node_type(node_type = nil, null: self.node_nullable, field_options: nil)
             if node_type
               @node_type = node_type
               # Add a default `node` field
-              field_options = {
+              base_field_options = {
                 name: :node,
                 type: node_type,
                 null: null,
                 description: "The item at the end of the edge.",
                 connection: false,
               }
-              if node_field_options
-                field_options.merge!(node_field_options)
+              if field_options
+                base_field_options.merge!(field_options)
               end
-              field(**field_options)
+              field(**base_field_options)
             end
             @node_type
           end

--- a/lib/graphql/types/relay/edge_behaviors.rb
+++ b/lib/graphql/types/relay/edge_behaviors.rb
@@ -16,11 +16,22 @@ module GraphQL
           #
           # @param node_type [Class] A `Schema::Object` subclass
           # @param null [Boolean]
-          def node_type(node_type = nil, null: self.node_nullable)
+          # @param node_field_options [Hash] Any extra arguments to pass to the `field :node` configuration
+          def node_type(node_type = nil, null: self.node_nullable, node_field_options: nil)
             if node_type
               @node_type = node_type
               # Add a default `node` field
-              field :node, node_type, null: null, description: "The item at the end of the edge.", connection: false
+              field_options = {
+                name: :node,
+                type: node_type,
+                null: null,
+                description: "The item at the end of the edge.",
+                connection: false,
+              }
+              if node_field_options
+                field_options.merge!(node_field_options)
+              end
+              field(**field_options)
             end
             @node_type
           end

--- a/spec/graphql/types/relay/base_connection_spec.rb
+++ b/spec/graphql/types/relay/base_connection_spec.rb
@@ -81,10 +81,10 @@ describe GraphQL::Types::Relay::BaseConnection do
       edge_type(GraphQL::Schema::Object.edge_type, field_options: { deprecation_reason: "passing extra args" })
     end
 
-    field = connection.fields["edges"]
-    assert_equal "passing extra args", field.deprecation_reason
+    edges_field = connection.fields["edges"]
+    assert_equal "passing extra args", edges_field.deprecation_reason
 
     nodes_field = connection.fields["nodes"]
-    assert_equal "passing extra args", field.deprecation_reason
+    assert_equal "passing extra args", nodes_field.deprecation_reason
   end
 end

--- a/spec/graphql/types/relay/base_connection_spec.rb
+++ b/spec/graphql/types/relay/base_connection_spec.rb
@@ -76,12 +76,15 @@ describe GraphQL::Types::Relay::BaseConnection do
     assert_equal false, NonNullAbleNodeDummy::NoNodesFieldClassOverrideConnectionType.has_nodes_field
   end
 
-  it "Supports extra kwargs for edges" do
+  it "Supports extra kwargs for edges and nodes" do
     connection = Class.new(GraphQL::Types::Relay::BaseConnection) do
-      edge_type(GraphQL::Schema::Object.edge_type, edges_field_options: { deprecation_reason: "passing extra args" })
+      edge_type(GraphQL::Schema::Object.edge_type, field_options: { deprecation_reason: "passing extra args" })
     end
 
     field = connection.fields["edges"]
+    assert_equal "passing extra args", field.deprecation_reason
+
+    nodes_field = connection.fields["nodes"]
     assert_equal "passing extra args", field.deprecation_reason
   end
 end

--- a/spec/graphql/types/relay/base_connection_spec.rb
+++ b/spec/graphql/types/relay/base_connection_spec.rb
@@ -75,4 +75,13 @@ describe GraphQL::Types::Relay::BaseConnection do
   it "supports class-level nodes_field config" do
     assert_equal false, NonNullAbleNodeDummy::NoNodesFieldClassOverrideConnectionType.has_nodes_field
   end
+
+  it "Supports extra kwargs for edges" do
+    connection = Class.new(GraphQL::Types::Relay::BaseConnection) do
+      edge_type(GraphQL::Schema::Object.edge_type, edges_field_options: { deprecation_reason: "passing extra args" })
+    end
+
+    field = connection.fields["edges"]
+    assert_equal "passing extra args", field.deprecation_reason
+  end
 end

--- a/spec/graphql/types/relay/base_edge_spec.rb
+++ b/spec/graphql/types/relay/base_edge_spec.rb
@@ -44,7 +44,7 @@ describe GraphQL::Types::Relay::BaseEdge do
   it "Supports extra kwargs for node field" do
     extension = Class.new(GraphQL::Schema::FieldExtension)
     connection = Class.new(GraphQL::Types::Relay::BaseEdge) do
-      node_type(GraphQL::Schema::Object, node_field_options: { extensions: [extension] })
+      node_type(GraphQL::Schema::Object, field_options: { extensions: [extension] })
     end
 
     field = connection.fields["node"]

--- a/spec/graphql/types/relay/base_edge_spec.rb
+++ b/spec/graphql/types/relay/base_edge_spec.rb
@@ -40,4 +40,15 @@ describe GraphQL::Types::Relay::BaseEdge do
   it "supports class-level node_nullable config" do
     assert_equal false, NonNullableDummy::NonNullableNodeClassOverrideEdgeType.node_nullable
   end
+
+  it "Supports extra kwargs for node field" do
+    extension = Class.new(GraphQL::Schema::FieldExtension)
+    connection = Class.new(GraphQL::Types::Relay::BaseEdge) do
+      node_type(GraphQL::Schema::Object, node_field_options: { extensions: [extension] })
+    end
+
+    field = connection.fields["node"]
+    assert_equal 1, field.extensions.size
+    assert_instance_of extension, field.extensions.first
+  end
 end


### PR DESCRIPTION
Accept `edge_type(... field_options: { ... })` and `node_type(..., field_options: { ... })` for customizing those fields. 

The `edge_type(field_options:)` argument is given to _both_ `field :edges` and `field :nodes`. 

Fixes #3417