### PR TITLE
Add table of contents to all guides

### DIFF
--- a/guides/_layouts/guide.html
+++ b/guides/_layouts/guide.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+toc: true
 ---
 <p class="breadcrumb">
   <a href="{{ site.baseurl }}/">GraphQL</a>
@@ -39,6 +40,7 @@ layout: default
   </div>
 {% endif %}
 <h1 class="guide-header">{{ page.title }}</h1>
+<div class="guide-table-of-contents">{% table_of_contents %}</div>
 <div class="guide-container">
   {{ content }}
 </div>

--- a/guides/_tasks/site.rb
+++ b/guides/_tasks/site.rb
@@ -40,8 +40,9 @@ end
 
 namespace :site do
   desc "View the documentation site locally"
-  task serve: [:build_doc] do
-    require "jekyll"
+  task serve: [] do
+  # task serve: [:build_doc] do
+      require "jekyll"
     options = {
       "source"      => File.expand_path("guides"),
       "destination" => File.expand_path("guides/_site"),

--- a/guides/changesets/definition.md
+++ b/guides/changesets/definition.md
@@ -59,7 +59,7 @@ See below for the different kind of modifications you can make in a changeset:
 - [Types](#types): changing one type definition for another
 - [Runtime](#runtime): choosing a behavior at runtime based on the current request and changeset
 
-### Fields
+## Fields
 
 In a Changeset, you can add, redefine, or remove fields that belong to object types, interface types, or resolvers. First, use `modifies ... do ... end`, naming the owner of the field:
 
@@ -78,7 +78,7 @@ Then...
 
 When a field is removed, queries that request that field will be invalid, unless the client has requested a previous API version where the field is still available.
 
-### Arguments
+## Arguments
 
 In a Changeset, you can add, redefine, or remove arguments that belong to fields, input objects, or resolvers. Use `modifies` to select the argument owner, for example:
 
@@ -109,7 +109,7 @@ Then...
 
 When arguments are removed, the schema will reject any queries which use them unless the client has requested a previous API version where the argument is still allowed.
 
-### Enum Values
+## Enum Values
 
 In a Changeset, you can add, redefine, or remove enum values. First, use `modifies ... do ... end`, naming the enum type:
 
@@ -128,7 +128,7 @@ Then...
 
 When enum values are removed, they won't be accepted as input and they won't be allowed as return values from fields unless the client has requested a previous API version where those values are still allowed.
 
-### Unions
+## Unions
 
 In a Changeset, you can add to or remove from a union's possible types. First, use `modifies ...`, naming the union type:
 
@@ -147,7 +147,7 @@ Then...
 
 When a possible type is removed, it will not be associated with the union type in introspection queries or schema dumps.
 
-### Interfaces
+## Interfaces
 
 In a Changeset, you can add to or remove from an object type's interface definitions. First, use `modifies ...`, naming the object type:
 
@@ -166,7 +166,7 @@ Then...
 
 When an interface implementation is removed, then the interface will not be associated with the object in introspection queries or schema dumps. Also, any fields inherited from the interface will be hidden from clients. (If the object defines the field itself, it will still be visible.)
 
-### Types
+## Types
 
 Using Changesets, it's possible to define a new type using the same name as an old type. (Only one type per name is allowed for each query, but different queries can use different types for the same name.)
 
@@ -230,7 +230,7 @@ end
 
 That way, legacy clients will continue to receive enum values while new clients will receive objects.
 
-### Runtime
+## Runtime
 
 While a query is running, you can check if a changeset applies by using its `.active?(context)` method. For example:
 

--- a/guides/changesets/installation.md
+++ b/guides/changesets/installation.md
@@ -11,7 +11,7 @@ index: 1
 
 Changesets require some updates to the schema (to define changesets) and some updates to your controller (to receive version headers from clients).
 
-### Schema Setup
+## Schema Setup
 
 To get started with [GraphQL-Enterprise](https://graphql.pro/enterprise) Changesets, you have to add them to your schema. They're added in several places:
 
@@ -62,7 +62,7 @@ To get started with [GraphQL-Enterprise](https://graphql.pro/enterprise) Changes
 
 Once those integrations are set up, you're ready to {% internal_link "write a changeset", "/changesets/definition" %} and start {% internal_link "releasing API versions", "/changesets/releases" %}!
 
-### Controller Setup
+## Controller Setup
 
 Additionally, your controller must pass `context[:changeset_version]` when running queries. To provide this, update your controller:
 

--- a/guides/changesets/releases.md
+++ b/guides/changesets/releases.md
@@ -22,7 +22,7 @@ end
 
 Only changesets on the list will be shown to clients. The `release ...` configuration in the changeset will be compared to `context[:changeset_version]` to determine if the changeset applies to the current request.
 
-### Inspecting Releases
+## Inspecting Releases
 
 To preview releases, you can create schema dumps by passing `context: { changeset_version: ... }` to {{ "Schema.to_definition" | api_doc }}.
 

--- a/guides/css/main.scss
+++ b/guides/css/main.scss
@@ -391,6 +391,47 @@ table {
     }
   }
 }
+
+.table-of-contents {
+  float: right;
+  border: 1px solid #aaaaaa;
+  border-radius: 3px;
+  padding: 15px;
+  margin: 0 10px 10px 10px;
+  width: 300px;
+  background: #fafafa;
+  .contents-header {
+    margin: 0 0 5px 20px;
+  }
+  .contents-list {
+    margin: 0;
+
+    .contents-entry {
+      list-style: none;
+      margin-left: 0;
+
+      .section-count {
+        color: #777777;
+        width: 20px;
+        display: inline-block;
+      }
+
+      &.entry-depth-2 {
+        padding-left: 0px;
+      }
+      &.entry-depth-3 {
+        padding-left: 10px;
+      }
+      &.entry-depth-4 {
+        padding-left: 20px;
+      }
+      &.entry-depth-5 {
+        padding-left: 30px;
+      }
+    }
+  }
+}
+
 /* pygments CSS, github theme */
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */

--- a/guides/defer/stream.md
+++ b/guides/defer/stream.md
@@ -13,7 +13,7 @@ pro: true
 
 __Note:__ `@stream` was added in GraphQL-Pro 1.21.0 and requires GraphQL-Ruby 1.13.6+.
 
-### Installation
+## Installation
 
 To support `@stream` in your schema, add it with `use GraphQL::Pro::Stream`:
 
@@ -26,7 +26,7 @@ end
 
 Additionally, you should update your controller to handle deferred parts of the response. See the {% internal_link "@defer setup guide", "defer/setup#sending-streaming-responses" %} for details. (`@stream` uses the same deferral pipeline as `@defer`, so the same setup instructions apply.)
 
-### Usage
+## Usage
 
 After that, you can include `@stream` in your queries, for example:
 

--- a/guides/development.md
+++ b/guides/development.md
@@ -19,7 +19,7 @@ So, you want to hack on GraphQL Ruby! Here are some tips for getting started.
 - [Versioning](#versioning) describes how changes are managed and released
 - [Releasing](#releasing) Gem versions
 
-### Setup
+## Setup
 
 Get your own copy of graphql-ruby by forking [`rmosolgo/graphql-ruby` on GitHub](https://github.com/rmosolgo/graphql-ruby) and cloning your fork.
 
@@ -29,9 +29,9 @@ Then, install the dependencies:
 - `bundle install`
 - Optional: [Ragel](https://www.colm.net/open-source/ragel/) is required to build the lexer
 
-### Running the Tests
+## Running the Tests
 
-#### Unit tests
+### Unit tests
 
 You can run the tests with
 
@@ -65,7 +65,7 @@ bundle exec rake test
 
 (This is provided by `minitest-focus`.)
 
-#### Integration tests
+### Integration tests
 
 You need to pick a specific gemfile from gemfiles/ to run integration tests. For example:
 
@@ -74,7 +74,7 @@ BUNDLE_GEMFILE=gemfiles/rails_6.1.gemfile bundle install
 BUNDLE_GEMFILE=gemfiles/rails_6.1.gemfile bundle exec rake test TEST=spec/integration/rails/graphql/relay/array_connection_spec.rb
 ```
 
-#### Other tests
+### Other tests
 
 There are system tests for checking ActionCable behavior, use:
 
@@ -88,7 +88,7 @@ And JavaScript tests:
 bundle exec rake test:js
 ```
 
-### Gemfiles, Gemfiles, Gemfiles
+## Gemfiles, Gemfiles, Gemfiles
 
 `graphql-ruby` has several gemfiles to ensure support for various Rails versions. You can specify a gemfile with `BUNDLE_GEMFILE`, eg:
 
@@ -96,7 +96,7 @@ bundle exec rake test:js
 BUNDLE_GEMFILE=gemfiles/rails_5.gemfile bundle exec rake test
 ```
 
-### Debugging with Pry
+## Debugging with Pry
 
 [`pry`](https://pryrepl.org/) is included with GraphQL-Ruby's development setup to help with debugging.
 
@@ -108,7 +108,7 @@ binding.pry
 
 Then, the program will pause and your terminal will become a Ruby REPL. Feel free to use `pry` in your development process!
 
-### Running the Benchmarks
+## Running the Benchmarks
 
 This project includes some Rake tasks to record benchmarks:
 
@@ -135,7 +135,7 @@ Keep these points in mind when using benchmarks:
 - The results are hardware-specific: computers with different hardware will have different results. So don't compare your results to results from other computers.
 - The results are environment-specific: CPU and memory availability are affected by other processes on your computer. So try to create similar environments for your before-and-after testing.
 
-### Coding Guidelines
+## Coding Guidelines
 
 GraphQL-Ruby uses a thorough test suite to make sure things work reliably day-after-day. Please include tests that describe your changes, for example:
 
@@ -145,7 +145,7 @@ GraphQL-Ruby uses a thorough test suite to make sure things work reliably day-af
 
 Don't fret about coding style or organization.  There's a minimal Rubocop config in `.rubocop.yml` which runs during CI. You can run it manually with `bundle exec rake rubocop`.
 
-### Lexer and Parser
+## Lexer and Parser
 
 The lexer and parser use a multistep build process:
 
@@ -157,7 +157,7 @@ To update the lexer or parser, you should update their corresponding _definition
 
 You will need Ragel to build the lexer (see above).
 
-#### Install Ragel and Colm on a Mac
+### Install Ragel and Colm on a Mac
 
 GraphQL Ruby requires Ragel 7.0.0.9 which is not available on Homebrew. To install it, you might have to download it from source.
 
@@ -181,7 +181,7 @@ make
 make install
 ```
 
-### Website
+## Website
 
 To update the website, update the `.md` files in `guides/`.
 
@@ -199,7 +199,7 @@ To publish the website with GitHub pages, run the Rake task:
 bundle exec rake site:publish
 ```
 
-#### Search Index
+### Search Index
 
 GraphQL-Ruby's search index is powered by Algolia. To update the index, you need the API key in an environment variable:
 
@@ -209,7 +209,7 @@ $ export ALGOLIA_API_KEY=...
 
 Without this key, the search index will fall out-of-sync with the website. Contact @rmosolgo to gain access to this key.
 
-#### API Docs
+### API Docs
 
 The GraphQL-Ruby website has its own rendered version of the gem's API docs. They're pushed to GitHub pages with a special process.
 
@@ -234,7 +234,7 @@ $ bundle exec rake site:publish
 
 Finally, check your work by visiting the docs on the website.
 
-### Versioning
+## Versioning
 
 GraphQL-Ruby does _not_ attempt to deliver "semantic versioning" for the reasons described in `jashkenas`'
 s post, ["Why Semantic Versioning Isn't"](https://gist.github.com/jashkenas/cbd2b088e20279ae2c8e). Instead, the following scheme is used as a guideline:
@@ -250,7 +250,7 @@ Pull requests and issues may be tagged with a [GitHub milestone](https://github.
 
 The [changelog](https://github.com/rmosolgo/graphql-ruby/blob/master/CHANGELOG.md) should always contain accurate and thorough information so that users can upgrade. If you have trouble upgrading based on the changelog, please open an issue on GitHub.
 
-### Releasing
+## Releasing
 
 GraphQL-Ruby doesn't have a strict release schedule. If you think it should, consider opening an issue to share your thoughts.
 
@@ -260,7 +260,7 @@ To cut a release:
   - Add a new heading for the new version, and paste the four categories of changes into the new section
   - Open the GitHub milestone corresponding to the new version
   - Check each pull request and put it in the category (or categories) that it belongs in
-    - If a change affects the default behavior of GraphQL-Ruby in a disruptive way, add it to `### Breaking Changes` and include migration notes if possible
+    - If a change affects the default behavior of GraphQL-Ruby in a disruptive way, add it to `## Breaking Changes` and include migration notes if possible
     - Include the PR number beside the change description for future reference
 - Update `lib/graphql/version.rb` with the new version number
 - Commit changes to master

--- a/guides/fields/arguments.md
+++ b/guides/fields/arguments.md
@@ -22,7 +22,7 @@ def search_posts(category:)
 end
 ```
 
-### Nullability
+## Nullability
 
 To make an argument optional, set `required: false`, and set default values for the corresponding keyword arguments:
 
@@ -52,7 +52,7 @@ def search_posts(**args)
 end
 ```
 
-#### Default Values
+### Default Values
 
 Another approach is to use `default_value: value` to provide a default value for the argument if it is not supplied in the query.
 
@@ -81,7 +81,7 @@ argument :email_address, String, required: :nullable
 ```
 
 
-### Deprecation
+## Deprecation
 
 **Experimental:** __Deprecated__ arguments can be marked by adding a `deprecation_reason:` keyword argument:
 
@@ -94,7 +94,7 @@ end
 
 Note argument deprecation is a stage 2 GraphQL [proposal](https://github.com/graphql/graphql-spec/pull/525) so not all clients will leverage this information.
 
-### Aliasing
+## Aliasing
 
 Use `as: :alternate_name` to use a different key from within your resolvers while
 exposing another key to clients.
@@ -109,7 +109,7 @@ def post(id:)
 end
 ```
 
-### Preprocessing
+## Preprocessing
 
 Provide a `prepare` function to modify or validate the value of an argument before the field's resolver method is executed:
 
@@ -127,7 +127,7 @@ def posts(start_date:)
 end
 ```
 
-### Automatic camelization
+## Automatic camelization
 
 Arguments that are snake_cased will be camelized in the GraphQL schema. Using the example of:
 
@@ -167,7 +167,7 @@ def posts(start_year:)
 end
 ```
 
-### Valid Argument Types
+## Valid Argument Types
 
 Only certain types are valid for arguments:
 

--- a/guides/fields/introduction.md
+++ b/guides/fields/introduction.md
@@ -26,7 +26,7 @@ The different elements of field definition are addressed below:
 - [Extra field metadata](#extra-field-metadata) for low-level access to the GraphQL-Ruby runtime
 - [Add default values for field parameters](#field-parameter-default-values)
 
-### Field Return Type
+## Field Return Type
 
 The second argument to `field(...)` is the return type. This can be:
 
@@ -50,7 +50,7 @@ field :teammates, [Types::User], null: false # `[User!]!`, always returns a list
 field :scores, [Integer, null: true] # `[Int]`, may return a list or `nil`, the list may contain a mix of `Integer`s and `nil`s
 ```
 
-### Field Documentation
+## Field Documentation
 
 Fields may be documented with a __description__ and may be __deprecated__.
 
@@ -79,7 +79,7 @@ field :email, String,
 
 Fields with a `deprecation_reason:` will appear as "deprecated" in GraphiQL.
 
-### Field Resolution
+## Field Resolution
 
 In general, fields return Ruby values corresponding to their GraphQL return types. For example, a field with the return type `String` should return a Ruby string, and a field with the return type `[User!]!` should return a Ruby array with zero or more `User` objects in it.
 
@@ -176,7 +176,7 @@ end
 
 Note that `resolver_method` _cannot_ be used in combination with `method` or `hash_key`.
 
-### Field Arguments
+## Field Arguments
 
 _Arguments_ allow fields to take input to their resolution. For example:
 
@@ -186,7 +186,7 @@ _Arguments_ allow fields to take input to their resolution. For example:
 
 Read more in the {% internal_link "Arguments guide", "/fields/arguments" %}
 
-### Extra Field Metadata
+## Extra Field Metadata
 
 Inside a field method, you can access some low-level objects from the GraphQL-Ruby runtime. Be warned, these APIs are subject to change, so check the changelog when updating.
 
@@ -219,7 +219,7 @@ At runtime, the requested runtime object will be passed to the field.
 
 __Custom extras__ are also possible. Any method on your field class can be passed to `extras: [...]`, and the value will be injected into the method. For example, `extras: [:owner]` will inject the object type who owns the field. Any new methods on your custom field class may be used, too.
 
-### Field Parameter Default Values
+## Field Parameter Default Values
 
 The field method requires you to pass `null:` keyword argument to determine whether the field is nullable or not. For another field you may want to override `camelize`, which is `true` by default. You can override this behavior by adding a custom field with overwritten `camelize` option, which is `true` by default.
 

--- a/guides/limiters/active_operations.md
+++ b/guides/limiters/active_operations.md
@@ -11,15 +11,15 @@ index: 2
 
 `GraphQL::Enterprise::ActiveOperationLimiter` prevents clients from running too many GraphQL operations at the same time. It uses {% internal_link "Redis", "limiters/redis" %} to track currently-running operations.
 
-### Why?
+## Why?
 
 Some clients may suddently swamp a server with tons of requests, occupying all available Ruby processes and therefore interrupting service for other clients. This limiter aims to prevent that at the GraphQL level by halting queries when a client already has lots of queries running. That way, server processes will remain available for other clients' requests.
 
-### Setup
+## Setup
 
 To use this limiter, update the schema configuration and include `context[:limiter_key]` in your queries.
 
-##### Schema Setup
+#### Schema Setup
 
 To setup the schema, add `use GraphQL::Enterprise::ActiveOperationLimiter` with a default `limit:` value:
 
@@ -38,7 +38,7 @@ It also accepts a `stale_request_seconds:` option. The limiter uses that value t
 
 Before requests will actually be halted, ["soft mode"](#soft-limits) must be disabled as described below.
 
-##### Query Setup
+#### Query Setup
 
 In order to limit clients, the limiter needs a client identifier for each GraphQL operation. By default, it checks `context[:limiter_key]` to find it:
 
@@ -57,7 +57,7 @@ Operations with the same `context[:limiter_key]` will rate limited in the same b
 
 To provide a client identifier another way, see [Customization](#customization).
 
-### Soft Limits
+## Soft Limits
 
 By default, the limiter doesn't actually halt queries; instead, it starts out in "soft mode". In this mode:
 
@@ -73,7 +73,7 @@ To disable "soft mode" and start limiting, use the [Dashboard](#dashboard) or [c
 MySchema.enterprise_active_operation_limiter.set_soft_limit(false)
 ```
 
-### Dashboard
+## Dashboard
 
 Once installed, your {% internal_link "GraphQL-Pro dashboard", "/pro/dashboard" %} will include a simple metrics view:
 
@@ -87,7 +87,7 @@ Also, the dashboard includes a link to enable or disable "soft mode":
 
 When "soft mode" is enabled, limited requests are _not_ actually halted (although they are _counted_). When "soft mode" is disabled, any over-limit requests are halted.
 
-### Customization
+## Customization
 
 `GraphQL::Enterprise::ActiveOperationLimiter` provides several hooks for customizing its behavior. To use these, make a subclass of the limiter and override methods as described:
 
@@ -105,7 +105,7 @@ The hooks are:
 - `def soft_limit?(key, query)` can be implemented to customize the application of "soft mode". By default, it checks a setting in redis.
 - `def handle_redis_error(err)` is called when the limit rescues an error from Redis. By default, it's passed to `warn` and the query is _not_ halted.
 
-### Instrumentation
+## Instrumentation
 
 While the limiter is installed, it adds some information to the query context about its operation. It can be acccessed at `context[:active_operation_limiter]`:
 

--- a/guides/limiters/redis.md
+++ b/guides/limiters/redis.md
@@ -11,7 +11,7 @@ index: 1
 
 Rate limiting requires persistent Redis instance, just like [Sidekiq](https://github.com/mperham/sidekiq/wiki/Using-Redis) or the {% internal_link "Operation Store", "/operation_store/redis_backend" %}. Set `maxmemory-policy noeviction` in `redis.conf` to ensure that Redis doesn't silently drop keys when it reaches its memory limit.
 
-### Memory Usage
+## Memory Usage
 
 Estimating memory usage depends on the string used to identify clients, since those are used in the Redis keys. Using 100-character client keys, the runtime limiter uses 400 bytes per client (two keys). Memory usage by the active operation limiter depends on the limit because each concurrent operation uses some memory; a higher limit permits more concurrent operations. With 10 active operations and a 100-character client key, the active operation limiter uses 350 bytes per client. Additionally, the limiters use up to 35kb for dashboards (2 limiters, for each one: 2x 60 per-minute keys, 24 hourly keys, and 30 daily keys @ 72 bytes per key).
 

--- a/guides/limiters/runtime.md
+++ b/guides/limiters/runtime.md
@@ -11,15 +11,15 @@ index: 3
 
 `GraphQL::Enterprise::RuntimeLimiter` applies an upper bound to processing time consumed by a single client. It uses {% internal_link "Redis", "limiters/redis" %} track time with a [token bucket](https://en.wikipedia.org/wiki/Token_bucket) algorithm.
 
-### Why?
+## Why?
 
 This limiter prevents a single client from consuming too much processing time, regardless of whether it comes a burst of short-lived queries (which the {% internal_link "Active Operation Limiter", "/limiters/active_operations" %} can prevent) or a small number of long-running queries. Unlike request counters or complexity calculations, the runtime limiter pays no attention to the structure of the incoming request. Instead, it simply measures the time spent on the request _as a whole_ and halts queries when a client consumes more than the limit.
 
-### Setup
+## Setup
 
 To use this limiter, update the schema configuration and include `context[:limiter_key]` in your queries.
 
-##### Schema Setup
+### Schema Setup
 
 To setup the schema, add `use GraphQL::Enterprise::RuntimeLimiter` with a default `limit_ms:` value:
 
@@ -38,7 +38,7 @@ It also accepts a `window_ms:` option, which is the duration over which `limit_m
 
 Before requests will actually be halted, ["soft mode"](#soft-limits) must be disabled as described below.
 
-##### Query Setup
+### Query Setup
 
 In order to limit clients, the limiter needs a client identifier for each GraphQL operation. By default, it checks `context[:limiter_key]` to find it:
 
@@ -57,7 +57,7 @@ Operations with the same `context[:limiter_key]` will rate limited in the same b
 
 To provide a client identifier another way, see [Customization](#customization).
 
-### Soft Limits
+## Soft Limits
 
 By default, the limiter doesn't actually halt queries; instead, it starts out in "soft mode". In this mode:
 
@@ -74,7 +74,7 @@ MySchema.enterprise_runtime_limiter.set_soft_limit(false)
 ```
 
 
-### Dashboard
+## Dashboard
 
 Once installed, your {% internal_link "GraphQL-Pro dashboard", "/pro/dashboard" %} will include a simple metrics view:
 
@@ -88,7 +88,7 @@ Also, the dashboard includes a link to enable or disable "soft mode":
 
 When "soft mode" is enabled, limited requests are _not_ actually halted (although they are _counted_). When "soft mode" is disabled, any over-limit requests are halted.
 
-### Customization
+## Customization
 
 `GraphQL::Enterprise::RuntimeLimiter` provides several hooks for customizing its behavior. To use these, make a subclass of the limiter and override methods as described:
 
@@ -106,7 +106,7 @@ The hooks are:
 - `def soft_limit?(key, query)` can be implemented to customize the application of "soft mode". By default, it checks a setting in redis.
 - `def handle_redis_error(err)` is called when the limit rescues an error from Redis. By default, it's passed to `warn` and the query is _not_ halted.
 
-### Instrumentation
+## Instrumentation
 
 While the limiter is installed, it adds some information to the query context about its operation. It can be acccessed at `context[:runtime_limiter]`:
 
@@ -136,7 +136,7 @@ You could use this to add detailed metrics to your application monitoring system
 MyMetrics.increment("graphql.runtime_limiter", tags: result.context[:runtime_limiter])
 ```
 
-### Some Caveats
+## Some Caveats
 
 The limiter will not _interrupt_ a long-running field. Instead, it stops executing new fields after a client exceeds its allowed processing time. This is because interrupting arbitrary code may have unintended consequences for I/O operations, see ["Timeout: Ruby's most dangerous API"](https://www.mikeperham.com/2015/05/08/timeout-rubys-most-dangerous-api/).
 

--- a/guides/object_cache/redis.md
+++ b/guides/object_cache/redis.md
@@ -11,7 +11,7 @@ index: 3
 
 `GraphQL::Enterprise::ObjectCache` requires a Redis connection to store cached responses. Unlike `OperationStore` or rate limiters, this Redis instance should be configured to evict keys as needed.
 
-### Data Structure
+## Data Structure
 
 Under the hood, `ObjectCache` stores a mapping of queries and objects. Additionally, there are back-references from objects to queries that reference them. In general, like this:
 
@@ -33,7 +33,7 @@ Under the hood, `ObjectCache` stores a mapping of queries and objects. Additiona
 
 These mappings enable proper clean-up when queries or objects are expired from the cache. Additionally, whenever `ObjectCache` finds incomplete data in storage (for example, a necessary key was evicted), then it invalidates the whole query and re-runs it.
 
-### Memory Management
+## Memory Management
 
 Memory consumption is hard to estimate since it depends on how many queries the cache receives, how many objects those queries reference, how big the response is for those queries, and how long the fingerprints are for each object and query. To manage memory, configure the Redis instance with a `maxmemory` and `maxmemory-policy` directive, for example:
 

--- a/guides/object_cache/runtime_considerations.md
+++ b/guides/object_cache/runtime_considerations.md
@@ -11,11 +11,11 @@ index: 4
 
 With caching configured, here are a few more things to keep in mind while queries are running.
 
-### Skipping the cache
+## Skipping the cache
 
 You can set `skip_object_cache: true` in your query `context: { ... }` to disable `ObjectCache` for a given query.
 
-### Manually adding an object to caching
+## Manually adding an object to caching
 
 By default, `ObjectCache` gathers the objects "behind" each GraphQL object in the result, then uses their fingerprints as cache keys. To manually register another object with the cache while a query is running, call `cacheable_object(...)`, passing the object. For example:
 
@@ -39,7 +39,7 @@ end
 
 (When the cache is disabled, `cacheable_object(...)` is a no-op.)
 
-### Measuring the cache
+## Measuring the cache
 
 While the cache is running, it logs some data in a Hash as `context[:object_cache]`. For example:
 

--- a/guides/object_cache/schema_setup.md
+++ b/guides/object_cache/schema_setup.md
@@ -11,7 +11,7 @@ index: 1
 
 To prepare the schema to serve cached responses, you have to add `GraphQL::Enterprise::ObjectCache` and implement a few hooks.
 
-### Add the Cache
+## Add the Cache
 
 In your schema, add `use GraphQL::Enterprise::ObjectCache, redis: ...`:
 
@@ -28,7 +28,7 @@ Additionally, it accepts some options for customizing how introspection is cache
 - `cache_introspection: { public: false }` to use {% internal_link "`public: false`", "/object_cache/caching#public" %} for all introspection fields. Use this if you hide schema members for some clients.
 - `cache_introspection: false` to completely disable caching on introspection fields.
 
-### Context Fingerprint
+## Context Fingerprint
 
 Additionally, you should implement `def self.private_context_fingerprint_for(context)` to return a string identifying the private scope of the given context. This method will be called whenever a query includes a {% internal_link "`public: false` type or field", "/object_cache/caching#public" %}. For example:
 
@@ -54,7 +54,7 @@ Whenever queries including `public: false` are cached, the private context finge
 
 The returned String should reflect any aspects of `context` that, if changed, should invalidate the cache. For example, if a user's permission level or team memberships change, then any previously-cached responses should be ignored.
 
-### Object Fingerprint
+## Object Fingerprint
 
 In order to determine whether cached results should be returned or invalidated, GraphQL needs a way to determine the "version" of each object in the query. It uses `Schema.object_fingerprint_for(object)` to do this. By default, it checks `.cache_key_with_version` (implemented by Rails), then `.to_param`, then it returns `nil`. Returning `nil` tells the cache not to use the cache _at all_. To customize this behavior, you can implement `def self.object_fingerprint_for(object)` in your schema:
 
@@ -78,7 +78,7 @@ end
 
 The returned strings are used as cache keys in the database -- whenever they change, stale data is left to be {% internal_link "cleaned up by Redis", "/object_cache/redis#memory-management" %}.
 
-### Object Identification
+## Object Identification
 
 `ObjectCache` depends on object identification hooks used elsewhere in GraphQL-Ruby:
 

--- a/guides/operation_store/client_workflow.md
+++ b/guides/operation_store/client_workflow.md
@@ -18,7 +18,7 @@ To use persisted queries with your client application, you must:
 
 This documentation also touches on {% internal_link "graphql-ruby-client sync", "/javascript_client/sync" %}, a JavaScript client library for using `OperationStore`.
 
-### Add a Client
+## Add a Client
 
 Clients are registered via {% internal_link "the dashboard","/operation_store/getting_started#add-routes" %}:
 
@@ -28,7 +28,7 @@ A default `secret` is provided for you, but you can also enter your own. The `se
 
 (Are you interested in a Ruby API for this? Please {% open_an_issue "OperationStore Ruby API" %} or email `support@graphql.pro`.)
 
-### Syncing
+## Syncing
 
 Once a client is registered, it can push queries to the server via {% internal_link "the Sync API","/operation_store/getting_started#add-routes" %}.
 
@@ -47,7 +47,7 @@ For example:
 
 For help syncing in another language, you can take inspiration from the [JavaScript implementation](https://github.com/rmosolgo/graphql-ruby/tree/master/javascript_client), {% open_an_issue "Implementing operation sync in another language" %}, or email `support@graphql.pro`.
 
-### Client Usage
+## Client Usage
 
 See the {% internal_link "Sync Guide", "/javascript_client/sync" %} for using OperationStore with Relay Modern, Apollo 1.x, Apollo Link, or plain JavaScript.
 
@@ -64,6 +64,6 @@ To run stored operations from another client, send a param called `operationId` 
 
 The server will use those values to fetch an operation from the database.
 
-#### Next Steps
+### Next Steps
 
 Learn more about `OperationStore`'s {% internal_link "authentication", "/operation_store/access_control" %} or read some tips for {% internal_link "server management","/operation_store/server_management" %}.

--- a/guides/operation_store/getting_started.md
+++ b/guides/operation_store/getting_started.md
@@ -18,7 +18,7 @@ To use `GraphQL::Pro::OperationStore` with your app, follow these steps:
 - [Update your controller](#update-the-controller) to support persisted queries
 - {% internal_link "Add a client","/operation_store/client_workflow" %} to start syncing queries
 
-#### Dependencies
+## Dependencies
 
 `OperationStore` requires two gems in your application environment:
 
@@ -27,11 +27,11 @@ To use `GraphQL::Pro::OperationStore` with your app, follow these steps:
 
 These are bundled with Rails by default.
 
-#### Prepare the Database
+## Prepare the Database
 
 If you're going to store data with ActiveRecord, {% internal_link "migrate the database", "/operation_store/active_record_backend" %} to prepare tables for it.
 
-#### Add `OperationStore`
+## Add `OperationStore`
 
 To hook up the storage to your schema, add the plugin:
 
@@ -47,7 +47,7 @@ By default, it uses `ActiveRecord`. It also accepts:
 - `redis:`, for using a {% internal_link "Redis backend", "/operation_store/redis_backend" %}; OR
 - `backend_class:`, for implementing custom persistence.
 
-#### Add Routes
+## Add Routes
 
 To use `OperationStore`, add two routes to your app:
 
@@ -84,7 +84,7 @@ mount lazy_routes.dashboard, at: "/graphql/dashboard"
 mount lazy_routes.operation_store_sync, at: "/graphql/sync"
 ```
 
-#### Update the Controller
+## Update the Controller
 
 Add `operation_id:` to your GraphQL context:
 
@@ -107,6 +107,6 @@ MySchema.execute(
 
 See {% internal_link "Server Management","/operation_store/server_management" %} for details about rejecting GraphQL from `params[:query]`.
 
-#### Next Steps
+## Next Steps
 
 Sync your operations with the {% internal_link "Client Workflow","/operation_store/client_workflow" %}.

--- a/guides/operation_store/overview.md
+++ b/guides/operation_store/overview.md
@@ -26,7 +26,7 @@ In other guides, you can read more about:
 
 Also, you can find a [demo app on GitHub](https://github.com/rmosolgo/graphql-pro-operation-store-example).
 
-### What are Persisted Queries?
+## What are Persisted Queries?
 
 _Persisted queries_ are GraphQL queries (`query`, `mutation`, or `subscription`) that are saved on the server and invoked by clients by _reference_. In this arrangement, clients don't send GraphQL queries over the network. Instead, clients send:
 
@@ -61,12 +61,12 @@ MyGraphQLEndpoint.post({
 })
 ```
 
-### Why Persisted Queries?
+## Why Persisted Queries?
 
 Using persisted queries improves the _security_, _efficiency_ and _visibility_ of your GraphQL system.
 
 
-#### Security
+### Security
 
 Persisted queries improve security because you can reject arbitrary GraphQL queries, removing an attack vector from your system. The query database serves a whitelist, so you can be sure that no unexpected queries will hit your system.
 
@@ -82,7 +82,7 @@ else
 end
 ```
 
-#### Efficiency
+### Efficiency
 
 Persisted queries improve the _efficiency_ of your system by reducing HTTP traffic. Instead of repeatedly sending GraphQL over the wire, queries are fetched from the database, so your requests require less bandwidth.
 
@@ -94,13 +94,13 @@ But _after_ using persisted queries, only the query identification info is sent 
 
 {{ "/operation_store/request_after.png" | link_to_img:"GraphQL request with persisted queries" }}
 
-#### Visibility
+### Visibility
 
 Persisted queries improve _visibility_ because you can track GraphQL usage from a single location. `OperationStore` maintains an index of type, field and argument usage so that you can analyze your traffic.
 
 {{ "/operation_store/operation_index.png" | link_to_img:"Index of GraphQL usage with persisted queries" }}
 
-### How it Works
+## How it Works
 
 `OperationStore` uses tables in your database to store normalized, deduplicated GraphQL strings. The database is immutable: new operations may be added, but operations are never modified or removed.
 
@@ -114,6 +114,6 @@ params[:operationId] # => "relay-app-v1/810c97f6631001..."
 
 `OperationStore` uses this to fetch the matching operation from the database. From there, the query is evaluated normally.
 
-### Getting Started
+## Getting Started
 
 See the {% internal_link "getting started guide","/operation_store/getting_started" %} to add `OperationStore` to your app.

--- a/guides/operation_store/server_management.md
+++ b/guides/operation_store/server_management.md
@@ -11,7 +11,7 @@ pro: true
 
 After {% internal_link "getting started","/operation_store/getting_started" %}, here some things to keep in mind.
 
-### Rejecting Arbitrary Queries
+## Rejecting Arbitrary Queries
 
 With persisted queries, you can stop accepting arbitrary GraphQL input. This way, malicious users can't run large or inappropriate queries on your server.
 
@@ -53,7 +53,7 @@ MySchema.execute(
 )
 ```
 
-### Archiving and Deleting Data
+## Archiving and Deleting Data
 
 Clients can only _add_ to the database, but as an administrator, you can also archive or delete entries from the database. (Make sure you {% internal_link "authorize access to the Dashboard","/pro/dashboard" %}.) This is a dangerous operation: by archiving or deleting something, any clients who depend on that data will crash.
 
@@ -66,7 +66,7 @@ If this is true, you can use "Archive" or "Delete" buttons to remove things from
 
 When an operation is archived, it's no longer available to clients, but it's still in the database. It can be unarchived later, so this is lower-risk than full deletion.
 
-### Integration with Your Application
+## Integration with Your Application
 
 It's on the road map to add a Ruby API to `OperationStore` so that you can integrate it with your application. For example, you might:
 

--- a/guides/pro/privacy.md
+++ b/guides/pro/privacy.md
@@ -10,12 +10,7 @@ index: 7
 
 The following statement describes what data GraphQL::Pro collects during normal operation and how that data is used.
 
-- [What Data We Collect And How It's Used](#what-data-we-collect-and-how-its-used)
-- [Third-Party Services](#third-party-services)
-- [Data Security](#data-security)
-- [More Information](#more-information)
-
-### What Data We Collect And How It's Used
+## What Data We Collect And How It's Used
 
 GraphQL::Pro collects the following kinds of data:
 
@@ -30,7 +25,7 @@ The `graphql-pro` Ruby gem collects no data and never "phones home" for any purp
 
 GraphQL::Pro is not directed at children under the age of 13. If you are under age 13, please do not use GraphQL::Pro.
 
-### Third-Party Services
+## Third-Party Services
 
 Use of GraphQL::Pro includes the following third-party services:
 
@@ -46,13 +41,13 @@ Stripe | Payment Processing
 MailChimp | Newsletter Management
 Google Apps | Company Infrastructure
 
-### Data Security
+## Data Security
 
 GraphQL::Pro does not collect ["Sensitive Personal Information"](https://gdpr-info.eu/art-9-gdpr/). GraphQL::Pro's systems are secured with strong, unique passwords and two-factor authentication is enabled wherever possible.
 
 You are responsible for using a strong, unique password to log into https://billing.graphql.pro.
 
-### More Information
+## More Information
 
 This document is managed [on GitHub](https://github.com/rmosolgo/graphql-ruby/blob/master/guides/pro/privacy.md). You can use a GitHub account to watch for changes or subscribe to a [public RSS feed](https://github.com/rmosolgo/graphql-ruby/commits/master.atom).
 

--- a/guides/queries/timeout.md
+++ b/guides/queries/timeout.md
@@ -20,7 +20,7 @@ After `max_seconds`, no new fields will be resolved. Instead, errors will be add
 
 __Note__ that this _does not interrupt_ field execution (doing so is [buggy](https://www.mikeperham.com/2015/05/08/timeout-rubys-most-dangerous-api/)). If you're making external calls (eg, HTTP requests or database queries), make sure to use a library-specific timeout for that operation (eg, [Redis timeout](https://github.com/redis/redis-rb#timeouts), [Net::HTTP](https://ruby-doc.org/stdlib-2.4.1/libdoc/net/http/rdoc/Net/HTTP.html)'s `ssl_timeout`, `open_timeout`, and `read_timeout`).
 
-### Custom Error Handling
+## Custom Error Handling
 
 To log the error, provide a subclass of `GraphQL::Schema::Timeout` with an overridden `handle_timeout` method:
 
@@ -36,7 +36,7 @@ class MySchema < GraphQL::Schema
 end
 ```
 
-### Customizing the Timeout Window
+## Customizing the Timeout Window
 
 To dynamically pick a timeout duration (or bypass it), override {{ "GraphQL::Schema::Timeout#max_seconds" | api_doc }} in your subclass. To bypass the timeout altogether, `max_seconds` can return `false`.
 
@@ -63,7 +63,7 @@ class MySchema < GraphQL::Schema
 end
 ```
 
-### Validation
+## Validation
 
 Queries can originate from a user, and may be crafted in a manner to take a long time to validate against the schema.
 

--- a/guides/schema/definition.md
+++ b/guides/schema/definition.md
@@ -8,6 +8,7 @@ desc: Defining your schema
 index: 1
 ---
 
+
 A GraphQL system is called a _schema_. The schema contains all the types and fields in the system. The schema executes queries and publishes an {% internal_link "introspection system","/schema/introspection" %}.
 
 Your GraphQL schema is a class that extends {{ "GraphQL::Schema" | api_doc }}, for example:

--- a/guides/schema/dynamic_types.md
+++ b/guides/schema/dynamic_types.md
@@ -14,11 +14,11 @@ At runtime, ensure that only one object is visible per name (type name, field na
 
 When using dynamic schema members, be sure to include the relevant `context: ...` when [generating schema definition files](#schema-dumps).
 
-### Different fields
+## Different fields
 
 You can customize which field definitions are used for each operation.
 
-#### Using `#visible?(context)`
+### Using `#visible?(context)`
 
 To serve different fields to different clients, implement `def visible?(context)` in your {% internal_link "base field class", "/type_definitions/extensions#customizing-fields" %}:
 
@@ -58,7 +58,7 @@ field :comments, Types::Comment.connection_type, null: false,
 
 With that configuration, `post { comments { ... } }` will use `def moderated_comments` when `context[:current_user]` is `nil` or is not `.staff?`, but when `context[:current_user].staff?` is `true`, it will use `def all_comments` instead.
 
-#### Using `.fields(context)`
+### Using `.fields(context)`
 
 To customize the set of fields used at runtime, you can implement `def self.fields(context)` in your type classes, for example:
 
@@ -76,15 +76,15 @@ end
 
 It should return a Hash of `{ String => GraphQL::Schema::Field }`.
 
-#### Hidden Return Types
+### Hidden Return Types
 
 Besides field visibility described above, if an field's return type is hidden (that is, it implements `self.visible?(context)` to return `false`), then the field will be hidden too.
 
-### Different arguments
+## Different arguments
 
 As with fields, you can use different sets of argument definitions for different GraphQL operations.
 
-#### Using `#visible?(context)`
+### Using `#visible?(context)`
 
 To serve different arguments to different clients, implement `def visible?(context)` in your {% internal_link "base argument class", "/type_definitions/extensions#customizing-arguments" %}:
 
@@ -126,17 +126,17 @@ end
 
 That way, any staff client will have the option of `id` or `databaseId` while non-staff clients must use `id`.
 
-#### Using `def arguments(context)`
+### Using `def arguments(context)`
 
 Also, you can implement `def arguments(context)` on your base field class to return a Hash of `{ String => GraphQL::Schema::Argument }`. If you take this approach, you might want some custom field classes for any types or resolvers that use `def arguments(context)`. That way, you don't have to reimplement the method for _all_ the fields in the schema.
 
-#### Hidden Input Types
+### Hidden Input Types
 
 Besides argument visibility described above, if an argument's input type is hidden (that is, it implements `self.visible?(context)` to return `false`), then the argument will be hidden too.
 
-### Different enum values
+## Different enum values
 
-#### Using `#visible?(context)`
+### Using `#visible?(context)`
 
 You can implement `def visible?(context)` in your {% internal_link "base enum value class", "/type_definitions/extensions#customizing-enum-values" %} to hide some enum values from some clients. For example:
 
@@ -175,7 +175,7 @@ class AccountStatus < Types::BaseEnum
 end
 ```
 
-#### Using `.enum_values(context)`
+### Using `.enum_values(context)`
 
 Alternatively, you can implement `def self.enum_values(context)` in your enum types to return an Array of {{ "GraphQL::Schema::EnumValue" | api_doc }}s. For example, to return a dynamic set of enum values:
 
@@ -194,7 +194,7 @@ class ProjectStatus < Types::BaseEnum
 end
 ```
 
-### Different types
+## Different types
 
 You can also use different types for each query. A few behaviors depend on the methods defined above:
 
@@ -205,7 +205,7 @@ You can also use different types for each query. A few behaviors depend on the m
 
 As you can imagine, these different hiding behaviors influence one another and they can cause some real head-scratchers when used simultaneously.
 
-#### Using `.visible?(context)`
+### Using `.visible?(context)`
 
 Type classes can implement `def self.visible?(context)` to hide themselves at runtime:
 
@@ -221,7 +221,7 @@ class Types::BanReason < Types::BaseEnum
 end
 ```
 
-#### Different definitions for the same type
+### Different definitions for the same type
 
 You can provide different implementations of the same type by:
 
@@ -283,7 +283,7 @@ end
 
 Input types (like input objects, scalars, and enums) work the same way with argument definitions.
 
-### Schema Dumps
+## Schema Dumps
 
 To dump a certain _version_ of the schema, provide the applicable `context: ...` to {{ "Schema.to_definition" | api_doc }}. For example:
 

--- a/guides/schema/object_identification.md
+++ b/guides/schema/object_identification.md
@@ -44,7 +44,7 @@ class MySchema < GraphQL::Schema
 end
 ```
 
-### Node interface
+## Node interface
 
 One requirement for Relay's object management is implementing the `"Node"` interface.
 
@@ -77,7 +77,7 @@ class MySchema < GraphQL::Schema
 end
 ```
 
-### UUID fields
+## UUID fields
 
 Nodes must have a field named `"id"` which returns a globally unique ID.
 
@@ -91,7 +91,7 @@ end
 
 This field will call the previously-defined `id_from_object` class method.
 
-### `node` field (find-by-UUID)
+## `node` field (find-by-UUID)
 
 You should also provide a root-level `node` field so that Relay can refetch objects from your schema. You can attach it like this:
 
@@ -104,7 +104,7 @@ class Types::QueryType < GraphQL::Schema::Object
 end
 ```
 
-### `nodes` field
+## `nodes` field
 
 You can also provide a root-level `nodes` field so that Relay can refetch objects by IDs:
 

--- a/guides/subscriptions/multi_tenant.md
+++ b/guides/subscriptions/multi_tenant.md
@@ -10,7 +10,7 @@ index: 8
 
 In a multi-tenant system, data from many different accounts is stored on the same server. (An account might be an organization, a customer, a namespace, a domain, etc -- these are all _tenants_.) Gems like [Apartment](https://github.com/influitive/apartment) assist with this arrangement, but it can also be implemented in the application. Here are a few considerations for this architecture when using GraphQL subscriptions.
 
-#### Add Tenant to `context`
+## Add Tenant to `context`
 
 All the approaches below will use `context[:tenant]` to identify the tenant during GraphQL execution, so make sure to assign it before executing a query:
 
@@ -24,7 +24,7 @@ context = {
 MySchema.execute(query_str, context: context, ...)
 ```
 
-#### Tenant-based `subscription_scope`
+## Tenant-based `subscription_scope`
 
 When subscriptions are delivered, {% internal_link "`subscription_scope`",  "subscriptions/subscription_classes#scope" %} is one element used to route data to the right subscriber. In short, it's the _implicit_ identifier for the receiver. In a multi-tenant architecture, `subscription_scope` should reference the context key that names the tenant, for example:
 
@@ -52,7 +52,7 @@ BudgetSchema.subscriptions.trigger(:budget_was_approved, {}, { ... }, scope: 123
 
 As long as `project_id` is unique among _all_ tenants, that would work fine too. But _some_ scope is required so that subscriptions can be disambiguated between tenants.
 
-#### Choosing a tenant for execution
+## Choosing a tenant for execution
 
 There are a few places where subscriptions might need to load data:
 

--- a/guides/subscriptions/overview.md
+++ b/guides/subscriptions/overview.md
@@ -16,25 +16,25 @@ _Subscriptions_ allow GraphQL clients to observe specific events and receive upd
 - The __Implementation__ provides application-specific methods for executing & delivering updates.
 - __Broadcasts__ can send the same GraphQL result to any number of subscribers.
 
-### Subscription Type
+## Subscription Type
 
 `subscription` is an entry point to your GraphQL schema, like `query` or `mutation`. It is defined by your `SubscriptionType`, a root-level `GraphQL::Schema::Object`.
 
 Read more in the {% internal_link "Subscription Type guide", "subscriptions/subscription_type" %}.
 
-### Subscription Classes
+## Subscription Classes
 
 {{ "GraphQL::Schema::Subscription" | api_doc }} is a resolver class with subscription-specific behaviors. Each subscription field should be implemented by a subscription class.
 
 Read more in the {% internal_link "Subscription Classes guide", "subscriptions/subscription_classes" %}
 
-### Triggers
+## Triggers
 
 After an event occurs in our application, _triggers_ begin the update process by sending a name and payload to GraphQL.
 
 Read more in the {% internal_link "Triggers guide","subscriptions/triggers" %}.
 
-### Implementation
+## Implementation
 
 Besides the GraphQL component, your application must provide some subscription-related plumbing, for example:
 
@@ -44,10 +44,10 @@ Besides the GraphQL component, your application must provide some subscription-r
 
 Read more in the {% internal_link "Implementation guide", "subscriptions/implementation" %} or check out the {% internal_link "ActionCable implementation", "subscriptions/action_cable_implementation" %}, {% internal_link "Pusher implementation", "subscriptions/pusher_implementation" %} or {% internal_link "Ably implementation", "subscriptions/ably_implementation" %}.
 
-### Broadcasts
+## Broadcasts
 
 By default, the subscription implementations listed above handle each subscription in total isolation. However, this behavior can be optimized by setting up broadcasts. Read more in the {% internal_link "Broadcast guide", "subscriptions/broadcast" %}.
 
-### Multi-Tenant
+## Multi-Tenant
 
 See the {% internal_link "Multi-tenant guide", "subscriptions/multi_tenant" %} for supporting multi-tenancy in GraphQL subscriptions.

--- a/guides/type_definitions/field_extensions.md
+++ b/guides/type_definitions/field_extensions.md
@@ -10,7 +10,7 @@ index: 10
 
 {{ "GraphQL::Schema::FieldExtension" | api_doc }} provides a way to modify user-defined fields in a programmatic way. For example, Relay connections are implemented as a field extension ({{ "GraphQL::Schema::Field::ConnectionExtension" | api_doc }}).
 
-### Making a new extension
+## Making a new extension
 
 Field extensions are subclasses of {{ "GraphQL::Schema::FieldExtension" | api_doc }}:
 
@@ -19,7 +19,7 @@ class MyExtension < GraphQL::Schema::FieldExtension
 end
 ```
 
-### Using an extension
+## Using an extension
 
 Defined extensions can be added to fields using the `extensions: [...]` option or the `extension(...)` method:
 
@@ -33,7 +33,7 @@ end
 
 See below for how extensions may modify fields.
 
-### Modifying field configuration
+## Modifying field configuration
 
 When extensions are attached, they are initialized with a `field:` and `options:`. Then, `#apply` is called, when they may extend the field they're attached to. For example:
 
@@ -48,7 +48,7 @@ end
 
 This way, an extension can encapsulate a behavior requiring several configuration options.
 
-### Adding default argument configurations
+## Adding default argument configurations
 
 Extensions may provide _default_ argument configurations which are applied if the field doesn't define the argument for itself. The configuration is passed to {{ "Schema::FieldExtension.default_argument" | api_doc }}. For example, to define a `:query` argument if the field doesn't already have one:
 
@@ -62,7 +62,7 @@ end
 
 Additionally, extensions may implement `def after_define` which is called _after_ the field's `do .. . end` block. This is helpful when an extension should provide _default_ configurations without overriding anything in the field definition. (When extensions are added by calling `field.extension(...)` on an already-defined field `def after_define` is called immediately.)
 
-### Modifying field execution
+## Modifying field execution
 
 Extensions have two hooks that wrap field resolution. Since GraphQL-Ruby supports deferred execution, these hooks _might not_ be called back-to-back.
 
@@ -72,7 +72,7 @@ After resolution and _after_ syncing lazy values (like `Promise`s from `graphql-
 
 See the linked API docs for the parameters of those methods.
 
-#### Execution "memo"
+### Execution "memo"
 
 One parameter to `after_resolve` deserves special attention: `memo:`. `resolve` _may_ yield a third value. For example:
 
@@ -97,7 +97,7 @@ This allows the `resolve` hook to pass data to `after_resolve`.
 
 Instance variables may not be used because, in a given GraphQL query, the same field may be resolved several times concurrently, and that would result in overriding the instance variable in an unpredictable way. (In fact, extensions are frozen to prevent instance variable writes.)
 
-### Extension options
+## Extension options
 
 The `extension(...)` method takes an optional second argument, for example:
 
@@ -116,7 +116,7 @@ def after_resolve(value:, **rest)
 end
 ```
 
-### Using `extras`
+## Using `extras`
 
 Extensions can have the same `extras` as fields (see {% internal_link "Extra Field Metadata", "fields/introduction#extra-field-metadata" %}). Add them by calling `extras` in the class definition:
 
@@ -128,7 +128,7 @@ end
 
 Any configured `extras` will be present in the given `arguments`, but removed before the field is resolved. (However, `extras` from _any_ extension will be present in `arguments` for _all_ extensions.)
 
-### Adding an extension by default
+## Adding an extension by default
 
 If you want to apply an extension to _all_ your fields, you can do this in your {% internal_link "BaseField", "/type_definitions/extensions.html#customizing-fields" %}'s `def initialize`, for example:
 


### PR DESCRIPTION
I have been spending time with the Rails guides lately and I'm thinking of improving this site to be more like them. Here's the first step. 

- Rails guides: 

    ![image](https://user-images.githubusercontent.com/2231765/153301024-1a62d35b-c48c-49d9-b85e-fc44e314d0ae.png)

- This branch:

    ![image](https://user-images.githubusercontent.com/2231765/153301815-be53f8b1-0568-4cb0-8737-1e75c5d23966.png)
