### PR TITLE
Use while instead of Array#each to improve performance

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -760,7 +760,11 @@ module GraphQL
             result_was_set = false
             idx = 0
             list_value = begin
-              value.each do |inner_value|
+              loop_i = 0
+              value_size = value.size
+              while loop_i < value_size
+                inner_value = value[loop_i]
+                loop_i += 1
                 break if dead_result?(response_list)
                 if !result_was_set
                   # Don't set the result unless `.each` is successful


### PR DESCRIPTION
To reduce overhead of yield in Array#each, this patch will use while.

before | after  | result
--     | --     | --
30.623 | 41.635 | 1.359x

### Environment
- macOS 13.0 beta
- Apple M1 Max
- Apple clang version 14.0.0 (clang-1400.0.28.1)
- Ruby 3.1.2

### Before
```
$ bundle exec rake bench:query
Warming up --------------------------------------
               query     3.000  i/100ms
Calculating -------------------------------------
               query     30.623  (± 0.0%) i/s -    156.000  in   5.094397s
```

### After
```
$ bundle exec rake bench:query
Warming up --------------------------------------
               query     4.000  i/100ms
Calculating -------------------------------------
               query     41.635  (± 0.0%) i/s -    212.000  in   5.092120s
```