### PR TITLE
Handle missing fields during Analysis

### DIFF
--- a/lib/graphql/analysis/ast/visitor.rb
+++ b/lib/graphql/analysis/ast/visitor.rb
@@ -100,16 +100,8 @@ module GraphQL
         def on_field(node, parent)
           @response_path.push(node.alias || node.name)
           parent_type = @object_types.last
-          field_definition = begin
-            @schema.get_field(parent_type, node.name, @query.context)
-          rescue ArgumentError => err
-            if err.message.include?("Invariant: unexpected field owner")
-              nil
-            else
-              raise
-            end
-          end
-
+          # This could be nil if the previous field wasn't found:
+          field_definition = parent_type && @schema.get_field(parent_type, node.name, @query.context)
           @field_definitions.push(field_definition)
           if !field_definition.nil?
             next_object_type = field_definition.type.unwrap

--- a/lib/graphql/analysis/ast/visitor.rb
+++ b/lib/graphql/analysis/ast/visitor.rb
@@ -100,7 +100,16 @@ module GraphQL
         def on_field(node, parent)
           @response_path.push(node.alias || node.name)
           parent_type = @object_types.last
-          field_definition = @schema.get_field(parent_type, node.name, @query.context)
+          field_definition = begin
+            @schema.get_field(parent_type, node.name, @query.context)
+          rescue ArgumentError => err
+            if err.message.include?("Invariant: unexpected field owner")
+              nil
+            else
+              raise
+            end
+          end
+
           @field_definitions.push(field_definition)
           if !field_definition.nil?
             next_object_type = field_definition.type.unwrap

--- a/spec/graphql/analysis/ast_spec.rb
+++ b/spec/graphql/analysis/ast_spec.rb
@@ -401,7 +401,7 @@ describe GraphQL::Analysis::AST do
       end
 
       class Query < BaseObject
-        field :article, String, null: true, visible: false do |f|
+        field :article, String. visible: false do |f|
           f.argument(:id, Integer, required: true)
         end
 

--- a/spec/graphql/analysis/ast_spec.rb
+++ b/spec/graphql/analysis/ast_spec.rb
@@ -367,4 +367,64 @@ describe GraphQL::Analysis::AST do
       refute is_introspection?("{ int __type(name: \"Thing\") { name } }")
     end
   end
+
+  describe "when there's a hidden field" do
+    class HiddenAnalyzedFieldSchema < GraphQL::Schema
+      class DoNothingAnalyzer < GraphQL::Analysis::AST::Analyzer
+        def on_enter_field(node, parent, visitor)
+          @result ||= []
+          @result << [node.name, visitor.field_definition.class]
+          super
+        end
+
+        def result
+          @result
+        end
+      end
+      class BaseField < GraphQL::Schema::Field
+        def initialize(*args, visible: true, **kwargs, &block)
+          @visible = visible
+          super(*args, **kwargs, &block)
+        end
+
+        def visible?(context)
+          return @visible
+        end
+      end
+
+      class BaseObject < GraphQL::Schema::Object
+        field_class BaseField
+      end
+
+      class Article < BaseObject
+        field :title, String, null: false
+      end
+
+      class Query < BaseObject
+        field :article, String, null: true, visible: false do |f|
+          f.argument(:id, Integer, required: true)
+        end
+
+        def article(id:)
+          { title: "hello world" }
+        end
+      end
+
+      query Query
+    end
+
+    it "uses nil for the field definition" do
+      gql = <<~GQL
+      {
+        article(id: 1) {
+          title
+        }
+      }
+      GQL
+
+      query = GraphQL::Query.new(HiddenAnalyzedFieldSchema, gql)
+      result = GraphQL::Analysis::AST.analyze_query(query, [HiddenAnalyzedFieldSchema::DoNothingAnalyzer])
+      assert_equal [[["article", NilClass], ["title", NilClass]]], result
+    end
+  end
 end

--- a/spec/graphql/analysis/ast_spec.rb
+++ b/spec/graphql/analysis/ast_spec.rb
@@ -401,7 +401,7 @@ describe GraphQL::Analysis::AST do
       end
 
       class Query < BaseObject
-        field :article, String. visible: false do |f|
+        field :article, String, visible: false do |f|
           f.argument(:id, Integer, required: true)
         end
 


### PR DESCRIPTION
On 1.12, this would actually _find_ `article` (an instance of BaseField), then visit `title`, but set `nil` for `visitor.field_definition`. After this change, it assigns `nil` in both cases, and I _think_ this is right -- `article` is hidden. It's visited, for compatibility's sake if nothing else, but the definition is nil, and same with `title`. 

I think the change that caused the error is here: 

https://github.com/rmosolgo/graphql-ruby/commit/c4f89186f59708b39ed5ae11c17e6f2d5c97c382#diff-ca02a7189be9dc9f1c0d328028ba139f8be8da82eca96bbfccd3c098b5ad03f7R1196


Previously, `Schema.get_field(type, field_name)` didn't run any visibility checks, so it would return `Query.article` without hesitation. (TODO: Why did it return `nil` for `title`?) Now, although it finds `Query.article`, it returns `nil` since the field doesn't pass the `.visible?` check. 

Before this change, 1.13.x would raise an error on `title`: 

```
ArgumentError: Invariant: unexpected field owner for "title": nil (NilClass)

This is probably a bug in GraphQL-Ruby, please report this error on GitHub: https://github.com/rmosolgo/graphql-ruby/issues/new?template=bug_report.md
```

It raised that error because `Query.article`'s field definition wasn't returned _previously_, so it pushed `nil` instead of a proper return type. 

Now, the visitor will continue with `nil` as the field definition instead.


Fixes #3845 

cc @cocoahero 