### PR TITLE
Improve error message (sometimes) caused by cyclical loading issues

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -503,7 +503,7 @@ module GraphQL
           # Not enough info to determine type
           message = "Can't determine the return type for #{self.path}"
           if @resolver_class
-            message += " (it has `resolver: #{@resolver_class}`, consider configuration a `type ...` for that class)"
+            message += " (it has `resolver: #{@resolver_class}`, perhaps that class is missing a `type ...` declaration, or perhaps its type causes a cyclical loading issue"
           end
           raise MissingReturnTypeError, message
         else


### PR DESCRIPTION
[The Resolver docs](https://graphql-ruby.org/fields/resolvers.html#nesting-resolvers-of-the-same-type) mentions the issue of cyclical loading issues and says they can case the error `Failed to build return type for Task.tasks from nil: Unexpected type input: (NilClass)`

However, the error I get when I cause this (Ruby 3.0.3, Zeitwerk, Rails 6.1.4.4) is [`Can't determine the return type for #{self.path} (it has `resolver: #{@resolver_class}`, consider configuration a `type ...` for that class)`](https://github.com/rmosolgo/graphql-ruby/blob/master/lib/graphql/schema/field.rb#L504-L506), which seems to indicate that an exception isn't being raised anymore by the resolver (since that would be caught in the `rescue` block right below this).

Since the error I was getting didn't match the documentation, it took a bit of time to track down the cause. Even a comment near where that error is raised would have been enough to realize it was caused by cyclical loading issues. I think the change I'm making here to the error message will help future implementors.

The clue here is that the field has a `@resolver_class` but a nil `@return_type_expr`, which I assume wouldn't have happened previously in the case of recursive resolution because the loader would have raised an error instead.

It seems there's no way to tell here whether the resolver class actually has a `type` declaration, so both cases will have the same error message. I can think ways to possibly improve this, but I'm not sure it's worth it.
