### PR TITLE
Dataloader: Batch across list items

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -762,17 +762,19 @@ module GraphQL
             scoped_context = context.scoped_context
             begin
               value.each do |inner_value|
-                break if dead_result?(response_list)
-                next_path = path.dup
-                next_path << idx
-                this_idx = idx
-                next_path.freeze
-                idx += 1
-                # This will update `response_list` with the lazy
-                after_lazy(inner_value, owner: inner_type, path: next_path, ast_node: ast_node, scoped_context: scoped_context, field: field, owner_object: owner_object, arguments: arguments, result_name: this_idx, result: response_list) do |inner_inner_value|
-                  continue_value = continue_value(next_path, inner_inner_value, owner_type, field, inner_type.non_null?, ast_node, this_idx, response_list)
-                  if HALT != continue_value
-                    continue_field(next_path, continue_value, owner_type, field, inner_type, ast_node, next_selections, false, owner_object, arguments, this_idx, response_list)
+                @dataloader.append_job do
+                  break if dead_result?(response_list)
+                  next_path = path.dup
+                  next_path << idx
+                  this_idx = idx
+                  next_path.freeze
+                  idx += 1
+                  # This will update `response_list` with the lazy
+                  after_lazy(inner_value, owner: inner_type, path: next_path, ast_node: ast_node, scoped_context: scoped_context, field: field, owner_object: owner_object, arguments: arguments, result_name: this_idx, result: response_list) do |inner_inner_value|
+                    continue_value = continue_value(next_path, inner_inner_value, owner_type, field, inner_type.non_null?, ast_node, this_idx, response_list)
+                    if HALT != continue_value
+                      continue_field(next_path, continue_value, owner_type, field, inner_type, ast_node, next_selections, false, owner_object, arguments, this_idx, response_list)
+                    end
                   end
                 end
               end

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -416,8 +416,10 @@ describe GraphQL::Dataloader do
               "6",                # recipeIngredient recipeId
             ]],
             [:mget, [
-              "3", "4",           # The two unfetched ingredients the first recipe
               "7",                # recipeIngredient ingredient_id
+            ]],
+            [:mget, [
+              "3", "4",           # The two unfetched ingredients the first recipe
             ]],
           ]
           assert_equal expected_log, database_log

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -667,12 +667,12 @@ describe GraphQL::Dataloader do
         it "batches calls in .authorized?" do
           query_str = "{ r1: recipe(id: 5) { name } r2: recipe(id: 6) { name } }"
           context = { authorized_batch_calls_count: 0 }
-          res = schema.execute(query_str, context: context)
+          schema.execute(query_str, context: context)
           assert_equal 1, context[:authorized_batch_calls_count]
 
           query_str = "{ recipes { name } }"
           context = { authorized_batch_calls_count: 0 }
-          res = schema.execute(query_str, context: context)
+          schema.execute(query_str, context: context)
           assert_equal 1, context[:authorized_batch_calls_count]
         end
 


### PR DESCRIPTION
We can get better batching if each item in a list is handled in its own job. 

TODO: 

- [x] ~~This causes a regression in another case. It's because of the `.coerce_value` call on input objects which doesn't pass a block, so it's resolved immediately.~~ I don't think this was actually a regression, it was just that, by adding a batch call to authorized, I required a  `.run` call where there wasn't previously one.
- [x] Run a profile: how much will this affect performance?

    The overhead here is one `Proc` per non-scalar/non-enum list item. Previously, list items were run in the surrounding dataloader job, which meant that each list item could cause the whole list to halt. Now, each item in a list (when the list returns Union, Interface, or Object type) spins up a new dataloader job, so it runs in its own fiber.

Fixes #3840 