### PR TITLE
Fix prometheus tracing guide

### DIFF
--- a/guides/queries/tracing.md
+++ b/guides/queries/tracing.md
@@ -181,10 +181,11 @@ The PrometheusExporter server must be run with a custom type collector that exte
 
 ```ruby
 # lib/graphql_collector.rb
+if defined?(PrometheusExporter::Server)
+  require 'graphql/tracing'
 
-require 'graphql/tracing'
-
-class GraphQLCollector < GraphQL::Tracing::PrometheusTracing::GraphQLCollector
+  class GraphQLCollector < GraphQL::Tracing::PrometheusTracing::GraphQLCollector
+  end
 end
 ```
 


### PR DESCRIPTION
Look [here](https://github.com/rmosolgo/graphql-ruby/blob/v2.10.0/lib/graphql/tracing.rb#L12-L14), `GraphQL::Tracing::PrometheusTracing::GraphQLCollector` only be required when used `PrometheusExporter::Server` startup, so it throwing `NameError` exception when used other server startup.

_PS: English is not my native language; please excuse typing errors._