### PR TITLE
Eagerly define @own_fields variables for Shape Friendliness

### DIFF
--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -129,6 +129,13 @@ module GraphQL
 
         private
 
+        def inherited(subclass)
+          super
+          subclass.class_eval do
+            @own_fields ||= nil
+          end
+        end
+
         # If `type` is an interface, and `self` has a type membership for `type`, then make sure it's visible.
         def visible_interface_implementation?(type, context, warden)
           if type.respond_to?(:kind) && type.kind.interface?


### PR DESCRIPTION
Ref: https://github.com/rmosolgo/graphql-ruby/pull/4293

I kinda got lost trying to fix many shapes issues at once, so I'm trying again one variable at a time.

This one the the second most common shape edge in our app:

```
Shape Edges Report
-----------------------------------
       527  @default_graphql_name
       494  @own_fields
```