### PR TITLE
Expose duplicated name as part of DuplicateNamesError error class.

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -73,7 +73,14 @@ module GraphQL
     extend GraphQL::Schema::Member::HasAstNode
     extend GraphQL::Schema::FindInheritedValue
 
-    class DuplicateNamesError < GraphQL::Error; end
+    class DuplicateNamesError < GraphQL::Error
+      attr_reader :duplicated_name
+      def initialize(duplicated_name:, duplicated_definition_1:, duplicated_definition_2:)
+        super(
+          "Found two visible type definitions for `#{duplicated_name}`: #{duplicated_definition_1}, #{duplicated_definition_2}"
+        )
+      end
+    end
 
     class UnresolvedLateBoundTypeError < GraphQL::Error
       attr_reader :type
@@ -219,7 +226,9 @@ module GraphQL
                 if visible_t.nil?
                   visible_t = t
                 else
-                  raise DuplicateNamesError, "Found two visible type definitions for `#{k}`: #{visible_t.inspect}, #{t.inspect}"
+                  raise DuplicateNamesError.new(
+                    duplicated_name: k, duplicated_definition_1: visible_t.inspect, duplicated_definition_2: t.inspect
+                  )
                 end
               end
             end
@@ -246,7 +255,9 @@ module GraphQL
               if visible_t.nil?
                 visible_t = t
               else
-                raise DuplicateNamesError, "Found two visible type definitions for `#{type_name}`: #{visible_t.inspect}, #{t.inspect}"
+                raise DuplicateNamesError.new(
+                  duplicated_name: type_name, duplicated_definition_1: visible_t.inspect, duplicated_definition_2: t.inspect
+                )
               end
             end
           end

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -76,8 +76,9 @@ module GraphQL
     class DuplicateNamesError < GraphQL::Error
       attr_reader :duplicated_name
       def initialize(duplicated_name:, duplicated_definition_1:, duplicated_definition_2:)
+        @duplicated_name = duplicated_name
         super(
-          "Found two visible type definitions for `#{duplicated_name}`: #{duplicated_definition_1}, #{duplicated_definition_2}"
+          "Found two visible definitions for `#{duplicated_name}`: #{duplicated_definition_1}, #{duplicated_definition_2}"
         )
       end
     end

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -73,12 +73,6 @@ module GraphQL
     extend GraphQL::Schema::Member::HasAstNode
     extend GraphQL::Schema::FindInheritedValue
 
-    class DuplicateTypeNamesError < GraphQL::Error
-      def initialize(type_name:, first_definition:, second_definition:, path:)
-        super("Multiple definitions for `#{type_name}`. Previously found #{first_definition.inspect} (#{first_definition.class}), then found #{second_definition.inspect} (#{second_definition.class}) at #{path.join(".")}")
-      end
-    end
-
     class DuplicateNamesError < GraphQL::Error; end
 
     class UnresolvedLateBoundTypeError < GraphQL::Error

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -55,7 +55,9 @@ module GraphQL
               if visible_item.nil?
                 visible_item = item
               else
-                raise Schema::DuplicateNamesError, "Found two visible definitions for `#{item.path}`: #{visible_item.inspect}, #{item.inspect}"
+                raise DuplicateNamesError.new(
+                  duplicated_name: item.path, duplicated_definition_1: visible_item.inspect, duplicated_definition_2: item.inspect
+                )
               end
             end
           end
@@ -362,7 +364,9 @@ module GraphQL
           if @reachable_type_set.add?(type)
             type_by_name = rt_hash[type.graphql_name] ||= type
             if type_by_name != type
-              raise DuplicateNamesError, "Found two visible type definitions for `#{type.graphql_name}`: #{type.inspect}, #{type_by_name.inspect}"
+              raise DuplicateNamesError.new(
+                duplicated_name: type.graphql_name, duplicated_definition_1: type.inspect, duplicated_definition_2: type_by_name.inspect
+              )
             end
             if type.kind.input_object?
               # recurse into visible arguments

--- a/spec/graphql/schema/dynamic_members_spec.rb
+++ b/spec/graphql/schema/dynamic_members_spec.rb
@@ -439,7 +439,7 @@ ERR
       MultifieldSchema::Query.get_field("f1")
     end
 
-    expected_message = "Found two visible definitions for `Query.f1`: #<MultifieldSchema::BaseField Query.f1: String>, #<MultifieldSchema::BaseField Query.f1: Int>"
+    expected_message = "Found two visible type definitions for `Query.f1`: #<MultifieldSchema::BaseField Query.f1: String>, #<MultifieldSchema::BaseField Query.f1: Int>"
     assert_equal expected_message, err.message
 
     # GraphQL usage
@@ -1068,7 +1068,7 @@ GRAPHQL
       err = assert_raises GraphQL::Schema::DuplicateNamesError do
         enum_type.values({ allowed_for: 2 })
       end
-      expected_message ="Found two visible definitions for `DuplicateEnumValue.ONE`: #<DuplicateNames::BaseEnumValue DuplicateEnumValue.ONE @value=\"ONE\" @description=\"second definition\">, #<DuplicateNames::BaseEnumValue DuplicateEnumValue.ONE @value=\"ONE\" @description=\"first definition\">"
+      expected_message ="Found two visible type definitions for `DuplicateEnumValue.ONE`: #<DuplicateNames::BaseEnumValue DuplicateEnumValue.ONE @value=\"ONE\" @description=\"second definition\">, #<DuplicateNames::BaseEnumValue DuplicateEnumValue.ONE @value=\"ONE\" @description=\"first definition\">"
       assert_equal expected_message, err.message
 
       # no get_value method ... yet ...
@@ -1103,7 +1103,7 @@ GRAPHQL
       err = assert_raises GraphQL::Schema::DuplicateNamesError do
         field.arguments({ allowed_for: 2 })
       end
-      expected_message = "Found two visible definitions for `DuplicateArgumentObject.multiArg.a`: #<DuplicateNames::BaseArgument DuplicateArgumentObject.multiArg.a: String @description=\"first definition\">, #<DuplicateNames::BaseArgument DuplicateArgumentObject.multiArg.a: Int @description=\"second definition\">"
+      expected_message = "Found two visible type definitions for `DuplicateArgumentObject.multiArg.a`: #<DuplicateNames::BaseArgument DuplicateArgumentObject.multiArg.a: String @description=\"first definition\">, #<DuplicateNames::BaseArgument DuplicateArgumentObject.multiArg.a: Int @description=\"second definition\">"
       assert_equal expected_message, err.message
 
       err2 = assert_raises GraphQL::Schema::DuplicateNamesError do
@@ -1140,7 +1140,7 @@ GRAPHQL
       err = assert_raises GraphQL::Schema::DuplicateNamesError do
         DuplicateNames::DuplicateFieldObject.fields({ allowed_for: 2 })
       end
-      expected_message = "Found two visible definitions for `DuplicateFieldObject.f`: #<DuplicateNames::BaseField DuplicateFieldObject.f: String>, #<DuplicateNames::BaseField DuplicateFieldObject.f: Int>"
+      expected_message = "Found two visible type definitions for `DuplicateFieldObject.f`: #<DuplicateNames::BaseField DuplicateFieldObject.f: String>, #<DuplicateNames::BaseField DuplicateFieldObject.f: Int>"
       assert_equal expected_message, err.message
 
       err2 = assert_raises GraphQL::Schema::DuplicateNamesError do

--- a/spec/graphql/schema/dynamic_members_spec.rb
+++ b/spec/graphql/schema/dynamic_members_spec.rb
@@ -438,8 +438,9 @@ ERR
     err = assert_raises GraphQL::Schema::DuplicateNamesError do
       MultifieldSchema::Query.get_field("f1")
     end
-
-    expected_message = "Found two visible type definitions for `Query.f1`: #<MultifieldSchema::BaseField Query.f1: String>, #<MultifieldSchema::BaseField Query.f1: Int>"
+    assert_equal "Query.f1", err.duplicated_name
+    
+    expected_message = "Found two visible definitions for `Query.f1`: #<MultifieldSchema::BaseField Query.f1: String>, #<MultifieldSchema::BaseField Query.f1: Int>"
     assert_equal expected_message, err.message
 
     # GraphQL usage
@@ -643,7 +644,8 @@ GRAPHQL
     err = assert_raises GraphQL::Schema::DuplicateNamesError do
       MultifieldSchema.get_type("Money")
     end
-    expected_message = "Found two visible type definitions for `Money`: MultifieldSchema::Money, MultifieldSchema::MoneyScalar"
+    assert_equal "Money", err.duplicated_name
+    expected_message = "Found two visible definitions for `Money`: MultifieldSchema::Money, MultifieldSchema::MoneyScalar"
     assert_equal expected_message, err.message
 
     assert_equal "⚛︎100",exec_query("{ thing(id: 1) { price } }")["data"]["thing"]["price"]
@@ -1028,23 +1030,27 @@ GRAPHQL
       err = assert_raises GraphQL::Schema::DuplicateNamesError do
         schema.types({ allowed_for: 2 })
       end
-      expected_message = "Found two visible type definitions for `DuplicateNameObject`: DuplicateNames::DuplicateNameObject1, DuplicateNames::DuplicateNameObject2"
+      assert_equal "DuplicateNameObject", err.duplicated_name
+      expected_message = "Found two visible definitions for `DuplicateNameObject`: DuplicateNames::DuplicateNameObject1, DuplicateNames::DuplicateNameObject2"
       assert_equal expected_message, err.message
 
       err2 = assert_raises GraphQL::Schema::DuplicateNamesError do
         schema.get_type("DuplicateNameObject", { allowed_for: 2 })
       end
+      assert_equal "DuplicateNameObject", err2.duplicated_name
 
       assert_equal expected_message, err2.message
 
       err3 = assert_raises GraphQL::Schema::DuplicateNamesError do
         schema.to_definition(context: { allowed_for: 2 })
       end
+      assert_equal "DuplicateNameObject", err3.duplicated_name
       assert_equal expected_message, err3.message
 
       err4 = assert_raises GraphQL::Schema::DuplicateNamesError do
         schema.to_json(context: { allowed_for: 2 })
       end
+      assert_equal "DuplicateNameObject", err4.duplicated_name
       assert_equal expected_message, err4.message
     end
 
@@ -1068,7 +1074,7 @@ GRAPHQL
       err = assert_raises GraphQL::Schema::DuplicateNamesError do
         enum_type.values({ allowed_for: 2 })
       end
-      expected_message ="Found two visible type definitions for `DuplicateEnumValue.ONE`: #<DuplicateNames::BaseEnumValue DuplicateEnumValue.ONE @value=\"ONE\" @description=\"second definition\">, #<DuplicateNames::BaseEnumValue DuplicateEnumValue.ONE @value=\"ONE\" @description=\"first definition\">"
+      expected_message ="Found two visible definitions for `DuplicateEnumValue.ONE`: #<DuplicateNames::BaseEnumValue DuplicateEnumValue.ONE @value=\"ONE\" @description=\"second definition\">, #<DuplicateNames::BaseEnumValue DuplicateEnumValue.ONE @value=\"ONE\" @description=\"first definition\">"
       assert_equal expected_message, err.message
 
       # no get_value method ... yet ...
@@ -1076,11 +1082,13 @@ GRAPHQL
       err3 = assert_raises GraphQL::Schema::DuplicateNamesError do
         schema.to_definition(context: { allowed_for: 2 })
       end
+      assert_equal "DuplicateEnumValue.ONE", err3.duplicated_name
       assert_equal expected_message, err3.message
 
       err4 = assert_raises GraphQL::Schema::DuplicateNamesError do
         schema.to_json(context: { allowed_for: 2 })
       end
+      assert_equal "DuplicateEnumValue.ONE", err4.duplicated_name
       assert_equal expected_message, err4.message
     end
 
@@ -1103,24 +1111,27 @@ GRAPHQL
       err = assert_raises GraphQL::Schema::DuplicateNamesError do
         field.arguments({ allowed_for: 2 })
       end
-      expected_message = "Found two visible type definitions for `DuplicateArgumentObject.multiArg.a`: #<DuplicateNames::BaseArgument DuplicateArgumentObject.multiArg.a: String @description=\"first definition\">, #<DuplicateNames::BaseArgument DuplicateArgumentObject.multiArg.a: Int @description=\"second definition\">"
+      expected_message = "Found two visible definitions for `DuplicateArgumentObject.multiArg.a`: #<DuplicateNames::BaseArgument DuplicateArgumentObject.multiArg.a: String @description=\"first definition\">, #<DuplicateNames::BaseArgument DuplicateArgumentObject.multiArg.a: Int @description=\"second definition\">"
       assert_equal expected_message, err.message
+      assert_equal "DuplicateArgumentObject.multiArg.a", err.duplicated_name
 
       err2 = assert_raises GraphQL::Schema::DuplicateNamesError do
         field.get_argument("a", { allowed_for: 2 })
       end
-
       assert_equal expected_message, err2.message
+      assert_equal "DuplicateArgumentObject.multiArg.a", err2.duplicated_name
 
       err3 = assert_raises GraphQL::Schema::DuplicateNamesError do
         schema.to_definition(context: { allowed_for: 2 })
       end
       assert_equal expected_message, err3.message
+      assert_equal "DuplicateArgumentObject.multiArg.a", err3.duplicated_name
 
       err4 = assert_raises GraphQL::Schema::DuplicateNamesError do
         schema.to_json(context: { allowed_for: 2 })
       end
       assert_equal expected_message, err4.message
+      assert_equal "DuplicateArgumentObject.multiArg.a", err4.duplicated_name
     end
 
     it "raises when a given context would permit multiple field definitions" do
@@ -1140,24 +1151,27 @@ GRAPHQL
       err = assert_raises GraphQL::Schema::DuplicateNamesError do
         DuplicateNames::DuplicateFieldObject.fields({ allowed_for: 2 })
       end
-      expected_message = "Found two visible type definitions for `DuplicateFieldObject.f`: #<DuplicateNames::BaseField DuplicateFieldObject.f: String>, #<DuplicateNames::BaseField DuplicateFieldObject.f: Int>"
+      expected_message = "Found two visible definitions for `DuplicateFieldObject.f`: #<DuplicateNames::BaseField DuplicateFieldObject.f: String>, #<DuplicateNames::BaseField DuplicateFieldObject.f: Int>"
       assert_equal expected_message, err.message
+      assert_equal "DuplicateFieldObject.f", err.duplicated_name
 
       err2 = assert_raises GraphQL::Schema::DuplicateNamesError do
         DuplicateNames::DuplicateFieldObject.get_field("f", { allowed_for: 2 })
       end
-
       assert_equal expected_message, err2.message
+      assert_equal "DuplicateFieldObject.f", err2.duplicated_name
 
       err3 = assert_raises GraphQL::Schema::DuplicateNamesError do
         schema.to_definition(context: { allowed_for: 2 })
       end
       assert_equal expected_message, err3.message
+      assert_equal "DuplicateFieldObject.f", err3.duplicated_name
 
       err4 = assert_raises GraphQL::Schema::DuplicateNamesError do
         schema.to_json(context: { allowed_for: 2 })
       end
       assert_equal expected_message, err4.message
+      assert_equal "DuplicateFieldObject.f", err4.duplicated_name
     end
   end
 end

--- a/spec/graphql/schema/enum_spec.rb
+++ b/spec/graphql/schema/enum_spec.rb
@@ -89,7 +89,7 @@ describe GraphQL::Schema::Enum do
       err = assert_raises GraphQL::Schema::DuplicateNamesError do
         MultipleNameTestEnum.enum_values
       end
-      expected_message = "Found two visible definitions for `MultipleNameTestEnum.B`: #<GraphQL::Schema::EnumValue MultipleNameTestEnum.B @value=:a>, #<GraphQL::Schema::EnumValue MultipleNameTestEnum.B @value=:b>"
+      expected_message = "Found two visible type definitions for `MultipleNameTestEnum.B`: #<GraphQL::Schema::EnumValue MultipleNameTestEnum.B @value=:a>, #<GraphQL::Schema::EnumValue MultipleNameTestEnum.B @value=:b>"
       assert_equal expected_message, err.message
     end
 

--- a/spec/graphql/schema/enum_spec.rb
+++ b/spec/graphql/schema/enum_spec.rb
@@ -89,8 +89,9 @@ describe GraphQL::Schema::Enum do
       err = assert_raises GraphQL::Schema::DuplicateNamesError do
         MultipleNameTestEnum.enum_values
       end
-      expected_message = "Found two visible type definitions for `MultipleNameTestEnum.B`: #<GraphQL::Schema::EnumValue MultipleNameTestEnum.B @value=:a>, #<GraphQL::Schema::EnumValue MultipleNameTestEnum.B @value=:b>"
+      expected_message = "Found two visible definitions for `MultipleNameTestEnum.B`: #<GraphQL::Schema::EnumValue MultipleNameTestEnum.B @value=:a>, #<GraphQL::Schema::EnumValue MultipleNameTestEnum.B @value=:b>"
       assert_equal expected_message, err.message
+      assert_equal "MultipleNameTestEnum.B", err.duplicated_name
     end
 
     it "returns them all in all_enum_value_definitions" do


### PR DESCRIPTION
I need to access the name error as part of the `DuplicateNamesError` class to implement a temporal fix in my App.

This PR does two things:

1) It removes `DuplicateTypeNamesError`. This error class was removed on https://github.com/rmosolgo/graphql-ruby/pull/3651 and it isn't used anymore.
2) Expose the duplicated type name in the `DuplicateNamesError` class. 