### PR TITLE
Try to make Dataloader work with Async gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'pry-byebug'
 if RUBY_VERSION >= "3.0"
   gem "libev_scheduler"
   gem "evt"
+  gem "async"
 end
 
 # Required for running `jekyll algolia ...` (via `rake site:update_search_index`)

--- a/spec/graphql/dataloader/async_dataloader_spec.rb
+++ b/spec/graphql/dataloader/async_dataloader_spec.rb
@@ -253,5 +253,11 @@ if Fiber.respond_to?(:scheduler) # Ruby 3+
       let(:scheduler_class) { Evt::Scheduler }
       include AsyncDataloaderAssertions
     end
+
+    describe "with async" do
+      require "async"
+      let(:scheduler_class) { Async::Scheduler }
+      include AsyncDataloaderAssertions
+    end
   end
 end


### PR DESCRIPTION
I'm hoping to get `Dataloader` working with the `async` gem, but it seems to work a bit differently than the others. 

I tried using `Fiber.schedule { ... }`, but since it runs the fiber immediately, `Fiber.yield` doesn't work the same way from inside the fiber. 

Also, the code previously expected `spawn_fiber` to return a non-running fiber, but `Fiber.schedule` returns an already-running fiber. So, gotta handle that nicely.

cc @bruno-  Do you have any further suggestions about how this might work?
