### PR TITLE
Validation performance improvements

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -87,6 +87,12 @@ namespace :bench do
     GraphQLBenchmark.run("validate")
   end
 
+  desc "Profile a validation"
+  task :validate_memory do
+    prepare_benchmark
+    GraphQLBenchmark.validate_memory
+  end
+
   desc "Generate a profile of the introspection query"
   task :profile do
     prepare_benchmark

--- a/benchmark/run.rb
+++ b/benchmark/run.rb
@@ -41,6 +41,14 @@ module GraphQLBenchmark
     end
   end
 
+  def self.validate_memory
+    report = MemoryProfiler.report do
+      FIELDS_WILL_MERGE_SCHEMA.validate(FIELDS_WILL_MERGE_QUERY)
+    end
+
+    report.pretty_print
+  end
+
   def self.profile
     # Warm up any caches:
     SCHEMA.execute(document: DOCUMENT)

--- a/benchmark/run.rb
+++ b/benchmark/run.rb
@@ -42,8 +42,11 @@ module GraphQLBenchmark
   end
 
   def self.validate_memory
+    FIELDS_WILL_MERGE_SCHEMA.validate(FIELDS_WILL_MERGE_QUERY)
+
     report = MemoryProfiler.report do
       FIELDS_WILL_MERGE_SCHEMA.validate(FIELDS_WILL_MERGE_QUERY)
+      nil
     end
 
     report.pretty_print

--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -197,7 +197,16 @@ module GraphQL
               else
                 module_eval <<-RUBY, __FILE__, __LINE__
                   def children
-                    @children ||= (#{children_of_type.keys.map { |k| "@#{k}" }.join(" + ")}).freeze
+                    @children ||= begin
+                      if #{children_of_type.keys.map { |k| "@#{k}.any?" }.join(" || ")}
+                        new_children = []
+                        #{children_of_type.keys.map { |k| "new_children.concat(@#{k})" }.join("; ")}
+                        new_children.freeze
+                        new_children
+                      else
+                        NO_CHILDREN
+                      end
+                    end
                   end
                 RUBY
               end

--- a/lib/graphql/static_validation/rules/fields_will_merge.rb
+++ b/lib/graphql/static_validation/rules/fields_will_merge.rb
@@ -50,9 +50,11 @@ module GraphQL
         @arg_conflicts = nil
 
         yield
-
-        field_conflicts.each_value { |error| add_error(error) }
-        arg_conflicts.each_value { |error| add_error(error) }
+        # don't initialize these if they weren't initialized in the block:
+        @field_conflicts && @field_conflicts.each_value { |error| add_error(error) }
+        @arg_conflicts && @arg_conflicts.each_value { |error| add_error(error) }
+        # field_conflicts.each_value { |error| add_error(error) }
+        # arg_conflicts.each_value { |error| add_error(error) }
       end
 
       def conflicts_within_selection_set(node, parent_type)
@@ -243,7 +245,9 @@ module GraphQL
       end
 
       def find_conflicts_between_sub_selection_sets(field1, field2, mutually_exclusive:)
-        return if field1.definition.nil? || field2.definition.nil?
+        return if field1.definition.nil? ||
+          field2.definition.nil? ||
+          (field1.node.selections.empty? && field2.node.selections.empty?)
 
         return_type1 = field1.definition.type.unwrap
         return_type2 = field2.definition.type.unwrap

--- a/lib/graphql/static_validation/rules/required_arguments_are_present.rb
+++ b/lib/graphql/static_validation/rules/required_arguments_are_present.rb
@@ -16,6 +16,8 @@ module GraphQL
       private
 
       def assert_required_args(ast_node, defn)
+        args = defn.arguments
+        return if args.empty?
         present_argument_names = ast_node.arguments.map(&:name)
         required_argument_names = defn.arguments.each_value
           .select { |a| a.type.kind.non_null? && !a.default_value? && context.warden.get_argument(defn, a.name) }


### PR DESCRIPTION
Oops, I forgot to check the performance of #3698, and it seems like it has increased the memory consumption of validation a good bit. I'm investigating some improvements to it, and the old code, too. Once I get them settled for 1.12.x, I'll work them into 1.13.x, too. 

cc @such 

TODO: 

- [x] remove commented code
- [x] investigate removing a few more short-lived arrays in fields_will_merge.rb

For the most extreme case benchmark, this makes a huge difference: 

```diff
- Total allocated: 1003971576 bytes (25070165 objects)
+ Total allocated: 1091296 bytes (20160 objects)
  Total retained:  0 bytes (0 objects)
```

(Yes, that's ~1000x _less_) 