### PR TITLE
Eagerly define @to_non_null_type variables for Shape Friendliness

### DIFF
--- a/lib/graphql/schema/late_bound_type.rb
+++ b/lib/graphql/schema/late_bound_type.rb
@@ -9,6 +9,8 @@ module GraphQL
       alias :graphql_name :name
       def initialize(local_name)
         @name = local_name
+        @to_non_null_type = nil
+        @to_list_type = nil
       end
 
       def unwrap

--- a/lib/graphql/schema/member/type_system_helpers.rb
+++ b/lib/graphql/schema/member/type_system_helpers.rb
@@ -4,6 +4,13 @@ module GraphQL
   class Schema
     class Member
       module TypeSystemHelpers
+        def initialize(*args, &block)
+          super
+          @to_non_null_type ||= nil
+          @to_list_type ||= nil
+        end
+        ruby2_keywords :initialize if respond_to?(:ruby2_keywords, true)
+
         # @return [Schema::NonNull] Make a non-null-type representation of this type
         def to_non_null_type
           @to_non_null_type ||= GraphQL::Schema::NonNull.new(self)
@@ -31,6 +38,16 @@ module GraphQL
         # @return [GraphQL::TypeKinds::TypeKind]
         def kind
           raise GraphQL::RequiredImplementationMissingError, "No `.kind` defined for #{self}"
+        end
+
+        private
+
+        def inherited(subclass)
+          super
+          subclass.class_eval do
+            @to_non_null_type ||= nil
+            @to_list_type ||= nil
+          end
         end
       end
     end


### PR DESCRIPTION
Ref: https://github.com/rmosolgo/graphql-ruby/pull/4293

I kinda got lost trying to fix many shapes issues at once, so I'm trying again one variable at a time.

This one the the third most common shape edge in our app:

```
Shape Edges Report
-----------------------------------
       527  @default_graphql_name
       494  @own_fields
       487  @to_non_null_type
```