### PR TITLE
Improve Datadog tracing support for ddtrace 1.0

### DIFF
--- a/spec/graphql/tracing/data_dog_tracing_spec.rb
+++ b/spec/graphql/tracing/data_dog_tracing_spec.rb
@@ -37,8 +37,14 @@ describe GraphQL::Tracing::DataDogTracing do
     assert_equal ["Ab"], Datadog::SPAN_RESOURCE_NAMES
   end
 
-  it "does not require a :tracing_fallback_transaction_name even if an operation name is not present" do
+  it "does not set resource if no value can be derived" do
     DataDogTest::TestSchema.execute("{ int }")
-    assert_equal [nil], Datadog::SPAN_RESOURCE_NAMES
+    assert_equal [], Datadog::SPAN_RESOURCE_NAMES
+  end
+
+  it "sets component and operation tags" do
+    DataDogTest::TestSchema.execute("{ int }")
+    assert_includes Datadog::SPAN_TAGS, ['component', 'graphql']
+    assert_includes Datadog::SPAN_TAGS, ['operation', 'execute_multiplex']
   end
 end

--- a/spec/support/datadog.rb
+++ b/spec/support/datadog.rb
@@ -6,12 +6,15 @@ end
 
 module Datadog
   SPAN_RESOURCE_NAMES = []
+  SPAN_TAGS = []
+
   def self.tracer
     DummyTracer.new
   end
 
   def self.clear_all
     SPAN_RESOURCE_NAMES.clear
+    SPAN_TAGS.clear
   end
 
 
@@ -29,14 +32,31 @@ module Datadog
 
   class DummyTracer
     def trace(platform_key, *args)
-      yield self
+      yield DummySpan.new
     end
+  end
 
+  class DummySpan
     def resource=(resource_name)
       SPAN_RESOURCE_NAMES << resource_name
     end
 
-    def span_type=(*args); end
-    def set_tag(*args); end
+    def span_type=(*args)end
+    def set_tag(key, value)
+      SPAN_TAGS << [key, value]
+    end
+  end
+
+  module Tracing
+    def self.trace(platform_key, *args)
+      yield DummySpan.new
+    end
+
+    module Metadata
+      module Ext
+        TAG_COMPONENT = 'component'
+        TAG_OPERATION = 'operation'
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR improves the support for GraphQL tracing with the Datadog tracing exporter.

The two changes are:
* Tag spans generated by GraphQL operations with an appropriate 'component' and 'operation' tags. This information was previously captured in the span name, as a concatenated pair. Having this information into two separate fields allows for richer grouping in the future.
* Span resource is not set to `nil` when `GraphQL::Tracing::DataDogTracing` cannot derive an appropriate rich value for it.  This allows for `ddtrace` to back-fill the resource value later in `ddtrace`s processing logic. Setting it explicitly to `nil`, as it was done before, sends a message to `ddtrace` that we explicitly don't want a resource, which was not the case here.