### PR TITLE
Pass along the initial payload in PusherLink

### DIFF
--- a/javascript_client/src/subscriptions/PusherLink.ts
+++ b/javascript_client/src/subscriptions/PusherLink.ts
@@ -91,6 +91,8 @@ class PusherLink extends ApolloLink {
         if (subscriptionChannel) {
           // Set up the pusher subscription for updates from the server
           const pusherChannel = this.pusher.subscribe(subscriptionChannel)
+          // Pass along the initial payload:
+          observer.next(data)
           // Subscribe for more update
           pusherChannel.bind("update", (payload: any) => {
             this._onUpdate(subscriptionChannel, observer, payload)

--- a/javascript_client/src/subscriptions/PusherLink.ts
+++ b/javascript_client/src/subscriptions/PusherLink.ts
@@ -92,7 +92,9 @@ class PusherLink extends ApolloLink {
           // Set up the pusher subscription for updates from the server
           const pusherChannel = this.pusher.subscribe(subscriptionChannel)
           // Pass along the initial payload:
-          observer.next(data)
+          if (data.data && Object.keys(data.data).length > 0) {
+            observer.next(data)
+          }
           // Subscribe for more update
           pusherChannel.bind("update", (payload: any) => {
             this._onUpdate(subscriptionChannel, observer, payload)

--- a/javascript_client/src/subscriptions/__tests__/PusherLinkTest.ts
+++ b/javascript_client/src/subscriptions/__tests__/PusherLinkTest.ts
@@ -144,7 +144,7 @@ describe("PusherLink", () => {
     })
 
     // Pretend the HTTP link finished
-    requestFinished({})
+    requestFinished({ data: "initial payload" })
 
     pusher.trigger(channelName, "update", {
       result: {
@@ -162,6 +162,7 @@ describe("PusherLink", () => {
 
     expect(log).toEqual([
       ["subscribe", "abcd-efgh"],
+      ["received", { data: "initial payload"}],
       ["received", { data: "data 1" }],
       ["received", { data: "data 2" }],
       ["unsubscribe", "abcd-efgh"]
@@ -185,7 +186,7 @@ describe("PusherLink", () => {
     })
 
     // Pretend the HTTP link finished
-    requestFinished({})
+    requestFinished({ data: "initial payload" })
 
     pusher.trigger(channelName, "update", {
       result: {
@@ -198,6 +199,7 @@ describe("PusherLink", () => {
 
     expect(log).toEqual([
       ["subscribe", "abcd-efgh"],
+      ["received", { data: "initial payload"}],
       ["received", { data: "data 1" }],
       ["unsubscribe", "abcd-efgh"]
     ])


### PR DESCRIPTION
Fixes #4276 

TODO: 

- [x] Should this also skip empty initial responses? https://github.com/rmosolgo/graphql-ruby/commit/44db672512f15bf810e8580b7ab854676e968d1f