### PR TITLE
Remove TruffleRuby from CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,8 +51,6 @@ jobs:
             ruby: 3.0
           - gemfile: gemfiles/rails_master.gemfile
             ruby: 3.0
-          - gemfile: gemfiles/rails_master.gemfile
-            ruby: truffleruby-head
     runs-on: ubuntu-latest
     steps:
     - run: echo BUNDLE_GEMFILE=${{ matrix.gemfile }} > $GITHUB_ENV


### PR DESCRIPTION
I'm tired of always seeing failed builds, and it seems like this is the flakiest one. Either Rails master is failing (as it did for a while when Rails generators wouldn't generate for `HEAD`, even when the invoked `rails ...` command was from `HEAD`) or TruffleRuby is failing (as it is currently because it's looking up `require "digest"` wrong, or something like that: https://github.com/oracle/truffleruby/issues/2511). 

If anyone wants to re-add a passing TruffleRuby build to this project (not truffleruby-head, not rails master), I'll try maintaining it again, but sheesh... 

cc @gogainda, in case you'd rather get this build _passing_ somehow ... (I can't figure out how to do it!)