### PR TITLE
Raise a more helpful error when a Dataloader::Source is used without a Dataloader

### DIFF
--- a/lib/graphql/dataloader/null_dataloader.rb
+++ b/lib/graphql/dataloader/null_dataloader.rb
@@ -11,7 +11,9 @@ module GraphQL
       # executed sychronously.
       def run; end
       def run_isolated; yield; end
-      def yield; end
+      def yield
+        raise GraphQL::Error, "GraphQL::Dataloader is not running -- add `use GraphQL::Dataloader` to your schema to use Dataloader sources."
+      end
 
       def append_job
         yield


### PR DESCRIPTION
Without this, it gave the "circular dependency" error message instead. Reported on Slack.