### PR TITLE
Minor table formating fix

### DIFF
--- a/guides/type_definitions/lists.md
+++ b/guides/type_definitions/lists.md
@@ -83,6 +83,7 @@ Combining list types and non-null types can be a bit tricky. There are four poss
 Here's how those combinations play out:
 
  &nbsp;  | nullable field | non-null field
+ ------|------|------
 nullable items  | <code>[Integer, null: true], null: true</code><br><code># => [Int]</code> | <code>[Integer, null: true], null: false</code><br><code># => [Int]!</code>
 non-null items   | <code>[Integer]</code><br><code># => [Int!]</code> | <code>[Integer], null: false</code><br><code># => [Int!]!</code>
 


### PR DESCRIPTION
Table in "Lists, Nullable Lists, and Lists of Nulls" section was not properly formatted and GitHub did not render it correctly.

**Before:**

![Screen Shot 2022-04-27 at 17 48 56](https://user-images.githubusercontent.com/47445/165521730-d67c19ee-9f1a-4224-9345-d9a16b19205e.png)

**After:**

![Screen Shot 2022-04-27 at 17 49 06](https://user-images.githubusercontent.com/47445/165521722-77ac79eb-e0a5-473a-8f11-d4e888ace8d3.png)

