### PR TITLE
Reduce indirection in #introspection? and #graphql_name

### DIFF
--- a/lib/graphql/schema/member/base_dsl_methods.rb
+++ b/lib/graphql/schema/member/base_dsl_methods.rb
@@ -79,7 +79,7 @@ module GraphQL
         end
 
         def introspection?
-          introspection
+          @introspection
         end
 
         # The mutation this type was derived from, if it was derived from a mutation

--- a/lib/graphql/schema/member/base_dsl_methods.rb
+++ b/lib/graphql/schema/member/base_dsl_methods.rb
@@ -22,12 +22,8 @@ module GraphQL
             GraphQL::NameValidator.validate!(new_name)
             @graphql_name = new_name
           else
-            overridden_graphql_name || default_graphql_name
+            @graphql_name ||= default_graphql_name
           end
-        end
-
-        def overridden_graphql_name
-          defined?(@graphql_name) ? @graphql_name : nil
         end
 
         # Just a convenience method to point out that people should use graphql_name instead
@@ -60,8 +56,8 @@ module GraphQL
           def inherited(child_class)
             child_class.introspection(introspection)
             child_class.description(description)
-            if overridden_graphql_name
-              child_class.graphql_name(overridden_graphql_name)
+            if defined?(@graphql_name) && (self.name.nil? || graphql_name != default_graphql_name)
+              child_class.graphql_name(graphql_name)
             end
             super
           end
@@ -125,10 +121,7 @@ module GraphQL
 
         def inherited(subclass)
           super
-          if subclass.name
-            # Prime this cached name:
-            subclass.default_graphql_name
-          end
+          subclass.default_graphql_name = nil
         end
       end
     end

--- a/lib/graphql/schema/member/base_dsl_methods.rb
+++ b/lib/graphql/schema/member/base_dsl_methods.rb
@@ -79,7 +79,7 @@ module GraphQL
         end
 
         def introspection?
-          @introspection
+          !!@introspection
         end
 
         # The mutation this type was derived from, if it was derived from a mutation
@@ -102,9 +102,7 @@ module GraphQL
         def default_graphql_name
           @default_graphql_name ||= begin
             raise GraphQL::RequiredImplementationMissingError, 'Anonymous class should declare a `graphql_name`' if name.nil?
-
-            -name.split("::").last.sub(/Type\Z/, "")
-          end
+            -name.split("::").last.sub(/Type\Z/, "")          end
         end
 
         def visible?(context)
@@ -119,12 +117,17 @@ module GraphQL
           true
         end
 
+        protected
+
+        attr_writer :default_graphql_name
+
         private
 
         def inherited(subclass)
           super
-          subclass.class_eval do
-            @default_graphql_name ||= nil
+          if subclass.name
+            # Prime this cached name:
+            subclass.default_graphql_name
           end
         end
       end


### PR DESCRIPTION
These methods can be called a lot at runtime, and simplifying their read behavior could make everything a hair faster.