### PR TITLE
Improve Shape Friendliness

### DIFF
--- a/lib/graphql/schema/directive.rb
+++ b/lib/graphql/schema/directive.rb
@@ -93,6 +93,18 @@ module GraphQL
         def repeatable(new_value)
           @repeatable = new_value
         end
+
+        private
+
+        def inherited(subclass)
+          super
+          subclass.class_eval do
+            @default_graphql_name = nil
+            @repeatable = nil
+            @default_directive = nil
+            @locations = nil
+          end
+        end
       end
 
       # @return [GraphQL::Schema::Field, GraphQL::Schema::Argument, Class, Module]

--- a/lib/graphql/schema/late_bound_type.rb
+++ b/lib/graphql/schema/late_bound_type.rb
@@ -9,6 +9,8 @@ module GraphQL
       alias :graphql_name :name
       def initialize(local_name)
         @name = local_name
+        @to_non_null_type = nil
+        @to_list_type = nil
       end
 
       def unwrap

--- a/lib/graphql/schema/member/base_dsl_methods.rb
+++ b/lib/graphql/schema/member/base_dsl_methods.rb
@@ -27,7 +27,7 @@ module GraphQL
         end
 
         def overridden_graphql_name
-          @graphql_name
+          defined?(@graphql_name) ? @graphql_name : nil
         end
 
         # Just a convenience method to point out that people should use graphql_name instead
@@ -47,8 +47,10 @@ module GraphQL
         def description(new_description = nil)
           if new_description
             @description = new_description
-          else
+          elsif defined?(@description)
             @description
+          else
+            nil
           end
         end
 
@@ -69,8 +71,10 @@ module GraphQL
         def introspection(new_introspection = nil)
           if !new_introspection.nil?
             @introspection = new_introspection
-          else
+          elsif defined?(@introspection)
             @introspection
+          else
+            false
           end
         end
 
@@ -83,8 +87,10 @@ module GraphQL
         def mutation(mutation_class = nil)
           if mutation_class
             @mutation = mutation_class
-          else
+          elsif defined?(@mutation)
             @mutation
+          else
+            nil
           end
         end
 
@@ -111,19 +117,6 @@ module GraphQL
 
         def authorized?(object, context)
           true
-        end
-
-        private
-
-        def inherited(subclass)
-          super
-          subclass.class_eval do
-            @graphql_name = nil
-            @default_graphql_name = nil
-            @mutation = nil
-            @introspection = false
-            @description = nil
-          end
         end
       end
     end

--- a/lib/graphql/schema/member/base_dsl_methods.rb
+++ b/lib/graphql/schema/member/base_dsl_methods.rb
@@ -27,7 +27,7 @@ module GraphQL
         end
 
         def overridden_graphql_name
-          defined?(@graphql_name) ? @graphql_name : nil
+          @graphql_name
         end
 
         # Just a convenience method to point out that people should use graphql_name instead
@@ -47,10 +47,8 @@ module GraphQL
         def description(new_description = nil)
           if new_description
             @description = new_description
-          elsif defined?(@description)
-            @description
           else
-            nil
+            @description
           end
         end
 
@@ -71,10 +69,8 @@ module GraphQL
         def introspection(new_introspection = nil)
           if !new_introspection.nil?
             @introspection = new_introspection
-          elsif defined?(@introspection)
-            @introspection
           else
-            false
+            @introspection
           end
         end
 
@@ -87,10 +83,8 @@ module GraphQL
         def mutation(mutation_class = nil)
           if mutation_class
             @mutation = mutation_class
-          elsif defined?(@mutation)
-            @mutation
           else
-            nil
+            @mutation
           end
         end
 
@@ -117,6 +111,19 @@ module GraphQL
 
         def authorized?(object, context)
           true
+        end
+
+        private
+
+        def inherited(subclass)
+          super
+          subclass.class_eval do
+            @graphql_name = nil
+            @default_graphql_name = nil
+            @mutation = nil
+            @introspection = false
+            @description = nil
+          end
         end
       end
     end

--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -129,6 +129,13 @@ module GraphQL
 
         private
 
+        def inherited(subclass)
+          super
+          subclass.class_eval do
+            @own_fields = nil
+          end
+        end
+
         # If `type` is an interface, and `self` has a type membership for `type`, then make sure it's visible.
         def visible_interface_implementation?(type, context, warden)
           if type.respond_to?(:kind) && type.kind.interface?

--- a/lib/graphql/schema/member/has_interfaces.rb
+++ b/lib/graphql/schema/member/has_interfaces.rb
@@ -82,6 +82,13 @@ module GraphQL
 
           visible_interfaces.uniq
         end
+
+        private
+
+        def inherited(subclass)
+          super
+          @own_interface_type_memberships = nil
+        end
       end
     end
   end

--- a/lib/graphql/schema/member/type_system_helpers.rb
+++ b/lib/graphql/schema/member/type_system_helpers.rb
@@ -32,6 +32,16 @@ module GraphQL
         def kind
           raise GraphQL::RequiredImplementationMissingError, "No `.kind` defined for #{self}"
         end
+
+        private
+
+        def inherited(subclass)
+          super
+          subclass.class_eval do
+            @to_non_null_type = nil
+            @to_list_type = nil
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Ruby 3.2 significantly changed how instance variables are store. It now use shapes, and in short, it's important for performance to define instance variables in a consistent order to limit the amount of shapes.

Otherwise, the number of shapes will increase past a point where MRI won't be able to cache instance variable access. The impact is even more important when YJIT is enabled.

This PR is data driven. I dump the list of Shapes from Shopify's monolith production environment, and GraphQL is the top offender:

```
Shape Edges Report
-----------------------------------
       770  @default_graphql_name
       697  @own_fields
       661  @to_non_null_type
       555  @own_interface_type_memberships
       472  @description
       389  @errors
```

NB: This PR doesn't aim to fix all of these issues, just the low hanging fruits.

cc @tenderlove @jemmaissroff 