### PR TITLE
Support apollo-style schema extensions

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -816,6 +816,15 @@ module GraphQL
         member.accessible?(ctx)
       end
 
+      def schema_directive(dir_class, **options)
+        @own_schema_directives ||= []
+        Member::HasDirectives.add_directive(self, @own_schema_directives, dir_class, options)
+      end
+
+      def schema_directives
+        Member::HasDirectives.get_directives(self, @own_schema_directives, :schema_directives)
+      end
+
       # This hook is called when a client tries to access one or more
       # fields that fail the `accessible?` check.
       #

--- a/lib/graphql/schema/member/has_directives.rb
+++ b/lib/graphql/schema/member/has_directives.rb
@@ -11,8 +11,7 @@ module GraphQL
         # @return [void]
         def directive(dir_class, **options)
           @own_directives ||= []
-          remove_directive(dir_class) unless dir_class.repeatable?
-          @own_directives << dir_class.new(self, **options)
+          HasDirectives.add_directive(self, @own_directives, dir_class, options)
           nil
         end
 
@@ -20,77 +19,93 @@ module GraphQL
         # @param dir_class [Class<GraphQL::Schema::Directive>]
         # @return [viod]
         def remove_directive(dir_class)
-          @own_directives && @own_directives.reject! { |d| d.is_a?(dir_class) }
+          HasDirectives.remove_directive(@own_directives, dir_class)
           nil
         end
 
         NO_DIRECTIVES = [].freeze
 
         def directives
-          case self
-          when Class
-            inherited_directives = if superclass.respond_to?(:directives)
-              superclass.directives
-            else
-              NO_DIRECTIVES
-            end
-            if inherited_directives.any? && @own_directives
-              dirs = []
-              merge_directives(dirs, inherited_directives)
-              merge_directives(dirs, @own_directives)
-              dirs
-            elsif @own_directives
-              @own_directives
-            elsif inherited_directives.any?
-              inherited_directives
-            else
-              NO_DIRECTIVES
-            end
-          when Module
-            dirs = nil
-            self.ancestors.reverse_each do |ancestor|
-              if ancestor.respond_to?(:own_directives) &&
-                  (anc_dirs = ancestor.own_directives).any?
+          HasDirectives.get_directives(self, @own_directives, :directives)
+        end
+
+        class << self
+          def add_directive(schema_member, directives, directive_class, directive_options)
+            remove_directive(directives, directive_class) unless directive_class.repeatable?
+            directives << directive_class.new(schema_member, **directive_options)
+          end
+
+          def remove_directive(directives, directive_class)
+            directives && directives.reject! { |d| d.is_a?(directive_class) }
+          end
+
+          def get_directives(schema_member, directives, directives_method)
+            case schema_member
+            when Class
+              inherited_directives = if schema_member.superclass.respond_to?(directives_method)
+                get_directives(schema_member.superclass, schema_member.superclass.public_send(directives_method), directives_method)
+              else
+                NO_DIRECTIVES
+              end
+              if inherited_directives.any? && directives
+                dirs = []
+                merge_directives(dirs, inherited_directives)
+                merge_directives(dirs, directives)
+                dirs
+              elsif directives
+                directives
+              elsif inherited_directives.any?
+                inherited_directives
+              else
+                NO_DIRECTIVES
+              end
+            when Module
+              dirs = nil
+              schema_member.ancestors.reverse_each do |ancestor|
+                if ancestor.respond_to?(:own_directives) &&
+                    (anc_dirs = ancestor.own_directives).any?
+                  dirs ||= []
+                  merge_directives(dirs, anc_dirs)
+                end
+              end
+              if directives
                 dirs ||= []
-                merge_directives(dirs, anc_dirs)
+                merge_directives(dirs, directives)
+              end
+              dirs || NO_DIRECTIVES
+            when HasDirectives
+              directives || NO_DIRECTIVES
+            else
+              raise "Invariant: how could #{schema_member} not be a Class, Module, or instance of HasDirectives?"
+            end
+          end
+
+          private
+
+          # Modify `target` by adding items from `dirs` such that:
+          # - Any name conflict is overriden by the incoming member of `dirs`
+          # - Any other member of `dirs` is appended
+          # @param target [Array<GraphQL::Schema::Directive>]
+          # @param dirs [Array<GraphQL::Schema::Directive>]
+          # @return [void]
+          def merge_directives(target, dirs)
+            dirs.each do |dir|
+              if (idx = target.find_index { |d| d.graphql_name == dir.graphql_name })
+                target.slice!(idx)
+                target.insert(idx, dir)
+              else
+                target << dir
               end
             end
-            if own_directives
-              dirs ||= []
-              merge_directives(dirs, own_directives)
-            end
-            dirs || NO_DIRECTIVES
-          when HasDirectives
-            @own_directives || NO_DIRECTIVES
-          else
-            raise "Invariant: how could #{self} not be a Class, Module, or instance of HasDirectives?"
+            nil
           end
         end
+
 
         protected
 
         def own_directives
           @own_directives
-        end
-
-        private
-
-        # Modify `target` by adding items from `dirs` such that:
-        # - Any name conflict is overriden by the incoming member of `dirs`
-        # - Any other member of `dirs` is appended
-        # @param target [Array<GraphQL::Schema::Directive>]
-        # @param dirs [Array<GraphQL::Schema::Directive>]
-        # @return [void]
-        def merge_directives(target, dirs)
-          dirs.each do |dir|
-            if (idx = target.find_index { |d| d.graphql_name == dir.graphql_name })
-              target.slice!(idx)
-              target.insert(idx, dir)
-            else
-              target << dir
-            end
-          end
-          nil
         end
       end
     end

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -1569,7 +1569,6 @@ type ReachableType implements Node {
     assert_equal ["id", "name", "nationality"], schema.types.fetch("Person").fields.keys.sort
   end
 
-  focus
   it "supports extending schemas with directives" do
     schema_sdl = <<~EOS
       directive @link(url: String, import: [String]) on SCHEMA


### PR DESCRIPTION
A few changes to support building definitions from Apollo Federation-style schema extensions

Fixes #4199 

- Add `Schema.schema_directives` which are the directives _on the schema itself_ (`Schema.directives` are the directives which may be used within the schema somewhere)
- Print directive definitions at the beginning of schema print-outs 
- Support `extend schema` with directives (most `extend`s are still not supported) 


__TODO__: it seems like apollo expects directives to work even when they aren't defined in the SDL, should graphql-ruby support this? 