### PR TITLE
Add InputObject.authorized?, call it

### DIFF
--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -147,14 +147,7 @@ module GraphQL
             end
           end
         elsif as_type.kind.input_object?
-          as_type.arguments(ctx).each do |_name, input_obj_arg|
-            input_obj_arg = input_obj_arg.type_class
-            # TODO: this skips input objects whose values were alread replaced with application objects.
-            # See: https://github.com/rmosolgo/graphql-ruby/issues/2633
-            if value.is_a?(InputObject) && value.key?(input_obj_arg.keyword) && !input_obj_arg.authorized?(obj, value[input_obj_arg.keyword], ctx)
-              return false
-            end
-          end
+          return as_type.authorized?(obj, value, ctx)
         end
         # None of the early-return conditions were activated,
         # so this is authorized.

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -79,6 +79,21 @@ module GraphQL
         end
       end
 
+      def self.authorized?(obj, value, ctx)
+        # Authorize each argument (but this doesn't apply if `prepare` is implemented):
+        if value.is_a?(InputObject)
+          arguments(ctx).each do |_name, input_obj_arg|
+            input_obj_arg = input_obj_arg.type_class
+            if value.key?(input_obj_arg.keyword) &&
+              !input_obj_arg.authorized?(obj, value[input_obj_arg.keyword], ctx)
+              return false
+            end
+          end
+        end
+        # It didn't early-return false:
+        true
+      end
+
       def unwrap_value(value)
         case value
         when Array

--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -307,7 +307,7 @@ describe GraphQL::Schema::InputObject do
 
         def self.authorized?(obj, arg, ctx)
           if arg.end <= 100
-            true
+            super
           else
             ctx.add_error(GraphQL::ExecutionError.new("Range too big"))
             false

--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -305,13 +305,22 @@ describe GraphQL::Schema::InputObject do
         argument :min, Integer
         argument :max, Integer, required: false
 
+        def self.authorized?(obj, arg, ctx)
+          if arg.end <= 100
+            true
+          else
+            ctx.add_error(GraphQL::ExecutionError.new("Range too big"))
+            false
+          end
+        end
+
         def prepare
           min..max
         end
       end
 
       class Query < GraphQL::Schema::Object
-        field :inputs, String, null: false do
+        field :inputs, String do
           argument :input, InputObj
         end
 
@@ -343,6 +352,16 @@ describe GraphQL::Schema::InputObject do
       res = InputObjectPrepareObjectTest::Schema.execute(query_str, variables: { input: { min: 5, max: 10 } })
       expected_obj = (5..10).inspect
       assert_equal expected_obj, res["data"]["inputs"]
+    end
+
+    it "authorizes the prepared value" do
+      query_str = <<-GRAPHQL
+        query ($input: InputObj!){ inputs(input: $input) }
+      GRAPHQL
+
+      res = InputObjectPrepareObjectTest::Schema.execute(query_str, variables: { input: { min: 5, max: 101 } })
+      assert_nil res["data"]["inputs"]
+      assert_equal ["Range too big"], res["errors"].map { |e| e["message"] }
     end
   end
 


### PR DESCRIPTION
Fixes #2633 

Previously, no `authorized?` methods were ever called on input objects. This meant, for input objects that used `def prepare`, there was no way to authorize the value (except inside `def prepare`, which was probably fine). But now there's a proper way to do it. 