### PR TITLE
Remove an unnecessary `require_relative`

### DIFF
--- a/lib/graphql/analysis/ast/max_query_complexity.rb
+++ b/lib/graphql/analysis/ast/max_query_complexity.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require_relative "./query_complexity"
 module GraphQL
   module Analysis
     module AST


### PR DESCRIPTION
This was causing a double require which resulted in warnings:

```
(…)/query_complexity.rb:22: warning: already initialized constant GraphQL::Analysis::AST::QueryComplexity::ScopedTypeComplexity::HASH_CHILDREN
(…)/query_complexity.rb:22: warning: previous definition of HASH_CHILDREN was here
```