### PR TITLE
Add a test and improve Object type shape

### DIFF
--- a/lib/graphql/schema/member/base_dsl_methods.rb
+++ b/lib/graphql/schema/member/base_dsl_methods.rb
@@ -46,7 +46,7 @@ module GraphQL
           elsif defined?(@description)
             @description
           else
-            nil
+            @description = nil
           end
         end
 
@@ -56,8 +56,13 @@ module GraphQL
           def inherited(child_class)
             child_class.introspection(introspection)
             child_class.description(description)
+            child_class.default_graphql_name = nil
+            child_class.default_relay = false
+
             if defined?(@graphql_name) && (self.name.nil? || graphql_name != default_graphql_name)
               child_class.graphql_name(graphql_name)
+            else
+              child_class.graphql_name = nil
             end
             super
           end
@@ -111,14 +116,7 @@ module GraphQL
 
         protected
 
-        attr_writer :default_graphql_name
-
-        private
-
-        def inherited(subclass)
-          super
-          subclass.default_graphql_name = nil
-        end
+        attr_writer :default_graphql_name, :graphql_name, :default_relay
       end
     end
   end

--- a/lib/graphql/schema/member/has_ast_node.rb
+++ b/lib/graphql/schema/member/has_ast_node.rb
@@ -3,6 +3,16 @@ module GraphQL
   class Schema
     class Member
       module HasAstNode
+        def self.extended(child_cls)
+          super
+          child_cls.ast_node = nil
+        end
+
+        def inherited(child_cls)
+          super
+          child_cls.ast_node = nil
+        end
+
         # If this schema was parsed from a `.graphql` file (or other SDL),
         # this is the AST node that defined this part of the schema.
         def ast_node(new_ast_node = nil)
@@ -14,6 +24,8 @@ module GraphQL
             nil
           end
         end
+
+        attr_writer :ast_node
       end
     end
   end

--- a/lib/graphql/schema/member/has_directives.rb
+++ b/lib/graphql/schema/member/has_directives.rb
@@ -4,6 +4,16 @@ module GraphQL
   class Schema
     class Member
       module HasDirectives
+        def self.extended(child_cls)
+          super
+          child_cls.module_eval { self.own_directives = nil }
+        end
+
+        def inherited(child_cls)
+          super
+          child_cls.own_directives = nil
+        end
+
         # Create an instance of `dir_class` for `self`, using `options`.
         #
         # It removes a previously-attached instance of `dir_class`, if there is one.
@@ -101,12 +111,9 @@ module GraphQL
           end
         end
 
-
         protected
 
-        def own_directives
-          @own_directives
-        end
+        attr_accessor :own_directives
       end
     end
   end

--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -133,6 +133,7 @@ module GraphQL
           super
           subclass.class_eval do
             @own_fields ||= nil
+            @field_class ||= nil
           end
         end
 

--- a/lib/graphql/schema/member/relay_shortcuts.rb
+++ b/lib/graphql/schema/member/relay_shortcuts.rb
@@ -58,6 +58,14 @@ module GraphQL
           end
         end
 
+        def inherited(child_class)
+          super
+          child_class.connection_type = nil
+          child_class.edge_type = nil
+          child_class.connection_type_class = nil
+          child_class.edge_type_class = nil
+        end
+
         protected
 
         def configured_connection_type_class
@@ -67,6 +75,8 @@ module GraphQL
         def configured_edge_type_class
           @edge_type_class
         end
+
+        attr_writer :edge_type, :connection_type, :connection_type_class, :edge_type_class
       end
     end
   end

--- a/lib/graphql/schema/member/type_system_helpers.rb
+++ b/lib/graphql/schema/member/type_system_helpers.rb
@@ -43,11 +43,11 @@ module GraphQL
         private
 
         def inherited(subclass)
-          super
           subclass.class_eval do
             @to_non_null_type ||= nil
             @to_list_type ||= nil
           end
+          super
         end
       end
     end

--- a/lib/graphql/types/relay/connection_behaviors.rb
+++ b/lib/graphql/types/relay/connection_behaviors.rb
@@ -15,10 +15,26 @@ module GraphQL
           child_class.node_nullable(true)
           child_class.edges_nullable(true)
           child_class.edge_nullable(true)
+          child_class.module_eval {
+            self.edge_type = nil
+            self.node_type = nil
+            self.edge_class = nil
+          }
           add_page_info_field(child_class)
         end
 
         module ClassMethods
+          def inherited(child_class)
+            super
+            child_class.has_nodes_field(has_nodes_field)
+            child_class.node_nullable(node_nullable)
+            child_class.edges_nullable(edges_nullable)
+            child_class.edge_nullable(edge_nullable)
+            child_class.edge_type = nil
+            child_class.node_type = nil
+            child_class.edge_class = nil
+          end
+
           # @return [Class]
           attr_reader :node_type
 
@@ -123,6 +139,10 @@ module GraphQL
               @nodes_field = new_value
             end
           end
+
+          protected
+
+          attr_writer :edge_type, :node_type,  :edge_class
 
           private
 

--- a/lib/graphql/types/relay/edge_behaviors.rb
+++ b/lib/graphql/types/relay/edge_behaviors.rb
@@ -8,11 +8,18 @@ module GraphQL
           child_class.description("An edge in a connection.")
           child_class.field(:cursor, String, null: false, description: "A cursor for use in pagination.")
           child_class.extend(ClassMethods)
+          child_class.class_eval { self.node_type = nil }
           child_class.extend(GraphQL::Types::Relay::DefaultRelay)
           child_class.node_nullable(true)
         end
 
         module ClassMethods
+          def inherited(child_class)
+            super
+            child_class.node_type = nil
+            child_class.node_nullable = nil
+          end
+
           # Get or set the Object type that this edge wraps.
           #
           # @param node_type [Class] A `Schema::Object` subclass
@@ -49,11 +56,15 @@ module GraphQL
           # Use `node_nullable(false)` in your base class to make non-null `node` field.
           def node_nullable(new_value = nil)
             if new_value.nil?
-              defined?(@node_nullable) ? @node_nullable : superclass.node_nullable
+              @node_nullable != nil ? @node_nullable : superclass.node_nullable
             else
               @node_nullable = new_value
             end
           end
+
+          protected
+
+          attr_writer :node_type, :node_nullable
         end
       end
     end

--- a/spec/graphql/schema/object_spec.rb
+++ b/spec/graphql/schema/object_spec.rb
@@ -364,4 +364,46 @@ describe GraphQL::Schema::Object do
       end
     end
   end
+
+  class ExampleGraphQLObject < GraphQL::Schema::Object
+    field :f1, String
+  end
+
+  it "has a consistent object shape" do
+    type_defn_shapes = Set.new
+    example_shapes_by_name = {}
+    ObjectSpace.each_object(Class) do |cls|
+      if cls < GraphQL::Schema::Object
+        shape = cls.instance_variables
+        # these are from a custom test
+        shape.delete(:@configs)
+        shape.delete(:@future_schema)
+        shape.delete(:@metadata)
+        if type_defn_shapes.add?(shape)
+          example_shapes_by_name[cls.graphql_name] = shape
+        end
+      end
+    end
+
+    # # Uncomment this to debug shapes:
+    # File.open("shapes.txt", "w+") do |f|
+    #   f.puts(type_defn_shapes.to_a.map { |ary| ary.inspect }.join("\n"))
+    #   example_shapes_by_name.each do |name, sh|
+    #     f.puts("#{name} ==> #{sh.inspect}")
+    #   end
+    # end
+
+    default_shape = ExampleGraphQLObject.instance_variables
+    default_edge_shape = Class.new(GraphQL::Types::Relay::BaseEdge).instance_variables
+    default_connection_shape = Class.new(GraphQL::Types::Relay::BaseConnection).instance_variables
+    default_mutation_payload_shape = Class.new(GraphQL::Schema::RelayClassicMutation) { graphql_name("DoSomething") }.payload_type.instance_variables
+    expected_default_shapes = Set.new([
+      default_shape,
+      default_edge_shape,
+      default_connection_shape,
+      default_mutation_payload_shape
+    ])
+
+    assert_equal expected_default_shapes, type_defn_shapes
+  end
 end


### PR DESCRIPTION
Part of #4299 

This adds to the schema memory footprint so far, though: 

```diff 
- Total allocated: 4060872 bytes (34279 objects)
+ Total allocated: 4241232 bytes (34291 objects)
- Total retained:  1833560 bytes (6185 objects)
+ Total retained:  2013120 bytes (6185 objects)
```

I want to see about keeping that down.