### PR TITLE
accept dates missing hyphen

### DIFF
--- a/lib/graphql/types/iso_8601_date_time.rb
+++ b/lib/graphql/types/iso_8601_date_time.rb
@@ -60,6 +60,9 @@ module GraphQL
           # But without this, it would zero out given any time part of `str_value` (hours and/or minutes)
           if dt.iso8601.start_with?(str_value)
             dt
+          elsif str_value.length == 8 && str_value.match?(/\A\d{8}\Z/)
+            # Allow dates that are missing the "-". eg. "20220404"
+            dt
           else
             nil
           end

--- a/spec/graphql/types/iso_8601_date_time_spec.rb
+++ b/spec/graphql/types/iso_8601_date_time_spec.rb
@@ -134,6 +134,24 @@ describe GraphQL::Types::ISO8601DateTime do
       assert_equal(expected_res, res)
     end
 
+    it "parses dates without times or dashes" do
+      res = parse_date("20180827")
+      # It uses the system default timezone when none is given
+      system_default_tz = Date.iso8601("2018-08-27").to_time.zone
+      system_default_offset = Date.iso8601("2018-08-27").to_time.utc_offset
+      expected_res = {
+        "year" => 2018,
+        "month" => 8,
+        "day" => 27,
+        "hour" => 0,
+        "minute" => 0,
+        "second" => 0,
+        "zone" => system_default_tz,
+        "utcOffset" => system_default_offset,
+      }
+      assert_equal(expected_res, res)
+    end
+
     it "rejects partial times" do
       expected_errors = ["Variable $date of type ISO8601DateTime! was provided invalid value"]
       assert_equal expected_errors, parse_date("2018-06-07T12:12").map { |e| e["message"] }


### PR DESCRIPTION
https://github.com/rmosolgo/graphql-ruby/commit/d045a207e0cf8bb53e31549f82b78c72a0e661c0 changed the behaviour for parsing dates (as date times) to make the parsing much safer. However, I have several consumers of my graphql apis who currently send datetime values as a date without hyphens (eg. "20220505"). I would like to make that use case continue to work in a safe way.