### PR TITLE
Don't pass along empty initial responses in Ably subscriptions

### DIFF
--- a/javascript_client/src/subscriptions/__tests__/createAblyHandlerTest.ts
+++ b/javascript_client/src/subscriptions/__tests__/createAblyHandlerTest.ts
@@ -185,6 +185,41 @@ describe("createAblyHandler", () => {
     expect(nextInvokedWith).toBeUndefined()
   })
 
+  it("doesn't dispatch anything for an empty data object", async () => {
+    let errorInvokedWith = undefined
+    let nextInvokedWith = undefined
+
+    const producer = createAblyHandler({
+      fetchOperation: () =>
+        new Promise(resolve =>
+          resolve({
+            headers: new Map([["X-Subscription-ID", "foo"]]),
+            body: { data: {} }
+          })
+        ),
+      ably: createDummyConsumer()
+    })
+
+    producer(
+      dummyOperation,
+      {},
+      {},
+      {
+        onError: (errors: any) => {
+          errorInvokedWith = errors
+        },
+        onNext: (response: any) => {
+          nextInvokedWith = response
+        },
+        onCompleted: () => {}
+      }
+    )
+
+    await nextTick()
+    expect(errorInvokedWith).toBeUndefined()
+    expect(nextInvokedWith).toBeUndefined()
+  })
+
   it("dispatches caught errors", async () => {
     let errorInvokedWith = undefined
     let nextInvokedWith = undefined

--- a/javascript_client/src/subscriptions/createAblyHandler.ts
+++ b/javascript_client/src/subscriptions/createAblyHandler.ts
@@ -55,7 +55,7 @@ function createAblyHandler(options: AblyHandlerOptions) {
         if (result.errors) {
           // What kind of error stuff belongs here?
           observer.onError(result.errors)
-        } else if (result.data) {
+        } else if (result.data && Object.keys(result.data).length > 0) {
           observer.onNext({ data: result.data })
         }
       }


### PR DESCRIPTION
This makes Apollo 1 subscriptions keep working with the interpreter runtime, which returns `{}` in the initial response by default.