### PR TITLE
Merge directive errors when they're on the same directive or location

### DIFF
--- a/lib/graphql/static_validation/error.rb
+++ b/lib/graphql/static_validation/error.rb
@@ -30,9 +30,9 @@ module GraphQL
         }.tap { |h| h["path"] = path unless path.nil? }
       end
 
-      private
-
       attr_reader :nodes
+
+      private
 
       def locations
         nodes.map do |node|

--- a/lib/graphql/static_validation/rules/directives_are_defined.rb
+++ b/lib/graphql/static_validation/rules/directives_are_defined.rb
@@ -9,11 +9,17 @@ module GraphQL
 
       def on_directive(node, parent)
         if !@directive_names.include?(node.name)
-          add_error(GraphQL::StaticValidation::DirectivesAreDefinedError.new(
-            "Directive @#{node.name} is not defined",
-            nodes: node,
-            directive: node.name
-          ))
+          @directives_are_defined_errors_by_name ||= {}
+          error = @directives_are_defined_errors_by_name[node.name] ||= begin
+            err = GraphQL::StaticValidation::DirectivesAreDefinedError.new(
+              "Directive @#{node.name} is not defined",
+              nodes: [],
+              directive: node.name
+            )
+            add_error(err)
+            err
+          end
+          error.nodes << node
         else
           super
         end

--- a/spec/graphql/static_validation/rules/directives_are_defined_spec.rb
+++ b/spec/graphql/static_validation/rules/directives_are_defined_spec.rb
@@ -9,7 +9,7 @@ describe GraphQL::StaticValidation::DirectivesAreDefined do
         id @skip(if: true),
         source @nonsense(if: false)
         ... on Cheese {
-          flavor @moreNonsense
+          flavor @moreNonsense @moreNonsense
         }
       }
     }
@@ -22,9 +22,16 @@ describe GraphQL::StaticValidation::DirectivesAreDefined do
           "locations"=>[{"line"=>5, "column"=>16}],
           "path"=>["query getCheese", "okCheese", "source"],
           "extensions"=>{"code"=>"undefinedDirective", "directiveName"=>"nonsense"}
-        }, {
+        },
+        {
+          "message"=>"The directive \"moreNonsense\" can only be used once at this location.",
+          "locations"=>[{"line"=>7, "column"=>18}, {"line"=>7, "column"=>32}],
+          "path"=>["query getCheese", "okCheese", "... on Cheese", "flavor"],
+          "extensions"=>{"code"=>"directiveNotUniqueForLocation", "directiveName"=>"moreNonsense"}
+        },
+        {
           "message"=>"Directive @moreNonsense is not defined",
-          "locations"=>[{"line"=>7, "column"=>18}],
+          "locations"=>[{"line"=>7, "column"=>18}, {"line"=>7, "column"=>32}],
           "path"=>["query getCheese", "okCheese", "... on Cheese", "flavor"],
           "extensions"=>{"code"=>"undefinedDirective", "directiveName"=>"moreNonsense"}
         }

--- a/spec/graphql/static_validation/rules/unique_directives_per_location_spec.rb
+++ b/spec/graphql/static_validation/rules/unique_directives_per_location_spec.rb
@@ -135,14 +135,7 @@ describe GraphQL::StaticValidation::UniqueDirectivesPerLocation do
     it "fails rule" do
       assert_includes errors, {
         "message" => 'The directive "A" can only be used once at this location.',
-        "locations" => [{ "line" => 4, "column" => 17 }, { "line" => 4, "column" => 20 }],
-        "path" => ["query", "type", "field"],
-        "extensions" => {"code"=>"directiveNotUniqueForLocation", "directiveName"=>"A"}
-      }
-
-      assert_includes errors, {
-        "message" => 'The directive "A" can only be used once at this location.',
-        "locations" => [{ "line" => 4, "column" => 17 }, { "line" => 4, "column" => 23 }],
+        "locations" => [{ "line" => 4, "column" => 17 }, { "line" => 4, "column" => 20 },  { "line" => 4, "column" => 23 }],
         "path" => ["query", "type", "field"],
         "extensions" => {"code"=>"directiveNotUniqueForLocation", "directiveName"=>"A"}
       }


### PR DESCRIPTION
This improves memory usage when the same invalid directive is repeated over and over. 

(When the invalid directives are different, `validate_max_errors ...` in the schema is probably the best choice.) 

Part of #4154 

From the script in the original issue: 

script | before | after 
--- | --- | --- 
innocent, total time | 0.000439 | 0.000449
unique, total time | 0.148472 | 0.166246
repeat, total time |0.135613 |  0.101214
  | | 
innocent, memsize | 22.728k | 22.912k
unique, memsize | 20.419M | 20.878M
repeat, memsize | 34.711M |  9.972M 

(The `unique` benchmark didn't improve because `validate_max_errors` is the best way to mitigate that.) 

I considered some kind of DRYing for "directive not defined" errors, but I found that GraphQL-JS also makes a separate error for each invalid directive: https://github.com/graphql/graphql-js/blob/5447189ee906a4583c834ef9a2bb0c92345180d6/src/validation/rules/KnownDirectivesRule.ts#L61-L66