### PR TITLE
Ensure correct hasNextPage Value When Relation is Already Loaded

### DIFF
--- a/lib/graphql/pagination/active_record_relation_connection.rb
+++ b/lib/graphql/pagination/active_record_relation_connection.rb
@@ -7,14 +7,6 @@ module GraphQL
     class ActiveRecordRelationConnection < Pagination::RelationConnection
       private
 
-      def relation_larger_than(relation, initial_offset, size)
-        if already_loaded?(relation)
-          (relation.size + initial_offset) > size
-        else
-          set_offset(sliced_nodes, initial_offset + size).exists?
-        end
-      end
-
       def relation_count(relation)
         int_or_hash = if already_loaded?(relation)
           relation.size

--- a/spec/integration/rails/graphql/relay/relation_connection_spec.rb
+++ b/spec/integration/rails/graphql/relay/relation_connection_spec.rb
@@ -102,7 +102,7 @@ describe "GraphQL::Relay::RelationConnection" do
 
       log_entries = log.split("\n")
       assert_equal 1, log_entries.size, "It should run 1 sql query"
-      edges_query, has_next_page_query = log_entries
+      edges_query, = log_entries.first
       assert_includes edges_query, "ORDER BY bases.name", "The query for edges _is_ ordered"
     end
 

--- a/spec/integration/rails/graphql/relay/relation_connection_spec.rb
+++ b/spec/integration/rails/graphql/relay/relation_connection_spec.rb
@@ -70,7 +70,7 @@ describe "GraphQL::Relay::RelationConnection" do
       first_page_result = star_wars_query(query_string, { "first" => 2})
       assert_equal(true, get_page_info(first_page_result)["hasNextPage"])
 
-      result = star_wars_query(query_string, { "first" => 2, after: get_page_info(first_page_result)["endCursor"] })
+      result = star_wars_query(query_string, { "first" => 2, "after" =>  get_page_info(first_page_result)["endCursor"] })
       assert_equal(false, get_page_info(result)["hasNextPage"])
     end
 

--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -173,7 +173,10 @@ module StarWars
       if complex_order
         all_bases = all_bases.order("bases.name DESC")
       end
-      all_bases
+
+      # Emulates ActiveRecord::Base.connected_to(role: :reading) do
+      # https://github.com/rails/rails/blob/d18fc329993df5a583ef721330cffb248ef9a213/activerecord/lib/active_record/connection_handling.rb#L355
+      all_bases.load
     end
 
     field :bases_clone, BaseConnection


### PR DESCRIPTION
This PR removes the overridden `ActiveRecordRelationConnection#relation_larger_than` method. The overridden method was flawed as demonstrated by the test case on this PR and the parent class implementation appears to return the correct result. 

Note that some of the timing related tests are failing for me (but some of them fail on `master` as well?). It may be that my change introduces additional queries since the some of the prior work done in this area was to [address performance](https://github.com/rmosolgo/graphql-ruby/issues/2695). That said, correctness comes first. There is probably a better fix for this issue but I am unfamiliar with the code base 😅. Please let me know if this commit would introduce additional issues. 

See Issue #4337 