### PR TITLE
Add specified_by_url for ISO8601 scalars

### DIFF
--- a/lib/graphql/types/iso_8601_date.rb
+++ b/lib/graphql/types/iso_8601_date.rb
@@ -14,6 +14,7 @@ module GraphQL
     # own Date type.
     class ISO8601Date < GraphQL::Schema::Scalar
       description "An ISO 8601-encoded date"
+      specified_by_url "https://tools.ietf.org/html/rfc3339"
 
       # @param value [Date,Time,DateTime,String]
       # @return [String]

--- a/lib/graphql/types/iso_8601_date_time.rb
+++ b/lib/graphql/types/iso_8601_date_time.rb
@@ -17,6 +17,7 @@ module GraphQL
     # own DateTime type.
     class ISO8601DateTime < GraphQL::Schema::Scalar
       description "An ISO 8601-encoded datetime"
+      specified_by_url "https://tools.ietf.org/html/rfc3339"
 
       # It's not compatible with Rails' default,
       # i.e. ActiveSupport::JSON::Encoder.time_precision (3 by default)


### PR DESCRIPTION
Link to the RFC 3339 specification https://tools.ietf.org/html/rfc3339, which in turn specifies to use ISO 8601