### PR TITLE
Eagerly define @own_interface_type_memberships for Shape Friendliness

### DIFF
--- a/lib/graphql/schema/member/has_interfaces.rb
+++ b/lib/graphql/schema/member/has_interfaces.rb
@@ -82,6 +82,15 @@ module GraphQL
 
           visible_interfaces.uniq
         end
+
+        private
+
+        def inherited(subclass)
+          super
+          subclass.class_eval do
+            @own_interface_type_memberships ||= nil
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Ref: https://github.com/rmosolgo/graphql-ruby/pull/4293

I kinda got lost trying to fix many shapes issues at once, so I'm trying again one variable at a time.

This one the the fourth most common shape edge in our app:

```
Shape Edges Report
-----------------------------------
       527  @default_graphql_name
       494  @own_fields
       487  @to_non_null_type
       413  @own_interface_type_memberships
```