### PR TITLE
Fix specifiedByUrl -> specifiedByURL

### DIFF
--- a/lib/graphql/introspection.rb
+++ b/lib/graphql/introspection.rb
@@ -29,7 +29,7 @@ fragment FullType on __Type {
   kind
   name
   description
-  #{include_specified_by_url ? "specifiedByUrl" : ""}
+  #{include_specified_by_url ? "specifiedByURL" : ""}
   fields(includeDeprecated: true) {
     name
     description

--- a/lib/graphql/introspection/type_type.rb
+++ b/lib/graphql/introspection/type_type.rb
@@ -27,7 +27,7 @@ module GraphQL
       end
       field :of_type, GraphQL::Schema::LateBoundType.new("__Type")
 
-      field :specified_by_url, String
+      field :specifiedByURL, String, resolver_method: :specified_by_url
 
       def specified_by_url
         if object.kind.scalar?

--- a/lib/graphql/schema/loader.rb
+++ b/lib/graphql/schema/loader.rb
@@ -142,7 +142,7 @@ module GraphQL
               Class.new(GraphQL::Schema::Scalar) do
                 graphql_name(type["name"])
                 description(type["description"])
-                specified_by_url(type["specifiedByUrl"])
+                specified_by_url(type["specifiedByURL"])
               end
             end
           when "UNION"

--- a/spec/graphql/introspection/type_type_spec.rb
+++ b/spec/graphql/introspection/type_type_spec.rb
@@ -8,9 +8,9 @@ describe GraphQL::Introspection::TypeType do
        milkType:      __type(name: "Milk") { interfaces { name }, fields { type { kind, name, ofType { name } } } }
        dairyAnimal:   __type(name: "DairyAnimal") { name, kind, enumValues(includeDeprecated: false) { name, isDeprecated } }
        dairyProduct:  __type(name: "DairyProduct") { name, kind, possibleTypes { name } }
-       animalProduct: __type(name: "AnimalProduct") { name, kind, specifiedByUrl, possibleTypes { name }, fields { name } }
+       animalProduct: __type(name: "AnimalProduct") { name, kind, specifiedByURL, possibleTypes { name }, fields { name } }
        missingType:   __type(name: "NotAType") { name }
-       timeType:      __type(name: "Time") { specifiedByUrl }
+       timeType:      __type(name: "Time") { specifiedByURL }
      }
   |}
   let(:result) { Dummy::Schema.execute(query_string, context: {}, variables: {"cheeseId" => 2}) }
@@ -70,14 +70,14 @@ describe GraphQL::Introspection::TypeType do
       "animalProduct" => {
         "name"=>"AnimalProduct",
         "kind"=>"INTERFACE",
-        "specifiedByUrl" => nil,
+        "specifiedByURL" => nil,
         "possibleTypes"=>[{"name"=>"Cheese"}, {"name"=>"Honey"}, {"name"=>"Milk"}],
         "fields"=>[
           {"name"=>"source"},
         ]
       },
       "missingType" => nil,
-      "timeType" => { "specifiedByUrl" => "https://time.graphql"}
+      "timeType" => { "specifiedByURL" => "https://time.graphql"}
     }}
     assert_equal(expected, result.to_h)
   end

--- a/spec/graphql/schema/printer_spec.rb
+++ b/spec/graphql/schema/printer_spec.rb
@@ -359,7 +359,7 @@ type __Type {
   name: String
   ofType: __Type
   possibleTypes: [__Type!]
-  specifiedByUrl: String
+  specifiedByURL: String
 }
 
 """


### PR DESCRIPTION
The spec spells the specifiedByURL introspection field by capitalizing the acronym, and fields are case sensitive.
(Previously the inflector generated specifiedByUrl)