### PR TITLE
Same Interface Shows Up Multiple Times in "Implements"

### DIFF
--- a/lib/graphql/language/printer.rb
+++ b/lib/graphql/language/printer.rb
@@ -170,7 +170,7 @@ module GraphQL
       end
 
       def print_implements(type)
-        " implements #{type.interfaces.map(&:name).join(" & ")}"
+        " implements #{type.interfaces.map(&:name).uniq.join(" & ")}"
       end
 
       def print_input_value_definition(input_value)

--- a/lib/graphql/language/printer.rb
+++ b/lib/graphql/language/printer.rb
@@ -170,7 +170,7 @@ module GraphQL
       end
 
       def print_implements(type)
-        " implements #{type.interfaces.map(&:name).uniq.join(" & ")}"
+        " implements #{type.interfaces.map(&:name).join(" & ")}"
       end
 
       def print_input_value_definition(input_value)

--- a/lib/graphql/schema/member/has_interfaces.rb
+++ b/lib/graphql/schema/member/has_interfaces.rb
@@ -33,9 +33,9 @@ module GraphQL
             end
           end
 
-          # Remove any String or late-bound interfaces which are being replaced
           own_interface_type_memberships.reject! { |old_i_m|
             if !(old_i_m.respond_to?(:abstract_type) && old_i_m.abstract_type.is_a?(Module))
+              # Remove any String or late-bound interfaces which are being replaced
               old_int_type = old_i_m.respond_to?(:abstract_type) ? old_i_m.abstract_type : old_i_m
               old_name = Schema::Member::BuildType.to_type_name(old_int_type)
 
@@ -44,6 +44,11 @@ module GraphQL
                 new_name = Schema::Member::BuildType.to_type_name(new_int_type)
 
                 new_name == old_name
+              }
+            elsif old_i_m.respond_to?(:abstract_type)
+              # Remove any existing implementations of the same interface
+              new_memberships.any? { |new_i_m|
+                new_i_m.respond_to?(:abstract_type) && new_i_m.abstract_type == old_i_m.abstract_type
               }
             end
           }
@@ -80,7 +85,7 @@ module GraphQL
             visible_interfaces.concat(superclass.interfaces(context))
           end
 
-          visible_interfaces.uniq
+          visible_interfaces
         end
       end
     end

--- a/lib/graphql/schema/member/has_interfaces.rb
+++ b/lib/graphql/schema/member/has_interfaces.rb
@@ -33,9 +33,9 @@ module GraphQL
             end
           end
 
+          # Remove any String or late-bound interfaces which are being replaced
           own_interface_type_memberships.reject! { |old_i_m|
             if !(old_i_m.respond_to?(:abstract_type) && old_i_m.abstract_type.is_a?(Module))
-              # Remove any String or late-bound interfaces which are being replaced
               old_int_type = old_i_m.respond_to?(:abstract_type) ? old_i_m.abstract_type : old_i_m
               old_name = Schema::Member::BuildType.to_type_name(old_int_type)
 
@@ -44,11 +44,6 @@ module GraphQL
                 new_name = Schema::Member::BuildType.to_type_name(new_int_type)
 
                 new_name == old_name
-              }
-            elsif old_i_m.respond_to?(:abstract_type)
-              # Remove any existing implementations of the same interface
-              new_memberships.any? { |new_i_m|
-                new_i_m.respond_to?(:abstract_type) && new_i_m.abstract_type == old_i_m.abstract_type
               }
             end
           }
@@ -82,13 +77,10 @@ module GraphQL
           end
 
           if self.is_a?(Class) && superclass <= GraphQL::Schema::Object
-            # add interfaces from superclass if not already present
-            superclass.interfaces(context).each do |sc_int|
-              visible_interfaces << sc_int unless visible_interfaces.include?(sc_int)
-            end
+            visible_interfaces.concat(superclass.interfaces(context))
           end
 
-          visible_interfaces
+          visible_interfaces.uniq
         end
       end
     end

--- a/lib/graphql/schema/member/has_interfaces.rb
+++ b/lib/graphql/schema/member/has_interfaces.rb
@@ -80,7 +80,7 @@ module GraphQL
             visible_interfaces.concat(superclass.interfaces(context))
           end
 
-          visible_interfaces
+          visible_interfaces.uniq
         end
       end
     end

--- a/lib/graphql/schema/member/has_interfaces.rb
+++ b/lib/graphql/schema/member/has_interfaces.rb
@@ -82,7 +82,10 @@ module GraphQL
           end
 
           if self.is_a?(Class) && superclass <= GraphQL::Schema::Object
-            visible_interfaces.concat(superclass.interfaces(context))
+            # add interfaces from superclass if not already present
+            superclass.interfaces(context).each do |sc_int|
+              visible_interfaces << sc_int unless visible_interfaces.include?(sc_int)
+            end
           end
 
           visible_interfaces

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -556,6 +556,36 @@ type Thing implements Named & Node {
       assert_schema_and_compare_output(schema)
     end
 
+    it "only adds the interface to the type once" do
+      schema = <<-SCHEMA
+interface Named implements Node {
+  id: ID
+  name: String
+}
+
+interface Node {
+  id: ID
+}
+
+type Query {
+  thing: Thing
+}
+
+type Thing implements Named & Node & Timestamped {
+  id: ID
+  name: String
+  timestamp: String
+}
+
+interface Timestamped implements Node {
+  id: ID
+  timestamp: String
+}
+      SCHEMA
+
+      assert_schema_and_compare_output(schema)
+    end
+
     it 'supports simple output enum' do
       schema = <<-SCHEMA
 schema {


### PR DESCRIPTION
Per #3613 I put interfaces in my interfaces 🎉   

But now my types have too many interfaces 🤢 

Specifically, if you've got a schema like this:
```graphql
interface Node { ... }
interface Named implements Node { ... }
interface Timestamped implements Node { ... }
```
And you add a type `Thing` that implements `Named` and `Timestamped`, printing the schema will give you this:
```graphql
type Thing implements Named & Node & Node & Timestamped { ... }
```
I didn't see much in the spec about this but the reference implementation doesn't like it:
https://github.com/graphql/graphql-js/blob/95dac43fd4bff037e06adaa7cfb44f497bca94a7/src/type/validate.ts#L338-L348 

It's also not stable - graphql-ruby will add an additional `& Node` each time you parse and then print the SDL.

First commit: does it just in the printer.

Second commit: tries to do it for the schema/introspection as well. Wasn't 100% sure about where the deduping should happen though (`#implements` vs `#interfaces` vs `#interface_type_memberships` vs `#own_interface_type_memberships`.)