### PR TITLE
Add `rake compile` to set-up instructions

### DIFF
--- a/guides/development.md
+++ b/guides/development.md
@@ -27,6 +27,7 @@ Then, install the dependencies:
 
 - Install SQLite3 and MongoDB (eg, `brew install sqlite && brew tap mongodb/brew && brew install mongodb-community`)
 - `bundle install`
+- `rake compile # If you get warnings at this step, you can ignore them.`
 - Optional: [Ragel](https://www.colm.net/open-source/ragel/) is required to build the lexer
 
 ## Running the Tests


### PR DESCRIPTION
I found I had to compile the C extension after cloning my fork.