### PR TITLE
1.13: lookup given hash_key: when possible

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -258,6 +258,10 @@ module GraphQL
         # TODO: I think non-string/symbol hash keys are wrongly normalized (eg `1` will not work)
         method_name = method || hash_key || name_s
         @dig_keys = dig
+        if hash_key
+          @hash_key = hash_key
+        end
+
         resolver_method ||= name_s.to_sym
 
         @method_str = -method_name.to_s
@@ -822,7 +826,7 @@ module GraphQL
             # Find a way to resolve this field, checking:
             #
             # - A method on the type instance;
-            # - Hash keys, if the wrapped object is a hash;
+            # - Hash keys, if the wrapped object is a hash or responds to `#[]`
             # - A method on the wrapped object;
             # - Or, raise not implemented.
             #
@@ -844,6 +848,8 @@ module GraphQL
               else
                 inner_object[@method_str]
               end
+            elsif defined?(@hash_key) && obj.object.respond_to?(:[])
+              obj.object[@hash_key]
             elsif obj.object.respond_to?(@method_sym)
               method_to_call = @method_sym
               method_receiver = obj.object

--- a/spec/graphql/schema/field_spec.rb
+++ b/spec/graphql/schema/field_spec.rb
@@ -601,6 +601,16 @@ describe GraphQL::Schema::Field do
   end
 
   describe "looking up hash keys with case" do
+    class HashLike
+      def initialize(value)
+        @value = value
+      end
+
+      def [](key)
+        @value
+      end
+    end
+
     class HashKeySchema < GraphQL::Schema
       class ResultType < GraphQL::Schema::Object
         field :lowercase, String, camelize: false, null: true
@@ -619,6 +629,8 @@ describe GraphQL::Schema::Field do
             "OtherCapital" => "explicit-hash-key-works"
           }
         end
+
+        field :hash_lookup, String, hash_key: :some_key
       end
 
       query(QueryType)
@@ -644,6 +656,11 @@ describe GraphQL::Schema::Field do
         "OtherCapital" => "explicit-hash-key-works"
       }
       assert_equal expected_result, search_results
+    end
+
+    it "does hash-style lookups on non-hash objects" do
+      res = HashKeySchema.execute("{ hashLookup }", root_value: HashLike.new("some value"))
+      assert_equal "some value", res["data"]["hashLookup"]
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/rmosolgo/graphql-ruby/pull/4072#issuecomment-1375790414

When a field is configured with `hash_key:`, look up that key using `[...]`, even if the underlying object isn't a Hash. (This code checks for `.respond_to?(:[])` to avoid breaking changes, which might be possible because of how `hash_key` was previously merged into `method_*` attributes.)