### PR TITLE
Reduce argument overhead

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -116,6 +116,12 @@ namespace :bench do
     prepare_benchmark
     GraphQLBenchmark.profile_batch_loaders
   end
+
+  desc "Run a very big introspection query"
+  task :profile_large_introspection do
+    prepare_benchmark
+    GraphQLBenchmark.profile_large_introspection
+  end
 end
 
 namespace :test do

--- a/benchmark/run.rb
+++ b/benchmark/run.rb
@@ -166,10 +166,32 @@ module GraphQLBenchmark
       field :id, ID, null: false
       field :int1, Integer, null: false
       field :int2, Integer, null: false
-      field :string1, String, null: false
-      field :string2, String, null: false
-      field :boolean1, Boolean, null: false
-      field :boolean2, Boolean, null: false
+      field :string1, String, null: false do
+        argument :arg1, String, required: false
+        argument :arg2, String, required: false
+        argument :arg3, String, required: false
+        argument :arg4, String, required: false
+      end
+
+      field :string2, String, null: false do
+        argument :arg1, String, required: false
+        argument :arg2, String, required: false
+        argument :arg3, String, required: false
+        argument :arg4, String, required: false
+      end
+
+      field :boolean1, Boolean, null: false do
+        argument :arg1, String, required: false
+        argument :arg2, String, required: false
+        argument :arg3, String, required: false
+        argument :arg4, String, required: false
+      end
+      field :boolean2, Boolean, null: false do
+        argument :arg1, String, required: false
+        argument :arg2, String, required: false
+        argument :arg3, String, required: false
+        argument :arg4, String, required: false
+      end
     end
 
     class QueryType < GraphQL::Schema::Object

--- a/benchmark/run.rb
+++ b/benchmark/run.rb
@@ -73,6 +73,43 @@ module GraphQLBenchmark
     StackProf::Report.new(result).print_text
   end
 
+  def self.profile_large_introspection
+    schema = Class.new(GraphQL::Schema) do
+      query_t = Class.new(GraphQL::Schema::Object) do
+        graphql_name("Query")
+        100.times do |n|
+          obj_t = Class.new(GraphQL::Schema::Object) do
+            graphql_name("Object#{n}")
+            5.times do |n2|
+              field :"field#{n2}", String do
+                argument :arg, String
+              end
+            end
+          end
+          field :"rootfield#{n}", obj_t
+        end
+      end
+      query(query_t)
+    end
+
+    Benchmark.ips do |x|
+      x.report("Run large introspection") {
+        schema.to_json
+      }
+    end
+
+    result = StackProf.run(mode: :wall, interval: 10) do
+      schema.to_json
+    end
+    StackProf::Report.new(result).print_text
+
+    report = MemoryProfiler.report do
+      schema.to_json
+    end
+    puts "\n\n"
+    report.pretty_print
+  end
+
   # Adapted from https://github.com/rmosolgo/graphql-ruby/issues/861
   def self.profile_large_result
     schema = ProfileLargeResult::Schema

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -650,27 +650,29 @@ module GraphQL
             arg_values = args
             using_arg_values = false
           end
-          # Faster than `.any?`
-          arguments(context).each_value do |arg|
-            arg_key = arg.keyword
-            if arg_values.key?(arg_key)
-              arg_value = arg_values[arg_key]
-              if using_arg_values
-                if arg_value.default_used?
-                  # pass -- no auth required for default used
-                  next
-                else
-                  application_arg_value = arg_value.value
-                  if application_arg_value.is_a?(GraphQL::Execution::Interpreter::Arguments)
-                    application_arg_value.keyword_arguments
+          if args.size > 0
+            args = context.warden.arguments(self)
+            args.each do |arg|
+              arg_key = arg.keyword
+              if arg_values.key?(arg_key)
+                arg_value = arg_values[arg_key]
+                if using_arg_values
+                  if arg_value.default_used?
+                    # pass -- no auth required for default used
+                    next
+                  else
+                    application_arg_value = arg_value.value
+                    if application_arg_value.is_a?(GraphQL::Execution::Interpreter::Arguments)
+                      application_arg_value.keyword_arguments
+                    end
                   end
+                else
+                  application_arg_value = arg_value
                 end
-              else
-                application_arg_value = arg_value
-              end
 
-              if !arg.authorized?(object, application_arg_value, context)
-                return false
+                if !arg.authorized?(object, application_arg_value, context)
+                  return false
+                end
               end
             end
           end

--- a/lib/graphql/schema/member/has_arguments.rb
+++ b/lib/graphql/schema/member/has_arguments.rb
@@ -167,7 +167,7 @@ module GraphQL
         # @return [Interpreter::Arguments, Execution::Lazy<Interpeter::Arguments>]
         def coerce_arguments(parent_object, values, context, &block)
           # Cache this hash to avoid re-merging it
-          arg_defns = self.arguments(context)
+          arg_defns = context.warden.arguments(self)
           total_args_count = arg_defns.size
 
           finished_args = nil
@@ -181,7 +181,7 @@ module GraphQL
               argument_values = {}
               resolved_args_count = 0
               raised_error = false
-              arg_defns.each do |arg_name, arg_defn|
+              arg_defns.each do |arg_defn|
                 context.dataloader.append_job do
                   begin
                     arg_defn.coerce_into_values(parent_object, values, context, argument_values)

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -79,6 +79,7 @@ module GraphQL
           def visible_enum_value?(ev, ctx); ev.visible?(ctx); end
           def visible_type_membership?(tm, ctx); tm.visible?(ctx); end
           def interface_type_memberships(obj_t, ctx); obj_t.interface_type_memberships; end
+          def arguments(owner, ctx); owner.arguments(ctx); end
         end
       end
 
@@ -173,8 +174,8 @@ module GraphQL
 
       # @param argument_owner [GraphQL::Field, GraphQL::InputObjectType]
       # @return [Array<GraphQL::Argument>] Visible arguments on `argument_owner`
-      def arguments(argument_owner)
-        @visible_arguments ||= read_through { |o| o.arguments(@context).each_value.select { |a| visible_argument?(a) } }
+      def arguments(argument_owner, ctx = nil)
+        @visible_arguments ||= read_through { |o| o.arguments(@context).each_value.select { |a| visible_argument?(a, @context) } }
         @visible_arguments[argument_owner]
       end
 


### PR DESCRIPTION
Looking at a profile, I found that `arguments(ctx)` hashes are merged over and over again at runtime, at least in these two places. We should cache these per-query, too.

```diff 
-                           3.335  (± 0.0%) i/s -     17.000  in   5.101803s
+                           3.532  (± 0.0%) i/s -     18.000  in   5.097713s


-      55774   (8.8%)       10019   (1.6%)     GraphQL::Schema::Member::HasArguments#arguments
-      93425  (14.7%)        5604   (0.9%)     GraphQL::Schema::Member::HasArguments#coerce_arguments
-      18269   (2.9%)        4890   (0.8%)     GraphQL::Schema::Warden#visible_argument?
-      26798   (4.2%)        3665   (0.6%)     GraphQL::Schema::Field#authorized?

+      58446  (10.2%)        5725   (1.0%)     GraphQL::Schema::Member::HasArguments#coerce_arguments
+      22136   (3.9%)        4406   (0.8%)     GraphQL::Schema::Member::HasArguments#arguments
+       7366   (1.3%)        2176   (0.4%)     GraphQL::Schema::Warden#visible_argument?
+       4344   (0.8%)        2673   (0.5%)     GraphQL::Schema::Field#authorized?


- Total allocated: 16748432 bytes (105490 objects)
+ Total allocated: 15404096 bytes (97488 objects)
```

TODO: 

- [x] Post benchmark improvements
- [ ] Port to 2.0.x

I also investigated caching coerced arguments in 1484b84d6, but I didn't see any further improvement in the introspection benchmark.