### PR TITLE
Require at least one Enum value

### DIFF
--- a/lib/graphql/schema/enum.rb
+++ b/lib/graphql/schema/enum.rb
@@ -34,6 +34,13 @@ module GraphQL
         end
       end
 
+      class MissingValuesError < GraphQL::Error
+        def initialize(enum_type)
+          @enum_type = enum_type
+          super("Enum types require at least one value, but #{enum_type.graphql_name} didn't provide any for this query. Make sure at least one value is defined and visible for this query.")
+        end
+      end
+
       class << self
         # Define a value for this enum
         # @param graphql_name [String, Symbol] the GraphQL value for this, usually `SCREAMING_CASE`

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -182,11 +182,11 @@ module GraphQL
       # @return [Array<GraphQL::EnumType::EnumValue>] Visible members of `enum_defn`
       def enum_values(enum_defn)
         @visible_enum_arrays ||= read_through { |e|
-         values = e.enum_values(@context)
-         if values.size == 0
-          raise GraphQL::Schema::Enum::MissingValuesError.new(e)
-         end
-         values
+          values = e.enum_values(@context)
+          if values.size == 0
+            raise GraphQL::Schema::Enum::MissingValuesError.new(e)
+          end
+          values
         }
         @visible_enum_arrays[enum_defn]
       end

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -181,7 +181,13 @@ module GraphQL
 
       # @return [Array<GraphQL::EnumType::EnumValue>] Visible members of `enum_defn`
       def enum_values(enum_defn)
-        @visible_enum_arrays ||= read_through { |e| e.enum_values(@context) }
+        @visible_enum_arrays ||= read_through { |e|
+         values = e.enum_values(@context)
+         if values.size == 0
+          raise GraphQL::Schema::Enum::MissingValuesError.new(e)
+         end
+         values
+        }
         @visible_enum_arrays[enum_defn]
       end
 

--- a/spec/graphql/schema/enum_spec.rb
+++ b/spec/graphql/schema/enum_spec.rb
@@ -126,6 +126,32 @@ describe GraphQL::Schema::Enum do
     end
   end
 
+  describe "missing values at runtime" do
+    class EmptyEnumSchema < GraphQL::Schema
+      class EmptyEnum < GraphQL::Schema::Enum
+      end
+
+      class Query < GraphQL::Schema::Object
+        field :empty_enum, EmptyEnum
+
+        def empty_enum
+          :something
+        end
+      end
+
+      query(Query)
+    end
+
+    it "requires at least one value at runtime" do
+      err = assert_raises GraphQL::Schema::Enum::MissingValuesError do
+        EmptyEnumSchema.execute("{ emptyEnum }")
+      end
+
+      expected_message = "Enum types require at least one value, but EmptyEnum didn't provide any for this query. Make sure at least one value is defined and visible for this query."
+      assert_equal expected_message, err.message
+    end
+  end
+
   describe "legacy tests" do
     let(:enum) { Dummy::DairyAnimal }
 

--- a/spec/graphql/schema/enum_spec.rb
+++ b/spec/graphql/schema/enum_spec.rb
@@ -140,6 +140,14 @@ describe GraphQL::Schema::Enum do
       end
 
       query(Query)
+
+      rescue_from(GraphQL::Schema::Enum::MissingValuesError) do |err, obj, args, ctx, field|
+        if ctx[:handle_error]
+          raise GraphQL::ExecutionError, "Something went wrong!!"
+        else
+          raise err
+        end
+      end
     end
 
     it "requires at least one value at runtime" do
@@ -149,6 +157,11 @@ describe GraphQL::Schema::Enum do
 
       expected_message = "Enum types require at least one value, but EmptyEnum didn't provide any for this query. Make sure at least one value is defined and visible for this query."
       assert_equal expected_message, err.message
+    end
+
+    it "can be rescued by rescue_error" do
+      res = EmptyEnumSchema.execute("{ emptyEnum }", context: { handle_error: true })
+      assert_equal ["Something went wrong!!"], res["errors"].map { |e| e["message"] }
     end
   end
 


### PR DESCRIPTION
This is required by the spec (https://spec.graphql.org/draft/#sec-Enums.Type-Validation) but wasn't actually validated by GraphQL-Ruby til now. I implemented it at runtime so that, if your schema hides enum values dynamically, it will still make sure the resulting schema is valid. 