### PR TITLE
BaseEdge (and subclasses) should be .default_relay? -> true

### DIFF
--- a/lib/graphql/types/relay/default_relay.rb
+++ b/lib/graphql/types/relay/default_relay.rb
@@ -13,7 +13,13 @@ module GraphQL
         end
 
         def default_relay?
-          !!@default_relay
+          if defined?(@default_relay)
+            @default_relay
+          elsif self.is_a?(Class)
+            superclass.respond_to?(:default_relay?) && superclass.default_relay?
+          else
+            false
+          end
         end
       end
     end

--- a/lib/graphql/types/relay/edge_behaviors.rb
+++ b/lib/graphql/types/relay/edge_behaviors.rb
@@ -8,6 +8,7 @@ module GraphQL
           child_class.description("An edge in a connection.")
           child_class.field(:cursor, String, null: false, description: "A cursor for use in pagination.")
           child_class.extend(ClassMethods)
+          child_class.extend(GraphQL::Types::Relay::DefaultRelay)
           child_class.node_nullable(true)
         end
 

--- a/spec/graphql/types/relay/base_edge_spec.rb
+++ b/spec/graphql/types/relay/base_edge_spec.rb
@@ -55,6 +55,6 @@ describe GraphQL::Types::Relay::BaseEdge do
   it "is a default relay type" do
     edge_type = NonNullableDummy::Schema.get_type("NonNullableNodeEdge")
     assert_equal true, edge_type.default_relay?
-    assert_equal true, GraphQL::Relay::Types::BaseEdge.default_relay?
+    assert_equal true, GraphQL::Types::Relay::BaseEdge.default_relay?
   end
 end

--- a/spec/graphql/types/relay/base_edge_spec.rb
+++ b/spec/graphql/types/relay/base_edge_spec.rb
@@ -51,4 +51,10 @@ describe GraphQL::Types::Relay::BaseEdge do
     assert_equal 1, field.extensions.size
     assert_instance_of extension, field.extensions.first
   end
+
+  it "is a default relay type" do
+    edge_type = NonNullableDummy::Schema.get_type("NonNullableNodeEdge")
+    assert_equal true, edge_type.default_relay?
+    assert_equal true, GraphQL::Relay::Types::BaseEdge.default_relay?
+  end
 end


### PR DESCRIPTION
Oops -- this built-in class should have returned true for `.default_relay?`, just like NodeInterface and BaseConnection: 

https://github.com/rmosolgo/graphql-ruby/blob/777291787f9aeae6c3fc7c0fe5b38234c57402d0/lib/graphql/types/relay/node_behaviors.rb#L8

https://github.com/rmosolgo/graphql-ruby/blob/777291787f9aeae6c3fc7c0fe5b38234c57402d0/lib/graphql/types/relay/connection_behaviors.rb#L12

Also, I think it should be inherited, so that subclasses return `true` here too.