### PR TITLE
Try using .then for all lazy handling

### DIFF
--- a/lib/graphql/dataloader/request.rb
+++ b/lib/graphql/dataloader/request.rb
@@ -14,6 +14,25 @@ module GraphQL
       def load
         @source.load(@key)
       end
+
+      def then(&block)
+        ThenRequest.new do
+          value = load
+          value.then do |v|
+            block.call(v)
+          end
+        end
+      end
+
+      class ThenRequest < Request
+        def initialize(&block)
+          @block = block
+        end
+
+        def load
+          @block.call
+        end
+      end
     end
   end
 end

--- a/lib/graphql/execution/interpreter.rb
+++ b/lib/graphql/execution/interpreter.rb
@@ -89,14 +89,20 @@ module GraphQL
                     tracer = multiplex
                     query = multiplex.queries.length == 1 ? multiplex.queries[0] : nil
                     queries = multiplex ? multiplex.queries : [query]
+                    pending_paths = []
                     final_values = queries.map do |query|
                       runtime = query.context.namespace(:interpreter_runtime)[:runtime]
-                      # it might not be present if the query has an error
-                      runtime ? runtime.final_result : nil
+                      if runtime
+                        pending_paths << runtime.pending_paths
+                        runtime.final_result
+                      else
+                        # it might not be present if the query has an error
+                        nil
+                      end
                     end
                     final_values.compact!
                     tracer.trace("execute_query_lazy", {multiplex: multiplex, query: query}) do
-                      Interpreter::Resolve.resolve_all(final_values, multiplex.dataloader)
+                      Interpreter::Resolve.resolve_all(schema, [final_values, *pending_paths], multiplex.dataloader)
                     end
                     queries.each do |query|
                       runtime = query.context.namespace(:interpreter_runtime)[:runtime]

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -974,17 +974,15 @@ module GraphQL
 
         def resolve_type(type, value, path)
           trace_payload = { context: context, type: type, object: value, path: path }
-          resolved_type, resolved_value = query.trace("resolve_type", trace_payload) do
+          before_resolved_type, before_resolved_value = query.trace("resolve_type", trace_payload) do
             query.resolve_type(type, value)
           end
 
-          if lazy?(resolved_type)
-            GraphQL::Execution::Lazy.new do
-              query.trace("resolve_type_lazy", trace_payload) do
-                schema.sync_lazy(resolved_type)
-              end
+          before_resolved_type.then do |resolved_type, resolved_value|
+            if resolved_value.nil?
+              resolved_value = before_resolved_value
             end
-          else
+
             [resolved_type, resolved_value]
           end
         end

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -1045,10 +1045,10 @@ module GraphQL
       # - Right away, if `value` is not registered with `lazy_resolve`
       # - After resolving `value`, if it's registered with `lazy_resolve` (eg, `Promise`)
       # @api private
-      def after_lazy(value, &block)
+      def after_lazy(value)
         value.then do |res|
           res.then do |res2|
-            block.call(res2)
+            yield(res2)
           end
         end
       end

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -1067,6 +1067,11 @@ module GraphQL
         end
       end
 
+      def sync_lazy_once(value)
+        lazy_method = lazy_method_name(value)
+        value.public_send(lazy_method)
+      end
+
       # @return [Symbol, nil] The method name to lazily resolve `obj`, or nil if `obj`'s class wasn't registered with {#lazy_resolve}.
       def lazy_method_name(obj)
         lazy_methods.get(obj)

--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -309,7 +309,7 @@ module GraphQL
           else
             load_method_owner.public_send(arg_load_method, coerced_value)
           end
-          context.schema.after_lazy(custom_loaded_value) do |custom_value|
+          custom_loaded_value.then do |custom_value|
             if loads
               if type.list?
                 loaded_values = custom_value.each_with_index.map { |custom_val, idx|

--- a/lib/graphql/schema/field/connection_extension.rb
+++ b/lib/graphql/schema/field/connection_extension.rb
@@ -26,7 +26,7 @@ module GraphQL
           # rename some inputs to avoid conflicts inside the block
           maybe_lazy = value
           value = nil
-          context.schema.after_lazy(maybe_lazy) do |resolved_value|
+          maybe_lazy.then do |resolved_value|
             value = resolved_value
             if value.is_a? GraphQL::ExecutionError
               # This isn't even going to work because context doesn't have ast_node anymore

--- a/lib/graphql/schema/member/has_arguments.rb
+++ b/lib/graphql/schema/member/has_arguments.rb
@@ -52,7 +52,7 @@ module GraphQL
               def #{method_owner}load_#{arg_defn.keyword}(values, context = nil)
                 argument = get_argument("#{arg_defn.graphql_name}")
                 (context || self.context).schema.after_lazy(values) do |values2|
-                  GraphQL::Execution::Lazy.all(values2.map { |value| load_application_object(argument, value, context || self.context) })
+                  values2.map { |value| load_application_object(argument, value, context || self.context) }
                 end
               end
               RUBY

--- a/lib/graphql/schema/object.rb
+++ b/lib/graphql/schema/object.rb
@@ -35,8 +35,7 @@ module GraphQL
         #
         # Probably only the framework should call this method.
         #
-        # This might return a {GraphQL::Execution::Lazy} if the user-provided `.authorized?`
-        # hook returns some lazy value (like a Promise).
+        # Use `.then { |obj| ... }` because application checks may return lazy values.
         #
         # The reason that the auth check is in this wrapper method instead of {.new} is because
         # of how it might return a Promise. It would be weird if `.new` returned a promise;
@@ -45,7 +44,7 @@ module GraphQL
         #
         # @param object [Object] The thing wrapped by this object
         # @param context [GraphQL::Query::Context]
-        # @return [GraphQL::Schema::Object, GraphQL::Execution::Lazy]
+        # @return [#then] an initialized instance of this class, or an object whose `.then` method will yield the instance eventually.
         # @raise [GraphQL::UnauthorizedError] if the user-provided hook returns `false`
         def authorized_new(object, context)
           trace_payload = { context: context, type: self, object: object, path: context[:current_path] }

--- a/lib/graphql/schema/object.rb
+++ b/lib/graphql/schema/object.rb
@@ -60,17 +60,7 @@ module GraphQL
             end
           end
 
-          auth_val = if context.schema.lazy?(maybe_lazy_auth_val)
-            GraphQL::Execution::Lazy.new do
-              context.query.trace("authorized_lazy", trace_payload) do
-                context.schema.sync_lazy(maybe_lazy_auth_val)
-              end
-            end
-          else
-            maybe_lazy_auth_val
-          end
-
-          context.schema.after_lazy(auth_val) do |is_authorized|
+          maybe_lazy_auth_val.then do |is_authorized|
             if is_authorized
               self.new(object, context)
             else

--- a/spec/graphql/authorization_spec.rb
+++ b/spec/graphql/authorization_spec.rb
@@ -4,9 +4,22 @@ require "spec_helper"
 describe "GraphQL::Authorization" do
   module AuthTest
     class Box
-      attr_reader :value
       def initialize(value:)
         @value = value
+      end
+
+      def value
+        if @value.is_a?(Proc)
+          @value = @value.call
+        end
+        @value
+      end
+
+      def then(&block)
+        self.class.new value: ->{
+          v = value
+          block.call(v)
+        }
       end
     end
 

--- a/spec/graphql/authorization_spec.rb
+++ b/spec/graphql/authorization_spec.rb
@@ -17,8 +17,9 @@ describe "GraphQL::Authorization" do
 
       def then(&block)
         self.class.new value: ->{
-          v = value
-          block.call(v)
+          value.then do |v|
+            block.call(v)
+          end
         }
       end
     end

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -357,7 +357,7 @@ describe GraphQL::Dataloader do
     end
 
     def on_enter_field(node, parent, visitor)
-      orig_args = args = @query.arguments_for(node, visitor.field_definition)
+      args = @query.arguments_for(node, visitor.field_definition)
       # This bug has been around for a while,
       # see https://github.com/rmosolgo/graphql-ruby/issues/3321
       if @query.schema.lazy?(args)

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -357,11 +357,11 @@ describe GraphQL::Dataloader do
     end
 
     def on_enter_field(node, parent, visitor)
-      args = @query.arguments_for(node, visitor.field_definition)
+      orig_args = args = @query.arguments_for(node, visitor.field_definition)
       # This bug has been around for a while,
       # see https://github.com/rmosolgo/graphql-ruby/issues/3321
-      if args.is_a?(GraphQL::Execution::Lazy)
-        args = args.value
+      if @query.schema.lazy?(args)
+        args = @query.schema.sync_lazy(args)
       end
       @fields << [node.name, args.keys]
     end

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -17,6 +17,14 @@ describe GraphQL::Execution::Interpreter do
         end
         @value
       end
+
+      def then
+        self.class.new do
+          value.then do |v|
+            yield(v)
+          end
+        end
+      end
     end
 
     class Expansion < GraphQL::Schema::Object
@@ -591,7 +599,7 @@ describe GraphQL::Execution::Interpreter do
 
         field :lazy_skip, String
         def lazy_skip
-          -> { context.skip }
+          Dummy::ThenProc.new { context.skip }
         end
 
         field :mixed_skips, [String]
@@ -600,7 +608,7 @@ describe GraphQL::Execution::Interpreter do
             "a",
             context.skip,
             "c",
-            -> { context.skip },
+            Dummy::ThenProc.new { context.skip },
             "e",
           ]
         end
@@ -609,7 +617,7 @@ describe GraphQL::Execution::Interpreter do
       class NothingSubscription < GraphQL::Schema::Subscription
         field :nothing, String
         def authorized?(*)
-          -> { true }
+          Dummy::ThenProc.new { true }
         end
 
         def update

--- a/spec/graphql/schema/argument_spec.rb
+++ b/spec/graphql/schema/argument_spec.rb
@@ -89,7 +89,7 @@ describe GraphQL::Schema::Argument do
       lazy_resolve(Proc, :call)
 
       def self.object_from_id(id, ctx)
-        -> { Jazz::GloballyIdentifiableType.find(id) }
+        Dummy::ThenProc.new { Jazz::GloballyIdentifiableType.find(id) }
       end
 
       orphan_types [Jazz::InstrumentType, UnauthorizedInstrumentType]

--- a/spec/graphql/schema/directive_spec.rb
+++ b/spec/graphql/schema/directive_spec.rb
@@ -129,7 +129,7 @@ Use `locations(OBJECT)` to update this directive's definition, or remove it from
         result = nil
         ctx.dataloader.run_isolated do
           result = yield
-          GraphQL::Execution::Interpreter::Resolve.resolve_all([result], ctx.dataloader)
+          GraphQL::Execution::Interpreter::Resolve.resolve_all(ctx.schema, [result], ctx.dataloader)
         end
 
         ctx[:count_fields] ||= Hash.new { |h, k| h[k] = [] }

--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -191,7 +191,7 @@ describe GraphQL::Schema::InputObject do
           argument :instrument_name, ID, loads: Jazz::InstrumentType, as: :instrument
 
           def self.load_instrument(instrument_name, context)
-            -> {
+            Dummy::ThenProc.new {
               instruments = Jazz::Models.data["Instrument"]
               instruments.find { |i| i.name == instrument_name }
             }
@@ -225,7 +225,7 @@ describe GraphQL::Schema::InputObject do
         lazy_resolve(Proc, :call)
 
         def self.object_from_id(id, ctx)
-          -> {
+          Dummy::ThenProc.new {
             if id.start_with?("thing-")
               OpenStruct.new(name: id)
             else
@@ -1129,7 +1129,7 @@ describe GraphQL::Schema::InputObject do
       query(Query)
 
       def self.object_from_id(id, ctx)
-        -> { nil }
+        Dummy::ThenProc.new { nil }
       end
 
       lazy_resolve(Proc, :call)

--- a/spec/graphql/schema/member/scoped_spec.rb
+++ b/spec/graphql/schema/member/scoped_spec.rb
@@ -17,7 +17,7 @@ describe GraphQL::Schema::Member::Scoped do
         elsif context[:lazy]
           # return everything, but make the runtime wait for it,
           # and add a flag for confirming it was called
-          ->() {
+          Dummy::ThenProc.new {
             context[:proc_called] = true
             items
           }
@@ -92,7 +92,7 @@ describe GraphQL::Schema::Member::Scoped do
       field :lazy_items, [Item], null: false
       field :lazy_items_connection, Item.connection_type, null: false, resolver_method: :lazy_items
       def lazy_items
-        ->() { items }
+        Dummy::ThenProc.new { items }
       end
     end
 

--- a/spec/graphql/schema/resolver_spec.rb
+++ b/spec/graphql/schema/resolver_spec.rb
@@ -11,6 +11,14 @@ describe GraphQL::Schema::Resolver do
       def value
         @get_value.call
       end
+
+      def then(&block)
+        self.class.new do
+          self.value.then do |v|
+            block.call(v)
+          end
+        end
+      end
     end
 
     class BaseResolver < GraphQL::Schema::Resolver
@@ -656,7 +664,7 @@ describe GraphQL::Schema::Resolver do
       end
 
       it 'raises the correct error on invalid return type' do
-        err = assert_raises(RuntimeError) do 
+        err = assert_raises(RuntimeError) do
           exec_query("mutation { resolverWithInvalidReady(int: 2) { int } }")
         end
         assert_match("Unexpected result from #ready?", err.message)


### PR DESCRIPTION
A long time ago, GraphQL-Ruby added `lazy_resolve(...)` specifically to handle GraphQL-Batch and its use of Promise.rb. `BatchLoader` also took up this API. 

Since then, Ruby added `.then` as a basic API to all objects, where an object yields itself (https://ruby-doc.org/core-3.0.2/Kernel.html#method-i-then). 

In my mind, this opens the possibility that we could greatly simplify `after_lazy`-type handling, using `.then` directly instead and reducing a lot of indirection and overhead. For most objects, it would call through directly. (However, it makes nested calls -- maybe this can be handled using the returned `Enumerator` when `.then` is called without a block?)  For promises, etc, it would return a chained Promise. Then, everything could be cleaned up at the end. 

I think this could remove a lot of overhead from code and runtime cases where lazy values (Promises, etc) are _not_ used. So, I'm exploring it here.

__TODO__ / to figure out: 
- [ ] `Lazy` blocks included some "around-" context (tracing blocks, error handling, context assignments). How can that be re-implemented here? 
    - ~~maybe error handling can be done inside methods where they might be raised instead of in runtime code~~ That's not right, those methods have already returned.
    - maybe context could be stashed with `@pending_paths`
- [ ] Consider compatibility implications of `.resolve_all` changes, will this still work with `@stream`/`@defer`? 
- [ ] Trampolining with enumerators returned from `.then` without a block? Performance is probably not good, but worth a try.