### PR TITLE
Fix cycles in `generate graphql:install`

### DIFF
--- a/lib/generators/graphql/templates/base_connection.erb
+++ b/lib/generators/graphql/templates/base_connection.erb
@@ -4,5 +4,9 @@ module Types
     # add `nodes` and `pageInfo` fields, as well as `edge_type(...)` and `node_nullable(...)` overrides
     include GraphQL::Types::Relay::ConnectionBehaviors
   end
+
+  class BaseObject
+    connection_type_class(Types::BaseConnection)
+  end
 end
 <% end -%>

--- a/lib/generators/graphql/templates/base_edge.erb
+++ b/lib/generators/graphql/templates/base_edge.erb
@@ -4,5 +4,9 @@ module Types
     # add `node` and `cursor` fields, as well as `node_type(...)` override
     include GraphQL::Types::Relay::EdgeBehaviors
   end
+
+  class BaseObject
+    edge_type_class(Types::BaseEdge)
+  end
 end
 <% end -%>

--- a/lib/generators/graphql/templates/base_object.erb
+++ b/lib/generators/graphql/templates/base_object.erb
@@ -4,4 +4,7 @@ module Types
     field_class Types::BaseField
   end
 end
+
+require_relative "base_edge.rb"
+require_relative "base_connection.rb"
 <% end -%>


### PR DESCRIPTION
There are two circular dependencies in the code generated from `rails generate graphql:install`. Whenever running Rails with `eager_load` of `true` (e.g., in production), you will encounter a bug, complaining that `Types::BaseObject` can not be found (because BaseObject needs BaseEdge which need BaseObject...).

I suspect the intention was to derive from `GraphQL::Schema::Object`, rather than `BaseObject` for both of these circular dependencies. The updated version works according to my testing, and it also matches the pattern of `Relay::Types::BaseEdge` and `Relay::Types::BaseConnection`.