### PR TITLE
Check for nullable result value to avoid errors on unsubscription

### DIFF
--- a/javascript_client/src/subscriptions/ActionCableLink.ts
+++ b/javascript_client/src/subscriptions/ActionCableLink.ts
@@ -46,7 +46,7 @@ class ActionCableLink extends ApolloLink {
           )
         },
         received: function(payload) {
-          if (payload.result.data || payload.result.errors) {
+          if (payload?.result?.data || payload?.result?.errors) {
             observer.next(payload.result)
           }
 

--- a/javascript_client/src/subscriptions/ActionCableLink.ts
+++ b/javascript_client/src/subscriptions/ActionCableLink.ts
@@ -46,7 +46,7 @@ class ActionCableLink extends ApolloLink {
           )
         },
         received: function(payload) {
-          if (payload?.result?.data || payload?.result?.errors) {
+          if (payload.result) {
             observer.next(payload.result)
           }
 

--- a/javascript_client/src/subscriptions/ActionCableLink.ts
+++ b/javascript_client/src/subscriptions/ActionCableLink.ts
@@ -46,7 +46,7 @@ class ActionCableLink extends ApolloLink {
           )
         },
         received: function(payload) {
-          if (payload.result) {
+          if (payload?.result?.data || payload?.result?.errors) {
             observer.next(payload.result)
           }
 


### PR DESCRIPTION
# Why

Currently when I run `unsubscribe` inside an `update` method for a subscription class (in ruby) this causes the front-end to fails, because the server sends a new message to the front end that looks like: 

```
{
  more: false
}
```

Now if you try to result `payload.result.data` this will error out, as result is undefined and you cannot read `.data` of undefined. 

# How I fixed it

By using conditional access to said properties, we can safely read `data` and `errors` while not trying to read some properties when `result` is undefined