### PR TITLE
Fix Typo in Markdown Syntax on /related_projects

### DIFF
--- a/guides/related_projects.md
+++ b/guides/related_projects.md
@@ -26,7 +26,7 @@ Want to add something? Please open a pull request [on GitHub](https://github.com
   - [`graphql-query-resolver`](https://github.com/nettofarah/graphql-query-resolver), a graphql-ruby add-on to minimize N+1 queries.
   - [`graphql-rails_logger`](https://github.com/jetruby/graphql-rails_logger), a logger which allows you to inspect GraphQL queries in a more readable format.
   - [`apollo_upload_server-ruby`](https://github.com/jetruby/apollo_upload_server-ruby), a middleware which allows you to upload files with GraphQL and multipart/form-data using [`apollo-upload-client`](https://github.com/jaydenseric/apollo-upload-client) library on front-end.
-  - [`graphql-sources](https://github.com/ksylvest/graphql-sources) a collection of common GraphQL [sources](https://graphql-ruby.org/dataloader/sources.html) to simplify using `ActiveRecord`, `ActiveStorage`, `Rails.cache`, and more.
+  - [`graphql-sources`](https://github.com/ksylvest/graphql-sources) a collection of common GraphQL [sources](https://graphql-ruby.org/dataloader/sources.html) to simplify using `ActiveRecord`, `ActiveStorage`, `Rails.cache`, and more.
 - [`search_object_graphql`](https://github.com/rstankov/SearchObjectGraphQL), a DSL for defining search resolvers for GraphQL.
 - [`action_policy-graphql`](https://github.com/palkan/action_policy-graphql), an integration for using [`action_policy`](https://github.com/palkan/action_policy) as an authorization framework for GraphQL applications.
 - [`graphql_rails`](https://github.com/samesystem/graphql_rails), Rails way GraphQL build tool


### PR DESCRIPTION
This fixes a rendering bug on the /related_projects page introduced by https://github.com/rmosolgo/graphql-ruby/pull/4134. Apologies for the typo not being caught earlier!

### Before
<img width="1032" alt="Screen Shot 2022-07-11 at 2 24 18 PM" src="https://user-images.githubusercontent.com/73432/178361066-6294a8ab-ca16-4699-8655-d6fe292eccc8.png">

### After

<img width="1014" alt="Screen Shot 2022-07-11 at 2 27 04 PM" src="https://user-images.githubusercontent.com/73432/178361447-6e39d5c0-5190-46fa-81d9-0759f7218583.png">


