### PR TITLE
Accept nullable variables for non-null arguments when the argument has a default value

### DIFF
--- a/lib/graphql/schema/non_null.rb
+++ b/lib/graphql/schema/non_null.rb
@@ -53,6 +53,10 @@ module GraphQL
       end
 
       def coerce_input(value, ctx)
+        # `.validate_input` above is used for variables, but this method is used for arguments
+        if value.nil?
+          raise GraphQL::ExecutionError, "`null` is not a valid input for `#{to_type_signature}`, please provide a value for this argument."
+        end
         of_type.coerce_input(value, ctx)
       end
 

--- a/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb
+++ b/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb
@@ -68,6 +68,12 @@ module GraphQL
         arg_defn = context.warden.get_argument(argument_owner, arg_node.name)
         arg_defn_type = arg_defn.type
 
+        # If the argument is non-null, but it was given a default value,
+        # then treat it as nullable in practice, see https://github.com/rmosolgo/graphql-ruby/issues/3793
+        if arg_defn_type.non_null? && arg_defn.default_value?
+          arg_defn_type = arg_defn_type.of_type
+        end
+
         var_inner_type = var_type.unwrap
         arg_inner_type = arg_defn_type.unwrap
 

--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -1048,14 +1048,11 @@ describe GraphQL::Schema::InputObject do
 
       it "null values are returned in coerced input" do
         input = MinimumInputObject.new({"a" => "Test", "b" => nil,"c" => "Test"})
-        result = input_type.coerce_isolated_input(input)
+        err = assert_raises GraphQL::ExecutionError do
+          input_type.coerce_isolated_input(input)
+        end
 
-        assert_equal 'Test', result[:a]
-
-        assert result.key?(:b)
-        assert_nil result[:b]
-
-        assert_equal "Test", result[:c]
+        assert_equal "`null` is not a valid input for `Int!`, please provide a value for this argument.", err.message
       end
 
       it "null values are preserved when argument has a default value" do


### PR DESCRIPTION
fixes #3793

Weirdly, `NonNull#validate_input` didn't work because that's called on _variable_ definitions with their values. But in this case, I specifically have to check a variable-provided value against the an argument type. Static validation won't work because, statically, we don't know if the variable value will be `null` or not. So it has to be dynamic in some way. 

Maybe it could have been added to `Query::Variables` -- that's where `.validate_input` is called -- but there aren't any references to variable _usages_ there, so there's no easy way to get the argument types to validate against. 