### PR TITLE
Pass and merge subscription's event and query ctxs

### DIFF
--- a/lib/graphql/subscriptions.rb
+++ b/lib/graphql/subscriptions.rb
@@ -127,7 +127,7 @@ module GraphQL
       }
       
        # merge event's and query's context together
-      context.merge!(event.context) if !event.context.nil? && !event.context.empty?
+      context.merge!(event.context) unless event.context.nil? || context.nil?
       
       execute_options[:validate] = validate_update?(**execute_options)
       result = @schema.execute(**execute_options)

--- a/lib/graphql/subscriptions.rb
+++ b/lib/graphql/subscriptions.rb
@@ -127,7 +127,7 @@ module GraphQL
       }
       
        # merge event's and query's context together
-      context.merge!(event.context) if event.context&.present?
+      context.merge!(event.context) if !event.context.nil? && !event.context.empty?
       
       execute_options[:validate] = validate_update?(**execute_options)
       result = @schema.execute(**execute_options)

--- a/lib/graphql/subscriptions.rb
+++ b/lib/graphql/subscriptions.rb
@@ -90,6 +90,7 @@ module GraphQL
         arguments: normalized_args,
         field: field,
         scope: scope,
+        context: context,
       )
       execute_all(event, object)
     end
@@ -124,6 +125,10 @@ module GraphQL
         variables: variables,
         root_value: object,
       }
+      
+       # merge event's and query's context together
+      context.merge!(event.context) if event.context&.present?
+      
       execute_options[:validate] = validate_update?(**execute_options)
       result = @schema.execute(**execute_options)
       subscriptions_context = result.context.namespace(:subscriptions)

--- a/spec/graphql/subscriptions/event_spec.rb
+++ b/spec/graphql/subscriptions/event_spec.rb
@@ -27,6 +27,14 @@ describe GraphQL::Subscriptions::Event do
     assert_equal %Q{:jsonSubscription:someJson:{"a":0,"b":1}}, event.topic
   end
 
+  it "should not serialize the context into the topic name" do
+    field = EventSchema.subscription.fields["jsonSubscription"]
+    context = { my_id: "abc" }
+    event = GraphQL::Subscriptions::Event.new(name: "test", arguments: { "someJson" => { "b" => 1, "a" => 0 } }, field: field, context: context, scope: nil)
+    assert_equal %Q{:jsonSubscription:someJson:{"a":0,"b":1}}, event.topic
+    assert_equal event.context[:my_id], "abc"
+  end
+
   it "should serialize two eqivalent JSON hashes with different key orderings into equivalent topic names" do
     field = EventSchema.subscription.fields["jsonSubscription"]
     event_a = GraphQL::Subscriptions::Event.new(name: "test", arguments: { "someJson" => { "b" => 1, "a" => 0 } }, field: field, context: nil, scope: nil)


### PR DESCRIPTION
When a subscription is triggered, there's an param to pass a `context:` but it's lost because it's not forwarded to the `Subscription::Event`.  

Now when `Subscription#execute_update` is executed, we can now merge query's context with event's context.  

This allows to pass an id of the sender of a query and compare it with the receiver of a subscription in the `#update` method, for example to prevent the sender of the subscription to receive its own updates by skipping it when the ids match.

Example:

````ruby
module Subscriptions
  class ExampleSubscription < ::Types::Base::Subscription
    payload_type ::Types::ExampleSubscriptionPayload

    argument :model_id, ID, required: true, loads: ::Types::Models::MyModel, can_can_action: :read

    def subscribe(model:)
      super
    end

    def update(model:)
      # skip update when the sender is the same as the receiver of the update
      return :no_update if self.context[:client_id].present? && 
            self.context[:sender_client_id].present? && 
            self.context[:client_id] == self.context[:sender_client_id]

      super
    end
  end
end
````

```ruby
MySchema.subscriptions.trigger(
   :my_update,
   # args:
   {
      model_id: "MODEL_ID"
   },
   # payload:
   {
      model: "MODEL_INSTANCE"
   },
   context: { sender_client_id: "SENDER_ID" }
)
```