### PR TITLE
Find required: true when a field instance is used

### DIFF
--- a/lib/graphql/rubocop/graphql/default_required_true.rb
+++ b/lib/graphql/rubocop/graphql/default_required_true.rb
@@ -25,16 +25,16 @@ module GraphQL
 
         def_node_matcher :argument_config_with_required_true?, <<-Pattern
         (
-          send nil? :argument ... (hash <$(pair (sym :required) (true)) ...>)
+          send {nil? _} :argument ... (hash <$(pair (sym :required) (true)) ...>)
         )
         Pattern
 
         def on_send(node)
           argument_config_with_required_true?(node) do |required_config|
             add_offense(required_config) do |corrector|
-                cleaned_node_source = source_without_keyword_argument(node, required_config)
-                corrector.replace(node, cleaned_node_source)
-              end
+              cleaned_node_source = source_without_keyword_argument(node, required_config)
+              corrector.replace(node, cleaned_node_source)
+            end
           end
         end
       end

--- a/spec/fixtures/cop/required_true.rb
+++ b/spec/fixtures/cop/required_true.rb
@@ -13,4 +13,8 @@ class Types::Something < Types::BaseObject
 
     argument :id_5, ID
   end
+
+  field :name2, String do |f|
+    f.argument(:id_1, ID, required: true)
+  end
 end

--- a/spec/fixtures/cop/required_true_corrected.rb
+++ b/spec/fixtures/cop/required_true_corrected.rb
@@ -12,4 +12,8 @@ class Types::Something < Types::BaseObject
 
     argument :id_5, ID
   end
+
+  field :name2, String do |f|
+    f.argument(:id_1, ID)
+  end
 end

--- a/spec/graphql/analysis/ast_spec.rb
+++ b/spec/graphql/analysis/ast_spec.rb
@@ -402,7 +402,7 @@ describe GraphQL::Analysis::AST do
 
       class Query < BaseObject
         field :article, String, visible: false do |f|
-          f.argument(:id, Integer, required: true)
+          f.argument(:id, Integer)
         end
 
         def article(id:)

--- a/spec/graphql/analysis/ast_spec.rb
+++ b/spec/graphql/analysis/ast_spec.rb
@@ -401,7 +401,7 @@ describe GraphQL::Analysis::AST do
       end
 
       class Query < BaseObject
-        field :article, String. visible: false do |f|
+        field :article, String, visible: false do |f|
           f.argument(:id, Integer, required: true)
         end
 

--- a/spec/graphql/cop/default_required_true_spec.rb
+++ b/spec/graphql/cop/default_required_true_spec.rb
@@ -6,7 +6,7 @@ describe "GraphQL::Cop::DefaultRequiredTrue" do
 
   it "finds and autocorrects `required: true` argument configurations" do
     result = run_rubocop_on("spec/fixtures/cop/required_true.rb")
-    assert_equal 3, rubocop_errors(result)
+    assert_equal 4, rubocop_errors(result)
 
     assert_includes result, <<-RUBY
     argument :id_1, ID, required: true
@@ -21,6 +21,11 @@ describe "GraphQL::Cop::DefaultRequiredTrue" do
     assert_includes result, <<-RUBY
     argument :id_3, ID, other_config: { something: false, required: true }, required: true, description: \"Something\"
                                                                             ^^^^^^^^^^^^^^
+    RUBY
+
+    assert_includes result, <<-RUBY
+    f.argument(:id_1, ID, required: true)
+                          ^^^^^^^^^^^^^^
     RUBY
 
     assert_rubocop_autocorrects_all("spec/fixtures/cop/required_true.rb")

--- a/spec/graphql/schema/field_extension_spec.rb
+++ b/spec/graphql/schema/field_extension_spec.rb
@@ -23,7 +23,7 @@ describe GraphQL::Schema::FieldExtension do
 
     class MultiplyByArgument < GraphQL::Schema::FieldExtension
       def apply
-        field.argument(:factor, Integer, required: true)
+        field.argument(:factor, Integer)
       end
 
       def resolve(object:, arguments:, context:)
@@ -38,7 +38,7 @@ describe GraphQL::Schema::FieldExtension do
 
     class MultiplyByArgumentUsingResolve < GraphQL::Schema::FieldExtension
       def apply
-        field.argument(:factor, Integer, required: true)
+        field.argument(:factor, Integer)
       end
 
       # `yield` returns the user-returned value
@@ -51,7 +51,7 @@ describe GraphQL::Schema::FieldExtension do
 
     class MultiplyByArgumentUsingAfterResolve < GraphQL::Schema::FieldExtension
       def apply
-        field.argument(:factor, Integer, required: true)
+        field.argument(:factor, Integer)
       end
 
       def resolve(object:, arguments:, context:)

--- a/spec/graphql/schema/field_spec.rb
+++ b/spec/graphql/schema/field_spec.rb
@@ -84,7 +84,7 @@ describe GraphQL::Schema::Field do
         graphql_name "JustAName"
 
         field :test, String do |field|
-          field.argument :test, String, required: true
+          field.argument :test, String
           field.description "A Description."
         end
       end.deprecated_to_graphql

--- a/spec/support/rubocop_test_helpers.rb
+++ b/spec/support/rubocop_test_helpers.rb
@@ -2,7 +2,7 @@
 
 module RubocopTestHelpers
   def run_rubocop_on(fixture_path, autocorrect: false)
-    `bundle exec rubocop --debug #{autocorrect ? "--auto-correct" : ""} --config spec/fixtures/cop/.rubocop.yml #{fixture_path}`
+    `bundle exec rubocop --debug #{autocorrect ? "--auto-correct" : ""} --config spec/fixtures/cop/.rubocop.yml #{fixture_path} 2>&1`
   end
 
   def rubocop_errors(rubocop_result)


### PR DESCRIPTION
Oops, the cop didn't handle the `yield(field_defn)` possibility for `field_defn.argument(..., required: true)`. Also, clean up test output.