### PR TITLE
1.13.x: don't re-encode schema member names in introspection

### DIFF
--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -51,7 +51,15 @@ module GraphQL
       # @param replace_null_with_default [Boolean] if `true`, incoming values of `null` will be replaced with the configured `default_value`
       def initialize(arg_name = nil, type_expr = nil, desc = nil, required: true, type: nil, name: nil, loads: nil, description: nil, ast_node: nil, default_value: NO_DEFAULT, as: nil, from_resolver: false, camelize: true, prepare: nil, method_access: true, owner:, validates: nil, directives: nil, deprecation_reason: nil, replace_null_with_default: false, &definition_block)
         arg_name ||= name
-        @name = -(camelize ? Member::BuildType.camelize(arg_name.to_s) : arg_name.to_s)
+        name_s = camelize ? Member::BuildType.camelize(arg_name.to_s) : arg_name.to_s
+        if name_s.encoding != Encoding::UTF_8
+          if name_s.frozen?
+            name_s = name_s.encode(Encoding::UTF_8)
+          else
+            name_s.encode!(Encoding::UTF_8)
+          end
+        end
+        @name = -name_s
         @type_expr = type_expr || type
         @description = desc || description
         @null = required != true

--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -51,15 +51,7 @@ module GraphQL
       # @param replace_null_with_default [Boolean] if `true`, incoming values of `null` will be replaced with the configured `default_value`
       def initialize(arg_name = nil, type_expr = nil, desc = nil, required: true, type: nil, name: nil, loads: nil, description: nil, ast_node: nil, default_value: NO_DEFAULT, as: nil, from_resolver: false, camelize: true, prepare: nil, method_access: true, owner:, validates: nil, directives: nil, deprecation_reason: nil, replace_null_with_default: false, &definition_block)
         arg_name ||= name
-        name_s = camelize ? Member::BuildType.camelize(arg_name.to_s) : arg_name.to_s
-        if name_s.encoding != Encoding::UTF_8
-          if name_s.frozen?
-            name_s = name_s.encode(Encoding::UTF_8)
-          else
-            name_s.encode!(Encoding::UTF_8)
-          end
-        end
-        @name = -name_s
+        @name = -(camelize ? Member::BuildType.camelize(arg_name.to_s) : arg_name.to_s)
         @type_expr = type_expr || type
         @description = desc || description
         @null = required != true

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -228,15 +228,7 @@ module GraphQL
           raise ArgumentError, "keyword `extras:` may only be used with method-based resolve and class-based field such as mutation class, please remove `field:`, `function:` or `resolve:`"
         end
         @original_name = name
-        name_s = name.to_s
-        if name_s.encoding != Encoding::UTF_8
-          if name_s.frozen?
-            name_s = name_s.encode(Encoding::UTF_8)
-          else
-            name_s.encode!(Encoding::UTF_8)
-          end
-        end
-        name_s = -name_s
+        name_s = -name.to_s
 
         @underscored_name = -Member::BuildType.underscore(name_s)
         @name = -(camelize ? Member::BuildType.camelize(name_s) : name_s)

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -228,7 +228,16 @@ module GraphQL
           raise ArgumentError, "keyword `extras:` may only be used with method-based resolve and class-based field such as mutation class, please remove `field:`, `function:` or `resolve:`"
         end
         @original_name = name
-        name_s = -name.to_s
+        name_s = name.to_s
+        if name_s.encoding != Encoding::UTF_8
+          if name_s.frozen?
+            name_s = name_s.encode(Encoding::UTF_8)
+          else
+            name_s.encode!(Encoding::UTF_8)
+          end
+        end
+        name_s = -name_s
+
         @underscored_name = -Member::BuildType.underscore(name_s)
         @name = -(camelize ? Member::BuildType.camelize(name_s) : name_s)
         @description = description

--- a/lib/graphql/schema/member/base_dsl_methods.rb
+++ b/lib/graphql/schema/member/base_dsl_methods.rb
@@ -108,7 +108,7 @@ module GraphQL
           @default_graphql_name ||= begin
             raise GraphQL::RequiredImplementationMissingError, 'Anonymous class should declare a `graphql_name`' if name.nil?
 
-            name.split("::").last.sub(/Type\Z/, "")
+            -name.split("::").last.sub(/Type\Z/, "").encode(Encoding::UTF_8)
           end
         end
 

--- a/lib/graphql/schema/member/base_dsl_methods.rb
+++ b/lib/graphql/schema/member/base_dsl_methods.rb
@@ -108,7 +108,7 @@ module GraphQL
           @default_graphql_name ||= begin
             raise GraphQL::RequiredImplementationMissingError, 'Anonymous class should declare a `graphql_name`' if name.nil?
 
-            -name.split("::").last.sub(/Type\Z/, "").encode(Encoding::UTF_8)
+            -name.split("::").last.sub(/Type\Z/, "")
           end
         end
 

--- a/lib/graphql/types/string.rb
+++ b/lib/graphql/types/string.rb
@@ -7,7 +7,7 @@ module GraphQL
 
       def self.coerce_result(value, ctx)
         str = value.to_s
-        if str.encoding == Encoding::UTF_8
+        if str.ascii_only? || str.encoding == Encoding::UTF_8
           str
         elsif str.frozen?
           str.encode(Encoding::UTF_8)


### PR DESCRIPTION
Backport #4319 