### PR TITLE
Input objects: authorize anything that responds to .key?

### DIFF
--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -57,7 +57,7 @@ module GraphQL
 
       def self.authorized?(obj, value, ctx)
         # Authorize each argument (but this doesn't apply if `prepare` is implemented):
-        if value.is_a?(InputObject)
+        if value.respond_to?(:key?)
           arguments(ctx).each do |_name, input_obj_arg|
             if value.key?(input_obj_arg.keyword) &&
               !input_obj_arg.authorized?(obj, value[input_obj_arg.keyword], ctx)


### PR DESCRIPTION
Fixes #3878 , but re-breaks #3604 

I think there's a better fix for #3604 now that InputObjects have their own `def self.authorized?(obj, value, ctx)` methods now: 

```ruby 
def self.authorized?(obj, value, ctx)
  true # skip auth for this input object -- since it's covered by `prepare`
end 
```