### PR TITLE
Ensure argument.value responds to arguments method before calling

### DIFF
--- a/lib/graphql/analysis/ast/field_usage.rb
+++ b/lib/graphql/analysis/ast/field_usage.rb
@@ -39,7 +39,7 @@ module GraphQL
               @used_deprecated_arguments << argument.definition.path
             end
 
-            if argument.definition.type.kind.input_object?
+            if argument.definition.type.kind.input_object? && argument.value.respond_to?(:arguments)
               extract_deprecated_arguments(argument.value.arguments.argument_values) # rubocop:disable Development/ContextIsPassedCop -- runtime args instance
             elsif argument.definition.type.list? && !argument.value.nil?
               argument


### PR DESCRIPTION
This was happening in `extract_deprecated_arguments` in `lib/graphql/analysis/ast/field_usage.rb` when the `argument.value` was a Hash.

Related issue: https://github.com/rmosolgo/graphql-ruby/issues/4056