### PR TITLE
Fix for double scope_items method call (Issue #4253)

### DIFF
--- a/lib/graphql/schema/field/scope_extension.rb
+++ b/lib/graphql/schema/field/scope_extension.rb
@@ -9,7 +9,7 @@ module GraphQL
             value
           else
             ret_type = @field.type.unwrap
-            if ret_type.respond_to?(:scope_items)
+            if ret_type.respond_to?(:scope_items) && !field.connection?
               ret_type.scope_items(value, context)
             else
               value


### PR DESCRIPTION
You can find the description of the case in this [issue](https://github.com/rmosolgo/graphql-ruby/issues/4253).