### PR TITLE
remove unused Lazy.resolve

### DIFF
--- a/lib/graphql/execution/lazy.rb
+++ b/lib/graphql/execution/lazy.rb
@@ -12,13 +12,6 @@ module GraphQL
     # - It has no error-catching functionality
     # @api private
     class Lazy
-      # Traverse `val`, lazily resolving any values along the way
-      # @param val [Object] A data structure containing mixed plain values and `Lazy` instances
-      # @return void
-      def self.resolve(val)
-        Resolve.resolve(val)
-      end
-
       attr_reader :path, :field
 
       # Create a {Lazy} which will get its inner value by calling the block


### PR DESCRIPTION
It looks like this was added long ago, but never actually used by the library. The way to resolve an individual lazy is with `.value`; the way to resolve a set of them is `Lazy::Resolve.resolve_all`.