### PR TITLE
Make scoped context work with Dataloader

### DIFF
--- a/lib/graphql/backtrace/table.rb
+++ b/lib/graphql/backtrace/table.rb
@@ -83,7 +83,7 @@ module GraphQL
           value = if top && @override_value
             @override_value
           else
-            value_at(@context.query.context.namespace(:interpreter)[:runtime], context_entry.path)
+            value_at(@context.query.context.namespace(:interpreter_runtime)[:runtime], context_entry.path)
           end
           rows << [
             "#{context_entry.ast_node ? context_entry.ast_node.position.join(":") : ""}",
@@ -112,7 +112,7 @@ module GraphQL
           if object.is_a?(GraphQL::Schema::Object)
             object = object.object
           end
-          value = value_at(context_entry.namespace(:interpreter)[:runtime], [])
+          value = value_at(context_entry.namespace(:interpreter_runtime)[:runtime], [])
           rows << [
             "#{position}",
             "#{op_type}#{op_name ? " #{op_name}" : ""}",

--- a/lib/graphql/dataloader.rb
+++ b/lib/graphql/dataloader.rb
@@ -289,7 +289,10 @@ module GraphQL
       fiber_locals = {}
 
       Thread.current.keys.each do |fiber_var_key|
-        fiber_locals[fiber_var_key] = Thread.current[fiber_var_key]
+        # This variable should be fresh in each new fiber
+        if fiber_var_key != :__graphql_runtime_info
+          fiber_locals[fiber_var_key] = Thread.current[fiber_var_key]
+        end
       end
 
       if @nonblocking

--- a/lib/graphql/execution/interpreter.rb
+++ b/lib/graphql/execution/interpreter.rb
@@ -68,7 +68,7 @@ module GraphQL
                           # they also have another item of state, which is private to that query
                           # in particular, assign it here:
                           runtime = Runtime.new(query: query)
-                          query.context.namespace(:interpreter)[:runtime] = runtime
+                          query.context.namespace(:interpreter_runtime)[:runtime] = runtime
 
                           query.trace("execute_query", {query: query}) do
                             runtime.run_eager
@@ -90,7 +90,7 @@ module GraphQL
                     query = multiplex.queries.length == 1 ? multiplex.queries[0] : nil
                     queries = multiplex ? multiplex.queries : [query]
                     final_values = queries.map do |query|
-                      runtime = query.context.namespace(:interpreter)[:runtime]
+                      runtime = query.context.namespace(:interpreter_runtime)[:runtime]
                       # it might not be present if the query has an error
                       runtime ? runtime.final_result : nil
                     end
@@ -99,7 +99,7 @@ module GraphQL
                       Interpreter::Resolve.resolve_all(final_values, multiplex.dataloader)
                     end
                     queries.each do |query|
-                      runtime = query.context.namespace(:interpreter)[:runtime]
+                      runtime = query.context.namespace(:interpreter_runtime)[:runtime]
                       if runtime
                         runtime.delete_interpreter_context(:current_path)
                         runtime.delete_interpreter_context(:current_field)
@@ -123,7 +123,7 @@ module GraphQL
                       end
                     else
                       result = {
-                        "data" => query.context.namespace(:interpreter)[:runtime].final_result
+                        "data" => query.context.namespace(:interpreter_runtime)[:runtime].final_result
                       }
 
                       if query.context.errors.any?

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -740,11 +740,10 @@ module GraphQL
       def handle_or_reraise(context, err)
         handler = Execution::Errors.find_handler_for(self, err.class)
         if handler
-          runtime_info = context.namespace(:interpreter) || {}
-          obj = runtime_info[:current_object]
-          args = runtime_info[:current_arguments]
+          obj = context[:current_object]
+          args = context[:current_arguments]
           args = args && args.keyword_arguments
-          field = runtime_info[:current_field]
+          field = context[:current_field]
           if obj.is_a?(GraphQL::Schema::Object)
             obj = obj.object
           end

--- a/lib/graphql/schema/directive/transform.rb
+++ b/lib/graphql/schema/directive/transform.rb
@@ -39,7 +39,7 @@ module GraphQL
           transform_name = arguments[:by]
           if TRANSFORMS.include?(transform_name) && return_value.respond_to?(transform_name)
             return_value = return_value.public_send(transform_name)
-            response = context.namespace(:interpreter)[:runtime].final_result
+            response = context.namespace(:interpreter_runtime)[:runtime].final_result
             *keys, last = path
             keys.each do |key|
               if response && (response = response[key])

--- a/spec/graphql/query/context_spec.rb
+++ b/spec/graphql/query/context_spec.rb
@@ -380,7 +380,8 @@ describe GraphQL::Query::Context do
 
     it "always retrieves a scoped context value if set" do
       context = GraphQL::Query::Context.new(query: OpenStruct.new(schema: schema), values: nil, object: nil)
-      context.namespace(:interpreter)[:current_path] = ["somewhere"]
+      runtime_info = Thread.current[:__graphql_runtime_info] ||= {}
+      runtime_info[:current_path] = ["somewhere"]
       expected_key = :a
       expected_value = :test
 
@@ -400,7 +401,7 @@ describe GraphQL::Query::Context do
       assert_nil(context.fetch(expected_key))
       assert_nil(context.dig(expected_key)) if RUBY_VERSION >= '2.3.0'
 
-      context.namespace(:interpreter)[:current_path] = ["something", "new"]
+      runtime_info[:current_path] = ["something", "new"]
 
       assert_equal(expected_value, context[expected_key])
       assert_equal({ expected_key => expected_value}, context.to_h)
@@ -409,7 +410,7 @@ describe GraphQL::Query::Context do
       assert_equal(expected_value, context.dig(expected_key)) if RUBY_VERSION >= '2.3.0'
 
       # Enter a child field:
-      context.namespace(:interpreter)[:current_path] = ["somewhere", "child"]
+      runtime_info[:current_path] = ["somewhere", "child"]
       assert_nil(context[expected_key])
       assert_equal({ expected_key => nil }, context.to_h)
       assert(context.key?(expected_key))
@@ -417,7 +418,7 @@ describe GraphQL::Query::Context do
       assert_nil(context.dig(expected_key)) if RUBY_VERSION >= '2.3.0'
 
       # And a grandchild field
-      context.namespace(:interpreter)[:current_path] = ["somewhere", "child", "grandchild"]
+      runtime_info[:current_path] = ["somewhere", "child", "grandchild"]
       context.scoped_set!(expected_key, :something_else)
       context.scoped_set!(:another_key, :another_value)
       assert_equal(:something_else, context[expected_key])


### PR DESCRIPTION
Fixes #4125 

I tried this approach before, but I forgot about _skipping_ `:__graphql_runtime_info` when copying thread variables into new fibers.