### PR TITLE
Fix: schema generation with camelized default value of input arguments

### DIFF
--- a/lib/graphql/language/document_from_schema_definition.rb
+++ b/lib/graphql/language/document_from_schema_definition.rb
@@ -196,9 +196,13 @@ module GraphQL
         when "INPUT_OBJECT"
           GraphQL::Language::Nodes::InputObject.new(
             arguments: default_value.to_h.map do |arg_name, arg_value|
-              arg = @warden.arguments(type).find { |a| a.keyword.to_s == arg_name.to_s }
+              args = @warden.arguments(type)
+              arg = args.find { |a| a.keyword.to_s == arg_name.to_s }
+              if arg.nil?
+                raise ArgumentError, "No argument definition on #{type.graphql_name} for argument: #{arg_name.inspect} (expected one of: #{args.map(&:keyword)})"
+              end
               GraphQL::Language::Nodes::Argument.new(
-                name: arg.graphql_name,
+                name: arg.graphql_name.to_s,
                 value: build_default_value(arg_value, arg.type)
               )
             end

--- a/lib/graphql/language/document_from_schema_definition.rb
+++ b/lib/graphql/language/document_from_schema_definition.rb
@@ -196,10 +196,10 @@ module GraphQL
         when "INPUT_OBJECT"
           GraphQL::Language::Nodes::InputObject.new(
             arguments: default_value.to_h.map do |arg_name, arg_value|
-              arg_type = @warden.arguments(type).find { |a| a.graphql_name == arg_name.to_s }.type
+              arg = @warden.arguments(type).find { |a| a.keyword.to_s == arg_name.to_s }
               GraphQL::Language::Nodes::Argument.new(
-                name: arg_name.to_s,
-                value: build_default_value(arg_value, arg_type)
+                name: arg.graphql_name,
+                value: build_default_value(arg_value, arg.type)
               )
             end
           )

--- a/spec/graphql/schema/printer_spec.rb
+++ b/spec/graphql/schema/printer_spec.rb
@@ -30,7 +30,7 @@ REASON
       argument :int, Int, required: false
       argument :float, Float, required: false
       argument :bool, Boolean, required: false
-      argument :enum, Choice, required: false, default_value: :foo
+      argument :some_enum, Choice, required: false, default_value: :foo
       argument :sub, [Sub, null: true], required: false
     end
 
@@ -72,8 +72,8 @@ REASON
 
       field :post, Post do
         argument :id, ID, description: "Post ID"
-        argument :varied, Varied, required: false, default_value: { id: "123", int: 234, float: 2.3, enum: :foo, sub: [{ string: "str" }] }
-        argument :varied_with_nulls, Varied, required: false, default_value: { id: nil, int: nil, float: nil, enum: nil, sub: nil }
+        argument :varied, Varied, required: false, default_value: { id: "123", int: 234, float: 2.3, some_enum: :foo, sub: [{ string: "str" }] }
+        argument :varied_with_nulls, Varied, required: false, default_value: { id: nil, int: nil, float: nil, some_enum: nil, sub: nil }
         argument :deprecated_arg, String, required: false, deprecation_reason: "Use something else"
       end
     end
@@ -543,8 +543,8 @@ type Query {
     Post ID
     """
     id: ID!
-    varied: Varied = {id: "123", int: 234, float: 2.3, enum: FOO, sub: [{string: "str"}]}
-    variedWithNulls: Varied = {id: null, int: null, float: null, enum: null, sub: null}
+    varied: Varied = {id: "123", int: 234, float: 2.3, someEnum: FOO, sub: [{string: "str"}]}
+    variedWithNulls: Varied = {id: null, int: null, float: null, someEnum: null, sub: null}
   ): Post
 }
 
@@ -569,10 +569,10 @@ type Subscription {
 
 input Varied {
   bool: Boolean
-  enum: Choice = FOO
   float: Float
   id: ID
   int: Int
+  someEnum: Choice = FOO
   sub: [Sub]
 }
 SCHEMA


### PR DESCRIPTION
Fixed an error when you're trying to generate schema with inputs with arguments names that can be camelized. 
 
I assume my fix is the proper method, as the default value expects the original keyword when writing the code.

The bottom example will fail when generating schema. 
```ruby
class ExampleInput < Types::BaseInputObject
  argument :updated_at, String, required: false
end

class ExampleQuery < BaseQuery
  argument :order_by, ExampleInput, required: false, default_value: { updated_at: 'DESC' }
end
```