### PR TITLE
Reverse string validity checks

### DIFF
--- a/lib/graphql/types/string.rb
+++ b/lib/graphql/types/string.rb
@@ -7,7 +7,7 @@ module GraphQL
 
       def self.coerce_result(value, ctx)
         str = value.to_s
-        if str.ascii_only? || str.encoding == Encoding::UTF_8
+        if str.encoding == Encoding::UTF_8 || str.ascii_only?
           str
         elsif str.frozen?
           str.encode(Encoding::UTF_8)


### PR DESCRIPTION
Oops, I think `.encode == ...` is faster than `ascii_only?`, so I'm reversing these conditions to make the most common case faster. (See https://github.com/rmosolgo/graphql-ruby/pull/4323#issuecomment-1429931183)