### PR TITLE
Call prepare before loads for all arguments

### DIFF
--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -259,26 +259,26 @@ module GraphQL
         # If this isn't lazy, then the block returns eagerly and assigns the result here
         # If it _is_ lazy, then we write the lazy to the hash, then update it later
         argument_values[arg_key] = context.schema.after_lazy(coerced_value) do |resolved_coerced_value|
+          owner.validate_directive_argument(self, resolved_coerced_value)
+          prepared_value = begin
+            prepare_value(parent_object, resolved_coerced_value, context: context)
+          rescue StandardError => err
+            context.schema.handle_or_reraise(context, err)
+          end
+
           if loads && !from_resolver?
             loaded_value = begin
-              load_and_authorize_value(owner, coerced_value, context)
+              load_and_authorize_value(owner, prepared_value, context)
             rescue StandardError => err
               context.schema.handle_or_reraise(context, err)
             end
           end
 
-          maybe_loaded_value = loaded_value || resolved_coerced_value
+          maybe_loaded_value = loaded_value || prepared_value
           context.schema.after_lazy(maybe_loaded_value) do |resolved_loaded_value|
-            owner.validate_directive_argument(self, resolved_loaded_value)
-            prepared_value = begin
-              prepare_value(parent_object, resolved_loaded_value, context: context)
-            rescue StandardError => err
-              context.schema.handle_or_reraise(context, err)
-            end
-
             # TODO code smell to access such a deeply-nested constant in a distant module
             argument_values[arg_key] = GraphQL::Execution::Interpreter::ArgumentValue.new(
-              value: prepared_value,
+              value: resolved_loaded_value,
               definition: self,
               default_used: default_used,
             )


### PR DESCRIPTION
Weirdly, the order here was different for resolvers than for other arguments. I think resolvers had the right before: prepare first, then load.

Fixes #4017 