### PR TITLE
docs: Fix top level docs for GraphQL::Schema::Enum

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -62,7 +62,7 @@ module GraphQL
   # Schemas can specify how queries should be executed against them.
   # `query_execution_strategy`, `mutation_execution_strategy` and `subscription_execution_strategy`
   # each apply to corresponding root types.
-  #  #
+  #
   # @example defining a schema
   #   class MySchema < GraphQL::Schema
   #     query QueryType
@@ -900,7 +900,7 @@ module GraphQL
       # A function to call when {#execute} receives an invalid query string
       #
       # The default is to add the error to `context.errors`
-      # @param err [GraphQL::ParseError] The error encountered during parsing
+      # @param parse_err [GraphQL::ParseError] The error encountered during parsing
       # @param ctx [GraphQL::Query::Context] The context for the query where the error occurred
       # @return void
       def parse_error(parse_err, ctx)

--- a/lib/graphql/schema/enum.rb
+++ b/lib/graphql/schema/enum.rb
@@ -1,24 +1,24 @@
 # frozen_string_literal: true
 
 module GraphQL
-  # Extend this class to define GraphQL enums in your schema.
-  #
-  # By default, GraphQL enum values are translated into Ruby strings.
-  # You can provide a custom value with the `value:` keyword.
-  #
-  # @example
-  #   # equivalent to
-  #   # enum PizzaTopping {
-  #   #   MUSHROOMS
-  #   #   ONIONS
-  #   #   PEPPERS
-  #   # }
-  #   class PizzaTopping < GraphQL::Enum
-  #     value :MUSHROOMS
-  #     value :ONIONS
-  #     value :PEPPERS
-  #   end
   class Schema
+    # Extend this class to define GraphQL enums in your schema.
+    #
+    # By default, GraphQL enum values are translated into Ruby strings.
+    # You can provide a custom value with the `value:` keyword.
+    #
+    # @example
+    #   # equivalent to
+    #   # enum PizzaTopping {
+    #   #   MUSHROOMS
+    #   #   ONIONS
+    #   #   PEPPERS
+    #   # }
+    #   class PizzaTopping < GraphQL::Enum
+    #     value :MUSHROOMS
+    #     value :ONIONS
+    #     value :PEPPERS
+    #   end
     class Enum < GraphQL::Schema::Member
       extend GraphQL::Schema::Member::ValidatesInput
 


### PR DESCRIPTION
## Expected Behavior

* The docs render the correct top-level-documentation for `GraphQL::Schema` and `GraphQL::Schema::Enum`.

## Actual Behavior

* When reading the top-level-documentation for `GraphQL::Schema::Enum`, it shows nothing. ([Link](https://graphql-ruby.org/api-doc/2.0.16/GraphQL/Schema/Enum.html))

![gql-docs-enum](https://user-images.githubusercontent.com/385500/210544519-0c3e2815-9d85-414a-b046-a522e71c09c4.png)

* When reading the top-level-documentation for `GraphQL::Schema`, it shows the docs for `GraphQL::Schema::Enum` instead. ([Link](https://graphql-ruby.org/api-doc/2.0.16/GraphQL/Schema))

![gql-docs-schema](https://user-images.githubusercontent.com/385500/210544534-c23ad013-d0c3-4c4a-8651-ac005d4ac62a.png)

## Fix

* Moved top-level-documentation within `lib/graphql/schema/enum.rb` from `Schema` to `Enum`.
* (minor): Fix typo on `GraphQL::Schema#parse_error` param docs
