### PR TITLE
Don't multiply count edges and nodes fields by page size

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -441,10 +441,15 @@ module GraphQL
             if lookahead.selects?(:total) || lookahead.selects?(:total_count) || lookahead.selects?(:count)
               metadata_complexity += 1
             end
+
+            nodes_edges_complexity = 0
+            nodes_edges_complexity += 1 if lookahead.selects?(:edges)
+            nodes_edges_complexity += 1 if lookahead.selects?(:nodes)
+
             # Possible bug: selections on `edges` and `nodes` are _both_ multiplied here. Should they be?
-            items_complexity = child_complexity - metadata_complexity
+            items_complexity = child_complexity - metadata_complexity - nodes_edges_complexity
             # Add 1 for _this_ field
-            1 + (max_possible_page_size * items_complexity) + metadata_complexity
+            1 + (max_possible_page_size * items_complexity) + metadata_complexity + nodes_edges_complexity
           end
         else
           defined_complexity = complexity

--- a/spec/graphql/analysis/ast/query_complexity_spec.rb
+++ b/spec/graphql/analysis/ast/query_complexity_spec.rb
@@ -229,6 +229,9 @@ describe GraphQL::Analysis::AST::QueryComplexity do
               id
             }
           }
+          nodes {
+            id
+          }
           pageInfo {
             hasNextPage
           }
@@ -239,7 +242,13 @@ describe GraphQL::Analysis::AST::QueryComplexity do
 
     it "gets the complexity" do
       complexity = reduce_result.first
-      assert_equal 7, complexity
+      expected_complexity = 1 + # rebels
+        1 + # ships
+        1 + # edges
+        1 + # nodes
+        1 + 1 + # pageInfo, hasNextPage
+        1 + 1 + 1 # node, id, id
+      assert_equal 9, complexity
     end
 
     describe "first/last" do
@@ -269,8 +278,8 @@ describe GraphQL::Analysis::AST::QueryComplexity do
 
         expected_complexity = (
           1 + # rebels
-          (1 + (5 * 3) + 2) + # s1
-          (1 + (3 * 2) + 0) # s2
+          (1 + 1 + (5 * 2) + 2) + # s1
+          (1 + 1 + (3 * 1) + 0) # s2
         )
         assert_equal expected_complexity, complexity
       end
@@ -289,7 +298,7 @@ describe GraphQL::Analysis::AST::QueryComplexity do
 
       it "uses field max_page_size" do
         complexity = reduce_result.first
-        assert_equal 1 + 1 + (1000 * 2), complexity
+        assert_equal 1 + 1 + 1 + (1000 * 1), complexity
       end
     end
 
@@ -307,7 +316,7 @@ describe GraphQL::Analysis::AST::QueryComplexity do
 
       it "uses schema default_max_page_size" do
         complexity = reduce_result.first
-        assert_equal 1 + 1 + (3 * 2) + 1, complexity
+        assert_equal 1 + 1 + 1 + (3 * 1) + 1, complexity
       end
     end
   end

--- a/spec/graphql/analysis/ast/query_complexity_spec.rb
+++ b/spec/graphql/analysis/ast/query_complexity_spec.rb
@@ -248,7 +248,7 @@ describe GraphQL::Analysis::AST::QueryComplexity do
         1 + # nodes
         1 + 1 + # pageInfo, hasNextPage
         1 + 1 + 1 # node, id, id
-      assert_equal 9, complexity
+      assert_equal expected_complexity, complexity
     end
 
     describe "first/last" do


### PR DESCRIPTION
Oops, we were previously adding an extra multiple of the max page size for the `edges { ... }` selection and `nodes { ... }` selection. But those should each count for _1_, not the page size. 

Part of #3755 