### PR TITLE
Pass arguments object instead of plain Hash

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -516,7 +516,7 @@ module GraphQL
               after_lazy(app_result, owner: owner_type, field: field_defn, path: next_path, ast_node: ast_node, scoped_context: context.scoped_context, owner_object: object, arguments: resolved_arguments, result_name: result_name, result: selection_result) do |inner_result|
                 continue_value = continue_value(next_path, inner_result, owner_type, field_defn, return_type.non_null?, ast_node, result_name, selection_result)
                 if HALT != continue_value
-                  continue_field(next_path, continue_value, owner_type, field_defn, return_type, ast_node, next_selections, false, object, kwarg_arguments, result_name, selection_result)
+                  continue_field(next_path, continue_value, owner_type, field_defn, return_type, ast_node, next_selections, false, object, resolved_arguments, result_name, selection_result)
                 end
               end
             end

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -268,6 +268,20 @@ describe GraphQL::Execution::Interpreter do
       def self.resolve_type(type, obj, ctx)
         FieldCounter
       end
+
+      class EnsureArgsAreObject
+        def self.trace(event, data)
+          case event
+          when "execute_field", "execute_field_lazy"
+            args = data[:query].context[:current_arguments]
+            if !args.is_a?(GraphQL::Execution::Interpreter::Arguments)
+              raise "Expected arguments object, got #{args.class}: #{args.inspect}"
+            end
+          end
+          yield
+        end
+      end
+      tracer EnsureArgsAreObject
     end
   end
 


### PR DESCRIPTION
Oops, this code path passes a plain hash instead of the `Interpreter::Arguments` instance. It ends up getting assigned to `context[:current_arguments]` which fails down the line.

TODO: 

- [x] Some test