### PR TITLE
Remove branch that uses code removed in 2.0

### DIFF
--- a/lib/graphql/relay/range_add.rb
+++ b/lib/graphql/relay/range_add.rb
@@ -35,10 +35,6 @@ module GraphQL
       # @param parent [Object] The owner of `collection`, will be passed to the connection if provided
       # @param edge_class [Class] The class to wrap `item` with (defaults to the connection's edge class)
       def initialize(collection:, item:, context:, parent: nil, edge_class: nil)
-        unless context.schema.new_connections?
-          raise ArgumentError, "No connections are defined for context.schema"
-        end
-
         conn_class = context.schema.connections.wrapper_for(collection)
         # The rest will be added by ConnectionExtension
         @connection = conn_class.new(collection, parent: parent, context: context, edge_class: edge_class)

--- a/lib/graphql/relay/range_add.rb
+++ b/lib/graphql/relay/range_add.rb
@@ -31,25 +31,22 @@ module GraphQL
 
       # @param collection [Object] The list of items to wrap in a connection
       # @param item [Object] The newly-added item (will be wrapped in `edge_class`)
+      # @param context [GraphQL::Query::Context] The surrounding `ctx`, will be passed to the connection
       # @param parent [Object] The owner of `collection`, will be passed to the connection if provided
-      # @param context [GraphQL::Query::Context] The surrounding `ctx`, will be passed to the connection if provided (this is required for cursor encoders)
       # @param edge_class [Class] The class to wrap `item` with (defaults to the connection's edge class)
-      def initialize(collection:, item:, parent: nil, context: nil, edge_class: nil)
-        if context && context.schema.new_connections?
-          conn_class = context.schema.connections.wrapper_for(collection)
-          # The rest will be added by ConnectionExtension
-          @connection = conn_class.new(collection, parent: parent, context: context, edge_class: edge_class)
-          # Check if this connection supports it, to support old versions of GraphQL-Pro
-          @edge = if @connection.respond_to?(:range_add_edge)
-            @connection.range_add_edge(item)
-          else
-            @connection.edge_class.new(item, @connection)
-          end
+      def initialize(collection:, item:, context:, parent: nil, edge_class: nil)
+        unless context.schema.new_connections?
+          raise ArgumentError, "No connections are defined for context.schema"
+        end
+
+        conn_class = context.schema.connections.wrapper_for(collection)
+        # The rest will be added by ConnectionExtension
+        @connection = conn_class.new(collection, parent: parent, context: context, edge_class: edge_class)
+        # Check if this connection supports it, to support old versions of GraphQL-Pro
+        @edge = if @connection.respond_to?(:range_add_edge)
+          @connection.range_add_edge(item)
         else
-          connection_class = BaseConnection.connection_for_nodes(collection)
-          @connection = connection_class.new(collection, {}, parent: parent, context: context)
-          edge_class ||= Relay::Edge
-          @edge = edge_class.new(item, @connection)
+          @connection.edge_class.new(item, @connection)
         end
 
         @parent = parent


### PR DESCRIPTION
BaseConnection was removed in 2.0 so that branch throws an error.  Context is now required