### PR TITLE
support for ddtrace 1.0 and keep backward compatibility

### DIFF
--- a/lib/graphql/tracing/data_dog_tracing.rb
+++ b/lib/graphql/tracing/data_dog_tracing.rb
@@ -48,11 +48,9 @@ module GraphQL
       end
 
       def tracer
-        if Gem::Version.new('1.0.0') >= Gem.loaded_specs["ddtrace"].version
-          options.fetch(:tracer, Datadog::Tracing)
-        else
-          options.fetch(:tracer, Datadog.tracer)
-        end
+        default_tracer = defined?(Datadog::Tracing) ? Datadog::Tracing : Datadog.tracer
+
+        options.fetch(:tracer, default_tracer)
       end
 
       def analytics_available?

--- a/lib/graphql/tracing/data_dog_tracing.rb
+++ b/lib/graphql/tracing/data_dog_tracing.rb
@@ -48,7 +48,11 @@ module GraphQL
       end
 
       def tracer
-        options.fetch(:tracer, Datadog.tracer)
+        if Gem::Version.new('1.0.0') >= Gem.loaded_specs["ddtrace"].version
+          options.fetch(:tracer, Datadog::Tracing)
+        else
+          options.fetch(:tracer, Datadog.tracer)
+        end
       end
 
       def analytics_available?


### PR DESCRIPTION
Datadog tracing is about to release the 1.0 version with some [changes](https://github.com/DataDog/dd-trace-rb/blob/v1.0.0.beta1/docs/UpgradeGuide.md).

The current integration is affected with one of this changes (the one about the [namespacing](https://github.com/DataDog/dd-trace-rb/blob/v1.0.0.beta1/docs/UpgradeGuide.md#namespacing--the-public-api))

This change fix the error and also keeps backward compatibility with older versions of the ddtrace gem