### PR TITLE
Require Rake before referencing `Rake::DSL`

### DIFF
--- a/lib/graphql/rake_task.rb
+++ b/lib/graphql/rake_task.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "fileutils"
+require "rake"
 require "graphql/rake_task/validate"
 
 module GraphQL


### PR DESCRIPTION
This file references `Rake::DSL`, and may be required in isolation, and so it should `require "rake"` before using it.

Without this, requiring this file in isolation blows up when encountering this constant.