### PR TITLE
remove error handling from Lazy#value

### DIFF
--- a/lib/graphql/execution/lazy.rb
+++ b/lib/graphql/execution/lazy.rb
@@ -29,15 +29,11 @@ module GraphQL
       def value
         if !@resolved
           @resolved = true
-          @value = begin
-            v = @get_value_func.call
-            if v.is_a?(Lazy)
-              v = v.value
-            end
-            v
-          rescue GraphQL::ExecutionError => err
-            err
+          v = @get_value_func.call
+          if v.is_a?(Lazy)
+            v = v.value
           end
+          @value = v
         end
 
         # `SKIP` was made into a subclass of `GraphQL::Error` to improve runtime performance


### PR DESCRIPTION
I saw this was never used, so I decided to remove it. (In queries with a lot of promises, etc, this is a hot path.)