### PR TITLE
Fix Field#scoped? to check resolver return value, too

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -145,8 +145,18 @@ module GraphQL
         if !@scope.nil?
           # The default was overridden
           @scope
+        elsif @return_type_expr
+          # Detect a list return type, but don't call `type` since that may eager-load an otherwise lazy-loaded type
+          @return_type_expr.is_a?(Array) ||
+            (@return_type_expr.is_a?(String) && @return_type_expr.include?("[")) ||
+            connection?
+        elsif @resolver_class
+          resolver_type = @resolver_class.type_expr
+          resolver_type.is_a?(Array) ||
+            (resolver_type.is_a?(String) && resolver_type.include?("[")) ||
+            connection?
         else
-          @return_type_expr && (@return_type_expr.is_a?(Array) || (@return_type_expr.is_a?(String) && @return_type_expr.include?("[")) || connection?)
+          false
         end
       end
 

--- a/spec/graphql/schema/field_spec.rb
+++ b/spec/graphql/schema/field_spec.rb
@@ -654,7 +654,7 @@ This is probably a bug in GraphQL-Ruby, please report this error on GitHub: http
   it "Delegates many properties to its @resolver_class" do
     resolver = Class.new(GraphQL::Schema::Resolver) do
       description "description 1"
-      type GraphQL::Types::Float, null: true
+      type [GraphQL::Types::Float], null: true
 
       argument :b, GraphQL::Types::Float
     end
@@ -664,7 +664,7 @@ This is probably a bug in GraphQL-Ruby, please report this error on GitHub: http
     end
 
     assert_equal "description 1", field.description
-    assert_equal "Float", field.type.to_type_signature
+    assert_equal "[Float!]", field.type.to_type_signature
     assert_equal 1, field.complexity
     assert_equal :resolve_with_support, field.resolver_method
     assert_nil field.broadcastable?
@@ -672,6 +672,7 @@ This is probably a bug in GraphQL-Ruby, please report this error on GitHub: http
     assert_nil field.max_page_size
     assert_equal [:blah], field.extras
     assert_equal [:b, :a], field.all_argument_definitions.map(&:keyword)
+    assert_equal true, field.scoped?
 
     resolver.description("description 2")
     resolver.type(GraphQL::Types::String, null: false)
@@ -691,5 +692,6 @@ This is probably a bug in GraphQL-Ruby, please report this error on GitHub: http
     assert_equal 100, field.max_page_size
     assert_equal [:blah, :foo], field.extras
     assert_equal [:b, :c, :a], field.all_argument_definitions.map(&:keyword)
+    assert_equal false, field.scoped?
   end
 end


### PR DESCRIPTION
Fixes #3989 

And was broken by #3916 