### PR TITLE
Call the id hook with the type, not the instance

### DIFF
--- a/lib/graphql/types/relay/node_behaviors.rb
+++ b/lib/graphql/types/relay/node_behaviors.rb
@@ -11,7 +11,7 @@ module GraphQL
         end
 
         def default_global_id
-          context.schema.id_from_object(object, self, context)
+          context.schema.id_from_object(object, self.class, context)
         end
       end
     end

--- a/spec/graphql/types/relay/node_behaviors_spec.rb
+++ b/spec/graphql/types/relay/node_behaviors_spec.rb
@@ -17,13 +17,15 @@ describe GraphQL::Types::Relay::NodeBehaviors do
 
     query(Query)
 
-    def self.id_from_object(obj, _type, _ctx)
+    def self.id_from_object(obj, type, context)
+      context[:id_from_object_type] = type
       "blah"
     end
   end
 
-  it "adds an `id` field that calls `schema.id_from_object`" do
+  it "adds an `id` field that calls `schema.id_from_object` with the type class" do
     res = NodeBehaviorsSchema.execute("{ thing { id } }")
     assert_equal "blah", res["data"]["thing"]["id"]
+    assert_equal NodeBehaviorsSchema::Thing, res.context[:id_from_object_type]
   end
 end


### PR DESCRIPTION
Oops, this code was previously passing the type _instance_, not the type class. But this hook should always expect a type definition there!