### PR TITLE
Allow multiples of repeatable directives

### DIFF
--- a/lib/graphql/schema/member/has_directives.rb
+++ b/lib/graphql/schema/member/has_directives.rb
@@ -11,7 +11,7 @@ module GraphQL
         # @return [void]
         def directive(dir_class, **options)
           @own_directives ||= []
-          remove_directive(dir_class)
+          remove_directive(dir_class) unless dir_class.repeatable?
           @own_directives << dir_class.new(self, **options)
           nil
         end


### PR DESCRIPTION
### What's up

When adding directives to an object, we currently overwrite any existing directives of the same class. However, if the directive is repeatable, we should be able to specify multiple directives without overwriting existing ones.

### Solution

Pretty simple: Don't remove existing directives if the directive in question is repeatable.

#### Caveats

I haven't explicitly checked the printer to make sure it does the right thing when printing multiple of the same directives. I assume it isn't really any different than if the object had multiple different directives.