### PR TITLE
Add Flexport as a graphql-ruby user

### DIFF
--- a/guides/index.html
+++ b/guides/index.html
@@ -20,7 +20,7 @@ rails generate graphql:install
       <div class="teaser">
         <p>
           <a href="{{ site.baseurl}}/getting_started">Get going fast</a> with the <code><a href="https://rubygems.org/gems/graphql">graphql</a></code> gem,
-          battle-tested and trusted by <a href="https://githubengineering.com/the-github-graphql-api/#open-source">GitHub</a>, <a href="https://www.graphql.com/articles/graphql-at-shopify">Shopify</a>, <a href="https://www.chime.com">Chime</a>, and <a href="https://www.kickstarter.com/">Kickstarter</a>.
+          battle-tested and trusted by <a href="https://githubengineering.com/the-github-graphql-api/#open-source">GitHub</a>, <a href="https://www.graphql.com/articles/graphql-at-shopify">Shopify</a>, <a href="https://flexport.com">Flexport</a>, </a><a href="https://www.chime.com">Chime</a>, and <a href="https://www.kickstarter.com/">Kickstarter</a>.
         </p>
       </div>
     </div>


### PR DESCRIPTION
[Flexport](https://flexport.com), a digital freight forwarder, is a big fan and user of `graphql-ruby`. It is the package that underlies our monolith's GraphQL usage, and we have anywhere between 50-100k LOC in Ruby GraphQL code made possible by this library. We'd love to be acknowledged as a "verified" user of `graphql-ruby`!

The placement of Flexport in the list of users was determined by organization size -- by my rough estimates (and perhaps some degree of bias), this order is roughly Shopify > Flexport > Chime > Kickstarter (ignoring GitHub). I'm happy to move Flexport around in the list as necessary.