### PR TITLE
Fix subscriptions that use loads/as

### DIFF
--- a/lib/graphql/subscriptions/event.rb
+++ b/lib/graphql/subscriptions/event.rb
@@ -100,13 +100,8 @@ module GraphQL
               arg_name = k.to_s
               camelized_arg_name = GraphQL::Schema::Member::BuildType.camelize(arg_name)
               arg_defn = get_arg_definition(arg_owner, camelized_arg_name, context)
-
-              if arg_defn
-                normalized_arg_name = camelized_arg_name
-              else
-                normalized_arg_name = arg_name
-                arg_defn = get_arg_definition(arg_owner, normalized_arg_name, context)
-              end
+              arg_defn ||= get_arg_definition(arg_owner, arg_name, context)
+              normalized_arg_name = arg_defn.graphql_name
               arg_base_type = arg_defn.type.unwrap
               # In the case where the value being emitted is seen as a "JSON"
               # type, treat the value as one atomic unit of serialization

--- a/spec/graphql/schema/subscription_spec.rb
+++ b/spec/graphql/schema/subscription_spec.rb
@@ -527,7 +527,7 @@ describe GraphQL::Schema::Subscription do
   end
 
   describe "applying `loads:`" do
-    it "includes `as:` in the event topic" do
+    it "uses the original argument name in the event topic" do
       assert_equal [], SubscriptionFieldSchema::InMemorySubscriptions::EVENT_REGISTRY.keys
       matz = SubscriptionFieldSchema::USERS["matz"]
       obj = OpenStruct.new(toot: { body: "I am a C programmer" }, user: matz)

--- a/spec/graphql/schema/subscription_spec.rb
+++ b/spec/graphql/schema/subscription_spec.rb
@@ -532,7 +532,7 @@ describe GraphQL::Schema::Subscription do
       matz = SubscriptionFieldSchema::USERS["matz"]
       obj = OpenStruct.new(toot: { body: "I am a C programmer" }, user: matz)
       SubscriptionFieldSchema.subscriptions.trigger(:toot_was_tooted, {handle: "matz"}, obj)
-      assert_equal [":tootWasTooted:user:matz"], SubscriptionFieldSchema::InMemorySubscriptions::EVENT_REGISTRY.keys
+      assert_equal [":tootWasTooted:handle:matz"], SubscriptionFieldSchema::InMemorySubscriptions::EVENT_REGISTRY.keys
     end
   end
 

--- a/spec/graphql/subscriptions_spec.rb
+++ b/spec/graphql/subscriptions_spec.rb
@@ -144,7 +144,7 @@ class ClassBasedInMemoryBackend < InMemoryBackend
   end
 
   class EventSubscription < GraphQL::Schema::Subscription
-    argument :user_id, ID
+    argument :user_id, ID, as: :user
     argument :payload_type, PayloadType, required: false, default_value: "ONE", prepare: ->(e, ctx) { e ? e.downcase : e }
     field :payload, Payload
   end
@@ -678,6 +678,9 @@ describe GraphQL::Subscriptions do
               }
             end
             assert_equal expected_sub_count, subscriptions_by_topic
+
+            schema.subscriptions.trigger(:event_subscription, { user_id: 3 }, {})
+            assert_equal 1, deliveries["1"].size
           end
 
           it "doesn't apply for plain fields" do


### PR DESCRIPTION
Oops -- this _never_ worked, as far as I can tell. 

The "topic" would be created with the `as:` name (without `Id`), but then triggering wouldn't work at all: 

- If you included `_id`, then the topic generated by `.trigger` wouldn't match the previously-generated topic 
- If you didn't include `_id`, then GraphQL-Ruby would :boom: because there wasn't a matching argument name 

So, I think the right thing to do is use the plan GraphQL argument name in the topic instead. 