### PR TITLE
Performance: reduce a duplicate call to Field#type

### DIFF
--- a/benchmark/run.rb
+++ b/benchmark/run.rb
@@ -80,7 +80,7 @@ module GraphQLBenchmark
         100.times do |n|
           obj_t = Class.new(GraphQL::Schema::Object) do
             graphql_name("Object#{n}")
-            5.times do |n2|
+            20.times do |n2|
               field :"field#{n2}", String do
                 argument :arg, String
               end

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -400,6 +400,7 @@ module GraphQL
               raise "Invariant: no field for #{owner_type}.#{field_name}"
             end
           end
+          # HERE
           return_type = field_defn.type
 
           next_path = path.dup
@@ -436,6 +437,7 @@ module GraphQL
 
         def evaluate_selection_with_args(arguments, field_defn, next_path, ast_node, field_ast_nodes, scoped_context, owner_type, object, is_eager_field, result_name, selection_result, parent_object)  # rubocop:disable Metrics/ParameterLists
           context.scoped_context = scoped_context
+          # HERE
           return_type = field_defn.type
           after_lazy(arguments, owner: owner_type, field: field_defn, path: next_path, ast_node: ast_node, scoped_context: context.scoped_context, owner_object: object, arguments: arguments, result_name: result_name, result: selection_result) do |resolved_arguments|
             if resolved_arguments.is_a?(GraphQL::ExecutionError) || resolved_arguments.is_a?(GraphQL::UnauthorizedError)

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -400,7 +400,7 @@ module GraphQL
               raise "Invariant: no field for #{owner_type}.#{field_name}"
             end
           end
-          # HERE
+
           return_type = field_defn.type
 
           next_path = path.dup
@@ -426,19 +426,17 @@ module GraphQL
           total_args_count = field_defn.arguments(context).size
           if total_args_count == 0
             resolved_arguments = GraphQL::Execution::Interpreter::Arguments::EMPTY
-            evaluate_selection_with_args(resolved_arguments, field_defn, next_path, ast_node, field_ast_nodes, scoped_context, owner_type, object, is_eager_field, result_name, selections_result, parent_object)
+            evaluate_selection_with_args(resolved_arguments, field_defn, next_path, ast_node, field_ast_nodes, scoped_context, owner_type, object, is_eager_field, result_name, selections_result, parent_object, return_type)
           else
             # TODO remove all arguments(...) usages?
             @query.arguments_cache.dataload_for(ast_node, field_defn, object) do |resolved_arguments|
-              evaluate_selection_with_args(resolved_arguments, field_defn, next_path, ast_node, field_ast_nodes, scoped_context, owner_type, object, is_eager_field, result_name, selections_result, parent_object)
+              evaluate_selection_with_args(resolved_arguments, field_defn, next_path, ast_node, field_ast_nodes, scoped_context, owner_type, object, is_eager_field, result_name, selections_result, parent_object, return_type)
             end
           end
         end
 
-        def evaluate_selection_with_args(arguments, field_defn, next_path, ast_node, field_ast_nodes, scoped_context, owner_type, object, is_eager_field, result_name, selection_result, parent_object)  # rubocop:disable Metrics/ParameterLists
+        def evaluate_selection_with_args(arguments, field_defn, next_path, ast_node, field_ast_nodes, scoped_context, owner_type, object, is_eager_field, result_name, selection_result, parent_object, return_type)  # rubocop:disable Metrics/ParameterLists
           context.scoped_context = scoped_context
-          # HERE
-          return_type = field_defn.type
           after_lazy(arguments, owner: owner_type, field: field_defn, path: next_path, ast_node: ast_node, scoped_context: context.scoped_context, owner_object: object, arguments: arguments, result_name: result_name, result: selection_result) do |resolved_arguments|
             if resolved_arguments.is_a?(GraphQL::ExecutionError) || resolved_arguments.is_a?(GraphQL::UnauthorizedError)
               continue_value(next_path, resolved_arguments, owner_type, field_defn, return_type.non_null?, ast_node, result_name, selection_result)

--- a/lib/graphql/tracing/platform_tracing.rb
+++ b/lib/graphql/tracing/platform_tracing.rb
@@ -36,6 +36,7 @@ module GraphQL
             trace_field = true # implemented with instrumenter
           else
             field = data[:field]
+            # HERE
             return_type = field.type.unwrap
             trace_field = if return_type.kind.scalar? || return_type.kind.enum?
               (field.trace.nil? && @trace_scalars) || field.trace


### PR DESCRIPTION
When building really big result sets (especially introspection, where there's almost nothing _except_ GraphQL overhead), these redundant `Field#type` calls add up. 

Amazingly, my profiles don't show any callees of this method, so I think they're all calls to the cached `@type` (https://github.com/rmosolgo/graphql-ruby/blob/1.13.x/lib/graphql/schema/field.rb#L602). So it's just the sheer _number_ of calls that creates the observed slowness.


It didn't make a big difference in this library's benchmark, but I think it'll do the job: 

```diff
-       1813   (0.2%)        1813   (0.2%)     GraphQL::Schema::Field#type
+        819   (0.2%)         819   (0.2%)     GraphQL::Schema::Field#type
```

TODO: 

- [x] Eliminate some of these calls (at least one of the ones in `Runtime`)
- [x] Port to 2.0.x