### PR TITLE
Fix Timeout with other Traces

### DIFF
--- a/lib/graphql/schema/timeout.rb
+++ b/lib/graphql/schema/timeout.rb
@@ -81,7 +81,7 @@ module GraphQL
 
             error
           else
-            yield
+            super
           end
         end
       end


### PR DESCRIPTION
Oops -- this call to `yield` short-circuited other traces in the mix. (Spotted by `@jturkel` here: https://github.com/rmosolgo/graphql-ruby/issues/4378#issuecomment-1466154477)