### PR TITLE
Assert Warden shape is consistent in tests

### DIFF
--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -96,6 +96,13 @@ module GraphQL
         @subscription = @schema.subscription
         @context = context
         @visibility_cache = read_through { |m| filter.call(m, context) }
+        # Initialize all ivars to improve object shape consistency:
+        @types = @visible_types = @reachable_types = @visible_parent_fields =
+          @visible_possible_types = @visible_fields = @visible_arguments = @visible_enum_arrays =
+          @visible_enum_values = @visible_interfaces = @type_visibility = @type_memberships =
+          @visible_and_reachable_type = @unions = @unfiltered_interfaces = @references_to =
+          @reachable_type_set =
+            nil
       end
 
       # @return [Hash<String, GraphQL::BaseType>] Visible types in the schema
@@ -347,7 +354,7 @@ module GraphQL
       end
 
       def reachable_type_set
-        return @reachable_type_set if defined?(@reachable_type_set)
+        return @reachable_type_set if @reachable_type_set
 
         @reachable_type_set = Set.new
         rt_hash = {}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,7 +42,7 @@ ERR
     end
   end
 
-  def prepare_ast(*args, **kwargs, &block)
+  def prepare_ast
     super
     setup_finalizer
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,14 +42,9 @@ ERR
     end
   end
 
-  def result(*args, **kwargs, &block)
-    setup_finalizer
+  def prepare_ast(*args, **kwargs, &block)
     super
-  end
-
-  def result=(*args, **kwargs, &block)
     setup_finalizer
-    super
   end
 
   private

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,49 @@ Minitest::Reporters.use! Minitest::Reporters::DefaultReporter.new(color: true)
 
 Minitest::Spec.make_my_diffs_pretty!
 
+module CheckWardenShape
+  DEFAULT_SHAPE = GraphQL::Schema::Warden.new(nil, context: {}, schema: GraphQL::Schema).instance_variables
+
+  class CheckShape
+    def initialize(warden)
+      @warden = warden
+    end
+
+    def call(_obj_id)
+      ivars = @warden.instance_variables
+      if ivars != DEFAULT_SHAPE
+        raise <<-ERR
+Object Shape Failed (#{@warden.class}):
+  - Expected: #{DEFAULT_SHAPE.inspect}
+  - Actual: #{ivars.inspect}
+ERR
+      # else # To make sure it's running properly:
+      #   puts "OK Warden #{@warden.object_id}"
+      end
+    end
+  end
+
+  def result(*args, **kwargs, &block)
+    setup_finalizer
+    super
+  end
+
+  def result=(*args, **kwargs, &block)
+    setup_finalizer
+    super
+  end
+
+  private
+
+  def setup_finalizer
+    if !@finalizer_defined
+      @finalizer_defined = true
+      ObjectSpace.define_finalizer(self, CheckShape.new(warden))
+    end
+  end
+end
+
+GraphQL::Query.prepend(CheckWardenShape)
 # Filter out Minitest backtrace while allowing backtrace from other libraries
 # to be shown.
 Minitest.backtrace_filter = Minitest::BacktraceFilter.new


### PR DESCRIPTION
Part of #4299 

This makes tests fail when a Warden is detected with an inconsistent shape, for example:

```
/Users/rmosolgo/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/rake-12.3.3/lib/rake/rake_test_loader.rb: warning: Exception in finalizer #<CheckWardenShape::CheckShape:0x00000001050e6d60 @warden=#<GraphQL::Schema::Warden:0x00000001042fba48 @schema=#<Class:0x000000010549de90>, @query=#<Class:0x000000010549e2f0>, @mutation=nil, @subscription=nil, @context=#<Query::Context ...>, @visibility_cache={GraphQL::Schema::Directive::Include=>true, GraphQL::Schema::Directive::Skip=>true, GraphQL::Schema::Directive::Deprecated=>true, GraphQL::Schema::Directive::OneOf=>true, #<GraphQL::Schema::Field Query.foo(...): Int>=>true, GraphQL::Types::Int=>true, #<Class:0x000000010549e2f0>=>true, #<GraphQL::Schema::Argument Query.foo.id: [ID]>=>true, GraphQL::Types::ID=>true}, @reachable_type_set=nil, @unfiltered_interfaces=nil, @unions=nil, @visible_and_reachable_type={GraphQL::Types::Int=>true, GraphQL::Types::ID=>true}, @type_memberships=nil, @type_visibility={GraphQL::Types::Int=>true, GraphQL::Types::ID=>true}, @visible_interfaces=nil, @visible_enum_values=nil, @visible_enum_arrays=nil, @visible_arguments={#<GraphQL::Schema::Field Query.foo(...): Int>=>[#<GraphQL::Schema::Argument Query.foo.id: [ID]>]}, @visible_fields=nil, @visible_possible_types=nil, @visible_parent_fields={#<Class:0x000000010549e2f0>=>{"foo"=>#<GraphQL::Schema::Field Query.foo(...): Int>}}, @reachable_types=nil, @visible_types=nil, @types=nil, @references_to={"Boolean"=>[#<GraphQL::Schema::Argument @include.if: Boolean! @description="Included when true.">, #<GraphQL::Schema::Argument @skip.if: Boolean! @description="Skipped when true.">, #<GraphQL::Schema::Argument @include.if: Boolean! @description="Included when true.">, #<GraphQL::Schema::Argument @skip.if: Boolean! @description="Skipped when true.">], "String"=>[#<GraphQL::Schema::Argument @deprecated.reason: String @description="Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted in [Markdown](https://daringfireball.net/projects/markdown/).">, #<GraphQL::Schema::Argument @deprecated.reason: String @description="Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted in [Markdown](https://daringfireball.net/projects/markdown/).">], "Int"=>[#<GraphQL::Schema::Field Query.foo(...): Int>], "ID"=>[#<GraphQL::Schema::Argument Query.foo.id: [ID]>]}>>
/Users/rmosolgo/code/graphql-ruby/spec/spec_helper.rb:34:in `call': Object Shape Failed (GraphQL::Schema::Warden): (RuntimeError)
  - Expected: [:@schema, :@query, :@mutation, :@subscription, :@context, :@visibility_cache, :@reachable_type_set, :@unfiltered_interfaces, :@unions, :@visible_and_reachable_type, :@type_memberships, :@type_visibility, :@visible_interfaces, :@visible_enum_values, :@visible_enum_arrays, :@visible_arguments, :@visible_fields, :@visible_possible_types, :@visible_parent_fields, :@reachable_types, :@visible_types, :@types]
  - Actual: [:@schema, :@query, :@mutation, :@subscription, :@context, :@visibility_cache, :@reachable_type_set, :@unfiltered_interfaces, :@unions, :@visible_and_reachable_type, :@type_memberships, :@type_visibility, :@visible_interfaces, :@visible_enum_values, :@visible_enum_arrays, :@visible_arguments, :@visible_fields, :@visible_possible_types, :@visible_parent_fields, :@reachable_types, :@visible_types, :@types, :@references_to]
```