### PR TITLE
Add attr_reader :options for TypeMembership

### DIFF
--- a/lib/graphql/schema/type_membership.rb
+++ b/lib/graphql/schema/type_membership.rb
@@ -11,6 +11,9 @@ module GraphQL
       # @return [Class<GraphQL::Schema::Union>, Module<GraphQL::Schema::Interface>]
       attr_reader :abstract_type
 
+      # @return [Hash]
+      attr_reader :options
+
       # Called when an object is hooked up to an abstract type, such as {Schema::Union.possible_types}
       # or {Schema::Object.implements} (for interfaces).
       #


### PR DESCRIPTION
In order to filter-out `interfaces-type` membership during `ApolloFederation` dumping the access to `TypeMembership#options` is opened.

The use case is the following:
1. We have schema like
```ruby
class Foobar < BaseType
  implements FooInterface
end
```
2. In order to drop it in 0 downtime fashion we need to mark this `implements`
```ruby
class Foobar < BaseType
  implements FooInterface, apollo_federation: false
end
```
3. So in order to access this `apollo_federation` key value we need to open access to `TypeMembership#options` instance variable