### PR TITLE
Fix trigger context initialization

### DIFF
--- a/lib/graphql/subscriptions.rb
+++ b/lib/graphql/subscriptions.rb
@@ -62,11 +62,8 @@ module GraphQL
     # @return [void]
     def trigger(event_name, args, object, scope: nil, context: {})
       # Make something as context-like as possible, even though there isn't a current query:
-      context = @schema.context_class.new(
-        query: GraphQL::Query.new(@schema, "", validate: false),
-        object: nil,
-        values: context
-      )
+      dummy_query = GraphQL::Query.new(@schema, "", validate: false, context: context)
+      context = dummy_query.context
       event_name = event_name.to_s
 
       # Try with the verbatim input first:


### PR DESCRIPTION
Oops -- the previous initialization code actually made it so that `context.query.context.to_h` was `{}`, so schema root fields might fail visibility checks even when a context was given to trigger.