### PR TITLE
Prevent race in ActionCableLink

### DIFF
--- a/javascript_client/src/subscriptions/ActionCableLink.ts
+++ b/javascript_client/src/subscriptions/ActionCableLink.ts
@@ -34,7 +34,7 @@ class ActionCableLink extends ApolloLink {
         channelId: channelId
       }, connectionParams), {
         connected: function() {
-          channel.perform(
+          this.perform(
             actionName,
             {
               query: operation.query ? print(operation.query) : null,


### PR DESCRIPTION
`channel` can still be `null` when the connected event fires. Use `this` instead, which is correctly set.