### PR TITLE
Allow null input objects in arguments during field usage analysis

### DIFF
--- a/lib/graphql/analysis/ast/field_usage.rb
+++ b/lib/graphql/analysis/ast/field_usage.rb
@@ -39,9 +39,11 @@ module GraphQL
               @used_deprecated_arguments << argument.definition.path
             end
 
+            next if argument.value.nil?
+
             if argument.definition.type.kind.input_object?
               extract_deprecated_arguments(argument.value.arguments.argument_values) # rubocop:disable Development/ContextIsPassedCop -- runtime args instance
-            elsif argument.definition.type.list? && !argument.value.nil?
+            elsif argument.definition.type.list?
               argument
                 .value
                 .select { |value| value.respond_to?(:arguments) }

--- a/spec/graphql/analysis/ast/field_usage_spec.rb
+++ b/spec/graphql/analysis/ast/field_usage_spec.rb
@@ -152,6 +152,23 @@ describe GraphQL::Analysis::AST::FieldUsage do
     end
   end
 
+  describe "query with an input object sent in as null" do
+    let(:query_string) {%|
+      query {
+        cheese(id: 1) {
+          id
+          dairyProduct(input: null) {
+            __typename
+          }
+        }
+      }
+    |}
+
+    it "tolerates null for object argument" do
+      result
+    end
+  end
+
   describe "query with deprecated arguments nested in an argument" do
     let(:query_string) {%|
       query {

--- a/spec/graphql/introspection/type_type_spec.rb
+++ b/spec/graphql/introspection/type_type_spec.rb
@@ -15,6 +15,7 @@ describe GraphQL::Introspection::TypeType do
   |}
   let(:result) { Dummy::Schema.execute(query_string, context: {}, variables: {"cheeseId" => 2}) }
   let(:cheese_fields) {[
+    {"name"=>"dairyProduct", "isDeprecated" => false, "type"=>{"kind"=>"UNION", "name"=>"DairyProduct", "ofType"=>nil}},
     {"name"=>"deeplyNullableCheese", "isDeprecated" => false, "type"=>{ "kind" => "OBJECT", "name" => "Cheese", "ofType" => nil}},
     {"name"=>"flavor",      "isDeprecated" => false, "type" => { "kind" => "NON_NULL", "name" => nil, "ofType" => { "name" => "String"}}},
     {"name"=>"id",          "isDeprecated" => false, "type" => { "kind" => "NON_NULL", "name" => nil, "ofType" => { "name" => "Int"}}},

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -109,12 +109,17 @@ module Dummy
       end
     end
 
-    field :nullable_cheese, Cheese, "Cheeses like this one" do
+    field :nullable_cheese, Cheese, "Not really a Cheese at all" do
       argument :source, [DairyAnimal], required: false
     end
     def nullable_cheese; raise("NotImplemented"); end
 
-    field :deeply_nullable_cheese, Cheese, "Cheeses like this one" do
+    field :dairy_product, "Dummy::DairyProduct", "Some related dairy product, perhaps" do
+      argument :input, "Dummy::DairyProductInput", required: false
+    end
+    def dairy_product; raise("NotImplemented"); end
+
+    field :deeply_nullable_cheese, Cheese, "Definitely not a cheese" do
       argument :source, [[DairyAnimal, null: true], null: true], required: false
     end
     def deeply_nullable_cheese; raise("NotImplemented"); end


### PR DESCRIPTION
Problem
---

When passing in an explicit `null` value for a nullable input object-type argument on a field, field usage analysis will raise an exception like this:

```
NoMethodError: undefined method `arguments' for nil:NilClass
    graphql-ruby/lib/graphql/analysis/ast/field_usage.rb:43:in `block in extract_deprecated_arguments'
    graphql-ruby/lib/graphql/analysis/ast/field_usage.rb:37:in `each_pair'
    graphql-ruby/lib/graphql/analysis/ast/field_usage.rb:37:in `extract_deprecated_arguments'
    graphql-ruby/lib/graphql/analysis/ast/field_usage.rb:22:in `on_leave_field'
```

Solution
---

Skip arguments with null values during field usage analysis.