### PR TITLE
Fix directive arguments performance issue

### DIFF
--- a/benchmark/run.rb
+++ b/benchmark/run.rb
@@ -139,9 +139,9 @@ module GraphQLBenchmark
     end
 
     ALL_FIELDS = GraphQL.parse <<-GRAPHQL
-      {
+      query($skip: Boolean = false) {
         foos {
-          id
+          id @skip(if: $skip)
           int1
           int2
           string1

--- a/lib/graphql/execution/interpreter/arguments_cache.rb
+++ b/lib/graphql/execution/interpreter/arguments_cache.rb
@@ -31,8 +31,10 @@ module GraphQL
           # If any jobs were enqueued, run them now,
           # since this might have been called outside of execution.
           # (The jobs are responsible for updating `result` in-place.)
-          @dataloader.run_isolated do
-            @storage[ast_node][argument_owner][parent_object]
+          if !@storage.key?(ast_node) || !@storage[ast_node].key?(argument_owner)
+            @dataloader.run_isolated do
+              @storage[ast_node][argument_owner][parent_object]
+            end
           end
           # Ack, the _hash_ is updated, but the key is eventually
           # overridden with an immutable arguments instance.

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -159,7 +159,8 @@ module GraphQL
           # Identify runtime directives by checking which of this schema's directives have overridden `def self.resolve`
           @runtime_directive_names = []
           noop_resolve_owner = GraphQL::Schema::Directive.singleton_class
-          schema.directives.each do |name, dir_defn|
+          @schema_directives = schema.directives
+          @schema_directives.each do |name, dir_defn|
             if dir_defn.method(:resolve).owner != noop_resolve_owner
               @runtime_directive_names << name
             end
@@ -802,7 +803,7 @@ module GraphQL
           if !dir_node
             yield
           else
-            dir_defn = schema.directives.fetch(dir_node.name)
+            dir_defn = @schema_directives.fetch(dir_node.name)
             if !dir_defn.is_a?(Class)
               dir_defn = dir_defn.type_class || raise("Only class-based directives are supported (not `@#{dir_node.name}`)")
             end
@@ -831,7 +832,7 @@ module GraphQL
         # Check {Schema::Directive.include?} for each directive that's present
         def directives_include?(node, graphql_object, parent_type)
           node.directives.each do |dir_node|
-            dir_defn = schema.directives.fetch(dir_node.name).type_class || raise("Only class-based directives are supported (not #{dir_node.name.inspect})")
+            dir_defn = @schema_directives.fetch(dir_node.name).type_class || raise("Only class-based directives are supported (not #{dir_node.name.inspect})")
             args = arguments(graphql_object, dir_defn, dir_node)
             if !dir_defn.include?(graphql_object, args, context)
               return false


### PR DESCRIPTION
Basically, there was a legacy-style usage of `arguments_cache.fetch(...)` that had to hit the data loader directly. But it wasn't smart about when that hit could be skipped. That method still isn't great, but it reduces the hits to dataloader. 

In my benchmark, there's still an issue where `args[:if]` is allocating an array, seemingly inside `def_delegators` from the Ruby standard library, because if I replace it with `args.keyword_arguments[:if]`, it doesn't record that allocation anymore. This is a separate issue... 

Fixes #3833 

cc @gopeter -- could you give this commit a try on your project and tell me how the performance looks?