### PR TITLE
[1.13] Pass class-based definitions to id_from_object when resolving global_id_field fields

### DIFF
--- a/lib/graphql/relay/global_id_resolve.rb
+++ b/lib/graphql/relay/global_id_resolve.rb
@@ -10,8 +10,7 @@ module GraphQL
         if obj.is_a?(GraphQL::Schema::Object)
           obj = obj.object
         end
-        type = @type.respond_to?(:graphql_definition) ? @type.graphql_definition(silence_deprecation_warning: true) : @type
-        ctx.query.schema.id_from_object(obj, type, ctx)
+        ctx.query.schema.id_from_object(obj, @type, ctx)
       end
     end
   end

--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -411,6 +411,9 @@ module StarWars
     end
 
     def self.id_from_object(object, type, ctx)
+      if !type.is_a?(Class)
+        raise "This handler should always receive a new-style class definition"
+      end
       GraphQL::Schema::UniqueWithinType.encode(type.graphql_name, object.id)
     end
 


### PR DESCRIPTION
Oops -- this field helper passed _legacy_ type definitions to `schema.id_from_object`, even for class-based types. That should be updated because legacy type definitions are gone in 2.0. 

Unfortunately, I'm not sure how to give a good deprecation warning in this case. If a Schema's `.id_from_object` method is being used by other GraphQL features (eg, `loads: ...`), then it will already be future-compatible. But for anyone _expecting_ a legacy type definition, this will break, and I don't know how to make that easier :( 

Fixes #3911 