### PR TITLE
Fix typo in code example in Argument Visibility docs

### DIFF
--- a/guides/authorization/visibility.md
+++ b/guides/authorization/visibility.md
@@ -86,7 +86,7 @@ class Types::BaseArgument < GraphQL::Schema::Argument
     super(*args, **kwargs, &block)
   end
 
-  def authorized?(ctx)
+  def visible?(ctx)
     super && (@require_logged_in ? ctx[:viewer].present? : true)
   end
 end


### PR DESCRIPTION
https://github.com/rmosolgo/graphql-ruby/blob/master/guides/authorization/visibility.md#argument-visibility

I guess there is a typo. Probably the `visible?` method should be used there

Compare the `authorized?` and `visible?` method signatures
https://github.com/rmosolgo/graphql-ruby/blob/master/lib/graphql/schema/argument.rb#L144-L146
https://github.com/rmosolgo/graphql-ruby/blob/master/lib/graphql/schema/argument.rb#L136-L138


