### PR TITLE
Fix argument "--no-graphiql" -> "--skip-graphiql"

### DIFF
--- a/guides/schema/generators.md
+++ b/guides/schema/generators.md
@@ -45,7 +45,7 @@ After installing you can see your new schema by:
 - `--relay` will add [Relay](https://facebook.github.io/relay/)-specific code to your schema
 - `--batch` will add [GraphQL::Batch](https://github.com/Shopify/graphql-batch) to your gemfile and include the setup in your schema
 - `--playground` will include `graphql_playground-rails` in the setup (mounted at `/playground`)
-- `--no-graphiql` will exclude `graphiql-rails` from the setup
+- `--skip-graphiql` will exclude `graphiql-rails` from the setup
 - `--schema=MySchemaName` will be used for naming the schema (default is `#{app_name}Schema`)
 
 ## Scaffolding Types

--- a/lib/generators/graphql/install_generator.rb
+++ b/lib/generators/graphql/install_generator.rb
@@ -47,7 +47,7 @@ module Graphql
     #
     # Accept a `--batch` option which adds `GraphQL::Batch` setup.
     #
-    # Use `--no-graphiql` to skip `graphiql-rails` installation.
+    # Use `--skip-graphiql` to skip `graphiql-rails` installation.
     #
     # TODO: also add base classes
     class InstallGenerator < Rails::Generators::Base


### PR DESCRIPTION
https://github.com/rmosolgo/graphql-ruby/blob/v2.0.5/guides/schema/generators.md
This doc says there is an option `--no-graphiql` for `graphql:install`, but `--skip-graphiql` is correct.
https://github.com/rmosolgo/graphql-ruby/blob/v2.0.5/lib/generators/graphql/install_generator.rb#L70-L73