### PR TITLE
Add field helper to get the unwrapped resolved type

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -581,6 +581,21 @@ module GraphQL
         raise MissingReturnTypeError, "Failed to build return type for #{@owner.graphql_name}.#{name} from #{@return_type_expr.inspect}: (#{err.class}) #{err.message}", err.backtrace
       end
 
+      def unwrapped_resolved_type
+        resolved_type =
+          if @resolver_class
+            @resolver_class.type
+          else
+            self.type
+          end
+
+        if resolved_type.is_a?(GraphQL::Schema::Wrapper)
+          resolved_type.unwrap
+        else
+          resolved_type
+        end
+      end
+
       def visible?(context)
         if @resolver_class
           @resolver_class.visible?(context)

--- a/spec/graphql/schema/field_spec.rb
+++ b/spec/graphql/schema/field_spec.rb
@@ -303,6 +303,22 @@ describe GraphQL::Schema::Field do
       end
     end
 
+    describe "unwrapped_resolved_type" do
+      it "tells the unwrapped return type" do
+        assert_equal "String", field.unwrapped_resolved_type.to_type_signature
+      end
+
+      it "returns the type class" do
+        field = Jazz::Query.fields["nowPlaying"]
+        assert_equal Jazz::PerformingAct, field.unwrapped_resolved_type
+      end
+
+      it "returns the resolved type" do
+        field = Jazz::Query.fields["musicStyle"]
+        assert_equal "String", field.unwrapped_resolved_type.to_type_signature
+      end
+    end
+
     describe "complexity" do
       it "accepts a keyword argument" do
         object = Class.new(Jazz::BaseObject) do

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -375,8 +375,19 @@ module Jazz
     field :falsey, Boolean, null: false
   end
 
-  class CamelizedBooleanInput <  GraphQL::Schema::InputObject
+  class CamelizedBooleanInput < GraphQL::Schema::InputObject
     argument :camelized_boolean, Boolean
+  end
+
+  class BaseResolver < GraphQL::Schema::Resolver
+  end
+
+  class MusicStyleResolver < BaseResolver
+    type String, null: false
+
+    def resolve
+      'Jazz'
+    end
   end
 
   # Another new-style definition, with method overrides
@@ -394,6 +405,7 @@ module Jazz
     field :inspect_key, InspectableKey, null: false do
       argument :key, Key
     end
+    field :music_style, resolver: MusicStyleResolver
     field :now_playing, PerformingAct, null: false
 
     def now_playing; Models.data["Ensemble"].first; end


### PR DESCRIPTION
Add an helper function in the field type to retrieve the underlying original type: unwrapped and resolved.

It is an attempt to solve #4083.

Please tell me if it is the relevant way to integrate this in the lib or if we should keep this logic outside. 🙂 