### PR TITLE
Link to fiber scheduler list

### DIFF
--- a/guides/dataloader/nonblocking.md
+++ b/guides/dataloader/nonblocking.md
@@ -33,7 +33,7 @@ Fiber.set_scheduler(MySchedulerImplementation.new)
 MySchema.execute(...)
 ```
 
-The scheduler must implement [`Fiber::SchedulerImplementation`](https://ruby-doc.org/core-3.0.2/Fiber/SchedulerInterface.html). Some implementations are available off-the-shelf:
+The scheduler must implement [`Fiber::SchedulerImplementation`](https://ruby-doc.org/core-3.0.2/Fiber/SchedulerInterface.html). Existing implementations can be found at [Fiber Scheduler List](https://github.com/bruno-/fiber_scheduler_list).
 
 - [`dsh0416/evt`](https://github.com/dsh0416/evt) supports several backends in `Evt::Scheduler`.
 -  [`digital-fabric/libev_scheduler`](https://github.com/digital-fabric/libev_scheduler) contains `Libev::Scheduler`, built on [`libev`](http://pod.tst.eu/http://cvs.schmorp.de/libev/ev.pod), an event loop written in C. ⚠️ This _works_, but it was failing oddly on GitHub actions, so CI is turned off for it.


### PR DESCRIPTION
Hi,

a `graphql-ruby` user pointed me to these docs https://graphql-ruby.org/dataloader/nonblocking.html

I've been playing with the [Fiber Scheduler](https://brunosutic.com/blog/ruby-fiber-scheduler) for the last couple weeks and I'm impressed you have a gem that's already using it. I literally thought no one in the WORLD has figured this out yet.

This PR proposes linking to [Fiber Scheduler List](https://github.com/bruno-/fiber_scheduler_list) instead of maintaining a list of available fiber schedulers in the [nonblocking dataloader doc](https://graphql-ruby.org/dataloader/nonblocking.html).