### PR TITLE
Demonstrate errors when using method attribute

### DIFF
--- a/spec/graphql/schema/field_spec.rb
+++ b/spec/graphql/schema/field_spec.rb
@@ -100,6 +100,32 @@ describe GraphQL::Schema::Field do
       end
     end
 
+    describe "connection fields" do
+      it "can return aggregated data for the nodes" do
+        query_str = <<-GRAPHQL
+        query {
+          bill: find(id: "Musician/Bill Evans") {
+            ... on Musician {
+              playsWith {
+                averageRating
+                isGood
+              }
+            }
+          }
+        }
+        GRAPHQL
+
+        res = Jazz::Schema.execute(query_str, max_complexity: 100)
+
+        assert_equal res['errors'], nil
+
+        bill = res.to_h['data']['bill']
+
+        assert_equal bill['playsWith']['averageRating'], 2.34
+        assert_equal bill['playsWith']['isGood'], false
+      end
+    end
+
     describe "extras" do
       it "can get errors, which adds path" do
         query_str = <<-GRAPHQL

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -288,8 +288,8 @@ module Jazz
     class MusicianPlaysWithConnection < BaseConnection
       edge_type(MusicianEdge)
 
-      field :average_rating, Float, method: :compute_average
-      field :is_good, Boolean, method: :good?
+      field :average_rating, Float # , method: :compute_average
+      field :is_good, Boolean # , method: :good?
 
       def compute_average
         ratings = object.nodes.map(&:rating)
@@ -304,6 +304,9 @@ module Jazz
 
         average >= 3.0
       end
+
+      alias_method :average_rating, :compute_average
+      alias_method :is_good, :good?
     end
 
     implements GloballyIdentifiableType


### PR DESCRIPTION
This branch reproduces an error we saw when writing code for a connection with aggregate fields using the `:method` field attribute.

It is perfectly possible to have custom fields on connections, just not to use the `:method` attribute.