### PR TITLE
Update documentation

### DIFF
--- a/guides/dataloader/sources.md
+++ b/guides/dataloader/sources.md
@@ -21,7 +21,7 @@ Sources will receive two kinds of inputs from `GraphQL::Dataloader`:
 
   Under the hood, each Source instance maintains a `key => object` cache.
 
-- _batch parameters_, which are the basis of batched groups. For example, if you're loading records from different database tables, the the table name would be a batch parameter.
+- _batch parameters_, which are the basis of batched groups. For example, if you're loading records from different database tables, the table name would be a batch parameter.
 
   Batch parameters are given to `dataloader.with(source_class, *batch_parameters)`, and the default is _no batch parameters_. When you define a source, you should add the batch parameters to `def initialize(...)` and store them in instance variables.
 


### PR DESCRIPTION
Thanks for the great gem, and extensive documentation! 🎉

I noticed a small repetition when perusing, this change removes an unnecessary _the_ from the `sources.md` page.