### PR TITLE
Add fallback_value option to Field

### DIFF
--- a/guides/fields/introduction.md
+++ b/guides/fields/introduction.md
@@ -87,6 +87,7 @@ By default, fields return values by:
 
 - Trying to call a method on the underlying object; _OR_
 - If the underlying object is a `Hash`, lookup a key in that hash.
+- An optional `:fallback_value` can be supplied that will be used if the above fail.
 
 The method name or hash key corresponds to the field name, so in this example:
 

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -645,7 +645,7 @@ module GraphQL
               inner_object = obj.object
 
               if defined?(@hash_key)
-                inner_object[@hash_key] || inner_object[@hash_key_str]
+                inner_object[@hash_key] || inner_object[@hash_key_str] || (@fallback_value != :not_given ? @fallback_value : nil)
               elsif obj.respond_to?(resolver_method)
                 method_to_call = resolver_method
                 method_receiver = obj
@@ -661,8 +661,12 @@ module GraphQL
                 elsif defined?(@hash_key)
                   if inner_object.key?(@hash_key)
                     inner_object[@hash_key]
-                  else
+                  elsif inner_object.key?(@hash_key_str)
                     inner_object[@hash_key_str]
+                  elsif @fallback_value != :not_given
+                    @fallback_value
+                  else
+                    nil
                   end
                 elsif inner_object.key?(@method_sym)
                   inner_object[@method_sym]
@@ -670,6 +674,8 @@ module GraphQL
                   inner_object[@method_str]
                 elsif @fallback_value != :not_given
                   @fallback_value
+                else
+                  nil
                 end
               elsif inner_object.respond_to?(@method_sym)
                 method_to_call = @method_sym

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -662,9 +662,12 @@ module GraphQL
                 end
               elsif inner_object.is_a?(Hash)
                 if inner_object.key?(@method_sym)
-                  inner_object[@method_sym]
-                else
+                  inner_object[@method_sym] 
+                elsif inner_object.key?(@method_str)
                   inner_object[@method_str]
+                # I think we need this here too bc if the thing is a Hash we end up here and otherwise just get nil back, even if a fallback_value is passed.
+                elsif @fallback_value != :not_given
+                  @fallback_value
                 end
               elsif inner_object.respond_to?(@method_sym)
                 method_to_call = @method_sym

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -665,7 +665,6 @@ module GraphQL
                   inner_object[@method_sym] 
                 elsif inner_object.key?(@method_str)
                   inner_object[@method_str]
-                # I think we need this here too bc if the thing is a Hash we end up here and otherwise just get nil back, even if a fallback_value is passed.
                 elsif @fallback_value != :not_given
                   @fallback_value
                 end

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -215,7 +215,6 @@ module GraphQL
       # @param method_conflict_warning [Boolean] If false, skip the warning if this field's method conflicts with a built-in method
       # @param validates [Array<Hash>] Configurations for validating this field
       # @fallback_value [Object] A fallback value if the method is not defined
-
       def initialize(type: nil, name: nil, owner: nil, null: nil, description: :not_given, deprecation_reason: nil, method: nil, hash_key: nil, dig: nil, resolver_method: nil, connection: nil, max_page_size: :not_given, scope: nil, introspection: false, camelize: true, trace: nil, complexity: nil, ast_node: nil, extras: EMPTY_ARRAY, extensions: EMPTY_ARRAY, connection_extension: self.class.connection_extension, resolver_class: nil, subscription_scope: nil, relay_node_field: false, relay_nodes_field: false, method_conflict_warning: true, broadcastable: nil, arguments: EMPTY_HASH, directives: EMPTY_HASH, validates: EMPTY_ARRAY, fallback_value: :not_given, &definition_block)
         if name.nil?
           raise ArgumentError, "missing first `name` argument or keyword `name:`"

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -214,7 +214,9 @@ module GraphQL
       # @param ast_node [Language::Nodes::FieldDefinition, nil] If this schema was parsed from definition, this AST node defined the field
       # @param method_conflict_warning [Boolean] If false, skip the warning if this field's method conflicts with a built-in method
       # @param validates [Array<Hash>] Configurations for validating this field
-      def initialize(type: nil, name: nil, owner: nil, null: nil, description: :not_given, deprecation_reason: nil, method: nil, hash_key: nil, dig: nil, resolver_method: nil, connection: nil, max_page_size: :not_given, scope: nil, introspection: false, camelize: true, trace: nil, complexity: nil, ast_node: nil, extras: EMPTY_ARRAY, extensions: EMPTY_ARRAY, connection_extension: self.class.connection_extension, resolver_class: nil, subscription_scope: nil, relay_node_field: false, relay_nodes_field: false, method_conflict_warning: true, broadcastable: nil, arguments: EMPTY_HASH, directives: EMPTY_HASH, validates: EMPTY_ARRAY, &definition_block)
+      # @fallback_value [Object] A fallback value if the method is not defined
+
+      def initialize(type: nil, name: nil, owner: nil, null: nil, description: :not_given, deprecation_reason: nil, method: nil, hash_key: nil, dig: nil, resolver_method: nil, connection: nil, max_page_size: :not_given, scope: nil, introspection: false, camelize: true, trace: nil, complexity: nil, ast_node: nil, extras: EMPTY_ARRAY, extensions: EMPTY_ARRAY, connection_extension: self.class.connection_extension, resolver_class: nil, subscription_scope: nil, relay_node_field: false, relay_nodes_field: false, method_conflict_warning: true, broadcastable: nil, arguments: EMPTY_HASH, directives: EMPTY_HASH, validates: EMPTY_ARRAY, fallback_value: :not_given, &definition_block)
         if name.nil?
           raise ArgumentError, "missing first `name` argument or keyword `name:`"
         end
@@ -280,6 +282,7 @@ module GraphQL
         @relay_nodes_field = relay_nodes_field
         @ast_node = ast_node
         @method_conflict_warning = method_conflict_warning
+        @fallback_value = fallback_value
 
         arguments.each do |name, arg|
           case arg
@@ -671,6 +674,8 @@ module GraphQL
                 else
                   inner_object.public_send(@method_sym)
                 end
+              elsif @fallback_value != :not_given
+                @fallback_value
               else
                 raise <<-ERR
               Failed to implement #{@owner.graphql_name}.#{@name}, tried:
@@ -679,7 +684,7 @@ module GraphQL
               - `#{inner_object.class}##{@method_sym}`, which did not exist
               - Looking up hash key `#{@method_sym.inspect}` or `#{@method_str.inspect}` on `#{inner_object}`, but it wasn't a Hash
 
-              To implement this field, define one of the methods above (and check for typos)
+              To implement this field, define one of the methods above (and check for typos), or supply a `fallback_value`.
               ERR
               end
             end

--- a/spec/graphql/schema/field_spec.rb
+++ b/spec/graphql/schema/field_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "spec_helper"
-
 describe GraphQL::Schema::Field do
   describe "graphql definition" do
     let(:object_class) { Jazz::Query }


### PR DESCRIPTION
Fixes #4020. This adds a parameter called `:fallback_value` to Field, which allows you to specify a value to be returned if the usual ways (calling the method on an object, or checking for the key in a hash) fail. It's useful if there is a query that returns objects that might or might not have a certain field.

The motivation for this is a scenario where we have a data model that has lots of entity types. All of them have an `id` property. Most of them have a `name` property, but some of them don't. We want all of them to implement an interface (Node) that has a required `id` property and an optional `name` property.
``` ruby
interface Node { id: ID! name: String }
```

The default for the `:fallback_value` param in the initializer is `:not_given`, which allows us to set `nil` as the fallback if we want. The most common use case is probably with interfaces, so that's where I wrote tests. Are there any other places this should be tested? I added documentation to guides/fields/introduction.md under `Field Resolution`. Does that seem sufficient? I added a blurb to the error message about supplying a `fallback_value` to implement the field.