### PR TITLE
Skip static and variable validation

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -309,7 +309,7 @@ module GraphQL
     end
 
     def_delegators :validation_pipeline, :validation_errors, :internal_representation,
-                   :analyzers, :ast_analyzers, :max_depth, :max_complexity
+                   :analyzers, :ast_analyzers, :max_depth, :max_complexity, :skip_static_validation=
 
     attr_accessor :analysis_errors
     def valid?


### PR DESCRIPTION
Draft PR to skip static and variable validation.

Within core, we'd have to set `query.query.skip_static_validation = true` as well for skipping.