### PR TITLE
Update the extension options section

### DIFF
--- a/guides/type_definitions/field_extensions.md
+++ b/guides/type_definitions/field_extensions.md
@@ -116,6 +116,12 @@ def after_resolve(value:, **rest)
 end
 ```
 
+If you use the `extensions: [...]` option, you can pass options using a hash:
+
+```ruby
+field :name, String, null: false, extensions: [LimitExtension => { limit: 20 }]
+```
+
 ## Using `extras`
 
 Extensions can have the same `extras` as fields (see {% internal_link "Extra Field Metadata", "fields/introduction#extra-field-metadata" %}). Add them by calling `extras` in the class definition:


### PR DESCRIPTION
Field extensions can be used using the `extensions: [...]` option.

```ruby
field :name, String, null: false, extensions: [UpcaseExtension]
```

That's documented [here](https://graphql-ruby.org/type_definitions/field_extensions.html#using-an-extension).

Then [below](https://graphql-ruby.org/type_definitions/field_extensions.html#extension-options) in that same page, it presents that field extensions can receive options.

I wondered if we could pass extension options using the `extensions: [...]` option. 🤔 

It turns out that we [can](https://github.com/rmosolgo/graphql-ruby/blob/99ee3ceb4595005e63c5acc7d8a56704dc5d6b8c/spec/graphql/schema/field_extension_spec.rb#L121). So, I thought that it would useful to document that in the `Extension options` section. That's this PR 😄 .