### PR TITLE
Abstract out notifications engine for tracing

### DIFF
--- a/lib/graphql/tracing/active_support_notifications_tracing.rb
+++ b/lib/graphql/tracing/active_support_notifications_tracing.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'graphql/tracing/notifications_tracing'
+
 module GraphQL
   module Tracing
     # This implementation forwards events to ActiveSupport::Notifications
@@ -8,27 +10,11 @@ module GraphQL
     # @see KEYS for event names
     module ActiveSupportNotificationsTracing
       # A cache of frequently-used keys to avoid needless string allocations
-      KEYS = {
-        "lex" => "lex.graphql",
-        "parse" => "parse.graphql",
-        "validate" => "validate.graphql",
-        "analyze_multiplex" => "analyze_multiplex.graphql",
-        "analyze_query" => "analyze_query.graphql",
-        "execute_query" => "execute_query.graphql",
-        "execute_query_lazy" => "execute_query_lazy.graphql",
-        "execute_field" => "execute_field.graphql",
-        "execute_field_lazy" => "execute_field_lazy.graphql",
-        "authorized" => "authorized.graphql",
-        "authorized_lazy" => "authorized_lazy.graphql",
-        "resolve_type" => "resolve_type.graphql",
-        "resolve_type_lazy" => "resolve_type.graphql",
-      }
+      KEYS = NotificationsTracing::KEYS
+      NOTIFICATIONS_ENGINE = NotificationsTracing.new(ActiveSupport::Notifications) if defined?(ActiveSupport)
 
-      def self.trace(key, metadata)
-        prefixed_key = KEYS[key] || "#{key}.graphql"
-        ActiveSupport::Notifications.instrument(prefixed_key, metadata) do
-          yield
-        end
+      def self.trace(key, metadata, &blk)
+        NOTIFICATIONS_ENGINE.trace(key, metadata, &blk)
       end
     end
   end

--- a/lib/graphql/tracing/notifications_tracing.rb
+++ b/lib/graphql/tracing/notifications_tracing.rb
@@ -27,11 +27,6 @@ module GraphQL
 
       MAX_KEYS_SIZE = 100
 
-      # Returns all the possible event names for this tracing implementation
-      def self.event_names
-        KEYS.values
-      end
-
       # Initialize a new NotificationsTracing instance
       #
       # @param [Object] notifications_engine The notifications engine to use

--- a/lib/graphql/tracing/notifications_tracing.rb
+++ b/lib/graphql/tracing/notifications_tracing.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module Tracing
+    # This implementation forwards events to a notification handler (i.e.
+    # ActiveSupport::Notifications or Dry::Monitor::Notifications)
+    # with a `graphql` suffix.
+    #
+    # @see KEYS for event names
+    class NotificationsTracing
+      # A cache of frequently-used keys to avoid needless string allocations
+      KEYS = {
+        "lex" => "lex.graphql",
+        "parse" => "parse.graphql",
+        "validate" => "validate.graphql",
+        "analyze_multiplex" => "analyze_multiplex.graphql",
+        "analyze_query" => "analyze_query.graphql",
+        "execute_query" => "execute_query.graphql",
+        "execute_query_lazy" => "execute_query_lazy.graphql",
+        "execute_field" => "execute_field.graphql",
+        "execute_field_lazy" => "execute_field_lazy.graphql",
+        "authorized" => "authorized.graphql",
+        "authorized_lazy" => "authorized_lazy.graphql",
+        "resolve_type" => "resolve_type.graphql",
+        "resolve_type_lazy" => "resolve_type.graphql",
+      }
+
+      MAX_KEYS_SIZE = 100
+
+      # Returns all the possible event names for this tracing implementation
+      def self.event_names
+        KEYS.values
+      end
+
+      # Initialize a new NotificationsTracing instance
+      #
+      # @param [Object] notifications_engine The notifications engine to use
+      def initialize(notifications_engine)
+        @notifications_engine = notifications_engine
+      end
+
+      # Sends a GraphQL tracing event to the notification handler
+      #
+      # @example
+      # . notifications_engine = Dry::Monitor::Notifications.new(:graphql)
+      # . tracer = GraphQL::Tracing::NotificationsTracing.new(notifications_engine)
+      # . tracer.trace("lex") { ... }
+      #
+      # @param [string] key The key for the event
+      # @param [Hash] metadata The metadata for the event
+      # @yield The block to execute for the event
+      def trace(key, metadata, &blk)
+        prefixed_key = KEYS[key] || "#{key}.graphql"
+
+        # Cache the new keys while making sure not to induce a memory leak
+        if KEYS.size < MAX_KEYS_SIZE
+          KEYS[key] ||= prefixed_key
+        end
+
+        @notifications_engine.instrument(prefixed_key, metadata, &blk)
+      end
+    end
+  end
+end

--- a/spec/graphql/tracing/notifications_tracing_spec.rb
+++ b/spec/graphql/tracing/notifications_tracing_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe GraphQL::Tracing::NotificationsTracing do
+  module NotificationsTracingTest
+    class Query < GraphQL::Schema::Object
+      field :int, Integer, null: false
+
+      def int
+        1
+      end
+    end
+
+    class Schema < GraphQL::Schema
+      query Query
+    end
+  end
+
+  describe "Observing" do
+    it "dispatchs the event to the notifications engine with suffixed key" do
+      dispatched_events = trigger_fake_notifications_tracer(NotificationsTracingTest::Schema)
+
+      assert dispatched_events.length > 0
+
+      dispatched_events.each do |event, payload|
+        assert event.end_with?(".graphql")
+        assert payload.is_a?(Hash)
+      end
+    end
+  end
+
+  def trigger_fake_notifications_tracer(schema)
+    dispatched_events = []
+    engine = Object.new
+
+    engine.define_singleton_method(:instrument) do |event, payload, &blk|
+      dispatched_events << [event, payload]
+      blk.call if blk
+    end
+
+    tracer = GraphQL::Tracing::NotificationsTracing.new(engine)
+    schema.tracer(tracer)
+    schema.execute "query X { int }"
+
+    dispatched_events
+  end
+end


### PR DESCRIPTION
It would be helpful to be able to use `dry-monitor` for a notifications engine for non-Rails apps. This PR adds support for that by abstracting out a new `NotificationsTracer` interface for that.

### Example

```ruby
$notifications_engine = Dry::Monitor::Notifications.new(:my_app)

class MySchema < GraphQL::Schema
  tracer(GraphQL::Tracing::NotificationsTracing.new($notifications_engine))
end
```

### Comments

I took care to make it so `ActiveSupportNotificationsTracing` uses this tracer under the hood in a backwards compatible way, but let me know if you would like me to change it at all.