### PR TITLE
Remove unused accessible? methods

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -826,10 +826,6 @@ module GraphQL
         member.visible?(ctx)
       end
 
-      def accessible?(member, ctx)
-        member.accessible?(ctx)
-      end
-
       def schema_directive(dir_class, **options)
         @own_schema_directives ||= []
         Member::HasDirectives.add_directive(self, @own_schema_directives, dir_class, options)
@@ -837,18 +833,6 @@ module GraphQL
 
       def schema_directives
         Member::HasDirectives.get_directives(self, @own_schema_directives, :schema_directives)
-      end
-
-      # This hook is called when a client tries to access one or more
-      # fields that fail the `accessible?` check.
-      #
-      # By default, an error is added to the response. Override this hook to
-      # track metrics or return a different error to the client.
-      #
-      # @param error [InaccessibleFieldsError] The analysis error for this check
-      # @return [AnalysisError, nil] Return an error to skip the query
-      def inaccessible_fields(error)
-        error
       end
 
       # This hook is called when an object fails an `authorized?` check.

--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -149,10 +149,6 @@ module GraphQL
         true
       end
 
-      def accessible?(context)
-        true
-      end
-
       def authorized?(obj, value, ctx)
         authorized_as_type?(obj, value, ctx, as_type: type)
       end

--- a/lib/graphql/schema/enum_value.rb
+++ b/lib/graphql/schema/enum_value.rb
@@ -73,7 +73,6 @@ module GraphQL
       end
 
       def visible?(_ctx); true; end
-      def accessible?(_ctx); true; end
       def authorized?(_ctx); true; end
     end
   end

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -591,14 +591,6 @@ module GraphQL
         end
       end
 
-      def accessible?(context)
-        if @resolver_class
-          @resolver_class.accessible?(context)
-        else
-          true
-        end
-      end
-
       def authorized?(object, args, context)
         if @resolver_class
           # The resolver _instance_ will check itself during `resolve()`

--- a/lib/graphql/schema/interface.rb
+++ b/lib/graphql/schema/interface.rb
@@ -28,16 +28,6 @@ module GraphQL
           true
         end
 
-        # The interface is accessible if any of its possible types are accessible
-        def accessible?(context)
-          context.schema.possible_types(self, context).each do |type|
-            if context.schema.accessible?(type, context)
-              return true
-            end
-          end
-          false
-        end
-
         def type_membership_class(membership_class = nil)
           if membership_class
             @type_membership_class = membership_class

--- a/lib/graphql/schema/member/base_dsl_methods.rb
+++ b/lib/graphql/schema/member/base_dsl_methods.rb
@@ -111,10 +111,6 @@ module GraphQL
           true
         end
 
-        def accessible?(context)
-          true
-        end
-
         def authorized?(object, context)
           true
         end

--- a/lib/graphql/types/relay/connection_behaviors.rb
+++ b/lib/graphql/types/relay/connection_behaviors.rb
@@ -79,10 +79,6 @@ module GraphQL
             true # Let nodes be filtered out
           end
 
-          def accessible?(ctx)
-            node_type.accessible?(ctx)
-          end
-
           def visible?(ctx)
             # if this is an abstract base class, there may be no `node_type`
             node_type ? node_type.visible?(ctx) : super

--- a/lib/graphql/types/relay/edge_behaviors.rb
+++ b/lib/graphql/types/relay/edge_behaviors.rb
@@ -41,10 +41,6 @@ module GraphQL
             true
           end
 
-          def accessible?(ctx)
-            node_type.accessible?(ctx)
-          end
-
           def visible?(ctx)
             node_type.visible?(ctx)
           end


### PR DESCRIPTION
As far as I know, this is entirely unused now and a relic of legacy authorization. The methods weren't called anywhere, and removing them broke no tests.