### PR TITLE
Don't allow re-assigning Query#validate after validation

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -34,7 +34,16 @@ module GraphQL
     attr_accessor :operation_name
 
     # @return [Boolean] if false, static validation is skipped (execution behavior for invalid queries is undefined)
-    attr_accessor :validate
+    attr_reader :validate
+
+    # @param new_validate [Boolean] if false, static validation is skipped. This can't be reasssigned after validation.
+    def validate=(new_validate)
+      if defined?(@validation_pipeline) && @validation_pipeline && @validation_pipeline.has_validated?
+        raise ArgumentError, "Can't reassign Query#validate= after validation has run, remove this assignment."
+      else
+        @validate = new_validate
+      end
+    end
 
     attr_writer :query_string
 

--- a/lib/graphql/query/validation_pipeline.rb
+++ b/lib/graphql/query/validation_pipeline.rb
@@ -45,6 +45,10 @@ module GraphQL
         @query_analyzers
       end
 
+      def has_validated?
+        @has_validated == true
+      end
+
       private
 
       # If the pipeline wasn't run yet, run it.

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -720,6 +720,24 @@ describe GraphQL::Query do
       assert_equal true, query.valid?
       assert_equal 0, query.static_errors.length
     end
+
+    it "can't be reassigned after validating" do
+      query = GraphQL::Query.new(schema, "{ nonExistingField }")
+      assert query.fingerprint
+      query.validate = false
+      assert_equal true, query.valid?
+      assert_equal 0, query.static_errors.length
+      err = assert_raises ArgumentError do
+        query.validate = true
+      end
+
+      err2 = assert_raises ArgumentError do
+        query.validate = false
+      end
+      expected_message = "Can't reassign Query#validate= after validation has run, remove this assignment."
+      assert_equal expected_message, err.message
+      assert_equal expected_message, err2.message
+    end
   end
 
   describe "validating with optional arguments and variables: nil" do


### PR DESCRIPTION
Since recently, you could assign `Query#validate=...` to tell a query whether it should run static validation or not. But the validation result is cached, so it'd be buggy to reassign this afterward. I'd like to warn people about it rather that allow a possible foot-gun. If this doesn't work, this other option is to bust the validation cache whenever this value is reassigned.

Fixes #3901