### PR TITLE
Don't run scoping on introspection queries

### DIFF
--- a/lib/graphql/introspection/directive_type.rb
+++ b/lib/graphql/introspection/directive_type.rb
@@ -11,8 +11,8 @@ module GraphQL
                     "to the executor."
       field :name, String, null: false, method: :graphql_name
       field :description, String
-      field :locations, [GraphQL::Schema::LateBoundType.new("__DirectiveLocation")], null: false
-      field :args, [GraphQL::Schema::LateBoundType.new("__InputValue")], null: false do
+      field :locations, [GraphQL::Schema::LateBoundType.new("__DirectiveLocation")], null: false, scope: false
+      field :args, [GraphQL::Schema::LateBoundType.new("__InputValue")], null: false, scope: false do
         argument :include_deprecated, Boolean, required: false, default_value: false
       end
       field :on_operation, Boolean, null: false, deprecation_reason: "Use `locations`.", method: :on_operation?

--- a/lib/graphql/introspection/field_type.rb
+++ b/lib/graphql/introspection/field_type.rb
@@ -7,7 +7,7 @@ module GraphQL
                   "a name, potentially a list of arguments, and a return type."
       field :name, String, null: false
       field :description, String
-      field :args, [GraphQL::Schema::LateBoundType.new("__InputValue")], null: false do
+      field :args, [GraphQL::Schema::LateBoundType.new("__InputValue")], null: false, scope: false do
         argument :include_deprecated, Boolean, required: false, default_value: false
       end
       field :type, GraphQL::Schema::LateBoundType.new("__Type"), null: false

--- a/lib/graphql/introspection/schema_type.rb
+++ b/lib/graphql/introspection/schema_type.rb
@@ -8,11 +8,11 @@ module GraphQL
                   "available types and directives on the server, as well as the entry points for "\
                   "query, mutation, and subscription operations."
 
-      field :types, [GraphQL::Schema::LateBoundType.new("__Type")], "A list of all types supported by this server.", null: false
+      field :types, [GraphQL::Schema::LateBoundType.new("__Type")], "A list of all types supported by this server.", null: false, scope: false
       field :query_type, GraphQL::Schema::LateBoundType.new("__Type"), "The type that query operations will be rooted at.", null: false
       field :mutation_type, GraphQL::Schema::LateBoundType.new("__Type"), "If this server supports mutation, the type that mutation operations will be rooted at."
       field :subscription_type, GraphQL::Schema::LateBoundType.new("__Type"), "If this server support subscription, the type that subscription operations will be rooted at."
-      field :directives, [GraphQL::Schema::LateBoundType.new("__Directive")], "A list of all directives supported by this server.", null: false
+      field :directives, [GraphQL::Schema::LateBoundType.new("__Directive")], "A list of all directives supported by this server.", null: false, scope: false
       field :description, String, resolver_method: :schema_description
 
       def schema_description

--- a/lib/graphql/introspection/type_type.rb
+++ b/lib/graphql/introspection/type_type.rb
@@ -14,15 +14,15 @@ module GraphQL
       field :kind, GraphQL::Schema::LateBoundType.new("__TypeKind"), null: false
       field :name, String, method: :graphql_name
       field :description, String
-      field :fields, [GraphQL::Schema::LateBoundType.new("__Field")] do
+      field :fields, [GraphQL::Schema::LateBoundType.new("__Field")], scope: false do
         argument :include_deprecated, Boolean, required: false, default_value: false
       end
-      field :interfaces, [GraphQL::Schema::LateBoundType.new("__Type")]
-      field :possible_types, [GraphQL::Schema::LateBoundType.new("__Type")]
-      field :enum_values, [GraphQL::Schema::LateBoundType.new("__EnumValue")] do
+      field :interfaces, [GraphQL::Schema::LateBoundType.new("__Type")], scope: false
+      field :possible_types, [GraphQL::Schema::LateBoundType.new("__Type")], scope: false
+      field :enum_values, [GraphQL::Schema::LateBoundType.new("__EnumValue")], scope: false do
         argument :include_deprecated, Boolean, required: false, default_value: false
       end
-      field :input_fields, [GraphQL::Schema::LateBoundType.new("__InputValue")]  do
+      field :input_fields, [GraphQL::Schema::LateBoundType.new("__InputValue")], scope: false  do
         argument :include_deprecated, Boolean, required: false, default_value: false
       end
       field :of_type, GraphQL::Schema::LateBoundType.new("__Type")


### PR DESCRIPTION
This overhead seems small, but it adds up proportional to the number of lists (arguments, fields, types, enum values, interfaces, possible types) in the result. So, for big schemas, it can add up!


```diff 
-        247   (0.1%)          62   (0.0%)     GraphQL::Schema::Field::ScopeExtension#after_resolve
+
```

(Using the introspection benchmark from 8f0e9e8662edc67844074c2392e1c81a066ac3fe)

TODO: 

- [ ] Port to 2.0.x