### PR TITLE
Fix wrong schema hook call on lazy denial from field authorization

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -615,6 +615,16 @@ module GraphQL
                 end
               end
               HALT
+            elsif value.is_a?(GraphQL::UnauthorizedFieldError)
+              value.field ||= field
+              # this hook might raise & crash, or it might return
+              # a replacement value
+              next_value = begin
+                schema.unauthorized_field(value)
+              rescue GraphQL::ExecutionError => err
+                err
+              end
+              continue_value(path, next_value, parent_type, field, is_non_null, ast_node, result_name, selection_result)
             elsif value.is_a?(GraphQL::UnauthorizedError)
               # this hook might raise & crash, or it might return
               # a replacement value

--- a/spec/graphql/authorization_spec.rb
+++ b/spec/graphql/authorization_spec.rb
@@ -666,6 +666,7 @@ describe "GraphQL::Authorization" do
               query = "{ unauthorized }"
               response = AuthTest::SchemaWithFieldHook.execute(query, root_value: 34, context: { lazy_field_authorized: false })
               assert_nil response["data"].fetch("unauthorized")
+              assert_equal ["Unauthorized field unauthorized on Query: 34"], response["errors"].map { |e| e["message"] }
             end
           end
 


### PR DESCRIPTION
When field authorization is lazily denied, the interpreter correctly calls `unauthorized_field` schema hook (used to wrongly call `unauthorized_object` instead).

Additionally, what do you think about creating `GraphQL::UnauthorizedObjectError` and removing all the mentions of `GraphQL::UnauthorizedError` (except for declaration and inheritance) to encourage a conscious decision since the logic is not always the same for objects and fields (as the bug shows).

Also, what do you think about asserting both `data` AND `errors` in every case of the test not to miss other edge cases like that?