### PR TITLE
Datadog tracing - Implement unified tagging `graphql.*`

### DIFF
--- a/lib/graphql/tracing/data_dog_tracing.rb
+++ b/lib/graphql/tracing/data_dog_tracing.rb
@@ -48,15 +48,7 @@ module GraphQL
           end
 
           if key == 'execute_query'
-            span.set_tag(:selected_operation_name, data[:query].selected_operation_name)
-            if data[:query].selected_operation_name
-              span.set_tag('graphql.operation.name', data[:query].selected_operation_name)
-            end
-
-            span.set_tag(:selected_operation_type, data[:query].selected_operation.operation_type)
-            span.set_tag('graphql.operation.type', data[:query].selected_operation.operation_type)
-
-            add_source_tag(span, data[:query].query_string)
+            annotate_execute_query_span(span, data)
           end
 
           prepare_span(key, data, span)
@@ -108,6 +100,20 @@ module GraphQL
 
       def platform_resolve_type_key(type)
         "#{type.graphql_name}.resolve_type"
+      end
+
+      def annotate_execute_query_span(span, data)
+        query = data.fetch(:query)
+
+        span.set_tag(:selected_operation_name, query.selected_operation_name)
+        if query.selected_operation_name
+          span.set_tag('graphql.operation.name', query.selected_operation_name)
+        end
+
+        span.set_tag(:selected_operation_type, query.selected_operation.operation_type)
+        span.set_tag('graphql.operation.type', query.selected_operation.operation_type)
+
+        add_source_tag(span, query.query_string)
       end
 
       def add_source_tag(span, query_string)


### PR DESCRIPTION
**Why** 

Datadog is working on unified tagging initiative, in order to provide unified experience across different language implementation

https://github.com/DataDog/dd-trace-rb/pull/2278

**What** 

##### graphql.source 

A representation of [source](https://graphql.org/graphql-js/language/#source-1) input to GraphQL.

candidates: `graphql.parse`, `graphql.validate`, and `graphql.execute`

##### graphql.operation.type

The [operation type](https://spec.graphql.org/June2018/#OperationType) is either query, mutation, or subscription and describes what type of operation intending to do.

candidate: `graphql.execute`

##### graphql.operation.type

The [operation name](https://graphql.org/learn/queries/#operation-name) is a meaningful and explicit name for operation. It is only required in multi-operation documents, but its use is encouraged because it is very helpful for debugging and server-side logging.

candidate: `graphql.execute`