### PR TITLE
Clean up thread-scoped context values after running a query

### DIFF
--- a/lib/graphql/execution/interpreter.rb
+++ b/lib/graphql/execution/interpreter.rb
@@ -146,6 +146,16 @@ module GraphQL
                   # Assign values here so that the query's `@executed` becomes true
                   queries.map { |q| q.result_values ||= {} }
                   raise
+                ensure
+                  queries.map { |query|
+                    runtime = query.context.namespace(:interpreter_runtime)[:runtime]
+                    if runtime
+                      runtime.delete_interpreter_context(:current_path)
+                      runtime.delete_interpreter_context(:current_field)
+                      runtime.delete_interpreter_context(:current_object)
+                      runtime.delete_interpreter_context(:current_arguments)
+                    end
+                  }
                 end
               end
             end


### PR DESCRIPTION
I think this will fix the flaky tests in CI (eg https://github.com/rmosolgo/graphql-ruby/actions/runs/4099883449/jobs/7070213090), where `context[...]` values are spilling over into other tests.