### PR TITLE
Make the introspection query backwards-compatible by default

### DIFF
--- a/lib/graphql/introspection.rb
+++ b/lib/graphql/introspection.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 module GraphQL
   module Introspection
-    def self.query(include_deprecated_args: false)
+    def self.query(include_deprecated_args: false, include_schema_description: false, include_is_repeatable: false, include_specified_by_url: false)
       # The introspection query to end all introspection queries, copied from
       # https://github.com/graphql/graphql-js/blob/master/src/utilities/introspectionQuery.js
       <<-QUERY
 query IntrospectionQuery {
   __schema {
-    description
+    #{include_schema_description ? "description" : ""}
     queryType { name }
     mutationType { name }
     subscriptionType { name }
@@ -18,7 +18,7 @@ query IntrospectionQuery {
       name
       description
       locations
-      isRepeatable
+      #{include_is_repeatable ? "isRepeatable" : ""}
       args#{include_deprecated_args ? '(includeDeprecated: true)' : ''} {
         ...InputValue
       }
@@ -29,7 +29,7 @@ fragment FullType on __Type {
   kind
   name
   description
-  specifiedByUrl
+  #{include_specified_by_url ? "specifiedByUrl" : ""}
   fields(includeDeprecated: true) {
     name
     description

--- a/spec/graphql/schema/loader_spec.rb
+++ b/spec/graphql/schema/loader_spec.rb
@@ -150,7 +150,7 @@ describe GraphQL::Schema::Loader do
   }
 
   let(:schema_json) {
-    schema.execute(GraphQL::Introspection.query(include_deprecated_args: true))
+    schema.execute(GraphQL::Introspection.query(include_deprecated_args: true, include_schema_description: true, include_specified_by_url: true, include_is_repeatable: true))
   }
 
   describe "load" do


### PR DESCRIPTION
Oops -- I added new fields in #3854 but forgot about how they can have downstream effects. Don't add them by default. 

Fixes #3873 