### PR TITLE
Reduce more allocations in Lookahead#selects?

### DIFF
--- a/lib/graphql/execution/lookahead.rb
+++ b/lib/graphql/execution/lookahead.rb
@@ -108,7 +108,9 @@ module GraphQL
           if (match_by_orig_name = all_fields.find { |f| f.original_name == field_name })
             match_by_orig_name
           else
-            guessed_name = Schema::Member::BuildType.camelize(field_name.name)
+            # Symbol#name is only present on 3.0+
+            sym_s = field_name.respond_to?(:name) ? field_name.name : field_name.to_s
+            guessed_name = Schema::Member::BuildType.camelize(sym_s)
             @query.get_field(selected_type, guessed_name)
           end
         end

--- a/lib/graphql/execution/lookahead.rb
+++ b/lib/graphql/execution/lookahead.rb
@@ -108,7 +108,7 @@ module GraphQL
           if (match_by_orig_name = all_fields.find { |f| f.original_name == field_name })
             match_by_orig_name
           else
-            guessed_name = Schema::Member::BuildType.camelize(field_name.to_s)
+            guessed_name = Schema::Member::BuildType.camelize(field_name.name)
             @query.get_field(selected_type, guessed_name)
           end
         end

--- a/lib/graphql/schema/member/build_type.rb
+++ b/lib/graphql/schema/member/build_type.rb
@@ -120,7 +120,7 @@ module GraphQL
         def camelize(string)
           return string if string == '_'
           return string unless string.include?("_")
-          camelized = string.split('_').map!(&:capitalize!).join
+          camelized = string.split('_').each(&:capitalize!).join
           camelized[0] = camelized[0].downcase
           if (match_data = string.match(/\A(_+)/))
             camelized = "#{match_data[0]}#{camelized}"

--- a/lib/graphql/schema/member/build_type.rb
+++ b/lib/graphql/schema/member/build_type.rb
@@ -120,7 +120,7 @@ module GraphQL
         def camelize(string)
           return string if string == '_'
           return string unless string.include?("_")
-          camelized = string.split('_').map(&:capitalize).join
+          camelized = string.split('_').map!(&:capitalize!).join
           camelized[0] = camelized[0].downcase
           if (match_data = string.match(/\A(_+)/))
             camelized = "#{match_data[0]}#{camelized}"


### PR DESCRIPTION
More fixing for #4187

I used this script to check my changes:

```ruby
require "bundler/inline"

gemfile do
  gem "graphql", path: "./"
  gem "memory_profiler"
end

class Schema < GraphQL::Schema
  class Query < GraphQL::Schema::Object
    field :field, String
    field :field2, String
  end

  query(Query)
end

query = GraphQL::Query.new(Schema, "{ field }")
lookahead = query.lookahead
lookahead.selects?(:field)
res = nil
report = MemoryProfiler.report do
  res = [
    lookahead.selects?(:field),
    lookahead.selects?(:field2),
    lookahead.selects?(:field_2),
    lookahead.selects?(:field_2),
    lookahead.selects?(:field_2),
    lookahead.selects?(:field3),
    lookahead.selects?(:field_3),
    lookahead.selects?("__field_4"),
  ]
end

pp res
report.pretty_print
```

And found the following changes (summarized):


```diff
-Total allocated: 37960 bytes (253 objects)
+Total allocated: 37600 bytes (244 objects)
 Total retained:  26752 bytes (139 objects)

 allocated memory by gem
 -----------------------------------
-     37816  graphql-ruby/lib
+     37456  graphql-ruby/lib
        144  other

 allocated objects by gem
 -----------------------------------
-       251  graphql-ruby/lib
+       242  graphql-ruby/lib
          2  other
          
 allocated objects by class
 -----------------------------------
-        66  Array
-        46  String
+        62  Array
         44  GraphQL::Schema::Field
+        41  String
         33  GraphQL::Schema::NonNull
         30  Hash
         16  GraphQL::Schema::List
        
Allocated String Report
 -----------------------------------
+         8  "Field"
+         8  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/build_type.rb:123
+
          6  "2"
          6  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/build_type.rb:123

          4  "F"
          4  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/build_type.rb:124

-         4  "Field"
-         4  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/build_type.rb:123
-
          4  "f"
          4  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/build_type.rb:124

-         4  "field"
-         4  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/build_type.rb:123
-
          3  "field2"
          3  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/build_type.rb:123

-         3  "field_2"
-         3  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/lookahead.rb:111
-

...

-         2  "field3"
-         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/lookahead.rb:111
-         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/build_type.rb:123

...

          1  "__field_4"
          1  lookahead-memory.rb:30

-         1  "field_3"
-         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/lookahead.rb:111
+         1  "field3"
+         1  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/build_type.rb:123

```