### PR TITLE
Support returning [Type, nil] from resolve_type

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -685,12 +685,16 @@ module GraphQL
             set_result(selection_result, result_name, r)
             r
           when "UNION", "INTERFACE"
-            resolved_type_or_lazy, resolved_value = resolve_type(current_type, value, path)
-            resolved_value ||= value
+            resolved_type_or_lazy = resolve_type(current_type, value, path)
+            after_lazy(resolved_type_or_lazy, owner: current_type, path: path, ast_node: ast_node, field: field, owner_object: owner_object, arguments: arguments, trace: false, result_name: result_name, result: selection_result) do |resolved_type_result|
+              if resolved_type_result.is_a?(Array) && resolved_type_result.length == 2
+                resolved_type, resolved_value = resolved_type_result
+              else
+                resolved_type = resolved_type_result
+                resolved_value = value
+              end
 
-            after_lazy(resolved_type_or_lazy, owner: current_type, path: path, ast_node: ast_node, field: field, owner_object: owner_object, arguments: arguments, trace: false, result_name: result_name, result: selection_result) do |resolved_type|
               possible_types = query.possible_types(current_type)
-
               if !possible_types.include?(resolved_type)
                 parent_type = field.owner_type
                 err_class = current_type::UnresolvedTypeError

--- a/lib/graphql/schema/member/has_arguments.rb
+++ b/lib/graphql/schema/member/has_arguments.rb
@@ -323,8 +323,14 @@ module GraphQL
               end
               # Double-check that the located object is actually of this type
               # (Don't want to allow arbitrary access to objects this way)
-              resolved_application_object_type = context.schema.resolve_type(argument.loads, application_object, context)
-              context.schema.after_lazy(resolved_application_object_type) do |application_object_type|
+              maybe_lazy_resolve_type = context.schema.resolve_type(argument.loads, application_object, context)
+              context.schema.after_lazy(maybe_lazy_resolve_type) do |resolve_type_result|
+                if resolve_type_result.is_a?(Array) && resolve_type_result.size == 2
+                  application_object_type, application_object = resolve_type_result
+                else
+                  application_object_type = resolve_type_result
+                  # application_object is already assigned
+                end
                 possible_object_types = context.warden.possible_types(argument.loads)
                 if !possible_object_types.include?(application_object_type)
                   err = GraphQL::LoadApplicationObjectFailedError.new(argument: argument, id: id, object: application_object)


### PR DESCRIPTION
Fixes #4085 

Another option is to call `continue_value` in this code, which would change the behavior like this: 

```diff 
- { "myUnion" => { "b" => nil } }
+ { "myUnion" => nil }
```

This would be _more_ like how objects are handle, but it would break some other tests in library. I'm open to it and I'll consider it if requested.