### PR TITLE
Add `leaf?` distinction to TypeKind

### DIFF
--- a/lib/graphql/type_kinds.rb
+++ b/lib/graphql/type_kinds.rb
@@ -5,12 +5,13 @@ module GraphQL
     # These objects are singletons, eg `GraphQL::TypeKinds::UNION`, `GraphQL::TypeKinds::SCALAR`.
     class TypeKind
       attr_reader :name, :description
-      def initialize(name, abstract: false, fields: false, wraps: false, input: false, description: nil)
+      def initialize(name, abstract: false, leaf: false, fields: false, wraps: false, input: false, description: nil)
         @name = name
         @abstract = abstract
         @fields = fields
         @wraps = wraps
         @input = input
+        @leaf = leaf
         @composite = fields? || abstract?
         @description = description
       end
@@ -27,6 +28,8 @@ module GraphQL
       # Is this TypeKind a valid query input?
       def input?;     @input;     end
       def to_s;       @name;      end
+      # Is this TypeKind a primitive value?
+      def leaf?; @leaf; end
       # Is this TypeKind composed of many values?
       def composite?; @composite; end
 
@@ -64,11 +67,11 @@ module GraphQL
     end
 
     TYPE_KINDS = [
-      SCALAR =        TypeKind.new("SCALAR", input: true, description: 'Indicates this type is a scalar.'),
+      SCALAR =        TypeKind.new("SCALAR", input: true, leaf: true, description: 'Indicates this type is a scalar.'),
       OBJECT =        TypeKind.new("OBJECT", fields: true, description: 'Indicates this type is an object. `fields` and `interfaces` are valid fields.'),
       INTERFACE =     TypeKind.new("INTERFACE", abstract: true, fields: true, description: 'Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.'),
       UNION =         TypeKind.new("UNION", abstract: true, description: 'Indicates this type is a union. `possibleTypes` is a valid field.'),
-      ENUM =          TypeKind.new("ENUM", input: true, description: 'Indicates this type is an enum. `enumValues` is a valid field.'),
+      ENUM =          TypeKind.new("ENUM", input: true, leaf: true, description: 'Indicates this type is an enum. `enumValues` is a valid field.'),
       INPUT_OBJECT =  TypeKind.new("INPUT_OBJECT", input: true, description: 'Indicates this type is an input object. `inputFields` is a valid field.'),
       LIST =          TypeKind.new("LIST", wraps: true, description: 'Indicates this type is a list. `ofType` is a valid field.'),
       NON_NULL =      TypeKind.new("NON_NULL", wraps: true, description: 'Indicates this type is a non-null. `ofType` is a valid field.'),

--- a/spec/graphql/type_kinds/type_kind_spec.rb
+++ b/spec/graphql/type_kinds/type_kind_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+describe GraphQL::TypeKinds::TypeKind do
+  describe ".leaf?" do
+    it "is true for enums and scalars, but false for others" do
+      assert GraphQL::Schema::Scalar.kind.leaf?
+      assert GraphQL::Schema::Enum.kind.leaf?
+      refute GraphQL::Schema::Object.kind.leaf?
+      refute GraphQL::Schema::Interface.kind.leaf?
+      refute GraphQL::Schema::Union.kind.leaf?
+      refute GraphQL::Schema::InputObject.kind.leaf?
+    end
+  end
+end

--- a/spec/graphql/type_kinds/type_kind_spec.rb
+++ b/spec/graphql/type_kinds/type_kind_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe GraphQL::TypeKinds::TypeKind do


### PR DESCRIPTION
### What

In this PR, I'd propose formalizing a proper `leaf?` distinction on TypeKind. 

### Why?

At present, `TypeKind` provides a `fields?` distinction (Object + Interface) that is a bit awkward because it slices across both Composite and Leaf distinctions...

- `fields?` != `Composite`, because it omits Union.
- `!fields?` != `Leaf`, because it _includes_ Union, which is not a Leaf.

**This ambiguity leads to awkward situations:**

- https://github.com/rmosolgo/graphql-ruby/pull/4347 should really be checking `.leaf?` rather than `!fields?`.
- https://github.com/rmosolgo/graphql-ruby/issues/4351 stems from ambiguity with the `fields?` distinction (spec validation should be checking `composite?`).
- As a library author, I currently need [my own helper](https://github.com/gmac/graphql-stitching-ruby/blob/main/lib/graphql/stitching/util.rb#L59-L61) to correctly assess the Leaf distinction. 