### PR TITLE
Make Relay::Node add an id field that calls the schema hook

### DIFF
--- a/lib/graphql/types/relay/node_behaviors.rb
+++ b/lib/graphql/types/relay/node_behaviors.rb
@@ -7,7 +7,11 @@ module GraphQL
         def self.included(child_module)
           child_module.extend(DefaultRelay)
           child_module.description("An object with an ID.")
-          child_module.field(:id, ID, null: false, description: "ID of the object.")
+          child_module.field(:id, ID, null: false, description: "ID of the object.", resolver_method: :default_global_id)
+        end
+
+        def default_global_id
+          context.schema.id_from_object(object, self, context)
         end
       end
     end

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -265,6 +265,10 @@ describe GraphQL::Execution::Interpreter do
         OpenStruct.new(id: id)
       end
 
+      def self.id_from_object(obj, type, ctx)
+        obj.id
+      end
+
       def self.resolve_type(type, obj, ctx)
         FieldCounter
       end

--- a/spec/graphql/types/relay/node_behaviors_spec.rb
+++ b/spec/graphql/types/relay/node_behaviors_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::Types::Relay::NodeBehaviors do
+  class NodeBehaviorsSchema < GraphQL::Schema
+    class Thing < GraphQL::Schema::Object
+      implements GraphQL::Types::Relay::Node
+    end
+
+    class Query < GraphQL::Schema::Object
+      field :thing, Thing
+
+      def thing
+        {}
+      end
+    end
+
+    query(Query)
+
+    def self.id_from_object(obj, _type, _ctx)
+      "blah"
+    end
+  end
+
+  it "adds an `id` field that calls `schema.id_from_object`" do
+    res = NodeBehaviorsSchema.execute("{ thing { id } }")
+    assert_equal "blah", res["data"]["thing"]["id"]
+  end
+end


### PR DESCRIPTION
Oops, the docs say that implementing this interface should add a field with this behavior, but it doesn't actually work this way. I think it'd be a nice improvement.