### PR TITLE
Resolvers: properly inherit args from parent classes that aren't attached to the schema

### DIFF
--- a/lib/graphql/schema/member/has_arguments.rb
+++ b/lib/graphql/schema/member/has_arguments.rb
@@ -148,7 +148,19 @@ module GraphQL
             end
           elsif defined?(@resolver_class) && @resolver_class
             all_defns = {}
-            all_defns.merge!(@resolver_class.own_field_arguments)
+            @resolver_class.all_field_argument_definitions.each do |arg_defn|
+              key = arg_defn.graphql_name
+              case (current_value = all_defns[key])
+              when nil
+                all_defns[key] = arg_defn
+              when Array
+                current_value << arg_defn
+              when GraphQL::Schema::Argument
+                all_defns[key] = [current_value, arg_defn]
+              else
+                raise "Invariant: Unexpected argument definition, #{current_value.class}: #{current_value.inspect}"
+              end
+            end
             all_defns.merge!(own_arguments)
           else
             all_defns = own_arguments

--- a/lib/graphql/schema/relay_classic_mutation.rb
+++ b/lib/graphql/schema/relay_classic_mutation.rb
@@ -92,6 +92,10 @@ module GraphQL
           dummy.own_arguments
         end
 
+        def all_field_argument_definitions
+          dummy.all_argument_definitions
+        end
+
         # Also apply this argument to the input type:
         def argument(*args, own_argument: false, **kwargs, &block)
           it = input_type # make sure any inherited arguments are already added to it

--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -216,8 +216,8 @@ module GraphQL
           get_argument(name, context)
         end
 
-        def own_field_arguments
-          own_arguments
+        def all_field_argument_definitions
+          all_argument_definitions
         end
 
         # Default `:resolve` set below.


### PR DESCRIPTION
Fixes #4005 

