### PR TITLE
Strip blank lines from introspection query

### DIFF
--- a/lib/graphql/introspection.rb
+++ b/lib/graphql/introspection.rb
@@ -4,7 +4,7 @@ module GraphQL
     def self.query(include_deprecated_args: false, include_schema_description: false, include_is_repeatable: false, include_specified_by_url: false, include_is_one_of: false)
       # The introspection query to end all introspection queries, copied from
       # https://github.com/graphql/graphql-js/blob/master/src/utilities/introspectionQuery.js
-      <<-QUERY
+      <<-QUERY.gsub(/\n{2,}/, "\n")
 query IntrospectionQuery {
   __schema {
     #{include_schema_description ? "description" : ""}


### PR DESCRIPTION
#4184 added

```diff
 fragment FullType on __Type {
   kind
   name
   description
   #{include_specified_by_url ? "specifiedByURL" : ""}
+  #{include_is_one_of ? "isOneOf" : ""}
   fields(includeDeprecated: true) {
     name
     description
```

to the introspection query, which introduces a new blank line when the condition is false and needlessly changes the query's fingerprint.

By stripping out blank lines, we ensure that the query is stable even if new conditional lines are added that don't actually end up adding any content.