### PR TITLE
Set default datadog tracer depending on available modules in ddtrace gem

### DIFF
--- a/lib/graphql/tracing/data_dog_tracing.rb
+++ b/lib/graphql/tracing/data_dog_tracing.rb
@@ -63,7 +63,9 @@ module GraphQL
       end
 
       def tracer
-        options.fetch(:tracer, Datadog.tracer)
+        default_tracer = defined?(Datadog::Tracing) ? Datadog::Tracing : Datadog.tracer
+
+        options.fetch(:tracer, default_tracer)
       end
 
       def analytics_available?


### PR DESCRIPTION
A bugfix for ddtrace. The `Datadog.tracer` doesn't exist anymore, causing this check to fail. This change was already applied in the 2.x branch, but not yet backported to `1.13.x`.