### PR TITLE
Replace `max_validation_errors` with `validate_max_errors` in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 - Input Objects: support `one_of` for input objects that allow exactly one argument #4184
 - Dataloader: add `source.merge({ ... })` for adding objects to dataloader source caches #4186
-- Validation: generate new schemas with a suggested `max_validation_errors` of 100 #4179
+- Validation: generate new schemas with a suggested `validate_max_errors` of 100 #4179
 
 ### Bug fixes
 
@@ -445,7 +445,7 @@ Since this version, GraphQL-Ruby is tested on Ruby 2.4+ and Rails 4+ only.
 ### New features
 
 - Subscriptions: Add `NO_UPDATE` constant for skipping subscription updates #3664
-- Validation: Add `Schema.max_validation_errors(integer)` for halting validation when it reaches a certain number #3683
+- Validation: Add `Schema.validate_max_errors(integer)` for halting validation when it reaches a certain number #3683
 - Call `self.load_...` methods on Input objects for loading arguments #3682
 - Use `import_methods` in Refinements when available #3674
 - `AppsignalTracing`: Add `set_action_name` #3659


### PR DESCRIPTION
CHANGELOG mentions `max_validation_errors` method but actually the method does not exist. There is `validate_max_errors` instead.
This PR replaces `max_validation_errors` with `validate_max_errors`.

---

In #2386, this feature was developed as `max_validation_errors` but this PR was not merged. This feature has been added as `validate_max_errors` in another PR. I guess it is the reason why there was the confusion in CHANGELOG.