### PR TITLE
Reduce runtime .is_a? calls in schema objects

### DIFF
--- a/lib/graphql/schema/directive.rb
+++ b/lib/graphql/schema/directive.rb
@@ -8,6 +8,7 @@ module GraphQL
     # - {.resolve}: Wraps field resolution (so it should call `yield` to continue)
     class Directive < GraphQL::Schema::Member
       extend GraphQL::Schema::Member::HasArguments
+      extend GraphQL::Schema::Member::HasArguments::HasDirectiveArguments
 
       class << self
         # Directives aren't types, they don't have kinds.

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -6,6 +6,7 @@ module GraphQL
   class Schema
     class Field
       include GraphQL::Schema::Member::HasArguments
+      include GraphQL::Schema::Member::HasArguments::FieldConfigured
       include GraphQL::Schema::Member::HasAstNode
       include GraphQL::Schema::Member::HasPath
       include GraphQL::Schema::Member::HasValidators

--- a/lib/graphql/schema/member/has_validators.rb
+++ b/lib/graphql/schema/member/has_validators.rb
@@ -18,12 +18,38 @@ module GraphQL
 
         # @return [Array<GraphQL::Schema::Validator>]
         def validators
-          own_validators = @own_validators || EMPTY_ARRAY
-          if self.is_a?(Class) && superclass.respond_to?(:validators) && (inherited_validators = superclass.validators).any?
-            inherited_validators + own_validators
-          else
-            own_validators
+          @own_validators || EMPTY_ARRAY
+        end
+
+        module ClassConfigured
+          def inherited(child_cls)
+            super
+            child_cls.extend(ClassValidators)
           end
+
+          module ClassValidators
+            include Schema::FindInheritedValue::EmptyObjects
+
+            def validators
+              inherited_validators = superclass.validators
+              if inherited_validators.any?
+                if @own_validators.nil?
+                  inherited_validators
+                else
+                  inherited_validators + @own_validators
+                end
+              elsif @own_validators.nil?
+                EMPTY_ARRAY
+              else
+                @own_validators
+              end
+            end
+          end
+        end
+
+        def self.extended(child_cls)
+          super
+          child_cls.extend(ClassConfigured)
         end
       end
     end

--- a/spec/graphql/schema/interface_spec.rb
+++ b/spec/graphql/schema/interface_spec.rb
@@ -336,7 +336,7 @@ interface Timestamped implements Node {
       end
       interfaces_names = thing_type["interfaces"].map { |i| i["name"] }.sort
 
-      assert_equal interfaces_names, ["Named", "Node", "Timestamped"]
+      assert_equal ["Named", "Node", "Timestamped"], interfaces_names
     end
   end
 

--- a/spec/graphql/schema/object_spec.rb
+++ b/spec/graphql/schema/object_spec.rb
@@ -40,13 +40,15 @@ describe GraphQL::Schema::Object do
       # one more than the parent class
       assert_equal 10, new_object_class.fields.size
       # inherited interfaces are present
-      assert_equal [
-          "GloballyIdentifiable",
-          "HasMusicians",
-          "InvisibleNameEntity",
-          "NamedEntity",
-          "PrivateNameEntity",
-        ], new_object_class.interfaces.map(&:graphql_name).sort
+      expected_interface_names = [
+        "GloballyIdentifiable",
+        "HasMusicians",
+        "InvisibleNameEntity",
+        "NamedEntity",
+        "PrivateNameEntity",
+      ]
+      assert_equal expected_interface_names, object_class.interfaces.map(&:graphql_name).sort
+      assert_equal expected_interface_names, new_object_class.interfaces.map(&:graphql_name).sort
       # The new field is present
       assert new_object_class.fields.key?("newField")
       # The overridden field is present:


### PR DESCRIPTION
Fixes #4314 

There are still a lot of calls at runtime, but these were "unnecessary" (they could be eliminated by making configuration code more complicated).

```diff 
-       6088   (1.1%)        6088   (1.1%)     Kernel#is_a?
+       4656   (0.8%)        4656   (0.8%)     Kernel#is_a?
```

<details>
<summary>`Kernel#is_a?` in before benchmark</summary>

<p>

```
$ stackprof tmp/introspection-before.dump --method="Kernel#is_a?"
Kernel#is_a? (<cfunc>:1)
  samples:  6781 self (1.0%)  /   6781 total (1.0%)
  callers:
    1233  (   18.2%)  GraphQL::Execution::Interpreter::Runtime#evaluate_selection
    1189  (   17.5%)  GraphQL::Schema::Member::HasArguments#arguments
     957  (   14.1%)  GraphQL::Schema::Field#resolve
     948  (   14.0%)  GraphQL::Execution::Interpreter::Runtime#evaluate_selection_with_args
     781  (   11.5%)  GraphQL::Schema::Member::HasValidators#validators
     650  (    9.6%)  GraphQL::Execution::Interpreter::Resolve.resolve
     383  (    5.6%)  GraphQL::Execution::Interpreter::Runtime#tap_or_each
     277  (    4.1%)  GraphQL::Execution::Interpreter::Runtime#gather_selections
     105  (    1.5%)  GraphQL::Schema::Warden.visible_entry?
      78  (    1.2%)  GraphQL::Schema::Member::HasArguments#validate_directive_argument
      54  (    0.8%)  GraphQL::Schema::Field#authorized?
      42  (    0.6%)  GraphQL::Execution::Interpreter::Runtime#continue_value
      37  (    0.5%)  GraphQL::Schema::Argument#prepare_value
      21  (    0.3%)  GraphQL::Schema::Member::HasValidators#validators
      18  (    0.3%)  GraphQL::Schema::Member::HasInterfaces#interfaces
       5  (    0.1%)  GraphQL::Language::Parser#make_node
       1  (    0.0%)  GraphQL::StaticValidation::LiteralValidator#recursively_validate
       1  (    0.0%)  GraphQL::Schema::FindInheritedValue#find_inherited_value
       1  (    0.0%)  GraphQL::Language::Visitor#on_node_with_modifications
```
</details>


<details>
<summary>`Kernel#is_a?` in **after** benchmark</summary>

<p>

```
$ stackprof tmp/introspection.dump --method="Kernel#is_a?"
Kernel#is_a? (<cfunc>:1)
  samples:  3534 self (0.8%)  /   3534 total (0.8%)
  callers:
     701  (   19.8%)  GraphQL::Schema::Field#resolve
     693  (   19.6%)  GraphQL::Execution::Interpreter::Runtime#evaluate_selection
     639  (   18.1%)  GraphQL::Execution::Interpreter::Runtime#evaluate_selection_with_args
     455  (   12.9%)  GraphQL::Execution::Interpreter::Resolve.resolve
     394  (   11.1%)  GraphQL::Schema::Warden.visible_entry?
     305  (    8.6%)  GraphQL::Execution::Interpreter::Runtime#tap_or_each
     174  (    4.9%)  GraphQL::Execution::Interpreter::Runtime#gather_selections
      75  (    2.1%)  GraphQL::Schema::Argument#prepare_value
      46  (    1.3%)  GraphQL::Schema::Field#authorized?
      43  (    1.2%)  GraphQL::Execution::Interpreter::Runtime#continue_value
       3  (    0.1%)  GraphQL::Language::Visitor#on_node_with_modifications
       3  (    0.1%)  GraphQL::Language::Parser#make_node
       1  (    0.0%)  GraphQL::StaticValidation::LiteralValidator#constant_scalar?
       1  (    0.0%)  GraphQL::Language::Visitor#on_abstract_node
       1  (    0.0%)  GraphQL::Schema::FindInheritedValue#find_inherited_value
```
</p>
</details