### PR TITLE
Don't run a duplicate query when paginating already-loaded relations

### DIFF
--- a/lib/graphql/pagination/active_record_relation_connection.rb
+++ b/lib/graphql/pagination/active_record_relation_connection.rb
@@ -9,7 +9,12 @@ module GraphQL
 
       def relation_larger_than(relation, size)
         initial_offset = relation.offset_value || 0
-        relation.offset(initial_offset + size).exists?
+        if initial_offset == 0 && relation.loaded?
+          # An unbounded, already-loaded relation
+          relation.size > size
+        else
+          relation.offset(initial_offset + size).exists?
+        end
       end
 
       def relation_count(relation)

--- a/lib/graphql/pagination/relation_connection.rb
+++ b/lib/graphql/pagination/relation_connection.rb
@@ -35,7 +35,7 @@ module GraphQL
             if @nodes && @nodes.count < first
               false
             else
-              relation_larger_than(sliced_nodes, first)
+              relation_larger_than(sliced_nodes, @sliced_nodes_offset, first)
             end
           else
             false
@@ -54,9 +54,10 @@ module GraphQL
       private
 
       # @param relation [Object] A database query object
+      # @param _initial_offset [Integer] The number of items already excluded from the relation
       # @param size [Integer] The value against which we check the relation size
       # @return [Boolean] True if the number of items in this relation is larger than `size`
-      def relation_larger_than(relation, size)
+      def relation_larger_than(relation, _initial_offset, size)
         relation_count(set_limit(relation, size + 1)) == size + 1
       end
 
@@ -111,36 +112,53 @@ module GraphQL
         end
       end
 
-      # Apply `before` and `after` to the underlying `items`,
-      # returning a new relation.
-      def sliced_nodes
-        @sliced_nodes ||= begin
+      def calculate_sliced_nodes_parameters
+        if defined?(@sliced_nodes_limit)
+          return
+        else
           paginated_nodes = items
 
           if after_offset
             previous_offset = relation_offset(items) || 0
-            paginated_nodes = set_offset(paginated_nodes, previous_offset + after_offset)
+            relation_offset = previous_offset + after_offset
           end
 
           if before_offset && after_offset
             if after_offset < before_offset
               # Get the number of items between the two cursors
               space_between = before_offset - after_offset - 1
-              @relation_limit = space_between
-              # paginated_nodes = set_limit(paginated_nodes, space_between)
+              relation_limit = space_between
             else
-              # TODO I think this is untested
               # The cursors overextend one another to an empty set
-              paginated_nodes = null_relation(paginated_nodes)
+              @sliced_nodes_null_relation = true
             end
           elsif before_offset
             # Use limit to cut off the tail of the relation
-            @relation_limit = before_offset - 1
-            # paginated_nodes = set_limit(paginated_nodes, before_offset - 1)
+            relation_limit = before_offset - 1
           end
 
-          if @relation_limit
-            paginated_nodes = set_limit(paginated_nodes, @relation_limit)
+          @sliced_nodes_limit = relation_limit
+          @sliced_nodes_offset = relation_offset || 0
+        end
+      end
+
+      # Apply `before` and `after` to the underlying `items`,
+      # returning a new relation.
+      def sliced_nodes
+        @sliced_nodes ||= begin
+          calculate_sliced_nodes_parameters
+          paginated_nodes = items
+
+          if @sliced_nodes_null_relation
+            paginated_nodes = null_relation(paginated_nodes)
+          else
+            if @sliced_nodes_limit
+              paginated_nodes = set_limit(paginated_nodes, @sliced_nodes_limit)
+            end
+
+            if @sliced_nodes_offset
+              paginated_nodes = set_offset(paginated_nodes, @sliced_nodes_offset)
+            end
           end
 
           paginated_nodes
@@ -161,40 +179,38 @@ module GraphQL
       # returning a new relation
       def limited_nodes
         @limited_nodes ||= begin
-          paginated_nodes = sliced_nodes
-          @relation_limit ||= relation_limit(paginated_nodes)
+          calculate_sliced_nodes_parameters
+          if @sliced_nodes_null_relation
+            # it's an empty set
+            return sliced_nodes
+          end
+          relation_limit = @sliced_nodes_limit
+          relation_offset = @sliced_nodes_offset
 
-          if first && (@relation_limit.nil? || @relation_limit > first)
+          if first && (relation_limit.nil? || relation_limit > first)
             # `first` would create a stricter limit that the one already applied, so add it
-            @relation_limit = first
-            # paginated_nodes = set_limit(paginated_nodes, first)
+            relation_limit = first
           end
 
           if last
-            if @relation_limit
-              if last <= @relation_limit
+            if relation_limit
+              if last <= relation_limit
                 # `last` is a smaller slice than the current limit, so apply it
-                offset = (relation_offset(paginated_nodes) || 0) + (@relation_limit - last)
-                paginated_nodes = set_offset(paginated_nodes, offset)
-                @relation_limit = last
-                # paginated_nodes = set_limit(paginated_nodes, last)
+                relation_offset += (relation_limit - last)
+                relation_limit = last
               end
             else
               # No limit, so get the last items
-              sliced_nodes_count = relation_count(@sliced_nodes)
-              offset = (relation_offset(paginated_nodes) || 0) + sliced_nodes_count - [last, sliced_nodes_count].min
-              paginated_nodes = set_offset(paginated_nodes, offset)
-              @relation_limit = last
+              sliced_nodes_count = relation_count(sliced_nodes)
+              relation_offset += (sliced_nodes_count - [last, sliced_nodes_count].min)
+              relation_limit = last
             end
           end
 
-          @paged_nodes_offset = relation_offset(paginated_nodes)
-
-          if paginated_nodes.loaded?
-            paginated_nodes.take(@relation_limit)
-          else
-            paginated_nodes.limit(@relation_limit)
-          end
+          @paged_nodes_offset = relation_offset
+          paginated_nodes = items
+          paginated_nodes = set_offset(paginated_nodes, relation_offset)
+          set_limit(paginated_nodes, relation_limit)
         end
       end
 

--- a/lib/graphql/pagination/relation_connection.rb
+++ b/lib/graphql/pagination/relation_connection.rb
@@ -116,8 +116,6 @@ module GraphQL
         if defined?(@sliced_nodes_limit)
           return
         else
-          paginated_nodes = items
-
           if after_offset
             previous_offset = relation_offset(items) || 0
             relation_offset = previous_offset + after_offset

--- a/spec/support/connection_assertions.rb
+++ b/spec/support/connection_assertions.rb
@@ -127,6 +127,14 @@ module ConnectionAssertions
           get_items
         end
 
+        field :preloaded_items, item.connection_type
+
+        def preloaded_items
+          relation = get_items
+          relation.load # force the unbounded relation to load from the database
+          relation
+        end
+
         private
 
         def get_items


### PR DESCRIPTION
Fixes #3775 

If the connection receives an already-loaded relation and can satisfy the query _without_ running another query, then don't run another query. Instead, choose ActiveRecord methods that will use already-loaded objects.

TODO: 

- [x] What if the relation has some other `LIMIT` or `OFFSET` applied, will this break? 
- [x] Implement without breaking Mongoid and Sequel code 

cc @crpahl