### PR TITLE
Add 'rake bench:profile_schema_memory_footprint' and work on it

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -116,6 +116,12 @@ namespace :bench do
     prepare_benchmark
     GraphQLBenchmark.profile_batch_loaders
   end
+
+  desc "Check the memory footprint of a large schema"
+  task :profile_schema_memory_footprint do
+    prepare_benchmark
+    GraphQLBenchmark.profile_schema_memory_footprint
+  end
 end
 
 namespace :test do

--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -75,7 +75,10 @@ module GraphQL
           end
         end
 
-        self.validates(validates)
+        if validates && !validates.empty?
+          self.validates(validates)
+        end
+
         if required == :nullable
           self.owner.validates(required: { argument: arg_name })
         end

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -303,7 +303,9 @@ module GraphQL
           end
         end
 
-        self.validates(validates)
+        if !validates.empty?
+          self.validates(validates)
+        end
 
         if definition_block
           if definition_block.arity == 1

--- a/lib/graphql/schema/object.rb
+++ b/lib/graphql/schema/object.rb
@@ -98,9 +98,14 @@ module GraphQL
       class << self
         # Set up a type-specific invalid null error to use when this object's non-null fields wrongly return `nil`.
         # It should help with debugging and bug tracker integrations.
-        def inherited(child_class)
-          child_class.const_set(:InvalidNullError, GraphQL::InvalidNullError.subclass_for(child_class))
-          super
+        def const_missing(name)
+          if name == :InvalidNullError
+            custom_err_class = GraphQL::InvalidNullError.subclass_for(self)
+            const_set(:InvalidNullError, custom_err_class)
+            custom_err_class
+          else
+            super
+          end
         end
 
         def kind


### PR DESCRIPTION
Discussed in #3947, I thought I'd write up a benchmark for static memory footprint. It could be fleshed out to include interfaces, unions, input objects, and enums, but it's a start! 

Also, some changes to improve it by 10%:

```diff
- Total allocated: 3247310 bytes (36263 objects)
+ Total allocated: 3110758 bytes (35554 objects)
- Total retained:  1043514 bytes (6475 objects)
+ Total retained:  906962 bytes (5766 objects)
```
