### PR TITLE
Remove unused string

### DIFF
--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -406,7 +406,6 @@ module GraphQL
             graphql_name(interface_type_definition.name)
             description(interface_type_definition.description)
             interface_type_definition.interfaces.each do |interface_name|
-              "Implements: #{interface_type_definition} -> #{interface_name}"
               interface_defn = type_resolver.call(interface_name)
               implements(interface_defn)
             end


### PR DESCRIPTION
👋🏼 Simply removes this unused string. This prevents ruby from generating this warning about it, especially when run from rake test:

```
build_from_definition.rb:394: warning: possibly useless use of a literal in void context
```

I am not sure why this was left here, even after looking at [the original commit](https://github.com/rmosolgo/graphql-ruby/commit/eaa1c7d5dc27a3c9c7659e0ef5f528a7b4322941#diff-1ff8d09dd48483a2bba959cc7627c912707deca2e3fd7e8896aaf1b9807fe7adR398), so I assumed it was not intentional. Spec for the module also passed, so I hope this is okay.