### PR TITLE
Add Tracing::Trace for method-based tracing

### DIFF
--- a/guides/queries/tracing.md
+++ b/guides/queries/tracing.md
@@ -8,9 +8,7 @@ desc: Observation hooks for execution
 index: 11
 ---
 
-{{ "GraphQL::Tracing" | api_doc }} provides a `.trace` hook to observe events from the GraphQL runtime.
-
-A tracer must implement `.trace`, for example:
+{{ "GraphQL::Tracing::Trace" | api_doc }} provides hooks to observe and modify events during runtime. Tracing hooks are methods, defined in modules and mixed in with {{ "Schema.trace_with" | api_doc }}.
 
 ```ruby
 class MyCustomTracer
@@ -30,20 +28,13 @@ end
 To run a tracer for __every query__, add it to the schema with `tracer`:
 
 ```ruby
-# Run `MyCustomTracer` for all queries
+# Run `MyCustomTrace` for all queries
 class MySchema < GraphQL::Schema
-  tracer(MyCustomTracer)
+  trace_with(MyCustomTrace)
 end
 ```
 
-Or, to run a tracer for __one query only__, add it to `context:` as `tracers: [...]`, for example:
-
-```ruby
-# Run `MyCustomTracer` for this query
-MySchema.execute(..., context: { tracers: [MyCustomTracer]})
-```
-
-For a full list of events, see the {{ "GraphQL::Tracing" | api_doc }} API docs.
+For a full list of methods and their arguments, see {{ "GraphQL::Tracing::Trace" | api_doc }}.
 
 ## ActiveSupport::Notifications
 
@@ -63,8 +54,6 @@ end
 Several monitoring platforms are supported out-of-the box by GraphQL-Ruby (see platforms below).
 
 Leaf fields are _not_ monitored (to avoid high cardinality in the metrics service).
-
-Implementations are based on {{ "Tracing::PlatformTracing" | api_doc }}.
 
 ## AppOptics
 

--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -42,8 +42,8 @@ This is probably a bug in GraphQL-Ruby, please report this error on GitHub: http
   # Turn a query string or schema definition into an AST
   # @param graphql_string [String] a GraphQL query string or schema definition
   # @return [GraphQL::Language::Nodes::Document]
-  def self.parse(graphql_string, tracer: GraphQL::Tracing::NullTracer)
-    parse_with_racc(graphql_string, tracer: tracer)
+  def self.parse(graphql_string, trace: GraphQL::Tracing::NullTrace)
+    parse_with_racc(graphql_string, trace: trace)
   end
 
   # Read the contents of `filename` and parse them as GraphQL
@@ -54,8 +54,8 @@ This is probably a bug in GraphQL-Ruby, please report this error on GitHub: http
     parse_with_racc(content, filename: filename)
   end
 
-  def self.parse_with_racc(string, filename: nil, tracer: GraphQL::Tracing::NullTracer)
-    GraphQL::Language::Parser.parse(string, filename: filename, tracer: tracer)
+  def self.parse_with_racc(string, filename: nil, trace: GraphQL::Tracing::NullTrace)
+    GraphQL::Language::Parser.parse(string, filename: filename, trace: trace)
   end
 
   # @return [Array<GraphQL::Language::Token>]

--- a/lib/graphql/analysis/ast.rb
+++ b/lib/graphql/analysis/ast.rb
@@ -21,7 +21,7 @@ module GraphQL
       def analyze_multiplex(multiplex, analyzers)
         multiplex_analyzers = analyzers.map { |analyzer| analyzer.new(multiplex) }
 
-        multiplex.trace("analyze_multiplex", { multiplex: multiplex }) do
+        multiplex.current_trace.analyze_multiplex(multiplex: multiplex) do
           query_results = multiplex.queries.map do |query|
             if query.valid?
               analyze_query(
@@ -48,7 +48,7 @@ module GraphQL
       # @param analyzers [Array<GraphQL::Analysis::AST::Analyzer>]
       # @return [Array<Any>] Results from those analyzers
       def analyze_query(query, analyzers, multiplex_analyzers: [])
-        query.trace("analyze_query", { query: query }) do
+        query.current_trace.analyze_query(query: query) do
           query_analyzers = analyzers
             .map { |analyzer| analyzer.new(query) }
             .select { |analyzer| analyzer.analyze? }

--- a/lib/graphql/execution/interpreter.rb
+++ b/lib/graphql/execution/interpreter.rb
@@ -34,7 +34,7 @@ module GraphQL
           end
 
           multiplex = Execution::Multiplex.new(schema: schema, queries: queries, context: context, max_complexity: max_complexity)
-          multiplex.trace("execute_multiplex", { multiplex: multiplex }) do
+          multiplex.current_trace.execute_multiplex(multiplex: multiplex) do
             schema = multiplex.schema
             queries = multiplex.queries
             query_instrumenters = schema.instrumenters[:query]
@@ -70,7 +70,7 @@ module GraphQL
                           runtime = Runtime.new(query: query)
                           query.context.namespace(:interpreter_runtime)[:runtime] = runtime
 
-                          query.trace("execute_query", {query: query}) do
+                          query.current_trace.execute_query(query: query) do
                             runtime.run_eager
                           end
                         rescue GraphQL::ExecutionError => err
@@ -95,7 +95,7 @@ module GraphQL
                       runtime ? runtime.final_result : nil
                     end
                     final_values.compact!
-                    tracer.trace("execute_query_lazy", {multiplex: multiplex, query: query}) do
+                    tracer.current_trace.execute_query_lazy(query: query) do
                       Interpreter::Resolve.resolve_all(final_values, multiplex.dataloader)
                     end
                     queries.each do |query|

--- a/lib/graphql/execution/interpreter.rb
+++ b/lib/graphql/execution/interpreter.rb
@@ -95,7 +95,7 @@ module GraphQL
                       runtime ? runtime.final_result : nil
                     end
                     final_values.compact!
-                    tracer.current_trace.execute_query_lazy(query: query) do
+                    tracer.current_trace.execute_query_lazy(multiplex: multiplex, query: query) do
                       Interpreter::Resolve.resolve_all(final_values, multiplex.dataloader)
                     end
                     queries.each do |query|

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -507,7 +507,7 @@ module GraphQL
             field_result = call_method_on_directives(:resolve, object, directives) do
               # Actually call the field resolver and capture the result
               app_result = begin
-                query.trace("execute_field", {owner: owner_type, field: field_defn, path: next_path, ast_node: ast_node, query: query, object: object, arguments: kwarg_arguments}) do
+                query.current_trace.execute_field(field: field_defn, ast_node: ast_node, query: query, object: object, arguments: kwarg_arguments) do
                   field_defn.resolve(object, kwarg_arguments, context)
                 end
               rescue GraphQL::ExecutionError => err
@@ -923,7 +923,7 @@ module GraphQL
               # but don't wrap the continuation below
               inner_obj = begin
                 if trace
-                  query.trace("execute_field_lazy", {owner: owner, field: field, path: path, query: query, object: owner_object, arguments: arguments, ast_node: ast_node}) do
+                  query.current_trace.execute_field_lazy(field: field, query: query, object: owner_object, arguments: arguments, ast_node: ast_node) do
                     schema.sync_lazy(lazy_obj)
                   end
                 else
@@ -973,14 +973,13 @@ module GraphQL
         end
 
         def resolve_type(type, value, path)
-          trace_payload = { context: context, type: type, object: value, path: path }
-          resolved_type, resolved_value = query.trace("resolve_type", trace_payload) do
+          resolved_type, resolved_value = query.current_trace.resolve_type(query: query, type: type, object: value) do
             query.resolve_type(type, value)
           end
 
           if lazy?(resolved_type)
             GraphQL::Execution::Lazy.new do
-              query.trace("resolve_type_lazy", trace_payload) do
+              query.current_trace.resolve_type_lazy(query: query, type: type, object: value) do
                 schema.sync_lazy(resolved_type)
               end
             end

--- a/lib/graphql/execution/multiplex.rb
+++ b/lib/graphql/execution/multiplex.rb
@@ -25,13 +25,14 @@ module GraphQL
     class Multiplex
       include Tracing::Traceable
 
-      attr_reader :context, :queries, :schema, :max_complexity, :dataloader
+      attr_reader :context, :queries, :schema, :max_complexity, :dataloader, :current_trace
 
       def initialize(schema:, queries:, context:, max_complexity:)
         @schema = schema
         @queries = queries
         @queries.each { |q| q.multiplex = self }
         @context = context
+        @current_trace = @context[:trace] || schema.trace_class.new
         @dataloader = @context[:dataloader] ||= @schema.dataloader_class.new
         @tracers = schema.tracers + (context[:tracers] || [])
         # Support `context: {backtrace: true}`

--- a/lib/graphql/execution/multiplex.rb
+++ b/lib/graphql/execution/multiplex.rb
@@ -32,7 +32,7 @@ module GraphQL
         @queries = queries
         @queries.each { |q| q.multiplex = self }
         @context = context
-        @current_trace = @context[:trace] || schema.trace_class.new
+        @current_trace = @context[:trace] || schema.new_trace
         @dataloader = @context[:dataloader] ||= @schema.dataloader_class.new
         @tracers = schema.tracers + (context[:tracers] || [])
         # Support `context: {backtrace: true}`

--- a/lib/graphql/execution/multiplex.rb
+++ b/lib/graphql/execution/multiplex.rb
@@ -32,7 +32,7 @@ module GraphQL
         @queries = queries
         @queries.each { |q| q.multiplex = self }
         @context = context
-        @current_trace = @context[:trace] || schema.new_trace
+        @current_trace = @context[:trace] || schema.new_trace(multiplex: self)
         @dataloader = @context[:dataloader] ||= @schema.dataloader_class.new
         @tracers = schema.tracers + (context[:tracers] || [])
         # Support `context: {backtrace: true}`

--- a/lib/graphql/language/parser.rb
+++ b/lib/graphql/language/parser.rb
@@ -16,22 +16,22 @@ module_eval(<<'...end parser.y/module_eval...', 'parser.y', 448)
 
 EMPTY_ARRAY = [].freeze
 
-def initialize(query_string, filename:, tracer: Tracing::NullTracer)
+def initialize(query_string, filename:, trace: Tracing::NullTrace)
   raise GraphQL::ParseError.new("No query string was present", nil, nil, query_string) if query_string.nil?
   @query_string = query_string
   @filename = filename
-  @tracer = tracer
+  @trace = trace
   @reused_next_token = [nil, nil]
 end
 
 def parse_document
   @document ||= begin
     # Break the string into tokens
-    @tracer.trace("lex", {query_string: @query_string}) do
+    @trace.lex(query_string: @query_string) do
       @tokens ||= GraphQL.scan(@query_string)
     end
     # From the tokens, build an AST
-    @tracer.trace("parse", {query_string: @query_string}) do
+    @trace.parse(query_string: @query_string) do
       if @tokens.empty?
         raise GraphQL::ParseError.new("Unexpected end of document", nil, nil, @query_string)
       else
@@ -44,17 +44,17 @@ end
 class << self
   attr_accessor :cache
 
-  def parse(query_string, filename: nil, tracer: GraphQL::Tracing::NullTracer)
-    new(query_string, filename: filename, tracer: tracer).parse_document
+  def parse(query_string, filename: nil, trace: GraphQL::Tracing::NullTrace)
+    new(query_string, filename: filename, trace: trace).parse_document
   end
 
-  def parse_file(filename, tracer: GraphQL::Tracing::NullTracer)
+  def parse_file(filename, trace: GraphQL::Tracing::NullTrace)
     if cache
       cache.fetch(filename) do
-        parse(File.read(filename), filename: filename, tracer: tracer)
+        parse(File.read(filename), filename: filename, trace: trace)
       end
     else
-      parse(File.read(filename), filename: filename, tracer: tracer)
+      parse(File.read(filename), filename: filename, trace: trace)
     end
   end
 end

--- a/lib/graphql/language/parser.y
+++ b/lib/graphql/language/parser.y
@@ -448,22 +448,22 @@ end
 
 EMPTY_ARRAY = [].freeze
 
-def initialize(query_string, filename:, tracer: Tracing::NullTracer)
+def initialize(query_string, filename:, trace: Tracing::NullTrace)
   raise GraphQL::ParseError.new("No query string was present", nil, nil, query_string) if query_string.nil?
   @query_string = query_string
   @filename = filename
-  @tracer = tracer
+  @trace = trace
   @reused_next_token = [nil, nil]
 end
 
 def parse_document
   @document ||= begin
     # Break the string into tokens
-    @tracer.trace("lex", {query_string: @query_string}) do
+    @trace.lex(query_string: @query_string) do
       @tokens ||= GraphQL.scan(@query_string)
     end
     # From the tokens, build an AST
-    @tracer.trace("parse", {query_string: @query_string}) do
+    @trace.parse(query_string: @query_string) do
       if @tokens.empty?
         raise GraphQL::ParseError.new("Unexpected end of document", nil, nil, @query_string)
       else
@@ -476,17 +476,17 @@ end
 class << self
   attr_accessor :cache
 
-  def parse(query_string, filename: nil, tracer: GraphQL::Tracing::NullTracer)
-    new(query_string, filename: filename, tracer: tracer).parse_document
+  def parse(query_string, filename: nil, trace: GraphQL::Tracing::NullTrace)
+    new(query_string, filename: filename, trace: trace).parse_document
   end
 
-  def parse_file(filename, tracer: GraphQL::Tracing::NullTracer)
+  def parse_file(filename, trace: GraphQL::Tracing::NullTrace)
     if cache
       cache.fetch(filename) do
-        parse(File.read(filename), filename: filename, tracer: tracer)
+        parse(File.read(filename), filename: filename, trace: trace)
       end
     else
-      parse(File.read(filename), filename: filename, tracer: tracer)
+      parse(File.read(filename), filename: filename, trace: trace)
     end
   end
 end

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -157,6 +157,11 @@ module GraphQL
 
     attr_accessor :multiplex
 
+    # @return [GraphQL::Tracing::Trace]
+    def current_trace
+      multiplex.current_trace
+    end
+
     def subscription_update?
       @subscription_topic && subscription?
     end

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -167,7 +167,7 @@ module GraphQL
 
     # @return [GraphQL::Tracing::Trace]
     def current_trace
-      @current_trace ||= multiplex ? multiplex.current_trace : schema.trace_class.new
+      @current_trace ||= multiplex ? multiplex.current_trace : schema.new_trace
     end
 
     def subscription_update?

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -96,16 +96,18 @@ module GraphQL
       @operations = nil
       @validate = validate
       context_tracers = (context ? context.fetch(:tracers, []) : [])
+      @tracers = schema.tracers + context_tracers
+
       # Support `ctx[:backtrace] = true` for wrapping backtraces
       if context && context[:backtrace] && !@tracers.include?(GraphQL::Backtrace::Tracer)
-        context_tracers += GraphQL::Backtrace::Tracer
+        context_tracers += [GraphQL::Backtrace::Tracer]
+        @tracers << GraphQL::Backtrace::Tracer
       end
 
       if context_tracers.any? && !(schema.trace_class <= GraphQL::Tracing::LegacyTrace)
         raise ArgumentError, "context[:tracers] and context[:backtrace] are not supported without `tracer_class(GraphQL::Tracing::LegacyTrace)` in the schema configuration, please add it."
       end
 
-      @tracers = schema.tracers + context_tracers
 
       @analysis_errors = []
       if variables.is_a?(String)

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -167,7 +167,7 @@ module GraphQL
 
     # @return [GraphQL::Tracing::Trace]
     def current_trace
-      @current_trace ||= multiplex ? multiplex.current_trace : schema.new_trace
+      @current_trace ||= multiplex ? multiplex.current_trace : schema.new_trace(multiplex: multiplex, query: self)
     end
 
     def subscription_update?
@@ -375,7 +375,7 @@ module GraphQL
       parse_error = nil
       @document ||= begin
         if query_string
-          GraphQL.parse(query_string, tracer: self)
+          GraphQL.parse(query_string, trace: self.current_trace)
         end
       rescue GraphQL::ParseError => err
         parse_error = err

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -954,9 +954,11 @@ module GraphQL
         trace_class.include(trace_mod)
       end
 
-      def new_trace
-        @trace_options ||= {}
-        trace_class.new(**@trace_options)
+      def new_trace(**options)
+        if defined?(@trace_options)
+          options = @trace_options.merge(options)
+        end
+        trace_class.new(**options)
       end
 
       def query_analyzer(new_analyzer)

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -146,8 +146,10 @@ module GraphQL
       def trace_class(new_class = nil)
         if new_class
           @trace_class = new_class
+        elsif !defined?(@trace_class)
+          @trace_class = Class.new(GraphQL::Tracing::Trace)
         end
-        @trace_class || GraphQL::Tracing::Trace
+        @trace_class
       end
 
       # Returns the JSON response of {Introspection::INTROSPECTION_QUERY}.
@@ -944,6 +946,17 @@ module GraphQL
 
       def tracers
         find_inherited_value(:tracers, EMPTY_ARRAY) + own_tracers
+      end
+
+      def trace_with(trace_mod, **options)
+        @trace_options ||= {}
+        @trace_options.merge!(options)
+        trace_class.include(trace_mod)
+      end
+
+      def new_trace
+        @trace_options ||= {}
+        trace_class.new(**@trace_options)
       end
 
       def query_analyzer(new_analyzer)

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -143,6 +143,13 @@ module GraphQL
         @subscriptions = new_implementation
       end
 
+      def trace_class(new_class = nil)
+        if new_class
+          @trace_class = new_class
+        end
+        @trace_class || GraphQL::Tracing::Trace
+      end
+
       # Returns the JSON response of {Introspection::INTROSPECTION_QUERY}.
       # @see {#as_json}
       # @return [String]

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -933,6 +933,12 @@ module GraphQL
       end
 
       def tracer(new_tracer)
+        if defined?(@trace_class) && !(@trace_class < GraphQL::Tracing::LegacyTrace)
+          raise ArgumentError, "Can't add tracer after configuring a `trace_class`, use GraphQL::Tracing::LegacyTrace to merge legacy tracers into a trace class instead."
+        elsif !defined?(@trace_class)
+          @trace_class = Class.new(GraphQL::Tracing::LegacyTrace)
+        end
+
         own_tracers << new_tracer
       end
 

--- a/lib/graphql/schema/object.rb
+++ b/lib/graphql/schema/object.rb
@@ -48,9 +48,7 @@ module GraphQL
         # @return [GraphQL::Schema::Object, GraphQL::Execution::Lazy]
         # @raise [GraphQL::UnauthorizedError] if the user-provided hook returns `false`
         def authorized_new(object, context)
-          trace_payload = { context: context, type: self, object: object, path: context[:current_path] }
-
-          maybe_lazy_auth_val = context.query.trace("authorized", trace_payload) do
+          maybe_lazy_auth_val = context.query.current_trace.authorized(query: context.query, type: self, object: object) do
             begin
               authorized?(object, context)
             rescue GraphQL::UnauthorizedError => err
@@ -62,7 +60,7 @@ module GraphQL
 
           auth_val = if context.schema.lazy?(maybe_lazy_auth_val)
             GraphQL::Execution::Lazy.new do
-              context.query.trace("authorized_lazy", trace_payload) do
+              context.query.current_trace.authorized_lazy(query: context.query, type: self, object: object) do
                 context.schema.sync_lazy(maybe_lazy_auth_val)
               end
             end

--- a/lib/graphql/schema/timeout.rb
+++ b/lib/graphql/schema/timeout.rb
@@ -33,60 +33,56 @@ module GraphQL
     #   end
     #
     class Timeout
-      def self.use(schema, **options)
-        tracer = new(**options)
-        schema.tracer(tracer)
+      def self.use(schema, max_seconds: nil)
+        timeout = self.new(max_seconds: max_seconds)
+        schema.trace_with(self::Trace, timeout: timeout)
       end
 
-      # @param max_seconds [Numeric] how many seconds the query should be allowed to resolve new fields
       def initialize(max_seconds:)
         @max_seconds = max_seconds
       end
 
-      def trace(key, data)
-        case key
-        when 'execute_multiplex'
-          data.fetch(:multiplex).queries.each do |query|
-            timeout_duration_s = max_seconds(query)
+      module Trace
+        # @param max_seconds [Numeric] how many seconds the query should be allowed to resolve new fields
+        def initialize(timeout:, **rest)
+          @timeout = timeout
+          super
+        end
+
+        def execute_multiplex(multiplex:)
+          multiplex.queries.each do |query|
+            timeout_duration_s = @timeout.max_seconds(query)
             timeout_state = if timeout_duration_s == false
               # if the method returns `false`, don't apply a timeout
               false
             else
               now = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
-              timeout_at = now + (max_seconds(query) * 1000)
+              timeout_at = now + (timeout_duration_s * 1000)
               {
                 timeout_at: timeout_at,
                 timed_out: false
               }
             end
-            query.context.namespace(self.class)[:state] = timeout_state
+            query.context.namespace(@timeout)[:state] = timeout_state
           end
+          super
+        end
 
-          yield
-        when 'execute_field', 'execute_field_lazy'
-          query_context = data[:context] || data[:query].context
-          timeout_state = query_context.namespace(self.class).fetch(:state)
+        def execute_field(query:, field:, **_rest)
+          timeout_state = query.context.namespace(@timeout).fetch(:state)
           # If the `:state` is `false`, then `max_seconds(query)` opted out of timeout for this query.
           if timeout_state != false && Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond) > timeout_state.fetch(:timeout_at)
-            error = if data[:context]
-              GraphQL::Schema::Timeout::TimeoutError.new(query_context.parent_type, query_context.field)
-            else
-              field = data.fetch(:field)
-              GraphQL::Schema::Timeout::TimeoutError.new(field.owner, field)
-            end
-
+            error = GraphQL::Schema::Timeout::TimeoutError.new(field)
             # Only invoke the timeout callback for the first timeout
             if !timeout_state[:timed_out]
               timeout_state[:timed_out] = true
-              handle_timeout(error, query_context.query)
+              @timeout.handle_timeout(error, query)
             end
 
             error
           else
             yield
           end
-        else
-          yield
         end
       end
 
@@ -114,8 +110,8 @@ module GraphQL
       # to take this error and raise a new one which _doesn't_ descend from {GraphQL::ExecutionError},
       # such as `RuntimeError`.
       class TimeoutError < GraphQL::ExecutionError
-        def initialize(parent_type, field)
-          super("Timeout on #{parent_type.graphql_name}.#{field.graphql_name}")
+        def initialize(field)
+          super("Timeout on #{field.path}")
         end
       end
     end

--- a/lib/graphql/static_validation/validator.rb
+++ b/lib/graphql/static_validation/validator.rb
@@ -27,7 +27,7 @@ module GraphQL
       # @param max_errors [Integer] Maximum number of errors before aborting validation. Any positive number will limit the number of errors. Defaults to nil for no limit.
       # @return [Array<Hash>]
       def validate(query, validate: true, timeout: nil, max_errors: nil)
-        query.trace("validate", { validate: validate, query: query }) do
+        query.current_trace.validate(validate: validate, query: query) do
           errors = if validate == false
             []
           else

--- a/lib/graphql/tracing.rb
+++ b/lib/graphql/tracing.rb
@@ -12,10 +12,14 @@ require "graphql/tracing/prometheus_tracing"
 
 # New Tracing:
 require "graphql/tracing/platform_trace"
+# require "graphql/tracing/active_support_notifications_trace"
 require "graphql/tracing/appoptics_trace"
+require "graphql/tracing/appsignal_trace"
 require "graphql/tracing/data_dog_trace"
 require "graphql/tracing/new_relic_trace"
-
+require "graphql/tracing/scout_trace"
+require "graphql/tracing/statsd_trace"
+# require "graphql/tracing/prometheus_trace"
 if defined?(PrometheusExporter::Server)
   require "graphql/tracing/prometheus_tracing/graphql_collector"
 end

--- a/lib/graphql/tracing.rb
+++ b/lib/graphql/tracing.rb
@@ -12,6 +12,7 @@ require "graphql/tracing/prometheus_tracing"
 
 # New Tracing:
 require "graphql/tracing/platform_trace"
+require "graphql/tracing/appoptics_trace"
 require "graphql/tracing/data_dog_trace"
 require "graphql/tracing/new_relic_trace"
 

--- a/lib/graphql/tracing.rb
+++ b/lib/graphql/tracing.rb
@@ -19,7 +19,7 @@ require "graphql/tracing/data_dog_trace"
 require "graphql/tracing/new_relic_trace"
 require "graphql/tracing/scout_trace"
 require "graphql/tracing/statsd_trace"
-# require "graphql/tracing/prometheus_trace"
+require "graphql/tracing/prometheus_trace"
 if defined?(PrometheusExporter::Server)
   require "graphql/tracing/prometheus_tracing/graphql_collector"
 end

--- a/lib/graphql/tracing.rb
+++ b/lib/graphql/tracing.rb
@@ -54,6 +54,66 @@ module GraphQL
   # - Otherwise, they receive `{context: ...}`
   #
   module Tracing
+    class Trace
+      def initialize
+      end
+
+      def lex(query_string:)
+        yield
+      end
+
+      def parse(query_string:)
+        yield
+      end
+
+      def validate(query:, validate:)
+        yield
+      end
+
+      def analyze_multiplex(multiplex:)
+        yield
+      end
+
+      def analyze_query(query:)
+        yield
+      end
+
+      def execute_multiplex(multiplex:)
+        yield
+      end
+
+      def execute_query(query:)
+        yield
+      end
+
+      def execute_query_lazy(query:)
+        yield
+      end
+
+      def execute_field(field:, query:, ast_node:, arguments:, object:)
+        yield
+      end
+
+      def execute_field_lazy(field:, query:, ast_node:, arguments:, object:)
+        yield
+      end
+
+      def authorized(query:, type:, object:)
+        yield
+      end
+
+      def authorized_lazy(query:, type:, object:)
+        yield
+      end
+
+      def resolve_type(query:, type:, object:)
+        yield
+      end
+
+      def resolve_type_lazy(query:, type:, object:)
+        yield
+      end
+    end
     # Objects may include traceable to gain a `.trace(...)` method.
     # The object must have a `@tracers` ivar of type `Array<<#trace(k, d, &b)>>`.
     # @api private

--- a/lib/graphql/tracing.rb
+++ b/lib/graphql/tracing.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
+# Legacy tracing:
 require "graphql/tracing/active_support_notifications_tracing"
-# require "graphql/tracing/active_support_notifications_trace"
 require "graphql/tracing/platform_tracing"
-require "graphql/tracing/platform_trace"
 require "graphql/tracing/appoptics_tracing"
 require "graphql/tracing/appsignal_tracing"
 require "graphql/tracing/data_dog_tracing"
@@ -11,6 +10,10 @@ require "graphql/tracing/scout_tracing"
 require "graphql/tracing/statsd_tracing"
 require "graphql/tracing/prometheus_tracing"
 
+# New Tracing:
+require "graphql/tracing/platform_trace"
+require "graphql/tracing/new_relic_trace"
+
 if defined?(PrometheusExporter::Server)
   require "graphql/tracing/prometheus_tracing/graphql_collector"
 end
@@ -18,8 +21,7 @@ end
 module GraphQL
   module Tracing
     class Trace
-      class << self
-        attr_accessor :schema
+      def initialize(**_options)
       end
 
       # TODO
@@ -81,9 +83,6 @@ module GraphQL
     end
 
     class LegacyTrace < Trace
-      def initialize
-      end
-
       # TODO: These are not migrated yet
       # def lex(query_string:)
       #   yield

--- a/lib/graphql/tracing.rb
+++ b/lib/graphql/tracing.rb
@@ -88,7 +88,7 @@ module GraphQL
         yield
       end
 
-      def execute_query_lazy(query:)
+      def execute_query_lazy(query:, multiplex:)
         yield
       end
 
@@ -150,8 +150,8 @@ module GraphQL
         query.trace("execute_query", { query: query }, &block)
       end
 
-      def execute_query_lazy(query:, &block)
-        query.trace("execute_query_lazy", { multiplex: query.multiplex, query: query }, &block)
+      def execute_query_lazy(query:, multiplex:, &block)
+        multiplex.trace("execute_query_lazy", { multiplex: multiplex, query: query }, &block)
       end
 
       def execute_field(field:, query:, ast_node:, arguments:, object:, &block)

--- a/lib/graphql/tracing.rb
+++ b/lib/graphql/tracing.rb
@@ -55,16 +55,18 @@ module GraphQL
   #
   module Tracing
     class Trace
-      def initialize
+      class << self
+        attr_accessor :schema
       end
 
-      def lex(query_string:)
-        yield
-      end
+      # TODO
+      # def lex(query_string:)
+      #   yield
+      # end
 
-      def parse(query_string:)
-        yield
-      end
+      # def parse(query_string:)
+      #   yield
+      # end
 
       def validate(query:, validate:)
         yield
@@ -114,6 +116,69 @@ module GraphQL
         yield
       end
     end
+
+    class LegacyTrace < Trace
+      def initialize
+      end
+
+      # TODO: These are not migrated yet
+      # def lex(query_string:)
+      #   yield
+      # end
+
+      # def parse(query_string:)
+      #   yield
+      # end
+
+      def validate(query:, validate:, &block)
+        query.trace("validate", { validate: validate, query: query }, &block)
+      end
+
+      def analyze_multiplex(multiplex:, &block)
+        multiplex.trace("analyze_multiplex", { multiplex: multiplex }, &block)
+      end
+
+      def analyze_query(query:, &block)
+        query.trace("analyze_query", { query: query }, &block)
+      end
+
+      def execute_multiplex(multiplex:, &block)
+        multiplex.trace("execute_multiplex", { multiplex: multiplex }, &block)
+      end
+
+      def execute_query(query:, &block)
+        query.trace("execute_query", { query: query }, &block)
+      end
+
+      def execute_query_lazy(query:, &block)
+        query.trace("execute_query_lazy", { multiplex: query.multiplex, query: query }, &block)
+      end
+
+      def execute_field(field:, query:, ast_node:, arguments:, object:, &block)
+        query.trace("execute_field", { field: field, query: query, ast_node: ast_node, arguments: arguments, object: object, owner: field.owner, path: query.context[:current_path] }, &block)
+      end
+
+      def execute_field_lazy(field:, query:, ast_node:, arguments:, object:, &block)
+        query.trace("execute_field_lazy", { field: field, query: query, ast_node: ast_node, arguments: arguments, object: object, owner: field.owner, path: query.context[:current_path] }, &block)
+      end
+
+      def authorized(query:, type:, object:, &block)
+        query.trace("authorized", { context: query.context, type: type, object: object, path: query.context[:current_path] }, &block)
+      end
+
+      def authorized_lazy(query:, type:, object:, &block)
+        query.trace("authorized_lazy", { context: query.context, type: type, object: object, path: query.context[:current_path] }, &block)
+      end
+
+      def resolve_type(query:, type:, object:, &block)
+        query.trace("resolve_type", { context: query.context, type: type, object: object, path: query.context[:current_path] }, &block)
+      end
+
+      def resolve_type_lazy(query:, type:, object:, &block)
+        query.trace("resolve_type_lazy", { context: query.context, type: type, object: object, path: query.context[:current_path] }, &block)
+      end
+    end
+
     # Objects may include traceable to gain a `.trace(...)` method.
     # The object must have a `@tracers` ivar of type `Array<<#trace(k, d, &b)>>`.
     # @api private

--- a/lib/graphql/tracing.rb
+++ b/lib/graphql/tracing.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 require "graphql/tracing/active_support_notifications_tracing"
+# require "graphql/tracing/active_support_notifications_trace"
 require "graphql/tracing/platform_tracing"
+require "graphql/tracing/platform_trace"
 require "graphql/tracing/appoptics_tracing"
 require "graphql/tracing/appsignal_tracing"
 require "graphql/tracing/data_dog_tracing"
@@ -14,45 +16,6 @@ if defined?(PrometheusExporter::Server)
 end
 
 module GraphQL
-  # Library entry point for performance metric reporting.
-  #
-  # @example Sending custom events
-  #   query.trace("my_custom_event", { ... }) do
-  #     # do stuff ...
-  #   end
-  #
-  # @example Adding a tracer to a schema
-  #  class MySchema < GraphQL::Schema
-  #    tracer MyTracer # <= responds to .trace(key, data, &block)
-  #  end
-  #
-  # @example Adding a tracer to a single query
-  #   MySchema.execute(query_str, context: { backtrace: true })
-  #
-  # Events:
-  #
-  # Key | Metadata
-  # ----|---------
-  # lex | `{ query_string: String }`
-  # parse | `{ query_string: String }`
-  # validate | `{ query: GraphQL::Query, validate: Boolean }`
-  # analyze_multiplex |  `{ multiplex: GraphQL::Execution::Multiplex }`
-  # analyze_query | `{ query: GraphQL::Query }`
-  # execute_multiplex | `{ multiplex: GraphQL::Execution::Multiplex }`
-  # execute_query | `{ query: GraphQL::Query }`
-  # execute_query_lazy | `{ query: GraphQL::Query?, multiplex: GraphQL::Execution::Multiplex? }`
-  # execute_field | `{ owner: Class, field: GraphQL::Schema::Field, query: GraphQL::Query, path: Array<String, Integer>, ast_node: GraphQL::Language::Nodes::Field}`
-  # execute_field_lazy | `{ owner: Class, field: GraphQL::Schema::Field, query: GraphQL::Query, path: Array<String, Integer>, ast_node: GraphQL::Language::Nodes::Field}`
-  # authorized | `{ context: GraphQL::Query::Context, type: Class, object: Object, path: Array<String, Integer> }`
-  # authorized_lazy | `{ context: GraphQL::Query::Context, type: Class, object: Object, path: Array<String, Integer> }`
-  # resolve_type | `{ context: GraphQL::Query::Context, type: Class, object: Object, path: Array<String, Integer> }`
-  # resolve_type_lazy | `{ context: GraphQL::Query::Context, type: Class, object: Object, path: Array<String, Integer> }`
-  #
-  # Note that `execute_field` and `execute_field_lazy` receive different data in different settings:
-  #
-  # - When using {GraphQL::Execution::Interpreter}, they receive `{field:, path:, query:}`
-  # - Otherwise, they receive `{context: ...}`
-  #
   module Tracing
     class Trace
       class << self

--- a/lib/graphql/tracing.rb
+++ b/lib/graphql/tracing.rb
@@ -12,11 +12,11 @@ require "graphql/tracing/prometheus_tracing"
 
 # New Tracing:
 require "graphql/tracing/platform_trace"
-# require "graphql/tracing/active_support_notifications_trace"
 require "graphql/tracing/appoptics_trace"
 require "graphql/tracing/appsignal_trace"
 require "graphql/tracing/data_dog_trace"
 require "graphql/tracing/new_relic_trace"
+require "graphql/tracing/notifications_trace"
 require "graphql/tracing/scout_trace"
 require "graphql/tracing/statsd_trace"
 require "graphql/tracing/prometheus_trace"

--- a/lib/graphql/tracing/active_support_notifications_trace.rb
+++ b/lib/graphql/tracing/active_support_notifications_trace.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'graphql/tracing/notifications_trace'
+
+module GraphQL
+  module Tracing
+    # This implementation forwards events to ActiveSupport::Notifications
+    # with a `graphql` suffix.
+    module ActiveSupportNotificationsTrace
+      include NotificationsTrace
+      def initialize(engine: ActiveSupport::Notifications, **rest)
+        super
+      end
+    end
+  end
+end

--- a/lib/graphql/tracing/appoptics_trace.rb
+++ b/lib/graphql/tracing/appoptics_trace.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module Tracing
+
+    # This class uses the AppopticsAPM SDK from the appoptics_apm gem to create
+    # traces for GraphQL.
+    #
+    # There are 4 configurations available. They can be set in the
+    # appoptics_apm config file or in code. Please see:
+    # {https://docs.appoptics.com/kb/apm_tracing/ruby/configure}
+    #
+    #     AppOpticsAPM::Config[:graphql][:enabled] = true|false
+    #     AppOpticsAPM::Config[:graphql][:transaction_name]  = true|false
+    #     AppOpticsAPM::Config[:graphql][:sanitize_query] = true|false
+    #     AppOpticsAPM::Config[:graphql][:remove_comments] = true|false
+    module AppOpticsTrace
+      include PlatformTrace
+      # These GraphQL events will show up as 'graphql.prep' spans
+      PREP_KEYS = ['lex', 'parse', 'validate', 'analyze_query', 'analyze_multiplex'].freeze
+      # These GraphQL events will show up as 'graphql.execute' spans
+      EXEC_KEYS = ['execute_multiplex', 'execute_query', 'execute_query_lazy'].freeze
+
+      # During auto-instrumentation this version of AppOpticsTracing is compared
+      # with the version provided in the appoptics_apm gem, so that the newer
+      # version of the class can be used
+
+      def self.version
+        Gem::Version.new('1.0.0')
+      end
+
+      [
+        'lex',
+        'parse',
+        'validate',
+        'analyze_query',
+        'analyze_multiplex',
+        'execute_multiplex',
+        'execute_query',
+        'execute_query_lazy',
+      ].each do |trace_method|
+        module_eval <<-RUBY
+          def #{trace_method}(**data)
+            return super if !defined?(AppOpticsAPM) || gql_config[:enabled] == false
+            layer = span_name("#{trace_method}")
+            kvs = metadata(data, layer)
+            kvs[:Key] = "#{trace_method}" if (PREP_KEYS + EXEC_KEYS).include?("#{trace_method}")
+
+            transaction_name(kvs[:InboundQuery]) if kvs[:InboundQuery] && layer == 'graphql.execute'
+
+            ::AppOpticsAPM::SDK.trace(layer, kvs) do
+              kvs.clear # we don't have to send them twice
+              super
+            end
+          end
+        RUBY
+      end
+
+      [:execute_field, :execute_field_lazy].each do |field_trace_method|
+        module_eval <<-RUBY, __FILE__, __LINE__
+          def #{field_trace_method}(**data)
+            return super if !defined?(AppOpticsAPM) || gql_config[:enabled] == false
+            field = data[:field]
+            return_type = field.type.unwrap
+            trace_field = if return_type.kind.scalar? || return_type.kind.enum?
+              (field.trace.nil? && @trace_scalars) || field.trace
+            else
+              true
+            end
+            platform_key = if trace_field
+              context = data[:query].context
+              cached_platform_key(context, field, :field) { platform_field_key(field.owner, field) }
+            else
+              nil
+            end
+            if platform_key && trace_field
+              layer = platform_key
+              kvs = metadata(data, layer)
+              kvs[:Key] = "#{field_trace_method}" if (PREP_KEYS + EXEC_KEYS).include?("#{field_trace_method}")
+
+              ::AppOpticsAPM::SDK.trace(layer, kvs) do
+                kvs.clear # we don't have to send them twice
+                super
+              end
+            else
+              super
+            end
+          end
+        RUBY
+      end
+
+      def platform_field_key(type, field)
+        "graphql.#{type.graphql_name}.#{field.graphql_name}"
+      end
+
+      def platform_authorized_key(type)
+        "graphql.authorized.#{type.graphql_name}"
+      end
+
+      def platform_resolve_type_key(type)
+        "graphql.resolve_type.#{type.graphql_name}"
+      end
+
+      private
+
+      def gql_config
+        ::AppOpticsAPM::Config[:graphql] ||= {}
+      end
+
+      def transaction_name(query)
+        return if gql_config[:transaction_name] == false ||
+          ::AppOpticsAPM::SDK.get_transaction_name
+
+        split_query = query.strip.split(/\W+/, 3)
+        split_query[0] = 'query' if split_query[0].empty?
+        name = "graphql.#{split_query[0..1].join('.')}"
+
+        ::AppOpticsAPM::SDK.set_transaction_name(name)
+      end
+
+      def multiplex_transaction_name(names)
+        return if gql_config[:transaction_name] == false ||
+          ::AppOpticsAPM::SDK.get_transaction_name
+
+        name = "graphql.multiplex.#{names.join('.')}"
+        name = "#{name[0..251]}..." if name.length > 254
+
+        ::AppOpticsAPM::SDK.set_transaction_name(name)
+      end
+
+      def span_name(key)
+        return 'graphql.prep' if PREP_KEYS.include?(key)
+        return 'graphql.execute' if EXEC_KEYS.include?(key)
+
+        key[/^graphql\./] ? key : "graphql.#{key}"
+      end
+
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      def metadata(data, layer)
+        data.keys.map do |key|
+          case key
+          when :context
+            graphql_context(data[key], layer)
+          when :query
+            graphql_query(data[key])
+          when :query_string
+            graphql_query_string(data[key])
+          when :multiplex
+            graphql_multiplex(data[key])
+          when :path
+            [key, data[key].join(".")]
+          else
+            [key, data[key]]
+          end
+        end.flatten(2).each_slice(2).to_h.merge(Spec: 'graphql')
+      end
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+      def graphql_context(context, layer)
+        context.errors && context.errors.each do |err|
+          AppOpticsAPM::API.log_exception(layer, err)
+        end
+
+        [[:Path, context.path.join('.')]]
+      end
+
+      def graphql_query(query)
+        return [] unless query
+
+        query_string = query.query_string
+        query_string = remove_comments(query_string) if gql_config[:remove_comments] != false
+        query_string = sanitize(query_string) if gql_config[:sanitize_query] != false
+
+        [[:InboundQuery, query_string],
+         [:Operation, query.selected_operation_name]]
+      end
+
+      def graphql_query_string(query_string)
+        query_string = remove_comments(query_string) if gql_config[:remove_comments] != false
+        query_string = sanitize(query_string) if gql_config[:sanitize_query] != false
+
+        [:InboundQuery, query_string]
+      end
+
+      def graphql_multiplex(data)
+        names = data.queries.map(&:operations).map(&:keys).flatten.compact
+        multiplex_transaction_name(names) if names.size > 1
+
+        [:Operations, names.join(', ')]
+      end
+
+      def sanitize(query)
+        return unless query
+
+        # remove arguments
+        query.gsub(/"[^"]*"/, '"?"')                 # strings
+          .gsub(/-?[0-9]*\.?[0-9]+e?[0-9]*/, '?') # ints + floats
+          .gsub(/\[[^\]]*\]/, '[?]')              # arrays
+      end
+
+      def remove_comments(query)
+        return unless query
+
+        query.gsub(/#[^\n\r]*/, '')
+      end
+    end
+  end
+end

--- a/lib/graphql/tracing/appoptics_trace.rb
+++ b/lib/graphql/tracing/appoptics_trace.rb
@@ -15,7 +15,6 @@ module GraphQL
     #     AppOpticsAPM::Config[:graphql][:sanitize_query] = true|false
     #     AppOpticsAPM::Config[:graphql][:remove_comments] = true|false
     module AppOpticsTrace
-      include PlatformTrace
       # These GraphQL events will show up as 'graphql.prep' spans
       PREP_KEYS = ['lex', 'parse', 'validate', 'analyze_query', 'analyze_multiplex'].freeze
       # These GraphQL events will show up as 'graphql.execute' spans
@@ -110,6 +109,8 @@ module GraphQL
           super
         end
       end
+
+      include PlatformTrace
 
       def platform_field_key(field)
         "graphql.#{field.owner.graphql_name}.#{field.graphql_name}"

--- a/lib/graphql/tracing/appoptics_trace.rb
+++ b/lib/graphql/tracing/appoptics_trace.rb
@@ -57,6 +57,7 @@ module GraphQL
       end
 
       def platform_execute_field(platform_key, data)
+        return super if !defined?(AppOpticsAPM) || gql_config[:enabled] == false
         layer = platform_key
         kvs = metadata(data, layer)
 
@@ -66,12 +67,47 @@ module GraphQL
         end
       end
 
-      def platform_execute_field_lazy(platform_key, data)
-        layer = platform_key
+      def authorized(**data)
+        return super if !defined?(AppOpticsAPM) || gql_config[:enabled] == false
+        layer = cached_platform_key(data[:query].context, data[:type], :authorized) { platform_authorized_key(data[:type]) }
         kvs = metadata(data, layer)
+
         ::AppOpticsAPM::SDK.trace(layer, kvs) do
           kvs.clear # we don't have to send them twice
-          yield
+          super
+        end
+      end
+
+      def authorized_lazy(**data)
+        return super if !defined?(AppOpticsAPM) || gql_config[:enabled] == false
+        layer = cached_platform_key(data[:query].context, data[:type], :authorized) { platform_authorized_key(data[:type]) }
+        kvs = metadata(data, layer)
+
+        ::AppOpticsAPM::SDK.trace(layer, kvs) do
+          kvs.clear # we don't have to send them twice
+          super
+        end
+      end
+
+      def resolve_type(**data)
+        return super if !defined?(AppOpticsAPM) || gql_config[:enabled] == false
+        layer = cached_platform_key(data[:query].context, data[:type], :resolve_type) { platform_resolve_type_key(data[:type]) }
+        kvs = metadata(data, layer)
+
+        ::AppOpticsAPM::SDK.trace(layer, kvs) do
+          kvs.clear # we don't have to send them twice
+          super
+        end
+      end
+
+      def resolve_type_lazy(**data)
+        return super if !defined?(AppOpticsAPM) || gql_config[:enabled] == false
+        layer = cached_platform_key(data[:query].context, data[:type], :resolve_type) { platform_resolve_type_key(data[:type]) }
+        kvs = metadata(data, layer)
+
+        ::AppOpticsAPM::SDK.trace(layer, kvs) do
+          kvs.clear # we don't have to send them twice
+          super
         end
       end
 

--- a/lib/graphql/tracing/appsignal_trace.rb
+++ b/lib/graphql/tracing/appsignal_trace.rb
@@ -50,8 +50,8 @@ module GraphQL
         end
       end
 
-      def platform_field_key(type, field)
-        "#{type.graphql_name}.#{field.graphql_name}.graphql"
+      def platform_field_key(field)
+        "#{field.owner.graphql_name}.#{field.graphql_name}.graphql"
       end
 
       def platform_authorized_key(type)

--- a/lib/graphql/tracing/appsignal_trace.rb
+++ b/lib/graphql/tracing/appsignal_trace.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module Tracing
+    module AppsignalTrace
+      include PlatformTrace
+
+
+      # @param set_action_name [Boolean] If true, the GraphQL operation name will be used as the transaction name.
+      #   This is not advised if you run more than one query per HTTP request, for example, with `graphql-client` or multiplexing.
+      #   It can also be specified per-query with `context[:set_appsignal_action_name]`.
+      def initialize(set_action_name: false, **rest)
+        @set_action_name = set_action_name
+        super
+      end
+
+      {
+        "lex" => "lex.graphql",
+        "parse" => "parse.graphql",
+        "validate" => "validate.graphql",
+        "analyze_query" => "analyze.graphql",
+        "analyze_multiplex" => "analyze.graphql",
+        "execute_multiplex" => "execute.graphql",
+        "execute_query" => "execute.graphql",
+        "execute_query_lazy" => "execute.graphql",
+      }.each do |trace_method, platform_key|
+        module_eval <<-RUBY
+          def #{trace_method}(**data)
+            #{
+              if trace_method == "execute_query"
+                <<-RUBY
+                set_this_txn_name =  data[:query].context[:set_appsignal_action_name]
+                if set_this_txn_name == true || (set_this_txn_name.nil? && @set_action_name)
+                  Appsignal::Transaction.current.set_action(transaction_name(data[:query]))
+                end
+                RUBY
+              end
+            }
+
+            Appsignal.instrument("#{platform_key}") do
+              super
+            end
+          end
+        RUBY
+      end
+
+      def platform_execute_field(platform_key, **_data)
+        Appsignal.instrument(platform_key) do
+          super
+        end
+      end
+
+      def platform_field_key(type, field)
+        "#{type.graphql_name}.#{field.graphql_name}.graphql"
+      end
+
+      def platform_authorized_key(type)
+        "#{type.graphql_name}.authorized.graphql"
+      end
+
+      def platform_resolve_type_key(type)
+        "#{type.graphql_name}.resolve_type.graphql"
+      end
+    end
+  end
+end

--- a/lib/graphql/tracing/appsignal_trace.rb
+++ b/lib/graphql/tracing/appsignal_trace.rb
@@ -24,7 +24,7 @@ module GraphQL
         "execute_query" => "execute.graphql",
         "execute_query_lazy" => "execute.graphql",
       }.each do |trace_method, platform_key|
-        module_eval <<-RUBY
+        module_eval <<-RUBY, __FILE__, __LINE__
           def #{trace_method}(**data)
             #{
               if trace_method == "execute_query"

--- a/lib/graphql/tracing/appsignal_trace.rb
+++ b/lib/graphql/tracing/appsignal_trace.rb
@@ -44,7 +44,7 @@ module GraphQL
         RUBY
       end
 
-      def platform_execute_field(platform_key, data)
+      def platform_execute_field(platform_key)
         Appsignal.instrument(platform_key) do
           super
         end

--- a/lib/graphql/tracing/appsignal_trace.rb
+++ b/lib/graphql/tracing/appsignal_trace.rb
@@ -44,7 +44,7 @@ module GraphQL
         RUBY
       end
 
-      def platform_execute_field(platform_key, **_data)
+      def platform_execute_field(platform_key, data)
         Appsignal.instrument(platform_key) do
           super
         end

--- a/lib/graphql/tracing/data_dog_trace.rb
+++ b/lib/graphql/tracing/data_dog_trace.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module Tracing
+    module DataDogTrace
+      include PlatformTrace
+
+      # @param analytics_enabled [Boolean] Deprecated
+      # @param analytics_sample_rate [Float] Deprecated
+      def initialize(tracer: nil, analytics_enabled: false, analytics_sample_rate: 1.0, service: "ruby-graphql", **rest)
+        if tracer.nil?
+          tracer = defined?(Datadog::Tracing) ? Datadog::Tracing : Datadog.tracer
+        end
+        @tracer = tracer
+
+        analytics_available = defined?(Datadog::Contrib::Analytics) \
+            && Datadog::Contrib::Analytics.respond_to?(:enabled?) \
+            && Datadog::Contrib::Analytics.respond_to?(:set_sample_rate)
+
+        @analytics_enabled = analytics_available && Datadog::Contrib::Analytics.enabled?(analytics_enabled)
+        @analytics_sample_rate = analytics_sample_rate
+        @service_name = service
+      end
+
+      {
+        'lex' => 'lex.graphql',
+        'parse' => 'parse.graphql',
+        'validate' => 'validate.graphql',
+        'analyze_query' => 'analyze.graphql',
+        'analyze_multiplex' => 'analyze.graphql',
+        'execute_multiplex' => 'execute.graphql',
+        'execute_query' => 'execute.graphql',
+        'execute_query_lazy' => 'execute.graphql',
+        'authorized' => 'authorize.graphql',
+        'authorized_lazy' => 'authorize.graphql',
+        'resolve_type' => 'resolve_type.graphql',
+        'resolve_type_lazy' => 'resolve_type.graphql',
+      }.each do |trace_method, trace_key|
+        module_eval <<-RUBY, __FILE__, __LINE__
+          def #{trace_method}(**data)
+            @tracer.trace("#{trace_key}", service: @service_name) do |span|
+              span.span_type = 'custom'
+              if defined?(Datadog::Tracing::Metadata::Ext) # Introduced in ddtrace 1.0
+                span.set_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT, 'graphql')
+                span.set_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION, '#{trace_method}')
+              end
+
+              #{
+                if trace_method == 'execute_multiplex'
+                  <<-RUBY
+                  operations = data[:multiplex].queries.map(&:selected_operation_name).join(', ')
+
+                  resource = if operations.empty?
+                    first_query = data[:multiplex].queries.first
+                    fallback_transaction_name(first_query && first_query.context)
+                  else
+                    operations
+                  end
+                  span.resource = resource if resource
+
+                  # For top span of query, set the analytics sample rate tag, if available.
+                  if @analytics_enabled
+                    Datadog::Contrib::Analytics.set_sample_rate(span, @analytics_sample_rate)
+                  end
+                  RUBY
+                elsif trace_method == 'execute_query'
+                  <<-RUBY
+                  span.set_tag(:selected_operation_name, data[:query].selected_operation_name)
+                  span.set_tag(:selected_operation_type, data[:query].selected_operation.operation_type)
+                  span.set_tag(:query_string, data[:query].query_string)
+                  RUBY
+                end
+              }
+              prepare_span("#{trace_method}", data, span)
+              super
+            end
+          end
+        RUBY
+      end
+
+      # Implement this method in a subclass to apply custom tags to datadog spans
+      # @param key [String] The event being traced
+      # @param data [Hash] The runtime data for this event (@see GraphQL::Tracing for keys for each event)
+      # @param span [Datadog::Tracing::SpanOperation] The datadog span for this event
+      def prepare_span(key, data, span)
+      end
+
+      def platform_field_key(type, field)
+        "#{type.graphql_name}.#{field.graphql_name}"
+      end
+
+      def platform_authorized_key(type)
+        "#{type.graphql_name}.authorized"
+      end
+
+      def platform_resolve_type_key(type)
+        "#{type.graphql_name}.resolve_type"
+      end
+    end
+  end
+end

--- a/lib/graphql/tracing/new_relic_trace.rb
+++ b/lib/graphql/tracing/new_relic_trace.rb
@@ -41,47 +41,15 @@ module GraphQL
         RUBY
       end
 
-      def execute_field(query:, field:, **_rest)
-        return_type = field.type.unwrap
-        trace_field = if return_type.kind.scalar? || return_type.kind.enum?
-          (field.trace.nil? && @trace_scalars) || field.trace
-        else
-          true
-        end
-        platform_key = if trace_field
-          context = query.context
-          cached_platform_key(context, field, :field) { platform_field_key(field.owner, field) }
-        else
-          nil
-        end
-        if platform_key && trace_field
-          NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped(platform_key) do
-            super
-          end
-        else
-          super
+      def platform_execute_field(platform_key, _data)
+        NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped(platform_key) do
+          yield
         end
       end
 
-      def execute_field_lazy(type:, field:, **_rest)
-        return_type = field.type.unwrap
-        trace_field = if return_type.kind.scalar? || return_type.kind.enum?
-          (field.trace.nil? && @trace_scalars) || field.trace
-        else
-          true
-        end
-        platform_key = if trace_field
-          context = query.context
-          cached_platform_key(context, field, :field) { platform_field_key(field.owner, field) }
-        else
-          nil
-        end
-        if platform_key && trace_field
-          NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped(platform_key) do
-            super
-          end
-        else
-          super
+      def platform_execute_field_lazy(platform_key, _data)
+        NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped(platform_key) do
+          yield
         end
       end
 

--- a/lib/graphql/tracing/new_relic_trace.rb
+++ b/lib/graphql/tracing/new_relic_trace.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module Tracing
+    module NewRelicTrace
+      include PlatformTrace
+
+      self.platform_keys = {
+        "lex" => "GraphQL/lex",
+        "parse" => "GraphQL/parse",
+        "validate" => "GraphQL/validate",
+        "analyze_query" => "GraphQL/analyze",
+        "analyze_multiplex" => "GraphQL/analyze",
+        "execute_multiplex" => "GraphQL/execute",
+        "execute_query" => "GraphQL/execute",
+        "execute_query_lazy" => "GraphQL/execute",
+      }
+
+      # @param set_transaction_name [Boolean] If true, the GraphQL operation name will be used as the transaction name.
+      #   This is not advised if you run more than one query per HTTP request, for example, with `graphql-client` or multiplexing.
+      #   It can also be specified per-query with `context[:set_new_relic_transaction_name]`.
+      def initialize(set_transaction_name: false, **_rest)
+        @set_transaction_name = set_transaction_name
+        super
+      end
+
+      def execute_query(query:)
+        set_this_txn_name =  query.context[:set_new_relic_transaction_name]
+        if set_this_txn_name == true || (set_this_txn_name.nil? && @set_transaction_name)
+          NewRelic::Agent.set_transaction_name(transaction_name(query))
+        end
+        NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped("GraphQL/execute") do
+          super
+        end
+      end
+
+      {
+        "lex" => "GraphQL/lex",
+        "parse" => "GraphQL/parse",
+        "validate" => "GraphQL/validate",
+        "analyze_query" => "GraphQL/analyze",
+        "analyze_multiplex" => "GraphQL/analyze",
+        "execute_multiplex" => "GraphQL/execute",
+        "execute_query_lazy" => "GraphQL/execute",
+      }.each do |trace_method, platform_key|
+        module_eval <<-RUBY, __FILE__, __LINE__
+          def #{trace_method}(**_keys)
+            NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped("#{platform_key}") do
+              super
+            end
+          end
+        RUBY
+      end
+
+      def execute_field(query:, field:, **_rest)
+        return_type = field.type.unwrap
+        trace_field = if return_type.kind.scalar? || return_type.kind.enum?
+          (field.trace.nil? && @trace_scalars) || field.trace
+        else
+          true
+        end
+        platform_key = if trace_field
+          context = query.context
+          cached_platform_key(context, field, :field) { platform_field_key(field.owner, field) }
+        else
+          nil
+        end
+        if platform_key && trace_field
+          NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped(platform_key) do
+            super
+          end
+        else
+          super
+        end
+      end
+
+      def execute_field_lazy(type:, field:, **_rest)
+        return_type = field.type.unwrap
+        trace_field = if return_type.kind.scalar? || return_type.kind.enum?
+          (field.trace.nil? && @trace_scalars) || field.trace
+        else
+          true
+        end
+        platform_key = if trace_field
+          context = query.context
+          cached_platform_key(context, field, :field) { platform_field_key(field.owner, field) }
+        else
+          nil
+        end
+        if platform_key && trace_field
+          NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped(platform_key) do
+            super
+          end
+        else
+          super
+        end
+      end
+
+      def authorized(type:, query:, **_rest)
+        platform_key = cached_platform_key(query.context, type, :authorized) { platform_authorized_key(type) }
+        NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped(platform_key) do
+          super
+        end
+      end
+
+      def authorized_lazy(type:, query:, **_rest)
+        platform_key = cached_platform_key(query.context, type, :authorized) { platform_authorized_key(type) }
+        NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped(platform_key) do
+          super
+        end
+      end
+
+      def resolve_type(type:, query:, **_rest)
+        platform_key = cached_platform_key(query.context, type, :resolve_type) { platform_resolve_type_key(type) }
+        NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped(platform_key) do
+          super
+        end
+      end
+
+      def resolve_type_lazy(type:, query:, **_rest)
+        platform_key = cached_platform_key(query.context, type, :resolve_type) { platform_resolve_type_key(type) }
+        NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped(platform_key) do
+          super
+        end
+      end
+
+      def platform_field_key(type, field)
+        "GraphQL/#{type.graphql_name}/#{field.graphql_name}"
+      end
+
+      def platform_authorized_key(type)
+        "GraphQL/Authorize/#{type.graphql_name}"
+      end
+
+      def platform_resolve_type_key(type)
+        "GraphQL/ResolveType/#{type.graphql_name}"
+      end
+    end
+  end
+end

--- a/lib/graphql/tracing/new_relic_trace.rb
+++ b/lib/graphql/tracing/new_relic_trace.rb
@@ -5,17 +5,6 @@ module GraphQL
     module NewRelicTrace
       include PlatformTrace
 
-      self.platform_keys = {
-        "lex" => "GraphQL/lex",
-        "parse" => "GraphQL/parse",
-        "validate" => "GraphQL/validate",
-        "analyze_query" => "GraphQL/analyze",
-        "analyze_multiplex" => "GraphQL/analyze",
-        "execute_multiplex" => "GraphQL/execute",
-        "execute_query" => "GraphQL/execute",
-        "execute_query_lazy" => "GraphQL/execute",
-      }
-
       # @param set_transaction_name [Boolean] If true, the GraphQL operation name will be used as the transaction name.
       #   This is not advised if you run more than one query per HTTP request, for example, with `graphql-client` or multiplexing.
       #   It can also be specified per-query with `context[:set_new_relic_transaction_name]`.

--- a/lib/graphql/tracing/new_relic_trace.rb
+++ b/lib/graphql/tracing/new_relic_trace.rb
@@ -47,37 +47,15 @@ module GraphQL
         end
       end
 
-      def platform_execute_field_lazy(platform_key, _data)
+      def platform_authorized(platform_key)
         NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped(platform_key) do
           yield
         end
       end
 
-      def authorized(type:, query:, **_rest)
-        platform_key = cached_platform_key(query.context, type, :authorized) { platform_authorized_key(type) }
+      def platform_resolve_type(platform_key)
         NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped(platform_key) do
-          super
-        end
-      end
-
-      def authorized_lazy(type:, query:, **_rest)
-        platform_key = cached_platform_key(query.context, type, :authorized) { platform_authorized_key(type) }
-        NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped(platform_key) do
-          super
-        end
-      end
-
-      def resolve_type(type:, query:, **_rest)
-        platform_key = cached_platform_key(query.context, type, :resolve_type) { platform_resolve_type_key(type) }
-        NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped(platform_key) do
-          super
-        end
-      end
-
-      def resolve_type_lazy(type:, query:, **_rest)
-        platform_key = cached_platform_key(query.context, type, :resolve_type) { platform_resolve_type_key(type) }
-        NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped(platform_key) do
-          super
+          yield
         end
       end
 

--- a/lib/graphql/tracing/new_relic_trace.rb
+++ b/lib/graphql/tracing/new_relic_trace.rb
@@ -41,7 +41,7 @@ module GraphQL
         RUBY
       end
 
-      def platform_execute_field(platform_key, _data)
+      def platform_execute_field(platform_key)
         NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped(platform_key) do
           yield
         end

--- a/lib/graphql/tracing/new_relic_trace.rb
+++ b/lib/graphql/tracing/new_relic_trace.rb
@@ -59,8 +59,8 @@ module GraphQL
         end
       end
 
-      def platform_field_key(type, field)
-        "GraphQL/#{type.graphql_name}/#{field.graphql_name}"
+      def platform_field_key(field)
+        "GraphQL/#{field.owner.graphql_name}/#{field.graphql_name}"
       end
 
       def platform_authorized_key(type)

--- a/lib/graphql/tracing/notifications_trace.rb
+++ b/lib/graphql/tracing/notifications_trace.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module Tracing
+    # This implementation forwards events to a notification handler (i.e.
+    # ActiveSupport::Notifications or Dry::Monitor::Notifications)
+    # with a `graphql` suffix.
+    module NotificationsTrace
+      include PlatformTrace
+      # Initialize a new NotificationsTracing instance
+      #
+      # @param engine [#instrument(key, metadata, block)] The notifications engine to use
+      def initialize(engine:, **rest)
+        @notifications_engine = engine
+        super
+      end
+
+      {
+        "lex" => "lex.graphql",
+        "parse" => "parse.graphql",
+        "validate" => "validate.graphql",
+        "analyze_multiplex" => "analyze_multiplex.graphql",
+        "analyze_query" => "analyze_query.graphql",
+        "execute_query" => "execute_query.graphql",
+        "execute_query_lazy" => "execute_query_lazy.graphql",
+        "execute_field" => "execute_field.graphql",
+        "execute_field_lazy" => "execute_field_lazy.graphql",
+        "authorized" => "authorized.graphql",
+        "authorized_lazy" => "authorized_lazy.graphql",
+        "resolve_type" => "resolve_type.graphql",
+        "resolve_type_lazy" => "resolve_type.graphql",
+      }.each do |trace_method, platform_key|
+        module_eval <<-RUBY, __FILE__, __LINE__
+          def #{trace_method}(**metadata, &blk)
+            @notifications_engine.instrument("#{platform_key}", metadata, &blk)
+          end
+        RUBY
+      end
+    end
+  end
+end

--- a/lib/graphql/tracing/platform_trace.rb
+++ b/lib/graphql/tracing/platform_trace.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module Tracing
+    module PlatformTrace
+      class << self
+        attr_accessor :platform_keys, :options
+
+        def inherited(child_class)
+          child_class.platform_keys = self.platform_keys
+        end
+      end
+
+      def initialize
+        @trace_scalars = self.class.options.fetch(:trace_scalars, false)
+        super
+      end
+
+      [
+        :lex, :parse, :validate,
+        :analyze_query, :analyze_multiplex,
+        :execute_multiplex, :execute_query, :execute_query_lazy,
+        # :execute_field, :execute_field_lazy,
+        :authorized, :authorized_lazy,
+        :resolve_type, :resolve_type_lazy,
+      ].each do |trace_method|
+        module_eval <<-RUBY, __FILE__, __LINE__
+          def #{trace_method}(**kwargs)
+            @#{trace_method}_key ||= @platform_keys.fetch("#{trace_method}")
+            platform_trace(@#{trace_method}_key, **kwargs) do
+              yield
+            end
+          end
+        RUBY
+      end
+
+      [:execute_field, :execute_field_lazy].each do |field_trace_method|
+        module_eval <<-RUBY, __FILE__, __LINE__
+          def #{field_trace_method}(field:, query:, **_rest)
+            return_type = field.type.unwrap
+            trace_field = if return_type.kind.scalar? || return_type.kind.enum?
+              (field.trace.nil? && @trace_scalars) || field.trace
+            else
+              true
+            end
+
+            platform_key = if trace_field
+              context = query.context
+              cached_platform_key(context, field, :field) { platform_field_key(field.owner, field) }
+            else
+              nil
+            end
+
+            if platform_key && trace_field
+              # TODO data here ?
+              data = {}
+              platform_trace(platform_key, "#{field_trace_method}", data) do
+                yield
+              end
+            else
+              yield
+            end
+          end
+        RUBY
+      end
+
+      [:authorized, :authorized_lazy].each do |auth_trace_method|
+        module_eval <<-RUBY, __FILE__, __LINE__
+        def #{auth_trace_method}(type:, query:, **rest)
+          @#{auth_trace_method}_key ||= @platform_keys.fetch("#{auth_trace_method}")
+          platform_key = cached_platform_key(query.context, type, :authorized) { platform_authorized_key(type) }
+          # TODO Data here?
+          platform_trace(@#{auth_trace_method}_key, data = {}) do
+            yield
+          end
+        end
+        RUBY
+      end
+
+      [:resolve_type, :resolve_type_lazy].each do |resolve_type_trace_method|
+        module_eval <<-RUBY, __FILE__, __LINE__
+        def #{resolve_type_trace_method}(type:, query:, **rest)
+          @#{resolve_type_trace_method}_key ||= @platform_keys.fetch("#{resolve_type_trace_method}")
+          platform_key = cached_platform_key(query.context, type, :resolve_type) { platform_authorized_key(type) }
+          # TODO Data here?
+          platform_trace(@#{resolve_type_trace_method}_key, data = {}) do
+            yield
+          end
+        end
+        RUBY
+      end
+
+      private
+
+      # Get the transaction name based on the operation type and name if possible, or fall back to a user provided
+      # one. Useful for anonymous queries.
+      def transaction_name(query)
+        selected_op = query.selected_operation
+        txn_name = if selected_op
+          op_type = selected_op.operation_type
+          op_name = selected_op.name || fallback_transaction_name(query.context) || "anonymous"
+          "#{op_type}.#{op_name}"
+        else
+          "query.anonymous"
+        end
+        "GraphQL/#{txn_name}"
+      end
+
+      def fallback_transaction_name(context)
+        context[:tracing_fallback_transaction_name]
+      end
+
+      attr_reader :options
+
+      # Different kind of schema objects have different kinds of keys:
+      #
+      # - Object types: `.authorized`
+      # - Union/Interface types: `.resolve_type`
+      # - Fields: execution
+      #
+      # So, they can all share one cache.
+      #
+      # If the key isn't present, the given block is called and the result is cached for `key`.
+      #
+      # @param ctx [GraphQL::Query::Context]
+      # @param key [Class, GraphQL::Field] A part of the schema
+      # @param trace_phase [Symbol] The stage of execution being traced (used by OpenTelementry tracing)
+      # @return [String]
+      def cached_platform_key(ctx, key, trace_phase)
+        cache = ctx.namespace(self.class)[:platform_key_cache] ||= {}
+        cache.fetch(key) { cache[key] = yield }
+      end
+    end
+  end
+end

--- a/lib/graphql/tracing/platform_trace.rb
+++ b/lib/graphql/tracing/platform_trace.rb
@@ -3,18 +3,6 @@
 module GraphQL
   module Tracing
     module PlatformTrace
-      module ClassMethods
-        attr_accessor :platform_keys
-
-        def inherited(child_class)
-          child_class.platform_keys = self.platform_keys
-        end
-      end
-
-      def self.included(child_mod)
-        child_mod.extend(ClassMethods)
-      end
-
       def initialize(trace_scalars: false, **_options)
         @trace_scalars = trace_scalars
         super

--- a/lib/graphql/tracing/platform_tracing.rb
+++ b/lib/graphql/tracing/platform_tracing.rb
@@ -73,8 +73,20 @@ module GraphQL
       end
 
       def self.use(schema_defn, options = {})
-        tracer = self.new(**options)
-        schema_defn.tracer(tracer)
+        if options[:legacy_tracing]
+          tracer = self.new(**options)
+          schema_defn.tracer(tracer)
+        else
+          tracing_name = self.name.split("::").last
+          trace_name = tracing_name.sub("Tracing", "Trace")
+          if GraphQL::Tracing.const_defined?(trace_name, false)
+            trace_module = GraphQL::Tracing.const_get(trace_name)
+            schema_defn.trace_with(trace_module, **options)
+          else
+            tracer = self.new(**options)
+            schema_defn.tracer(tracer)
+          end
+        end
       end
 
       private

--- a/lib/graphql/tracing/platform_tracing.rb
+++ b/lib/graphql/tracing/platform_tracing.rb
@@ -40,7 +40,7 @@ module GraphQL
 
           platform_key = if trace_field
             context = data.fetch(:query).context
-            cached_platform_key(context, field, :field) { platform_field_key(data[:owner], field) }
+            cached_platform_key(context, field, :field) { platform_field_key(field.owner, field) }
           else
             nil
           end

--- a/lib/graphql/tracing/prometheus_trace.rb
+++ b/lib/graphql/tracing/prometheus_trace.rb
@@ -30,11 +30,11 @@ module GraphQL
         RUBY
       end
 
-      def platform_execute_field(platform_key, _data, &block)
+      def platform_execute_field(platform_key, &block)
         instrument_execution(platform_key, "execute_field", &block)
       end
 
-      def platform_execute_field_lazy(platform_key, _data, &block)
+      def platform_execute_field_lazy(platform_key, &block)
         instrument_execution(platform_key, "execute_field_lazy", &block)
       end
 

--- a/lib/graphql/tracing/prometheus_trace.rb
+++ b/lib/graphql/tracing/prometheus_trace.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module Tracing
+    module PrometheusTrace
+      include PlatformTrace
+
+      def initialize(client: PrometheusExporter::Client.default, keys_whitelist: ["execute_field", "execute_field_lazy"], collector_type: "graphql", **rest)
+        @client = client
+        @keys_whitelist = keys_whitelist
+        @collector_type = collector_type
+
+        super(**rest)
+      end
+
+      {
+        'lex' => "graphql.lex",
+        'parse' => "graphql.parse",
+        'validate' => "graphql.validate",
+        'analyze_query' => "graphql.analyze",
+        'analyze_multiplex' => "graphql.analyze",
+        'execute_multiplex' => "graphql.execute",
+        'execute_query' => "graphql.execute",
+        'execute_query_lazy' => "graphql.execute",
+      }.each do |trace_method, platform_key|
+        module_eval <<-RUBY, __FILE__, __LINE__
+          def #{trace_method}(**data, &block)
+            instrument_execution("#{platform_key}", "#{trace_method}", &block)
+          end
+        RUBY
+      end
+
+      def platform_execute_field(platform_key, _data, &block)
+        instrument_execution(platform_key, "execute_field", &block)
+      end
+
+      def platform_execute_field_lazy(platform_key, _data, &block)
+        instrument_execution(platform_key, "execute_field_lazy", &block)
+      end
+
+      def platform_authorized(platform_key, &block)
+        instrument_execution(platform_key, "authorized", &block)
+      end
+
+      def platform_authorized_lazy(platform_key, &block)
+        instrument_execution(platform_key, "authorized_lazy", &block)
+      end
+
+      def platform_resolve_type(platform_key, &block)
+        instrument_execution(platform_key, "resolve_type", &block)
+      end
+
+      def platform_resolve_type_lazy(platform_key, &block)
+        instrument_execution(platform_key, "resolve_type_lazy", &block)
+      end
+
+      def platform_field_key(type, field)
+        "#{type.graphql_name}.#{field.graphql_name}"
+      end
+
+      def platform_authorized_key(type)
+        "#{type.graphql_name}.authorized"
+      end
+
+      def platform_resolve_type_key(type)
+        "#{type.graphql_name}.resolve_type"
+      end
+
+      private
+
+      def instrument_execution(platform_key, key, &block)
+        if @keys_whitelist.include?(key)
+          start = ::Process.clock_gettime ::Process::CLOCK_MONOTONIC
+          result = block.call
+          duration = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) - start
+          @client.send_json(
+            type: @collector_type,
+            duration: duration,
+            platform_key: platform_key,
+            key: key
+          )
+          result
+        else
+          yield
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/tracing/prometheus_trace.rb
+++ b/lib/graphql/tracing/prometheus_trace.rb
@@ -54,8 +54,8 @@ module GraphQL
         instrument_execution(platform_key, "resolve_type_lazy", &block)
       end
 
-      def platform_field_key(type, field)
-        "#{type.graphql_name}.#{field.graphql_name}"
+      def platform_field_key(field)
+        field.path
       end
 
       def platform_authorized_key(type)

--- a/lib/graphql/tracing/prometheus_tracing.rb
+++ b/lib/graphql/tracing/prometheus_tracing.rb
@@ -27,9 +27,9 @@ module GraphQL
         super opts
       end
 
-      def platform_trace(platform_key, key, data, &block)
+      def platform_trace(platform_key, key, _data, &block)
         return yield unless @keys_whitelist.include?(key)
-        instrument_execution(platform_key, key, data, &block)
+        instrument_execution(platform_key, key, &block)
       end
 
       def platform_field_key(type, field)
@@ -46,7 +46,7 @@ module GraphQL
 
       private
 
-      def instrument_execution(platform_key, key, data, &block)
+      def instrument_execution(platform_key, key, &block)
         start = ::Process.clock_gettime ::Process::CLOCK_MONOTONIC
         result = block.call
         duration = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) - start

--- a/lib/graphql/tracing/scout_trace.rb
+++ b/lib/graphql/tracing/scout_trace.rb
@@ -30,12 +30,12 @@ module GraphQL
         def #{trace_method}(**data)
           #{
             if trace_method == "execute_query"
-            <<-RUBY
-            set_this_txn_name = data[:query].context[:set_scout_transaction_name]
-            if set_this_txn_name == true || (set_this_txn_name.nil? && @set_transaction_name)
-              ScoutApm::Transaction.rename(transaction_name(data[:query]))
-            end
-            RUBY
+              <<-RUBY
+              set_this_txn_name = data[:query].context[:set_scout_transaction_name]
+              if set_this_txn_name == true || (set_this_txn_name.nil? && @set_transaction_name)
+                ScoutApm::Transaction.rename(transaction_name(data[:query]))
+              end
+              RUBY
             end
           }
 

--- a/lib/graphql/tracing/scout_trace.rb
+++ b/lib/graphql/tracing/scout_trace.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module Tracing
+    module ScoutTrace
+      include PlatformTrace
+
+      INSTRUMENT_OPTS = { scope: true }
+
+      # @param set_transaction_name [Boolean] If true, the GraphQL operation name will be used as the transaction name.
+      #   This is not advised if you run more than one query per HTTP request, for example, with `graphql-client` or multiplexing.
+      #   It can also be specified per-query with `context[:set_scout_transaction_name]`.
+      def initialize(set_transaction_name: false, **_rest)
+        self.class.include(ScoutApm::Tracer)
+        @set_transaction_name = set_transaction_name
+        super
+      end
+
+      {
+        "lex" => "lex.graphql",
+        "parse" => "parse.graphql",
+        "validate" => "validate.graphql",
+        "analyze_query" => "analyze.graphql",
+        "analyze_multiplex" => "analyze.graphql",
+        "execute_multiplex" => "execute.graphql",
+        "execute_query" => "execute.graphql",
+        "execute_query_lazy" => "execute.graphql",
+      }.each do |trace_method, platform_key|
+        module_eval <<-RUBY, __FILE__, __LINE__
+        def #{trace_method}(**data)
+          #{
+            if trace_method == "execute_query"
+            <<-RUBY
+            set_this_txn_name = data[:query].context[:set_scout_transaction_name]
+            if set_this_txn_name == true || (set_this_txn_name.nil? && @set_transaction_name)
+              ScoutApm::Transaction.rename(transaction_name(data[:query]))
+            end
+            RUBY
+            end
+          }
+
+          self.class.instrument("GraphQL", "#{platform_key}", INSTRUMENT_OPTS) do
+            super
+          end
+        end
+        RUBY
+      end
+
+      def platform_execute_field(platform_key, _data, &block)
+        self.class.instrument("GraphQL", platform_key, INSTRUMENT_OPTS, &block)
+      end
+
+      def platform_authorized(platform_key, &block)
+        self.class.instrument("GraphQL", platform_key, INSTRUMENT_OPTS, &block)
+      end
+
+      alias :platform_authorized_lazy :platform_authorized
+      alias :platform_resolve_type :platform_authorized
+      alias :platform_resolve_type_lazy :platform_authorized
+
+      def platform_field_key(type, field)
+        "#{type.graphql_name}.#{field.graphql_name}"
+      end
+
+      def platform_authorized_key(type)
+        "#{type.graphql_name}.authorized"
+      end
+
+      def platform_resolve_type_key(type)
+        "#{type.graphql_name}.resolve_type"
+      end
+    end
+  end
+end

--- a/lib/graphql/tracing/scout_trace.rb
+++ b/lib/graphql/tracing/scout_trace.rb
@@ -54,12 +54,10 @@ module GraphQL
         self.class.instrument("GraphQL", platform_key, INSTRUMENT_OPTS, &block)
       end
 
-      alias :platform_authorized_lazy :platform_authorized
       alias :platform_resolve_type :platform_authorized
-      alias :platform_resolve_type_lazy :platform_authorized
 
-      def platform_field_key(type, field)
-        "#{type.graphql_name}.#{field.graphql_name}"
+      def platform_field_key(field)
+        field.path
       end
 
       def platform_authorized_key(type)

--- a/lib/graphql/tracing/scout_trace.rb
+++ b/lib/graphql/tracing/scout_trace.rb
@@ -46,7 +46,7 @@ module GraphQL
         RUBY
       end
 
-      def platform_execute_field(platform_key, _data, &block)
+      def platform_execute_field(platform_key, &block)
         self.class.instrument("GraphQL", platform_key, INSTRUMENT_OPTS, &block)
       end
 

--- a/lib/graphql/tracing/statsd_trace.rb
+++ b/lib/graphql/tracing/statsd_trace.rb
@@ -30,7 +30,7 @@ module GraphQL
         RUBY
       end
 
-      def platform_execute_field(platform_key, _data, &block)
+      def platform_execute_field(platform_key, &block)
         @statsd.time(platform_key, &block)
       end
 

--- a/lib/graphql/tracing/statsd_trace.rb
+++ b/lib/graphql/tracing/statsd_trace.rb
@@ -38,12 +38,10 @@ module GraphQL
         @statsd.time(key, &block)
       end
 
-      alias :authorized_lazy :platform_authorized
       alias :platform_resolve_type :platform_authorized
-      alias :platform_resolve_type_lazy :platform_authorized
 
-      def platform_field_key(type, field)
-        "graphql.#{type.graphql_name}.#{field.graphql_name}"
+      def platform_field_key(field)
+        "graphql.#{field.path}"
       end
 
       def platform_authorized_key(type)

--- a/lib/graphql/tracing/statsd_trace.rb
+++ b/lib/graphql/tracing/statsd_trace.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module Tracing
+    module StatsdTrace
+      include PlatformTrace
+
+      # @param statsd [Object] A statsd client
+      def initialize(statsd:, **rest)
+        @statsd = statsd
+        super(**rest)
+      end
+
+      {
+        'lex' => "graphql.lex",
+        'parse' => "graphql.parse",
+        'validate' => "graphql.validate",
+        'analyze_query' => "graphql.analyze_query",
+        'analyze_multiplex' => "graphql.analyze_multiplex",
+        'execute_multiplex' => "graphql.execute_multiplex",
+        'execute_query' => "graphql.execute_query",
+        'execute_query_lazy' => "graphql.execute_query_lazy",
+      }.each do |trace_method, platform_key|
+        module_eval <<-RUBY, __FILE__, __LINE__
+          def #{trace_method}(**data)
+            @statsd.time("#{platform_key}") do
+              super
+            end
+          end
+        RUBY
+      end
+
+      def platform_execute_field(platform_key, _data, &block)
+        @statsd.time(platform_key, &block)
+      end
+
+      def platform_authorized(key, &block)
+        @statsd.time(key, &block)
+      end
+
+      alias :authorized_lazy :platform_authorized
+      alias :platform_resolve_type :platform_authorized
+      alias :platform_resolve_type_lazy :platform_authorized
+
+      def platform_field_key(type, field)
+        "graphql.#{type.graphql_name}.#{field.graphql_name}"
+      end
+
+      def platform_authorized_key(type)
+        "graphql.authorized.#{type.graphql_name}"
+      end
+
+      def platform_resolve_type_key(type)
+        "graphql.resolve_type.#{type.graphql_name}"
+      end
+    end
+  end
+end

--- a/spec/graphql/backtrace_spec.rb
+++ b/spec/graphql/backtrace_spec.rb
@@ -81,6 +81,7 @@ describe GraphQL::Backtrace do
     schema_class.class_exec {
       lazy_resolve(LazyError, :raise_err)
       query_analyzer(ErrorAnalyzer)
+      trace_class(GraphQL::Tracing::LegacyTrace)
     }
     schema_class
   }
@@ -212,6 +213,7 @@ describe GraphQL::Backtrace do
     it "raises original exception instead of a TracedError when error does not occur during resolving" do
       instrumentation_schema = Class.new(schema) do
         instrument(:query, ErrorInstrumentation)
+        trace_class(GraphQL::Tracing::LegacyTrace)
       end
 
       assert_raises(RuntimeError) {

--- a/spec/graphql/language/parser_spec.rb
+++ b/spec/graphql/language/parser_spec.rb
@@ -224,7 +224,11 @@ describe GraphQL::Language::Parser do
 
   it "serves traces" do
     TestTracing.clear
-    GraphQL.parse("{ t: __typename }", tracer: TestTracing)
+    schema = Class.new(GraphQL::Schema) do
+      tracer(TestTracing)
+    end
+    query = GraphQL::Query.new(schema, "{ t: __typename }")
+    GraphQL.parse("{ t: __typename }", trace: query.current_trace)
     traces = TestTracing.traces
     assert_equal 2, traces.length
     lex_trace, parse_trace = traces

--- a/spec/graphql/tracing/appoptics_trace_spec.rb
+++ b/spec/graphql/tracing/appoptics_trace_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Tests for appoptics_apm tracing
+#
+# if any of these tests fail, please file an issue at
+# https://github.com/appoptics/appoptics-apm-ruby
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+require 'spec_helper'
+
+describe GraphQL::Tracing::AppOpticsTrace do
+  module AppOpticsTraceTest
+    class Schema < GraphQL::Schema
+      def self.id_from_object(_object = nil, _type = nil, _context = {})
+        SecureRandom.uuid
+      end
+
+      class Address < GraphQL::Schema::Object
+        global_id_field :id
+        field :street, String
+        field :number, Integer
+      end
+
+      class Company < GraphQL::Schema::Object
+        global_id_field :id
+        field :name, String
+        field :address, Schema::Address
+
+        def address
+          OpenStruct.new(
+            id: AppOpticsTraceTest::Schema.id_from_object,
+            street: 'MyStreetName',
+            number: 'MyStreetNumber'
+          )
+        end
+      end
+
+      class Query < GraphQL::Schema::Object
+        field :int, Integer, null: false
+        def int; 1; end
+
+        field :company, Company do
+          argument :id, ID
+        end
+
+        def company(id:)
+          OpenStruct.new(
+            id: id,
+            name: 'MyName')
+        end
+      end
+
+      query Query
+      trace_with GraphQL::Tracing::AppOpticsTrace
+    end
+  end
+
+  before do
+    load 'spec/support/appoptics.rb'
+
+    $appoptics_tracing_spans = []
+    $appoptics_tracing_kvs = []
+    $appoptics_tracing_name = nil
+    AppOpticsAPM::Config[:graphql] = { :enabled => true,
+                                       :remove_comments => true,
+                                       :sanitize_query => true,
+                                       :transaction_name => true
+    }
+  end
+
+  it 'calls AppOpticsAPM::SDK.trace with names and kvs' do
+    query = 'query Query { int }'
+    AppOpticsTraceTest::Schema.execute(query)
+
+    assert_equal $appoptics_tracing_name, 'graphql.query.Query'
+    refute $appoptics_tracing_spans.find { |name| name !~ /^graphql\./ }
+    assert_equal $appoptics_tracing_kvs.compact.size, $appoptics_tracing_spans.compact.size
+    assert_equal($appoptics_tracing_kvs[0][:Spec], 'graphql')
+    assert_equal($appoptics_tracing_kvs[0][:InboundQuery], query)
+  end
+
+  it 'uses type + field keys' do
+    query = <<-QL
+    query { company(id: 1) # there is a comment here
+            { id name address
+               { street }
+            }
+          }
+   # and another one here
+   QL
+
+   AppOpticsTraceTest::Schema.execute(query)
+
+    assert_equal $appoptics_tracing_name, 'graphql.query.company'
+    refute $appoptics_tracing_spans.find { |name| name !~ /^graphql\./ }
+    assert_equal $appoptics_tracing_kvs.compact.size, $appoptics_tracing_spans.compact.size
+    assert_includes($appoptics_tracing_spans, 'graphql.Query.company')
+    assert_includes($appoptics_tracing_spans, 'graphql.Company.address')
+  end
+
+  # case: appoptics_apm didn't get required
+  it 'should not barf, when AppOpticsAPM is undefined' do
+    Object.send(:remove_const, :AppOpticsAPM)
+    query = 'query Query { int }'
+
+    begin
+      AppOpticsTraceTest::Schema.execute(query)
+    rescue StandardError => e
+      msg = e.message.split("\n").first
+      flunk "failed: It raised '#{msg}' when AppOpticsAPM is undefined."
+    end
+  end
+
+  # case: appoptics may have encountered a compile or service key problem
+  it 'should not barf, when appoptics is present but not loaded' do
+    AppOpticsAPM.stub(:loaded, false) do
+      query = 'query Query { int }'
+
+      begin
+        AppOpticsTraceTest::Schema.execute(query)
+      rescue StandardError => e
+        msg = e.message.split("\n").first
+        flunk "failed: It raised '#{msg}' when AppOpticsAPM is not loaded."
+      end
+    end
+  end
+
+  # case: using appoptics_apm < 4.12.0, without default graphql configs
+  it 'creates traces by default when it cannot find configs for graphql' do
+    AppOpticsAPM::Config.clear
+
+    query = 'query Query { int }'
+    AppOpticsTraceTest::Schema.execute(query)
+
+    refute $appoptics_tracing_spans.empty?, 'failed: no traces were created'
+  end
+
+  it 'should not create traces when disabled' do
+    AppOpticsAPM::Config[:graphql][:enabled] = false
+
+    query = 'query Query { int }'
+    AppOpticsTraceTest::Schema.execute(query)
+
+    assert $appoptics_tracing_spans.empty?, 'failed: traces were created'
+  end
+end

--- a/spec/graphql/tracing/data_dog_trace_spec.rb
+++ b/spec/graphql/tracing/data_dog_trace_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe GraphQL::Tracing::DataDogTrace do
+  module DataDogTraceTest
+    class Query < GraphQL::Schema::Object
+      include GraphQL::Types::Relay::HasNodeField
+
+      field :int, Integer, null: false
+
+      def int
+        1
+      end
+    end
+
+    class TestSchema < GraphQL::Schema
+      query(Query)
+      trace_with(GraphQL::Tracing::DataDogTrace)
+    end
+
+    class CustomTracerTestSchema < GraphQL::Schema
+      module CustomDataDogTracing
+        include GraphQL::Tracing::DataDogTrace
+        def prepare_span(trace_key, data, span)
+          span.set_tag("custom:#{trace_key}", data.keys.join(","))
+        end
+      end
+      query(Query)
+      trace_with(CustomDataDogTracing)
+    end
+  end
+
+  before do
+    Datadog.clear_all
+  end
+
+  it "falls back to a :tracing_fallback_transaction_name when provided" do
+    DataDogTraceTest::TestSchema.execute("{ int }", context: { tracing_fallback_transaction_name: "Abcd" })
+    assert_equal ["Abcd"], Datadog::SPAN_RESOURCE_NAMES
+  end
+
+  it "does not use the :tracing_fallback_transaction_name if an operation name is present" do
+    DataDogTraceTest::TestSchema.execute(
+      "query Ab { int }",
+      context: { tracing_fallback_transaction_name: "Cd" }
+    )
+    assert_equal ["Ab"], Datadog::SPAN_RESOURCE_NAMES
+  end
+
+  it "does not set resource if no value can be derived" do
+    DataDogTraceTest::TestSchema.execute("{ int }")
+    assert_equal [], Datadog::SPAN_RESOURCE_NAMES
+  end
+
+  it "sets component and operation tags" do
+    DataDogTraceTest::TestSchema.execute("{ int }")
+    assert_includes Datadog::SPAN_TAGS, ['component', 'graphql']
+    assert_includes Datadog::SPAN_TAGS, ['operation', 'execute_multiplex']
+  end
+
+  it "sets custom tags tags" do
+    DataDogTraceTest::CustomTracerTestSchema.execute("{ int }")
+    expected_custom_tags = [
+      ["custom:lex", "query_string"],
+      ["custom:parse", "query_string"],
+      ["custom:execute_multiplex", "multiplex"],
+      ["custom:analyze_multiplex", "multiplex"],
+      ["custom:validate", "validate,query"],
+      ["custom:analyze_query", "query"],
+      ["custom:execute_query", "query"],
+      ["custom:authorized", "query,type,object"],
+      ["custom:execute_query_lazy", "multiplex,query"],
+    ]
+
+    actual_custom_tags = Datadog::SPAN_TAGS.reject { |t| t[0] == "operation" || t[0] == "component" || t[0].is_a?(Symbol) }
+    assert_equal expected_custom_tags, actual_custom_tags
+  end
+end

--- a/spec/graphql/tracing/data_dog_tracing_spec.rb
+++ b/spec/graphql/tracing/data_dog_tracing_spec.rb
@@ -4,6 +4,14 @@ require "spec_helper"
 
 describe GraphQL::Tracing::DataDogTracing do
   module DataDogTest
+    class Thing < GraphQL::Schema::Object
+      field :str, String
+
+      def str
+        "blah"
+      end
+    end
+
     class Query < GraphQL::Schema::Object
       include GraphQL::Types::Relay::HasNodeField
 
@@ -11,6 +19,12 @@ describe GraphQL::Tracing::DataDogTracing do
 
       def int
         1
+      end
+
+      field :thing, Thing
+
+      def thing
+        :thing
       end
     end
 
@@ -59,7 +73,7 @@ describe GraphQL::Tracing::DataDogTracing do
   end
 
   it "sets custom tags tags" do
-    DataDogTest::CustomTracerTestSchema.execute("{ int }")
+    DataDogTest::CustomTracerTestSchema.execute("{ thing { str } }")
     expected_custom_tags = [
       ["custom:lex", "query_string"],
       ["custom:parse", "query_string"],
@@ -68,6 +82,8 @@ describe GraphQL::Tracing::DataDogTracing do
       ["custom:validate", "validate,query"],
       ["custom:analyze_query", "query"],
       ["custom:execute_query", "query"],
+      ["custom:authorized", "context,type,object,path"],
+      ["custom:execute_field", "field,query,ast_node,arguments,object,owner,path"],
       ["custom:authorized", "context,type,object,path"],
       ["custom:execute_query_lazy", "multiplex,query"],
     ]

--- a/spec/graphql/tracing/new_relic_trace_spec.rb
+++ b/spec/graphql/tracing/new_relic_trace_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::Tracing::NewRelicTrace do
+  module NewRelicTraceTest
+    class Thing < GraphQL::Schema::Object
+      implements GraphQL::Types::Relay::Node
+    end
+
+    class Query < GraphQL::Schema::Object
+      include GraphQL::Types::Relay::HasNodeField
+
+      field :int, Integer, null: false
+
+      def int
+        1
+      end
+    end
+
+    class SchemaWithoutTransactionName < GraphQL::Schema
+      query(Query)
+      trace_with(GraphQL::Tracing::NewRelicTrace)
+      orphan_types(Thing)
+
+      def self.object_from_id(_id, _ctx)
+        :thing
+      end
+
+      def self.resolve_type(_type, _obj, _ctx)
+        Thing
+      end
+    end
+
+    class SchemaWithTransactionName < GraphQL::Schema
+      query(Query)
+      trace_with(GraphQL::Tracing::NewRelicTrace, set_transaction_name: true)
+    end
+
+    class SchemaWithScalarTrace < GraphQL::Schema
+      query(Query)
+      trace_with(GraphQL::Tracing::NewRelicTrace, trace_scalars: true)
+    end
+  end
+
+  before do
+    NewRelic.clear_all
+  end
+
+  it "works with the built-in node field, even though it doesn't have an @owner" do
+    res = NewRelicTraceTest::SchemaWithoutTransactionName.execute '{ node(id: "1") { __typename } }'
+    assert_equal "Thing", res["data"]["node"]["__typename"]
+  end
+
+  it "can leave the transaction name in place" do
+    NewRelicTraceTest::SchemaWithoutTransactionName.execute "query X { int }"
+    assert_equal [], NewRelic::TRANSACTION_NAMES
+  end
+
+  it "can override the transaction name" do
+    NewRelicTraceTest::SchemaWithTransactionName.execute "query X { int }"
+    assert_equal ["GraphQL/query.X"], NewRelic::TRANSACTION_NAMES
+  end
+
+  it "can override the transaction name per query" do
+    # Override with `false`
+    NewRelicTraceTest::SchemaWithTransactionName.execute "{ int }", context: { set_new_relic_transaction_name: false }
+    assert_equal [], NewRelic::TRANSACTION_NAMES
+    # Override with `true`
+    NewRelicTraceTest::SchemaWithoutTransactionName.execute "{ int }", context: { set_new_relic_transaction_name: true }
+    assert_equal ["GraphQL/query.anonymous"], NewRelic::TRANSACTION_NAMES
+  end
+
+  it "falls back to a :tracing_fallback_transaction_name when provided" do
+    NewRelicTraceTest::SchemaWithTransactionName.execute("{ int }", context: { tracing_fallback_transaction_name: "Abcd" })
+    assert_equal ["GraphQL/query.Abcd"], NewRelic::TRANSACTION_NAMES
+  end
+
+  it "does not use the :tracing_fallback_transaction_name if an operation name is present" do
+    NewRelicTraceTest::SchemaWithTransactionName.execute(
+      "query Ab { int }",
+      context: { tracing_fallback_transaction_name: "Cd" }
+    )
+    assert_equal ["GraphQL/query.Ab"], NewRelic::TRANSACTION_NAMES
+  end
+
+  it "does not require a :tracing_fallback_transaction_name even if an operation name is not present" do
+    NewRelicTraceTest::SchemaWithTransactionName.execute("{ int }")
+    assert_equal ["GraphQL/query.anonymous"], NewRelic::TRANSACTION_NAMES
+  end
+
+  it "traces scalars when trace_scalars is true" do
+    NewRelicTraceTest::SchemaWithScalarTrace.execute "query X { int }"
+    assert_includes NewRelic::EXECUTION_SCOPES, "GraphQL/Query/int"
+  end
+end

--- a/spec/graphql/tracing/new_relic_tracing_spec.rb
+++ b/spec/graphql/tracing/new_relic_tracing_spec.rb
@@ -46,6 +46,10 @@ describe GraphQL::Tracing::NewRelicTracing do
     NewRelic.clear_all
   end
 
+  it "Actually uses the new-style trace under the hood" do
+    assert NewRelicTest::SchemaWithoutTransactionName.trace_class < GraphQL::Tracing::NewRelicTrace
+  end
+
   it "works with the built-in node field, even though it doesn't have an @owner" do
     res = NewRelicTest::SchemaWithoutTransactionName.execute '{ node(id: "1") { __typename } }'
     assert_equal "Thing", res["data"]["node"]["__typename"]

--- a/spec/graphql/tracing/notifications_trace_spec.rb
+++ b/spec/graphql/tracing/notifications_trace_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe GraphQL::Tracing::NotificationsTrace do
+  module NotificationsTraceTest
+    class Query < GraphQL::Schema::Object
+      field :int, Integer, null: false
+
+      def int
+        1
+      end
+    end
+
+    class Schema < GraphQL::Schema
+      query Query
+    end
+  end
+
+  describe "Observing" do
+    it "dispatchs the event to the notifications engine with suffixed key" do
+      dispatched_events = trigger_fake_notifications_tracer(NotificationsTraceTest::Schema)
+
+      assert dispatched_events.length > 0
+
+      dispatched_events.each do |event, payload|
+        assert event.end_with?(".graphql")
+        assert payload.is_a?(Hash)
+      end
+    end
+  end
+
+  def trigger_fake_notifications_tracer(schema)
+    dispatched_events = []
+    engine = Object.new
+
+    engine.define_singleton_method(:instrument) do |event, payload, &blk|
+      dispatched_events << [event, payload]
+      blk.call if blk
+    end
+
+    schema.trace_with GraphQL::Tracing::NotificationsTrace, engine: engine
+    schema.execute "query X { int }"
+
+    dispatched_events
+  end
+end

--- a/spec/graphql/tracing/platform_trace_spec.rb
+++ b/spec/graphql/tracing/platform_trace_spec.rb
@@ -112,7 +112,7 @@ describe GraphQL::Tracing::PlatformTrace do
 
     it "traces resolve_type and differentiates field calls on different types" do
       scalar_schema = Class.new(Dummy::Schema) { trace_with(CustomPlatformTrace, trace_scalars: true) }
-      scalar_schema.execute(" { allEdible { __typename origin } }")
+      scalar_schema.execute(" { allEdible { __typename fatContent } }")
       expected_trace = [
           "em",
           "am",
@@ -133,24 +133,24 @@ describe GraphQL::Tracing::PlatformTrace do
           "Cheese.authorized",
           "DynamicFields.authorized",
           "D._",
-          "C.o",
+          "C.f",
           "Edible.resolve_type",
           "Cheese.authorized",
           "Cheese.authorized",
           "DynamicFields.authorized",
           "D._",
-          "C.o",
+          "C.f",
           "Edible.resolve_type",
           "Cheese.authorized",
           "Cheese.authorized",
           "DynamicFields.authorized",
           "D._",
-          "C.o",
+          "C.f",
           "Edible.resolve_type",
           "Milk.authorized",
           "DynamicFields.authorized",
           "D._",
-          "M.o",
+          "E.f",
         ]
 
       assert_equal expected_trace, CustomPlatformTrace::TRACE

--- a/spec/graphql/tracing/platform_trace_spec.rb
+++ b/spec/graphql/tracing/platform_trace_spec.rb
@@ -32,7 +32,7 @@ describe GraphQL::Tracing::PlatformTrace do
       yield
     end
 
-    def platform_execute_field(platform_key, data)
+    def platform_execute_field(platform_key)
       TRACE << platform_key
       yield
     end

--- a/spec/graphql/tracing/platform_trace_spec.rb
+++ b/spec/graphql/tracing/platform_trace_spec.rb
@@ -1,0 +1,222 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::Tracing::PlatformTrace do
+  module CustomPlatformTrace
+    include GraphQL::Tracing::PlatformTrace
+    TRACE = []
+
+    {
+      "lex" => "l",
+      "parse" => "p",
+      "validate" => "v",
+      "analyze_query" => "aq",
+      "analyze_multiplex" => "am",
+      "execute_multiplex" => "em",
+      "execute_query" => "eq",
+      "execute_query_lazy" => "eql",
+    }.each do |method_name, trace_key|
+      define_method(method_name) do |**data, &block|
+        TRACE << trace_key
+        block.call
+      end
+    end
+
+    def platform_authorized(platform_key)
+      TRACE << platform_key
+      yield
+    end
+
+    def platform_resolve_type(platform_key)
+      TRACE << platform_key
+      yield
+    end
+
+    def platform_execute_field(platform_key, data)
+      TRACE << platform_key
+      yield
+    end
+
+    def platform_field_key(field)
+      "#{field.owner.graphql_name[0]}.#{field.graphql_name[0]}"
+    end
+
+    def platform_authorized_key(type)
+      "#{type.graphql_name}.authorized"
+    end
+
+    def platform_resolve_type_key(type)
+      "#{type.graphql_name}.resolve_type"
+    end
+  end
+
+  describe "calling a platform tracer" do
+    let(:schema) {
+      Class.new(Dummy::Schema) { trace_with(CustomPlatformTrace) }
+    }
+
+    before do
+      CustomPlatformTrace::TRACE.clear
+    end
+
+    it "runs the introspection query (handles late-bound types)" do
+      assert schema.execute(GraphQL::Introspection::INTROSPECTION_QUERY)
+    end
+
+    it "calls the platform's own method with its own keys" do
+      schema.execute(" { cheese(id: 1) { flavor } }")
+      expected_trace = [
+          "em",
+          "am",
+          "l",
+          "p",
+          "v",
+          "aq",
+          "eq",
+          "Query.authorized",
+          "Q.c", # notice that the flavor is skipped
+          "Cheese.authorized",
+          "eql",
+          "Cheese.authorized", # This is the lazy part, calling the proc
+        ]
+
+      assert_equal expected_trace, CustomPlatformTrace::TRACE
+    end
+
+    it "traces during Query#result" do
+      query_str = "{ cheese(id: 1) { flavor } }"
+      expected_trace = [
+        # This is from the extra validation
+        "v",
+        "em",
+        "am",
+        "l",
+        "p",
+        "v",
+        "aq",
+        "eq",
+        "Query.authorized",
+        "Q.c", # notice that the flavor is skipped
+        "Cheese.authorized",
+        "eql",
+        "Cheese.authorized", # This is the lazy part, calling the proc
+      ]
+
+      query = GraphQL::Query.new(schema, query_str)
+      # First, validate
+      schema.validate(query.query_string)
+      # Then execute
+      query.result
+      assert_equal expected_trace, CustomPlatformTrace::TRACE
+    end
+
+    it "traces resolve_type and differentiates field calls on different types" do
+      scalar_schema = Class.new(Dummy::Schema) { trace_with(CustomPlatformTrace, trace_scalars: true) }
+      scalar_schema.execute(" { allEdible { __typename origin } }")
+      expected_trace = [
+          "em",
+          "am",
+          "l",
+          "p",
+          "v",
+          "aq",
+          "eq",
+          "Query.authorized",
+          "Q.a",
+          "Edible.resolve_type",
+          "Edible.resolve_type",
+          "Edible.resolve_type",
+          "Edible.resolve_type",
+          "eql",
+          "Edible.resolve_type",
+          "Cheese.authorized",
+          "Cheese.authorized",
+          "DynamicFields.authorized",
+          "D._",
+          "C.o",
+          "Edible.resolve_type",
+          "Cheese.authorized",
+          "Cheese.authorized",
+          "DynamicFields.authorized",
+          "D._",
+          "C.o",
+          "Edible.resolve_type",
+          "Cheese.authorized",
+          "Cheese.authorized",
+          "DynamicFields.authorized",
+          "D._",
+          "C.o",
+          "Edible.resolve_type",
+          "Milk.authorized",
+          "DynamicFields.authorized",
+          "D._",
+          "M.o",
+        ]
+
+      assert_equal expected_trace, CustomPlatformTrace::TRACE
+    end
+  end
+
+  describe "by default, scalar fields are not traced" do
+    let(:schema) {
+      Class.new(Dummy::Schema) {
+        trace_with(CustomPlatformTrace)
+      }
+    }
+
+    before do
+      CustomPlatformTrace::TRACE.clear
+    end
+
+    it "only traces traceTrue, not traceFalse or traceNil" do
+      schema.execute(" { tracingScalar { traceNil traceFalse traceTrue } }")
+      expected_trace = [
+          "em",
+          "am",
+          "l",
+          "p",
+          "v",
+          "aq",
+          "eq",
+          "Query.authorized",
+          "Q.t",
+          "TracingScalar.authorized",
+          "T.t",
+          "eql",
+        ]
+      assert_equal expected_trace, CustomPlatformTrace::TRACE
+    end
+  end
+
+  describe "when scalar fields are traced by default, they are unless specified" do
+    let(:schema) {
+      Class.new(Dummy::Schema) do
+        trace_with(CustomPlatformTrace, trace_scalars: true)
+      end
+    }
+
+    before do
+      CustomPlatformTrace::TRACE.clear
+    end
+
+    it "traces traceTrue and traceNil but not traceFalse" do
+      schema.execute(" { tracingScalar { traceNil traceFalse traceTrue } }")
+      expected_trace = [
+          "em",
+          "am",
+          "l",
+          "p",
+          "v",
+          "aq",
+          "eq",
+          "Query.authorized",
+          "Q.t",
+          "TracingScalar.authorized",
+          "T.t",
+          "T.t",
+          "eql",
+        ]
+      assert_equal expected_trace, CustomPlatformTrace::TRACE
+    end
+  end
+end

--- a/spec/graphql/tracing/platform_tracing_spec.rb
+++ b/spec/graphql/tracing/platform_tracing_spec.rb
@@ -116,7 +116,6 @@ describe GraphQL::Tracing::PlatformTracing do
       assert_equal expected_trace, CustomPlatformTracer::TRACE
     end
 
-    focus
     it "traces resolve_type and differentiates field calls on different types" do
       scalar_schema = Class.new(Dummy::Schema) { use(CustomPlatformTracer, trace_scalars: true) }
 

--- a/spec/graphql/tracing/platform_tracing_spec.rb
+++ b/spec/graphql/tracing/platform_tracing_spec.rb
@@ -115,6 +115,54 @@ describe GraphQL::Tracing::PlatformTracing do
 
       assert_equal expected_trace, CustomPlatformTracer::TRACE
     end
+
+    focus
+    it "traces resolve_type and differentiates field calls on different types" do
+      scalar_schema = Class.new(Dummy::Schema) { use(CustomPlatformTracer, trace_scalars: true) }
+
+      scalar_schema.execute(" { allEdible { __typename fatContent } }")
+      expected_trace = [
+        "em",
+        "am",
+        "l",
+        "p",
+        "v",
+        "aq",
+        "eq",
+        "Query.authorized",
+        "Q.a",
+        "Edible.resolve_type",
+        "Edible.resolve_type",
+        "Edible.resolve_type",
+        "Edible.resolve_type",
+        "eql",
+        "Edible.resolve_type",
+        "Cheese.authorized",
+        "Cheese.authorized",
+        "DynamicFields.authorized",
+        "D._",
+        "C.f",
+        "Edible.resolve_type",
+        "Cheese.authorized",
+        "Cheese.authorized",
+        "DynamicFields.authorized",
+        "D._",
+        "C.f",
+        "Edible.resolve_type",
+        "Cheese.authorized",
+        "Cheese.authorized",
+        "DynamicFields.authorized",
+        "D._",
+        "C.f",
+        "Edible.resolve_type",
+        "Milk.authorized",
+        "DynamicFields.authorized",
+        "D._",
+        "E.f",
+      ]
+
+      assert_equal expected_trace, CustomPlatformTracer::TRACE
+    end
   end
 
   describe "by default, scalar fields are not traced" do

--- a/spec/graphql/tracing/prometheus_trace_spec.rb
+++ b/spec/graphql/tracing/prometheus_trace_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe GraphQL::Tracing::PrometheusTracing do
+  module PrometheusTraceTest
+    class Query < GraphQL::Schema::Object
+      field :int, Integer, null: false
+
+      def int
+        1
+      end
+    end
+
+    class Schema < GraphQL::Schema
+      query Query
+
+    end
+  end
+
+  describe "Observing" do
+    it "sends JSON to Prometheus client" do
+      client = Minitest::Mock.new
+
+      client.expect :send_json, true do |obj|
+        obj[:type] == 'graphql' &&
+          obj[:key] == 'execute_field' &&
+          obj[:platform_key] == 'Query.int'
+      end
+
+      PrometheusTraceTest::Schema.trace_with GraphQL::Tracing::PrometheusTrace,
+        client: client,
+        trace_scalars: true
+
+        PrometheusTraceTest::Schema.execute "query X { int }"
+    end
+  end
+end

--- a/spec/graphql/tracing/scout_trace_spec.rb
+++ b/spec/graphql/tracing/scout_trace_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe GraphQL::Tracing::ScoutTrace do
+  module ScoutApmTraceTest
+    class Query < GraphQL::Schema::Object
+      include GraphQL::Types::Relay::HasNodeField
+
+      field :int, Integer, null: false
+
+      def int
+        1
+      end
+    end
+
+    class ScoutSchemaBase < GraphQL::Schema
+      query(Query)
+    end
+
+    class SchemaWithoutTransactionName < ScoutSchemaBase
+      trace_with GraphQL::Tracing::ScoutTrace
+    end
+
+    class SchemaWithTransactionName < ScoutSchemaBase
+      trace_with GraphQL::Tracing::ScoutTrace, set_transaction_name: true
+    end
+  end
+
+  before do
+    ScoutApm.clear_all
+  end
+
+  it "can leave the transaction name in place" do
+    ScoutApmTraceTest::SchemaWithoutTransactionName.execute "query X { int }"
+    assert_equal [], ScoutApm::TRANSACTION_NAMES
+  end
+
+  it "can override the transaction name" do
+    ScoutApmTraceTest::SchemaWithTransactionName.execute "query X { int }"
+    assert_equal ["GraphQL/query.X"], ScoutApm::TRANSACTION_NAMES
+  end
+
+  it "can override the transaction name per query" do
+    # Override with `false`
+    ScoutApmTraceTest::SchemaWithTransactionName.execute "{ int }", context: { set_scout_transaction_name: false }
+    assert_equal [], ScoutApm::TRANSACTION_NAMES
+    # Override with `true`
+    ScoutApmTraceTest::SchemaWithoutTransactionName.execute "{ int }", context: { set_scout_transaction_name: true }
+    assert_equal ["GraphQL/query.anonymous"], ScoutApm::TRANSACTION_NAMES
+  end
+end

--- a/spec/graphql/tracing/statsd_trace_spec.rb
+++ b/spec/graphql/tracing/statsd_trace_spec.rb
@@ -19,7 +19,7 @@ describe GraphQL::Tracing::StatsdTracing do
     end
   end
 
-  class StatsdTestSchema < GraphQL::Schema
+  class StatsdTraceTestSchema < GraphQL::Schema
     class Thing < GraphQL::Schema::Object
       field :str, String
       def str; "blah"; end
@@ -38,7 +38,7 @@ describe GraphQL::Tracing::StatsdTracing do
 
     query(Query)
 
-    use GraphQL::Tracing::StatsdTracing, statsd: MockStatsd
+    trace_with GraphQL::Tracing::StatsdTrace, statsd: MockStatsd
   end
 
   before do
@@ -46,7 +46,7 @@ describe GraphQL::Tracing::StatsdTracing do
   end
 
   it "gathers timings" do
-    StatsdTestSchema.execute("query X { int thing { str } }")
+    StatsdTraceTestSchema.execute("query X { int thing { str } }")
     expected_timings = [
       "graphql.execute_multiplex",
       "graphql.analyze_multiplex",

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -517,6 +517,7 @@ module Dummy
     subscription Subscription
     max_depth 5
     orphan_types Honey, Beverage
+    trace_class GraphQL::Tracing::LegacyTrace
 
     rescue_from(NoSuchDairyError) { |err| raise GraphQL::ExecutionError, err.message  }
 


### PR DESCRIPTION
Implements #4313 


When tracing _only_ `Hash`es: 

```diff
- Total allocated: 5732040 bytes (28113 objects)
+ Total allocated: 3882696 bytes (17105 objects)
```

<details>
<summary>Remaining Hash allocations after this change, just FYI</summary>

<p>

```
      4010  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:114
      4001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:265
      4001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/member/has_arguments.rb:286
      3001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema/field.rb:808
      1001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:41
      1001  /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:65
```

</p>

</details>

TODO: 

- [x] Make each schema class have its own tracer class that inherits from its superclass's tracer class 
  - [x] Add behaviors via modules ... dsl? `tracer_module(...)`? 
  - ~~How to keep options separate between modules?~~ punt
- [x] update tests to use this new API 
- [x] build a compatibility layer that calls old-style tracing (strings) from a new-style tracing object 
- [x] Update the built-in tracers
- ~~Decide if/how to handle `backtrace: true`~~ punt
- [x] Make sure it works with `shopify/graphql-metrics`
- [x] Update the docs