### PR TITLE
Platform Tracing: fallback transaction name

### DIFF
--- a/lib/graphql/tracing/data_dog_tracing.rb
+++ b/lib/graphql/tracing/data_dog_tracing.rb
@@ -20,7 +20,12 @@ module GraphQL
 
           if key == 'execute_multiplex'
             operations = data[:multiplex].queries.map(&:selected_operation_name).join(', ')
-            span.resource = operations unless operations.empty?
+            span.resource = if operations.empty?
+              first_query = data[:multiplex].queries.first
+              fallback_transaction_name(first_query && first_query.context)
+            else
+              operations
+            end
 
             # For top span of query, set the analytics sample rate tag, if available.
             if analytics_enabled?

--- a/lib/graphql/tracing/platform_tracing.rb
+++ b/lib/graphql/tracing/platform_tracing.rb
@@ -104,17 +104,22 @@ module GraphQL
 
       private
 
-      # Get the transaction name based on the operation type and name
+      # Get the transaction name based on the operation type and name if possible, or fall back to a user provided
+      # one. Useful for anonymous queries.
       def transaction_name(query)
         selected_op = query.selected_operation
-        if selected_op
+        txn_name = if selected_op
           op_type = selected_op.operation_type
-          op_name = selected_op.name || "anonymous"
+          op_name = selected_op.name || fallback_transaction_name(query.context) || "anonymous"
+          "#{op_type}.#{op_name}"
         else
-          op_type = "query"
-          op_name = "anonymous"
+          "query.anonymous"
         end
-        "GraphQL/#{op_type}.#{op_name}"
+        "GraphQL/#{txn_name}"
+      end
+
+      def fallback_transaction_name(context)
+        context[:tracing_fallback_transaction_name]
       end
 
       attr_reader :options

--- a/spec/graphql/tracing/data_dog_tracing_spec.rb
+++ b/spec/graphql/tracing/data_dog_tracing_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe GraphQL::Tracing::DataDogTracing do
+  module DataDogTest
+    class Query < GraphQL::Schema::Object
+      add_field GraphQL::Types::Relay::NodeField
+
+      field :int, Integer, null: false
+
+      def int
+        1
+      end
+    end
+
+    class TestSchema < GraphQL::Schema
+      query(Query)
+      use(GraphQL::Tracing::DataDogTracing)
+    end
+  end
+
+  before do
+    Datadog.clear_all
+  end
+
+  it "falls back to a :tracing_fallback_transaction_name when provided" do
+    DataDogTest::TestSchema.execute("{ int }", context: { tracing_fallback_transaction_name: "Abcd" })
+    assert_equal ["Abcd"], Datadog::SPAN_RESOURCE_NAMES
+  end
+
+  it "does not use the :tracing_fallback_transaction_name if an operation name is present" do
+    DataDogTest::TestSchema.execute(
+      "query Ab { int }",
+      context: { tracing_fallback_transaction_name: "Cd" }
+    )
+    assert_equal ["Ab"], Datadog::SPAN_RESOURCE_NAMES
+  end
+
+  it "does not require a :tracing_fallback_transaction_name even if an operation name is not present" do
+    DataDogTest::TestSchema.execute("{ int }")
+    assert_equal [nil], Datadog::SPAN_RESOURCE_NAMES
+  end
+end

--- a/spec/graphql/tracing/new_relic_tracing_spec.rb
+++ b/spec/graphql/tracing/new_relic_tracing_spec.rb
@@ -70,6 +70,24 @@ describe GraphQL::Tracing::NewRelicTracing do
     assert_equal ["GraphQL/query.anonymous"], NewRelic::TRANSACTION_NAMES
   end
 
+  it "falls back to a :tracing_fallback_transaction_name when provided" do
+    NewRelicTest::SchemaWithTransactionName.execute("{ int }", context: { tracing_fallback_transaction_name: "Abcd" })
+    assert_equal ["GraphQL/query.Abcd"], NewRelic::TRANSACTION_NAMES
+  end
+
+  it "does not use the :tracing_fallback_transaction_name if an operation name is present" do
+    NewRelicTest::SchemaWithTransactionName.execute(
+      "query Ab { int }",
+      context: { tracing_fallback_transaction_name: "Cd" }
+    )
+    assert_equal ["GraphQL/query.Ab"], NewRelic::TRANSACTION_NAMES
+  end
+
+  it "does not require a :tracing_fallback_transaction_name even if an operation name is not present" do
+    NewRelicTest::SchemaWithTransactionName.execute("{ int }")
+    assert_equal ["GraphQL/query.anonymous"], NewRelic::TRANSACTION_NAMES
+  end
+
   it "traces scalars when trace_scalars is true" do
     NewRelicTest::SchemaWithScalarTrace.execute "query X { int }"
     assert_includes NewRelic::EXECUTION_SCOPES, "GraphQL/Query/int"

--- a/spec/support/datadog.rb
+++ b/spec/support/datadog.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+# A stub for the Datadog agent, so we can make assertions about how it is used
+if defined?(Datadog)
+  raise "Expected Datadog to be undefined, so that we could define a stub for it."
+end
+
+module Datadog
+  SPAN_RESOURCE_NAMES = []
+  def self.tracer
+    DummyTracer.new
+  end
+
+  def self.clear_all
+    SPAN_RESOURCE_NAMES.clear
+  end
+
+
+  module Contrib
+    module Analytics
+      def self.set_sample_rate(rate)
+        rate
+      end
+
+      def self.enabled?(_bool)
+        nil
+      end
+    end
+  end
+
+  class DummyTracer
+    def trace(platform_key, *args)
+      yield self
+    end
+
+    def resource=(resource_name)
+      SPAN_RESOURCE_NAMES << resource_name
+    end
+
+    def span_type=(*args); end
+    def set_tag(*args); end
+  end
+end


### PR DESCRIPTION
Enable a developer to provide the platform trace API a fallback name to
use when a query name is not provided.

Note that this is a *fallback*, the query name is preferred when
available.

Testing is limited to Datadog and New Relic.

Support is within any tracer that delegates to
`PlatformTracing#transaction_name`, which appears to include AppSignal
and Scout. Not sure if that is exhaustive.

Fixes #3769