### PR TITLE
Use Array#+ to insert an object to frozen Array instead of #dup and #<<

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -401,8 +401,7 @@ module GraphQL
           end
           return_type = field_defn.type
 
-          next_path = path.dup
-          next_path << result_name
+          next_path = path + [result_name]
           next_path.freeze
 
           # This seems janky, but we need to know
@@ -768,8 +767,7 @@ module GraphQL
                   set_result(selection_result, result_name, response_list)
                   result_was_set = true
                 end
-                next_path = path.dup
-                next_path << idx
+                next_path = path + [idx]
                 this_idx = idx
                 next_path.freeze
                 idx += 1


### PR DESCRIPTION
This patch might improve performance where it insert an object into frozen array.

### Environment
- macOS 13.0 beta
- Apple M1 Max
- Apple clang version 14.0.0 (clang-1400.0.28.1)
- Ruby 3.1.2

### Benchmark result
```
Warming up --------------------------------------
             dup, <<   735.025k i/100ms
                   +     1.141M i/100ms
Calculating -------------------------------------
             dup, <<      7.374M (± 0.4%) i/s -     74.238M in  10.067378s
                   +     11.360M (± 0.5%) i/s -    114.081M in  10.042478s

Comparison:
                   +: 11360174.1 i/s
             dup, <<:  7374162.2 i/s - 1.54x  (± 0.00) slower
```

### Benchmark code
```ruby
require 'benchmark/ips'

Benchmark.ips do |x|
  x.time = 10

  path = ["__schema", "types"].freeze

  x.report('dup, <<') {
    next_path = path.dup
    next_path << 1
  }

  x.report('+') {
    next_path = path + [1]
  }

  x.compare!
end
```