### PR TITLE
Use GlobalID methods instead of manually handling the encoding/decoding

### DIFF
--- a/guides/schema/object_identification.md
+++ b/guides/schema/object_identification.md
@@ -20,24 +20,12 @@ class MySchema < GraphQL::Schema
   def self.id_from_object(object, type_definition, query_ctx)
     # Generate a unique string ID for `object` here
     # For example, use Rails' GlobalID library (https://github.com/rails/globalid):
-    object_id = object.to_global_id.to_s
-    # Remove this redundant prefix to make IDs shorter:
-    object_id = object_id.sub("gid://#{GlobalID.app}/", "")
-    encoded_id = Base64.urlsafe_encode64(object_id, padding: false)
-    # Add a type hint
-    type_hint = type_definition.graphql_name.first
-    "#{type_hint}_#{encoded_id}"
+    object.to_gid_param
   end
 
-  def self.object_from_id(encoded_id_with_hint, query_ctx)
+  def self.object_from_id(global_id, query_ctx)
     # For example, use Rails' GlobalID library (https://github.com/rails/globalid):
-    # Split off the type hint
-    _type_hint, encoded_id = encoded_id_with_hint.split("_", 2)
-    # Decode the ID
-    id = Base64.urlsafe_decode64(encoded_id)
-    # Rebuild it for Rails then find the object:
-    full_global_id = "gid://#{GlobalID.app}/#{id}"
-    GlobalID::Locator.locate(full_global_id)
+    GlobalID.find(global_id)
   end
 end
 ```

--- a/guides/schema/object_identification.md
+++ b/guides/schema/object_identification.md
@@ -23,9 +23,7 @@ class MySchema < GraphQL::Schema
     object_id = object.to_global_id.to_s
     # Remove this redundant prefix to make IDs shorter:
     object_id = object_id.sub("gid://#{GlobalID.app}/", "")
-    encoded_id = Base64.urlsafe_encode64(object_id)
-    # Remove the "=" padding
-    encoded_id = encoded_id.sub(/=+/, "")
+    encoded_id = Base64.urlsafe_encode64(object_id, padding: false)
     # Add a type hint
     type_hint = type_definition.graphql_name.first
     "#{type_hint}_#{encoded_id}"

--- a/lib/generators/graphql/relay.rb
+++ b/lib/generators/graphql/relay.rb
@@ -33,25 +33,13 @@ module Graphql
   # Return a string UUID for `object`
   def self.id_from_object(object, type_definition, query_ctx)
     # For example, use Rails' GlobalID library (https://github.com/rails/globalid):
-    object_id = object.to_global_id.to_s
-    # Remove this redundant prefix to make IDs shorter:
-    object_id = object_id.sub("gid://\#{GlobalID.app}/", "")
-    encoded_id = Base64.urlsafe_encode64(object_id, padding: false)
-    # Add a type hint
-    type_hint = type_definition.graphql_name.first
-    "\#{type_hint}_\#{encoded_id}"
+    object.to_gid_param
   end
 
   # Given a string UUID, find the object
-  def self.object_from_id(encoded_id_with_hint, query_ctx)
+  def self.object_from_id(global_id, query_ctx)
     # For example, use Rails' GlobalID library (https://github.com/rails/globalid):
-    # Split off the type hint
-    _type_hint, encoded_id = encoded_id_with_hint.split("_", 2)
-    # Decode the ID
-    id = Base64.urlsafe_decode64(encoded_id)
-    # Rebuild it for Rails then find the object:
-    full_global_id = "gid://\#{GlobalID.app}/\#{id}"
-    GlobalID::Locator.locate(full_global_id)
+    GlobalID.find(global_id)
   end
 RUBY
         inject_into_file schema_file_path, schema_code, before: /^end\n/m, force: false

--- a/lib/generators/graphql/relay.rb
+++ b/lib/generators/graphql/relay.rb
@@ -36,9 +36,7 @@ module Graphql
     object_id = object.to_global_id.to_s
     # Remove this redundant prefix to make IDs shorter:
     object_id = object_id.sub("gid://\#{GlobalID.app}/", "")
-    encoded_id = Base64.urlsafe_encode64(object_id)
-    # Remove the "=" padding
-    encoded_id = encoded_id.sub(/=+/, "")
+    encoded_id = Base64.urlsafe_encode64(object_id, padding: false)
     # Add a type hint
     type_hint = type_definition.graphql_name.first
     "\#{type_hint}_\#{encoded_id}"

--- a/spec/integration/rails/generators/graphql/install_generator_spec.rb
+++ b/spec/integration/rails/generators/graphql/install_generator_spec.rb
@@ -346,9 +346,7 @@ RUBY
     object_id = object.to_global_id.to_s
     # Remove this redundant prefix to make IDs shorter:
     object_id = object_id.sub("gid://#{GlobalID.app}/", "")
-    encoded_id = Base64.urlsafe_encode64(object_id)
-    # Remove the "=" padding
-    encoded_id = encoded_id.sub(/=+/, "")
+    encoded_id = Base64.urlsafe_encode64(object_id, padding: false)
     # Add a type hint
     type_hint = type_definition.graphql_name.first
     "#{type_hint}_#{encoded_id}"

--- a/spec/integration/rails/generators/graphql/install_generator_spec.rb
+++ b/spec/integration/rails/generators/graphql/install_generator_spec.rb
@@ -343,25 +343,13 @@ RUBY
   # Return a string UUID for `object`
   def self.id_from_object(object, type_definition, query_ctx)
     # For example, use Rails\' GlobalID library (https://github.com/rails/globalid):
-    object_id = object.to_global_id.to_s
-    # Remove this redundant prefix to make IDs shorter:
-    object_id = object_id.sub("gid://#{GlobalID.app}/", "")
-    encoded_id = Base64.urlsafe_encode64(object_id, padding: false)
-    # Add a type hint
-    type_hint = type_definition.graphql_name.first
-    "#{type_hint}_#{encoded_id}"
+    object.to_gid_param
   end
 
   # Given a string UUID, find the object
-  def self.object_from_id(encoded_id_with_hint, query_ctx)
+  def self.object_from_id(global_id, query_ctx)
     # For example, use Rails\' GlobalID library (https://github.com/rails/globalid):
-    # Split off the type hint
-    _type_hint, encoded_id = encoded_id_with_hint.split("_", 2)
-    # Decode the ID
-    id = Base64.urlsafe_decode64(encoded_id)
-    # Rebuild it for Rails then find the object:
-    full_global_id = "gid://#{GlobalID.app}/#{id}"
-    GlobalID::Locator.locate(full_global_id)
+    GlobalID.find(global_id)
   end
 end
 '


### PR DESCRIPTION
Just a simple improvement.

Related: I'm curious about how this method of encoding the id is better than [what we suggested before](https://github.com/rmosolgo/graphql-ruby/pull/3627/files) (`object.to_gid.to_param`)? Why the extra work? That method produces a good looking string (like `Z2lkOi8vcmV2aWV3cy9SZXZpZXcvNDc`) too and is easier to locate.

Edit: Looks like it's even simpler: `object.to_gid_param`.