### PR TITLE
fix: references to non-existent GraphQL::Tracing::Trace

### DIFF
--- a/guides/queries/tracing.md
+++ b/guides/queries/tracing.md
@@ -8,7 +8,7 @@ desc: Observation hooks for execution
 index: 11
 ---
 
-{{ "GraphQL::Tracing::Trace" | api_doc }} provides hooks to observe and modify events during runtime. Tracing hooks are methods, defined in modules and mixed in with {{ "Schema.trace_with" | api_doc }}.
+{{ "GraphQL::Tracing" | api_doc }} provides hooks to observe and modify events during runtime. Tracing hooks are methods, defined in modules and mixed in with {{ "Schema.trace_with" | api_doc }}.
 
 ```ruby
 module CustomTrace
@@ -30,7 +30,7 @@ class MySchema < GraphQL::Schema
 end
 ```
 
-For a full list of methods and their arguments, see {{ "GraphQL::Tracing::Trace" | api_doc }}.
+For a full list of methods and their arguments, see {{ "GraphQL::Tracing" | api_doc }}.
 
 ## ActiveSupport::Notifications
 


### PR DESCRIPTION
The [tracing guide] references [`GraphQL::Tracing::Trace`][trace] in the current API docs, which does not exist in recent versions of graphql-ruby. This PR alters the guide to reference [`GraphQL::Tracing`][tracing] instead, which I believe to be the relevant module based on context within the guide's text.

[tracing guide]: https://graphql-ruby.org/queries/tracing.html
[trace]: https://graphql-ruby.org/api-doc/2.0.17/GraphQL/Tracing/Trace
[tracing]: https://graphql-ruby.org/api-doc/2.0.17/GraphQL/Tracing