### PR TITLE
Fixed an edge case (get it?) on connections where the "before" option was functioning incorrectly.

### DIFF
--- a/lib/graphql/pagination/array_connection.rb
+++ b/lib/graphql/pagination/array_connection.rb
@@ -35,9 +35,11 @@ module GraphQL
       def load_nodes
         @nodes ||= begin
           sliced_nodes = if before && after
-            items[index_from_cursor(after)..index_from_cursor(before)-1] || []
+            end_idx = index_from_cursor(before)-1
+            end_idx < 0 ? [] : items[index_from_cursor(after)...end_idx] || []
           elsif before
-            items[0..index_from_cursor(before)-2] || []
+            end_idx = index_from_cursor(before)-2
+            end_idx < 0 ? [] : items[0..end_idx] || []
           elsif after
             items[index_from_cursor(after)..-1] || []
           else

--- a/spec/support/connection_assertions.rb
+++ b/spec/support/connection_assertions.rb
@@ -247,6 +247,11 @@ module ConnectionAssertions
           bogus_huge_cursor = NonceEnabledEncoder.encode("100")
           res = exec_query(query_str, first: 3, after: bogus_huge_cursor)
           assert_names([], res)
+
+          # It returns nothing before the first cursor
+          first_cursor = NonceEnabledEncoder.encode("1")
+          res = exec_query(query_str, first: 3, before: first_cursor)
+          assert_names([], res)
         end
 
         it "handles negative firsts and lasts by treating them as zero" do


### PR DESCRIPTION
### Problem

Consider the following request and response:

```graphql
query {
  animals (first: 5, before: null) {
    edges {
      cursor
    }
  }
}
```

```json
{
  "data": {
    "animals": {
      "edges": [
        { "cursor": "1" },
        { "cursor": "2" },
        { "cursor": "3" },
        { "cursor": "4" },
        { "cursor": "5" }
      ]
    }
  }
}
```

But what if we pass in a `before` cursor that's equal to the first item? We get this:

```graphql
query {
  animals (first: 5, before: "1") {
    edges {
      cursor
    }
  }
}
```

```json
{
  "data": {
    "animals": {
      "edges": [
        { "cursor": "1" },
        { "cursor": "2" },
        { "cursor": "3" },
        { "cursor": "4" },
        { "cursor": "5" }
      ]
    }
  }
}
```

But that's not correct. Those edges are not before the first edge. The actual response should be this:

```json
{
  "data": {
    "animals": {
      "edges": []
    }
  }
}
```

### Cause

The calculation for the range of nodes that should be loaded is `items[0..index_from_cursor(before)-2] || []`. So if the `before` cursor is the first cursor, then the node range becomes `[0..-1]`, encompassing all items in the list.