### PR TITLE
Pass dataloader instance into multiplex context

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -932,6 +932,7 @@ module GraphQL
           {
             backtrace: ctx[:backtrace],
             tracers: ctx[:tracers],
+            dataloader: ctx[:dataloader],
           }
         else
           {}


### PR DESCRIPTION
If you want to pass your own dataloader into the initial context of `Schema.execute` it is not correctly then passed to the underlaying multiplex context. This changes fixes this by passing it with the other special items
```ruby
# Some of the query context _should_ be passed to the multiplex, too
multiplex_context = if (ctx = kwargs[:context])
  {
    backtrace: ctx[:backtrace],
    tracers: ctx[:tracers],
    dataloader: ctx[:dataloader],
  }
else
  {}
end
```