### PR TITLE
[Docs] Correction in object_from_id

### DIFF
--- a/guides/schema/object_identification.md
+++ b/guides/schema/object_identification.md
@@ -31,7 +31,7 @@ class MySchema < GraphQL::Schema
     "#{type_hint}_#{encoded_id}"
   end
 
-  def self.object_from_id(id, query_ctx)
+  def self.object_from_id(encoded_id_with_hint, query_ctx)
     # For example, use Rails' GlobalID library (https://github.com/rails/globalid):
     # Split off the type hint
     _type_hint, encoded_id = encoded_id_with_hint.split("_", 2)


### PR DESCRIPTION
Renamed the `id` parameter to `encoded_id_with_hint` in the `object_from_id` method. Previously, the method referenced an undefined variable (`encoded_id_with_hint`) that was supposed to be the global id that gets passed into `object_from_id`.