### PR TITLE
Fix `hash_key` attribute to work with keys commonly responded to by underlying GraphQL objects

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -641,6 +641,8 @@ module GraphQL
 
               if @hash_key
                 inner_object[@hash_key]
+              elsif @dig_keys
+                inner_object.dig(*@dig_keys)
               elsif obj.respond_to?(resolver_method)
                 method_to_call = resolver_method
                 method_receiver = obj
@@ -651,9 +653,7 @@ module GraphQL
                   obj.public_send(resolver_method)
                 end
               elsif inner_object.is_a?(Hash)
-                if @dig_keys
-                  inner_object.dig(*@dig_keys)
-                elsif inner_object.key?(@method_sym)
+                if inner_object.key?(@method_sym)
                   inner_object[@method_sym]
                 else
                   inner_object[@method_str]

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -28,6 +28,8 @@ module GraphQL
       # @return [String] Method or hash key on the underlying object to look up
       attr_reader :method_str
 
+      attr_reader :hash_key
+
       # @return [Symbol] The method on the type to look up
       def resolver_method
         if @resolver_class
@@ -243,9 +245,9 @@ module GraphQL
           end
         end
 
-        # TODO: I think non-string/symbol hash keys are wrongly normalized (eg `1` will not work)
-        method_name = method || hash_key || name_s
+        method_name = method || name_s
         @dig_keys = dig
+        @hash_key = hash_key
         resolver_method ||= name_s.to_sym
 
         @method_str = -method_name.to_s
@@ -642,7 +644,9 @@ module GraphQL
               # - A method on the wrapped object;
               # - Or, raise not implemented.
               #
-              if obj.respond_to?(resolver_method)
+              if @hash_key
+                obj.object[@hash_key]
+              elsif obj.respond_to?(resolver_method)
                 method_to_call = resolver_method
                 method_receiver = obj
                 # Call the method with kwargs, if there are any

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -29,6 +29,7 @@ module GraphQL
       attr_reader :method_str
 
       attr_reader :hash_key
+      attr_reader :dig_keys
 
       # @return [Symbol] The method on the type to look up
       def resolver_method

--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -72,7 +72,7 @@ module GraphQL
         def add_field(field_defn, method_conflict_warning: field_defn.method_conflict_warning?)
           # Check that `field_defn.original_name` equals `resolver_method` and `method_sym` --
           # that shows that no override value was given manually.
-          if method_conflict_warning && CONFLICT_FIELD_NAMES.include?(field_defn.resolver_method) && field_defn.original_name == field_defn.resolver_method && field_defn.original_name == field_defn.method_sym
+          if method_conflict_warning && CONFLICT_FIELD_NAMES.include?(field_defn.resolver_method) && field_defn.original_name == field_defn.resolver_method && field_defn.original_name == field_defn.method_sym && field_defn.hash_key.nil? && field_defn.dig_keys.nil?
             warn(conflict_field_name_warning(field_defn))
           end
           prev_defn = own_fields[field_defn.name]

--- a/spec/graphql/schema/field_spec.rb
+++ b/spec/graphql/schema/field_spec.rb
@@ -596,6 +596,8 @@ describe GraphQL::Schema::Field do
         field :Capital, String, camelize: false, null: true
         field :Other, String, camelize: true, null: true
         field :OtherCapital, String, camelize: false, null: true, hash_key: "OtherCapital"
+        # regression test against https://github.com/rmosolgo/graphql-ruby/issues/3944
+        field :method, String, camelize: false, null: false, hash_key: "some_random_key"
       end
 
       class QueryType < GraphQL::Schema::Object
@@ -605,7 +607,8 @@ describe GraphQL::Schema::Field do
             "lowercase" => "lowercase-works",
             "Capital" => "capital-camelize-false-works",
             "Other" => "capital-camelize-true-works",
-            "OtherCapital" => "explicit-hash-key-works"
+            "OtherCapital" => "explicit-hash-key-works",
+            "some_random_key" => "hash-key-works-when-underlying-object-responds-to-field-name"
           }
         end
       end
@@ -617,6 +620,7 @@ describe GraphQL::Schema::Field do
       res = HashKeySchema.execute <<-GRAPHQL
       {
         searchResults {
+          method
           lowercase
           Capital
           Other
@@ -630,7 +634,8 @@ describe GraphQL::Schema::Field do
         "lowercase" => "lowercase-works",
         "Capital" => "capital-camelize-false-works",
         "Other" => "capital-camelize-true-works",
-        "OtherCapital" => "explicit-hash-key-works"
+        "OtherCapital" => "explicit-hash-key-works",
+        "method" => "hash-key-works-when-underlying-object-responds-to-field-name"
       }
       assert_equal expected_result, search_results
     end


### PR DESCRIPTION
Fixes https://github.com/rmosolgo/graphql-ruby/issues/3944
Fixes https://github.com/rmosolgo/graphql-ruby/issues/3861

Closes #3947 as duplicate
- Removed some of the more complicated changes to focus on fixing the underlying issue first, and looking at refactoring further in later PRs to reduce the cognitive overload of having so many changes to a fundamental class