### PR TITLE
Improve interface type membership lookup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem 'pry'
 gem 'pry-stack_explorer', platform: :ruby
 gem 'graphql-batch'
 gem 'pry-byebug'
-gem "graphql-metrics"
 
 if RUBY_VERSION >= "3.0"
   gem "libev_scheduler"

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'pry'
 gem 'pry-stack_explorer', platform: :ruby
 gem 'graphql-batch'
 gem 'pry-byebug'
+gem "graphql-metrics"
 
 if RUBY_VERSION >= "3.0"
   gem "libev_scheduler"

--- a/benchmark/run.rb
+++ b/benchmark/run.rb
@@ -6,6 +6,7 @@ require "benchmark/ips"
 require "stackprof"
 require "memory_profiler"
 require "graphql/batch"
+require "graphql/metrics"
 
 module GraphQLBenchmark
   QUERY_STRING = GraphQL::Introspection::INTROSPECTION_QUERY
@@ -83,7 +84,7 @@ module GraphQLBenchmark
       }
     end
 
-    result = StackProf.run(mode: :wall) do
+    result = StackProf.run(mode: :wall, interval: 1) do
       schema.execute(document: document)
     end
     StackProf::Report.new(result).print_text
@@ -111,8 +112,20 @@ module GraphQLBenchmark
       }
     }
 
+    module Bar
+      include GraphQL::Schema::Interface
+      field :string_array, [String], null: false
+    end
+
+    module Baz
+      include Bar
+      field :int_array, [Integer], null: false
+      field :boolean_array, [Boolean], null: false
+    end
+
 
     class FooType < GraphQL::Schema::Object
+      implements Bar
       field :id, ID, null: false
       field :int1, Integer, null: false
       field :int2, Integer, null: false
@@ -120,9 +133,6 @@ module GraphQLBenchmark
       field :string2, String, null: false
       field :boolean1, Boolean, null: false
       field :boolean2, Boolean, null: false
-      field :string_array, [String], null: false
-      field :int_array, [Integer], null: false
-      field :boolean_array, [Boolean], null: false
     end
 
     class QueryType < GraphQL::Schema::Object
@@ -135,7 +145,28 @@ module GraphQLBenchmark
 
     class Schema < GraphQL::Schema
       query QueryType
-      use GraphQL::Dataloader
+      class DummyPlatformTracer < GraphQL::Tracing::PlatformTracing
+        self.platform_keys = GraphQL::Tracing::DataDogTracing.platform_keys
+
+        def platform_trace(platform_key, key, data)
+          yield
+        end
+
+        def platform_authorized_key(t)
+          t.graphql_name
+        end
+
+        def platform_field_key(t, f)
+          f.path
+        end
+      end
+
+
+      query_analyzer GraphQL::Metrics::Analyzer
+
+      instrument :query, GraphQL::Metrics::Instrumentation.new # Both of these are required if either is used.
+      tracer GraphQL::Metrics::Tracer.new                      # <-- Note!
+      # use GraphQL::Dataloader
     end
 
     ALL_FIELDS = GraphQL.parse <<-GRAPHQL

--- a/benchmark/run.rb
+++ b/benchmark/run.rb
@@ -6,7 +6,6 @@ require "benchmark/ips"
 require "stackprof"
 require "memory_profiler"
 require "graphql/batch"
-require "graphql/metrics"
 
 module GraphQLBenchmark
   QUERY_STRING = GraphQL::Introspection::INTROSPECTION_QUERY
@@ -118,14 +117,15 @@ module GraphQLBenchmark
     end
 
     module Baz
-      include Bar
+      include GraphQL::Schema::Interface
+      implements Bar
       field :int_array, [Integer], null: false
       field :boolean_array, [Boolean], null: false
     end
 
 
     class FooType < GraphQL::Schema::Object
-      implements Bar
+      implements Baz
       field :id, ID, null: false
       field :int1, Integer, null: false
       field :int2, Integer, null: false
@@ -145,27 +145,6 @@ module GraphQLBenchmark
 
     class Schema < GraphQL::Schema
       query QueryType
-      class DummyPlatformTracer < GraphQL::Tracing::PlatformTracing
-        self.platform_keys = GraphQL::Tracing::DataDogTracing.platform_keys
-
-        def platform_trace(platform_key, key, data)
-          yield
-        end
-
-        def platform_authorized_key(t)
-          t.graphql_name
-        end
-
-        def platform_field_key(t, f)
-          f.path
-        end
-      end
-
-
-      query_analyzer GraphQL::Metrics::Analyzer
-
-      instrument :query, GraphQL::Metrics::Instrumentation.new # Both of these are required if either is used.
-      tracer GraphQL::Metrics::Tracer.new                      # <-- Note!
       # use GraphQL::Dataloader
     end
 

--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -134,7 +134,7 @@ module GraphQL
           if type.respond_to?(:kind) && type.kind.interface?
             implements_this_interface = false
             implementation_is_visible = false
-            interface_type_memberships.each do |tm|
+            warden.interface_type_memberships(self, context).each do |tm|
               if tm.abstract_type == type
                 implements_this_interface ||= true
                 if warden.visible_type_membership?(tm, context)

--- a/lib/graphql/schema/member/has_interfaces.rb
+++ b/lib/graphql/schema/member/has_interfaces.rb
@@ -57,7 +57,17 @@ module GraphQL
         end
 
         def interface_type_memberships
-          own_interface_type_memberships + ((self.is_a?(Class) && superclass.respond_to?(:interface_type_memberships)) ? superclass.interface_type_memberships : [])
+          own_tms = own_interface_type_memberships
+          if (self.is_a?(Class) && superclass.respond_to?(:interface_type_memberships))
+            inherited_tms = superclass.interface_type_memberships
+            if inherited_tms.size > 0
+              own_tms + inherited_tms
+            else
+              own_tms
+            end
+          else
+            own_tms
+          end
         end
 
         # param context [Query::Context] If omitted, skip filtering.

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -78,6 +78,7 @@ module GraphQL
           def visible_type?(type, ctx); type.visible?(ctx); end
           def visible_enum_value?(ev, ctx); ev.visible?(ctx); end
           def visible_type_membership?(tm, ctx); tm.visible?(ctx); end
+          def interface_type_memberships(obj_t, ctx); obj_t.interface_type_memberships; end
         end
       end
 
@@ -229,6 +230,13 @@ module GraphQL
 
       def visible_type_membership?(type_membership, _ctx = nil)
         visible?(type_membership)
+      end
+
+      def interface_type_memberships(obj_type, _ctx = nil)
+        @type_memberships ||= read_through do |obj_t|
+          obj_t.interface_type_memberships
+        end
+        @type_memberships[obj_type]
       end
 
       private


### PR DESCRIPTION
Looking over some profiling artifacts, I noticed this call to `interface_type_memberships` wasn't cached, so objects were repeatedly building this array over and over. The more interfaces and superclasses an object has, the more this overhead would've added up. I was able to confirm a reduction in allocated memory and time spent calculating this by running the new benchmark: 

```diff 
# ... 
-        176   (0.0%)          25   (0.0%)     GraphQL::Schema::Member::HasFields#get_field
+          4   (0.0%)           1   (0.0%)     GraphQL::Schema::Member::HasFields#get_field

-         32   (0.0%)          17   (0.0%)     GraphQL::Schema::Member::HasInterfaces#interface_type_memberships
+          4   (0.0%)           3   (0.0%)     GraphQL::Schema::Warden#interface_type_memberships


# ... 
- Total allocated: 12937088 bytes (69487 objects)
+ Total allocated: 12935984 bytes (69454 objects)

# ...
-         40  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_interfaces.rb
-         39  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb
-         37  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb
+         40  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/warden.rb
+         39  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_fields.rb
# ...
+          4  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_interfaces.rb
```

TODO: 

- [ ] Forward-port to 2.0.x