### PR TITLE
Remove deprecated datadog tracer analytic options

### DIFF
--- a/guides/queries/tracing.md
+++ b/guides/queries/tracing.md
@@ -157,8 +157,6 @@ You may provide `options` as a `Hash` with the following values:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
-| `analytics_enabled` | Enable analytics for spans. `true` for on, `nil` to defer to Datadog global setting, `false` for off. | `false` |
-| `analytics_sample_rate` | Rate which tracing data should be sampled for Datadog analytics. Must be a float between `0` and `1.0`. | `1.0` |
 | `service` | Service name used for `graphql` instrumentation | `'ruby-graphql'` |
 | `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |
 

--- a/lib/graphql/tracing/data_dog_tracing.rb
+++ b/lib/graphql/tracing/data_dog_tracing.rb
@@ -75,10 +75,12 @@ module GraphQL
       end
 
       def analytics_enabled?
+        # [Deprecated] options[:analytics_enabled] will be removed in the future
         analytics_available? && Datadog::Contrib::Analytics.enabled?(options.fetch(:analytics_enabled, false))
       end
 
       def analytics_sample_rate
+        # [Deprecated] options[:analytics_sample_rate] will be removed in the future
         options.fetch(:analytics_sample_rate, 1.0)
       end
 


### PR DESCRIPTION
**Why & What** 

Datadog GraphQL integration is deprecating `analytics_enabled`, `analytics_sample_rate`. Hence, marking it with comment, and removing it from documentation to prevent it more usage

https://github.com/DataDog/dd-trace-rb/pull/2214