### PR TITLE
Update testing.md

### DIFF
--- a/guides/dataloader/testing.md
+++ b/guides/dataloader/testing.md
@@ -47,7 +47,7 @@ You can also test `Dataloader` behavior outside of GraphQL using {{ "GraphQL::Da
 
 ```ruby
 def test_it_fetches_objects_by_id
-  user_1, user_2, user_3 = 3.times { User.create! }
+  user_1, user_2, user_3 = 3.times.map { User.create! }
 
   database_queries = 0
   callback = lambda {|_name, _started, _finished, _unique_id, _payload| database_queries += 1 }


### PR DESCRIPTION
Hi, I have added a small fix to testing.md.
Use `3.times.map` instead of `3.times` to convert to an array.