### PR TITLE
Spike attempting to use Fiber#transfer instead of yield / resume

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,14 @@ gem 'pry-stack_explorer', platform: :ruby
 gem 'graphql-batch'
 gem 'pry-byebug'
 
-if RUBY_VERSION >= "3.0"
+if RUBY_VERSION >= "3.0" && RUBY_VERSION < "3.1"
   gem "libev_scheduler"
   gem "evt"
+end
+
+if RUBY_VERSION >= "3.1"
+  gem "fiber_scheduler"
+  gem "async"
 end
 
 # Required for running `jekyll algolia ...` (via `rake site:update_search_index`)

--- a/lib/graphql/dataloader.rb
+++ b/lib/graphql/dataloader.rb
@@ -92,7 +92,7 @@ module GraphQL
     #
     # @return [void]
     def yield
-      Fiber.yield
+      @parent_fiber.transfer
       nil
     end
 
@@ -137,6 +137,9 @@ module GraphQL
       if @nonblocking && !Fiber.scheduler
         raise "`nonblocking: true` requires `Fiber.scheduler`, assign one with `Fiber.set_scheduler(...)` before executing GraphQL."
       end
+
+      @parent_fiber = Fiber.current
+
       # At a high level, the algorithm is:
       #
       #  A) Inside Fibers, run jobs from the queue one-by-one
@@ -274,7 +277,7 @@ module GraphQL
     end
 
     def resume(fiber)
-      fiber.resume
+      fiber.transfer
     rescue UncaughtThrowError => e
       throw e.tag, e.value
     end

--- a/spec/graphql/dataloader/async_dataloader_spec.rb
+++ b/spec/graphql/dataloader/async_dataloader_spec.rb
@@ -235,22 +235,35 @@ if Fiber.respond_to?(:scheduler) # Ruby 3+
       end
     end
 
-    describe "With the toy scheduler from Ruby's tests" do
-      let(:scheduler_class) { ::DummyScheduler }
+    # describe "With the toy scheduler from Ruby's tests" do
+    #   let(:scheduler_class) { ::DummyScheduler }
+    #   include AsyncDataloaderAssertions
+    # end
+
+    # if RUBY_ENGINE == "ruby" && !ENV["GITHUB_ACTIONS"]
+    #   describe "With libev_scheduler" do
+    #     require "libev_scheduler"
+    #     let(:scheduler_class) { Libev::Scheduler }
+    #     include AsyncDataloaderAssertions
+    #   end
+    # end
+
+    # describe "with evt" do
+    #   require "evt"
+    #   let(:scheduler_class) { Evt::Scheduler }
+    #   include AsyncDataloaderAssertions
+    # end
+
+    describe "with async" do
+      require "async"
+      let(:scheduler_class) { Async::Scheduler }
       include AsyncDataloaderAssertions
     end
 
-    if RUBY_ENGINE == "ruby" && !ENV["GITHUB_ACTIONS"]
-      describe "With libev_scheduler" do
-        require "libev_scheduler"
-        let(:scheduler_class) { Libev::Scheduler }
-        include AsyncDataloaderAssertions
-      end
-    end
 
-    describe "with evt" do
-      require "evt"
-      let(:scheduler_class) { Evt::Scheduler }
+    describe "with fiber_scheduler" do
+      require "fiber_scheduler"
+      let(:scheduler_class) { FiberScheduler }
       include AsyncDataloaderAssertions
     end
   end


### PR DESCRIPTION
As requested in https://github.com/rmosolgo/graphql-ruby/issues/4003 here is the diff for the spike I made for Fiber#transfer support.

I was mistaken in the issue to say that async dataloader specs were passing for both `fiber_scheduler` and `async`. In fact there are 3 failures when using `async` still. This may or may not be due to the implementation of `Async::Scheduler` itself being incomplete. According to Bruno the only gem which covers 100% of the fiber scheduler spec is his own `fiber_sheduler` gem.

As you can see it's an extremely minimal diff. A hunch as to why a lot of specs outside of `async_dataloader_spec.rb` are failing is that the `@parent_fiber` idea is too naive and needs some more sophisticated approach. I had worked neither with the GraphQL gem nor Fiber's before attempting this so felt lost pretty quickly 😅