### PR TITLE
Fix auth of loaded resolver args

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -617,13 +617,10 @@ module GraphQL
       end
 
       def authorized?(object, args, context)
-        resolver_authed = if @resolver_class
+        if @resolver_class
           # The resolver _instance_ will check itself during `resolve()`
           @resolver_class.authorized?(object, context)
         else
-          true
-        end
-        resolver_authed && begin
           if (arg_values = context[:current_arguments])
             # ^^ that's provided by the interpreter at runtime, and includes info about whether the default value was used or not.
             using_arg_values = true

--- a/lib/graphql/schema/relay_classic_mutation.rb
+++ b/lib/graphql/schema/relay_classic_mutation.rb
@@ -155,6 +155,14 @@ module GraphQL
           end
         end
       end
+
+      private
+
+      def authorize_arguments(args, values)
+        # remove the `input` wrapper to match values
+        input_args = args["input"].type.unwrap.arguments(context)
+        super(input_args, values)
+      end
     end
   end
 end

--- a/spec/graphql/schema/relay_classic_mutation_spec.rb
+++ b/spec/graphql/schema/relay_classic_mutation_spec.rb
@@ -528,7 +528,7 @@ describe GraphQL::Schema::RelayClassicMutation do
         def authorized?(_object, args, context)
           authed_val = context[:authorized_value] ||= Hash.new { |h,k| h[k] = {} }
           if (prev_val = authed_val[context[:current_path]][self.path])
-            raise "Duplicate `#authorized?` call on #{self.path} @ #{context[:current_path]}"
+            raise "Duplicate `#authorized?` call on #{self.path} @ #{context[:current_path]} (was: #{prev_val.inspect}, is: #{args.inspect})"
           end
           authed_val[context[:current_path]][self.path] = args
           authed = context[:authorized] ||= {}


### PR DESCRIPTION
Oops -- #3738 didn't work right on loaded objects. With resolver instances, it actually introduced a double-pass on `#authorized?` -- once _before_ the object was loaded, and once after it. But I didn't have a test that caught that. (It blew up with GraphQL-Pro's pundit integration because the integration would fail to find a policy for `nil` -- the argument value _before_ loading.) 

