### PR TITLE
Allow `nil` as an enum ruby value

### DIFF
--- a/lib/graphql/schema/enum_value.rb
+++ b/lib/graphql/schema/enum_value.rb
@@ -25,16 +25,19 @@ module GraphQL
       include GraphQL::Schema::Member::HasDirectives
       include GraphQL::Schema::Member::HasDeprecationReason
 
+      UNDEFINED_VALUE = Object.new.freeze
+      private_constant :UNDEFINED_VALUE
+
       attr_reader :graphql_name
 
       # @return [Class] The enum type that owns this value
       attr_reader :owner
 
-      def initialize(graphql_name, desc = nil, owner:, ast_node: nil, directives: nil, description: nil, value: nil, deprecation_reason: nil, &block)
+      def initialize(graphql_name, desc = nil, owner:, ast_node: nil, directives: nil, description: nil, value: UNDEFINED_VALUE, deprecation_reason: nil, &block)
         @graphql_name = graphql_name.to_s
         GraphQL::NameValidator.validate!(@graphql_name)
         @description = desc || description
-        @value = value.nil? ? @graphql_name : value
+        @value = value === UNDEFINED_VALUE ? @graphql_name : value
         if deprecation_reason
           self.deprecation_reason = deprecation_reason
         end

--- a/spec/graphql/introspection/type_type_spec.rb
+++ b/spec/graphql/introspection/type_type_spec.rb
@@ -27,6 +27,7 @@ describe GraphQL::Introspection::TypeType do
   ]}
 
   let(:dairy_animals) {[
+    {"name"=>"NONE",       "isDeprecated"=> false },
     {"name"=>"COW",       "isDeprecated"=> false },
     {"name"=>"DONKEY",    "isDeprecated"=> false },
     {"name"=>"GOAT",      "isDeprecated"=> false },

--- a/spec/graphql/schema/enum_spec.rb
+++ b/spec/graphql/schema/enum_spec.rb
@@ -171,6 +171,7 @@ describe GraphQL::Schema::Enum do
     it "coerces names to underlying values" do
       assert_equal("YAK", enum.coerce_isolated_input("YAK"))
       assert_equal(1, enum.coerce_isolated_input("COW"))
+      assert_equal(nil, enum.coerce_isolated_input("NONE"))
     end
 
     it "coerces invalid names to nil" do
@@ -178,6 +179,7 @@ describe GraphQL::Schema::Enum do
     end
 
     it "coerces result values to value's value" do
+      assert_equal("NONE", enum.coerce_isolated_result(nil))
       assert_equal("YAK", enum.coerce_isolated_result("YAK"))
       assert_equal("COW", enum.coerce_isolated_result(1))
       assert_equal("REINDEER", enum.coerce_isolated_result('reindeer'))
@@ -282,7 +284,7 @@ describe GraphQL::Schema::Enum do
         assert(!result.valid?)
         assert_equal(
           result.problems.first['explanation'],
-          "Expected \"bad enum\" to be one of: COW, DONKEY, GOAT, REINDEER, SHEEP, YAK"
+          "Expected \"bad enum\" to be one of: NONE, COW, DONKEY, GOAT, REINDEER, SHEEP, YAK"
         )
       end
     end

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -61,6 +61,7 @@ module Dummy
 
   class DairyAnimal < BaseEnum
     description "An animal which can yield milk"
+    value("NONE",     "No animal", value: nil)
     value("COW",      "Animal with black and white spots", value: 1)
     value("DONKEY",   "Animal with fur", value: :donkey)
     value("GOAT",     "Animal with horns")


### PR DESCRIPTION
Use dummy object instead of `nil` for undefined value, so we can distingush explicitly passed `nil`.

Right now we have:
```ruby
require 'graphql'

class MyEnumType < GraphQL::Schema::Enum
  value 'NO_VALUE', value: nil
  value 'ONE_VALUE', value: 1
end

p MyEnumType.coerce_input('NO_VALUE', GraphQL::Query::NullContext) # => 'NO_VALUE'
```

Not sure how to properly test it because added test is in `legacy tests` block, please advise.