### PR TITLE
Recognize .graphqls files as schema files in Schema.from_definition

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -110,8 +110,8 @@ module GraphQL
       # @param using [Hash] Plugins to attach to the created schema with `use(key, value)`
       # @return [Class] the schema described by `document`
       def from_definition(definition_or_path, default_resolve: nil, parser: GraphQL.default_parser, using: {})
-        # If the file ends in `.graphql`, treat it like a filepath
-        if definition_or_path.end_with?(".graphql")
+        # If the file ends in `.graphql` or `.graphqls`, treat it like a filepath
+        if definition_or_path.end_with?(".graphql") || definition_or_path.end_with?(".graphqls")
           GraphQL::Schema::BuildFromDefinition.from_definition_path(
             definition_or_path,
             default_resolve: default_resolve,


### PR DESCRIPTION
Many libraries use the file extension `.graphqls` to distinguish between files containing schema definitions vs. files containing GraphQL queries, etc.

This simple PR modifies `Schema.from_definition` to recognize this alternative file extension.