### PR TITLE
Remove EmptyScopedContext, optimize ScopedContext allocations

### DIFF
--- a/spec/graphql/query/context_spec.rb
+++ b/spec/graphql/query/context_spec.rb
@@ -441,6 +441,13 @@ describe GraphQL::Query::Context do
       context.scoped_set!(expected_key, expected_value)
       assert_equal(expected_value, context[expected_key])
     end
+
+    it "has a #current_path method" do
+      context = GraphQL::Query::Context.new(query: OpenStruct.new(schema: schema), values: nil, object: nil)
+      current_result = OpenStruct.new(path: ["somewhere", "child", "grandchild"])
+      Thread.current[:__graphql_runtime_info][:current_result] = current_result
+      assert_equal ["somewhere", "child", "grandchild"], context.scoped_context.current_path
+    end
   end
 
   describe "Adding extensions to the response" do


### PR DESCRIPTION
Fixes #4373 

Originally I added `EmptyScopedContext` to simplify (and speed up) scoped context checks at runtime. But it introduced some incompatibilities. So I'll ditch it but roll some improvements into the normal `ScopedContext` class.