### PR TITLE
Only allow object types to be union types, fixes #4243

### DIFF
--- a/lib/graphql/schema/union.rb
+++ b/lib/graphql/schema/union.rb
@@ -70,9 +70,18 @@ module GraphQL
         private
 
         def assert_valid_union_member(type_defn)
-          if type_defn.is_a?(Module) && !type_defn.is_a?(Class)
+          case type_defn
+          when Class
+            if !type_defn.kind.object?
+              raise ArgumentError, "Union possible_types can only be object types (not #{type_defn.kind.name}, #{type_defn.inspect})"
+            end
+          when Module
             # it's an interface type, defined as a module
             raise ArgumentError, "Union possible_types can only be object types (not interface types), remove #{type_defn.graphql_name} (#{type_defn.inspect})"
+          when String, GraphQL::Schema::LateBoundType
+            # Ok - assume it will get checked later
+          else
+            raise ArgumentError, "Union possible_types can only be class-based GraphQL types (not #{type_defn.inspect} (#{type_defn.class.name}))."
           end
         end
       end

--- a/spec/graphql/schema/union_spec.rb
+++ b/spec/graphql/schema/union_spec.rb
@@ -137,6 +137,46 @@ describe GraphQL::Schema::Union do
     end
   end
 
+  it "doesn't allow adding non-object types" do
+    object_type = Class.new(GraphQL::Schema::Object) do
+      graphql_name "SomeObject"
+    end
+
+    err = assert_raises ArgumentError do
+      Class.new(GraphQL::Schema::Union) do
+        graphql_name "SomeUnion"
+        possible_types object_type, GraphQL::Types::Int
+      end
+    end
+    expected_message = "Union possible_types can only be object types (not SCALAR, "
+    assert_includes err.message, expected_message
+
+    input_type = Class.new(GraphQL::Schema::InputObject) do
+      graphql_name "SomeInput"
+      argument :arg, GraphQL::Types::Int
+    end
+
+    err = assert_raises ArgumentError do
+      Class.new(GraphQL::Schema::Union) do
+        graphql_name "SomeUnion"
+        possible_types object_type, input_type
+      end
+    end
+
+    expected_message = "Union possible_types can only be object types (not INPUT_OBJECT, "
+    assert_includes err.message, expected_message
+
+    err = assert_raises ArgumentError do
+      Class.new(GraphQL::Schema::Union) do
+        graphql_name "SomeUnion"
+        possible_types object_type, 1234
+      end
+    end
+
+    expected_message = "Union possible_types can only be class-based GraphQL types (not 1234 (Integer))."
+    assert_includes err.message, expected_message
+  end
+
   it "doesn't allow adding interface" do
     object_type = Class.new(GraphQL::Schema::Object) do
       graphql_name "SomeObject"


### PR DESCRIPTION
If you need to override this for backwards compatibility, you can redefine `def self.assert_valid_union_member(type_defn)` in your own base Union class with the previous code. (But I can't imagine what non-Object types _used_ to do here!)