### PR TITLE
Eagerly define `@default_graphql_name` variables for Shape Friendliness

### DIFF
--- a/lib/graphql/schema/directive.rb
+++ b/lib/graphql/schema/directive.rb
@@ -21,9 +21,9 @@ module GraphQL
         # but downcase the first letter.
         def default_graphql_name
           @default_graphql_name ||= begin
-            camelized_name = super
+            camelized_name = super.dup
             camelized_name[0] = camelized_name[0].downcase
-            camelized_name
+            -camelized_name
           end
         end
 
@@ -92,6 +92,15 @@ module GraphQL
 
         def repeatable(new_value)
           @repeatable = new_value
+        end
+
+        private
+
+        def inherited(subclass)
+          super
+          subclass.class_eval do
+            @default_graphql_name ||= nil
+          end
         end
       end
 

--- a/lib/graphql/schema/member/base_dsl_methods.rb
+++ b/lib/graphql/schema/member/base_dsl_methods.rb
@@ -103,7 +103,7 @@ module GraphQL
           @default_graphql_name ||= begin
             raise GraphQL::RequiredImplementationMissingError, 'Anonymous class should declare a `graphql_name`' if name.nil?
 
-            name.split("::").last.sub(/Type\Z/, "")
+            -name.split("::").last.sub(/Type\Z/, "")
           end
         end
 
@@ -117,6 +117,15 @@ module GraphQL
 
         def authorized?(object, context)
           true
+        end
+
+        private
+
+        def inherited(subclass)
+          super
+          subclass.class_eval do
+            @default_graphql_name ||= nil
+          end
         end
       end
     end


### PR DESCRIPTION
Ref: https://github.com/rmosolgo/graphql-ruby/pull/4293

I kinda got lost trying to fix many shapes issues at once, so I'm trying again one variable at a time.

This one the the most common shape edge in our app:

```

Shape Edges Report
-----------------------------------
       527  @default_graphql_name
```

