### PR TITLE
JS: fix header handling, add changeset-version option

### DIFF
--- a/guides/javascript_client/sync.md
+++ b/guides/javascript_client/sync.md
@@ -53,6 +53,7 @@ option | description
 `--header={key}:{value}` | Add a header to the outgoing HTTP request (may be repeated)
 `--add-typename` | Add `__typename` to all selection sets (for use with Apollo Client)
 `--verbose` | Output some debug information
+`--changeset-version` | Set a {% internal_link "Changeset Version", "/changesets/installation#controller-setup" %} when syncing these queries
 
 You can see these and a few others with `graphql-ruby-client sync --help`.
 

--- a/javascript_client/src/__tests__/cliTest.ts
+++ b/javascript_client/src/__tests__/cliTest.ts
@@ -12,7 +12,7 @@ describe("CLI", () => {
   })
 
   it("runs with some options", () => {
-    var buffer = childProcess.execSync("node ./cli.js sync --client=something --header=Abcd:efgh --header=\"Abc: 123 45\" --mode=file --path=\"**/doc1.graphql\"", {stdio: "pipe"})
+    var buffer = childProcess.execSync("node ./cli.js sync --client=something --header=Abcd:efgh --header=\"Abc: 123 45\" --changeset-version=2023-01-01 --mode=file --path=\"**/doc1.graphql\"", {stdio: "pipe"})
     var response = buffer.toString().replace(/\033\[[0-9;]*m/g, "")
     expect(response).toEqual("No URL; Generating artifacts without syncing them\nGenerating client module in src/OperationStoreClient.js...\n✓ Done!\n")
   })

--- a/javascript_client/src/__tests__/cliTest.ts
+++ b/javascript_client/src/__tests__/cliTest.ts
@@ -16,4 +16,10 @@ describe("CLI", () => {
     var response = buffer.toString().replace(/\033\[[0-9;]*m/g, "")
     expect(response).toEqual("No URL; Generating artifacts without syncing them\nGenerating client module in src/OperationStoreClient.js...\n✓ Done!\n")
   })
+
+  it("runs with just one header", () => {
+    var buffer = childProcess.execSync("node ./cli.js sync --client=something --header=Ab-cd:ef-gh --mode=file --path=\"**/doc1.graphql\"", {stdio: "pipe"})
+    var response = buffer.toString().replace(/\033\[[0-9;]*m/g, "")
+    expect(response).toEqual("No URL; Generating artifacts without syncing them\nGenerating client module in src/OperationStoreClient.js...\n✓ Done!\n")
+  })
 })

--- a/javascript_client/src/__tests__/syncTest.ts
+++ b/javascript_client/src/__tests__/syncTest.ts
@@ -53,16 +53,18 @@ describe("sync operations", () => {
         headers: {
           "X-Something-Special": "🎂",
         },
+        changesetVersion: "2023-05-05",
         quiet: true,
-        send: (_sendPayload: object, options: { url: string, headers: {[key: string]: string} }) => {
+        send: (_sendPayload: object, options: { url: string, headers: {[key: string]: string}, changesetVersion: string }) => {
           url = options.url
           Object.keys(options.headers).forEach((h) => {
             url += "?" + h + "=" + options.headers[h]
           })
+          url += "&changesetVersion=" + options.changesetVersion
         },
       }
       return sync(options).then(function() {
-        expect(url).toEqual("bogus?X-Something-Special=🎂")
+        expect(url).toEqual("bogus?X-Something-Special=🎂&changesetVersion=2023-05-05")
       })
     })
   })

--- a/javascript_client/src/cli.ts
+++ b/javascript_client/src/cli.ts
@@ -34,6 +34,7 @@ optional arguments:
                                               - otherwise, "project"
   --header=<header>:<value>                 Add a header to the outgoing HTTP request
                                               (may be repeated)
+  --changeset-version=<version>             Populates \`context[:changeset_version]\` for this sync (for the GraphQL-Enterprise "Changesets" feature)
   --add-typename                            Automatically adds the "__typename" field to your queries
   --quiet                                   Suppress status logging
   --verbose                                 Print debug output
@@ -72,6 +73,7 @@ optional arguments:
       addTypename: argv["add-typename"],
       quiet: argv.hasOwnProperty("quiet"),
       verbose: argv.hasOwnProperty("verbose"),
+      changesetVersion: argv["changset-version"],
     })
 
     result.then(function() {

--- a/javascript_client/src/cli.ts
+++ b/javascript_client/src/cli.ts
@@ -47,10 +47,15 @@ optional arguments:
   } else {
     var parsedHeaders: {[key: string]: string} = {}
     if (argv.header) {
-      argv.header.forEach((h: string) => {
-        var headerParts = h.split(":")
+      if (typeof(argv.header) === "string") {
+        var headerParts = argv.header.split(":")
         parsedHeaders[headerParts[0]] = headerParts[1]
-      })
+      } else {
+        argv.header.forEach((h: string) => {
+          var headerParts = h.split(":")
+          parsedHeaders[headerParts[0]] = headerParts[1]
+        })
+      }
     }
     var result = sync({
       path: argv.path,

--- a/javascript_client/src/sync/__tests__/sendPayloadTest.ts
+++ b/javascript_client/src/sync/__tests__/sendPayloadTest.ts
@@ -44,6 +44,21 @@ describe("Posting GraphQL to OperationStore Endpoint", () => {
     })
   })
 
+  it("Sends headers and changeset version", () => {
+    var mock = nock("http://example.com", {
+      reqheaders: {
+        thing: "Stuff",
+        "Changeset-Version": "2023-01-01",
+      }
+    })
+      .post("/stored_operations/sync")
+      .reply(200, { result: "ok" })
+
+    return sendPayload("payload", { url: "http://example.com/stored_operations/sync", headers: { thing: "Stuff" }, changesetVersion: "2023-01-01" }).then(function(_response) {
+      expect(mock.isDone()).toEqual(true)
+    })
+  })
+
   it("Adds an hmac-sha256 header if key is present", () => {
     var payload = { "payload": [1,2,3] }
     var key = "2f26b770ded2a04279bc4bf824ca54ac"

--- a/javascript_client/src/sync/index.ts
+++ b/javascript_client/src/sync/index.ts
@@ -21,6 +21,7 @@ interface SyncOptions {
   verbose?: boolean,
   quiet?: boolean,
   addTypename?: boolean,
+  changesetVersion?: string,
   headers?: {[key: string]: string},
 }
 /**
@@ -42,6 +43,7 @@ interface SyncOptions {
  * @param {Function} options.hash - A custom hash function for query strings with the signature `options.hash(string) => digest` (Default is `md5(string) => digest`)
  * @param {Boolean} options.verbose - If true, log debug output
  * @param {Object<String, String>} options.headers - If present, extra headers to add to the HTTP request
+ * @param {String} options.changesetVersion - If present, sent to populate `context[:changeset_version]` on the server
  * @return {Promise} Rejects with an Error or String if something goes wrong. Resolves with the operation payload if successful.
 */
 function sync(options: SyncOptions) {
@@ -147,6 +149,7 @@ function sync(options: SyncOptions) {
         secret: encryptionKey,
         verbose: verbose,
         headers: options.headers,
+        changesetVersion: options.changesetVersion,
       }
       var sendPromise = Promise.resolve(sendFunc(payload, sendOpts))
       return sendPromise.then(function(response) {

--- a/javascript_client/src/sync/sendPayload.ts
+++ b/javascript_client/src/sync/sendPayload.ts
@@ -8,7 +8,8 @@ interface SendPayloadOptions {
   secret?: string,
   client?: string,
   verbose?: boolean,
-  headers?: [string],
+  headers?: { [key: string]: string },
+  changesetVersion?: string,
 }
 /**
  * Use HTTP POST to send this payload to the endpoint.
@@ -41,6 +42,9 @@ function sendPayload(payload: any, options: SendPayloadOptions) {
     'Content-Length': Buffer.byteLength(postData).toString()
   }
 
+  if (options.changesetVersion) {
+    defaultHeaders["Changeset-Version"] = options.changesetVersion
+  }
   var allHeaders = Object.assign({}, options.headers, defaultHeaders)
 
   var httpOptions = {


### PR DESCRIPTION
Fixes https://github.com/rmosolgo/graphql-ruby/discussions/4304

TODO: 

- [x] release a graphql-pro version that receives `Changeset-Version` and uses it for validation