### PR TITLE
Fix `current_depth` method

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -599,16 +599,6 @@ module GraphQL
           path
         end
 
-        def current_depth
-          ti = thread_info
-          depth = 1
-          result = ti[:current_result]
-          while (result = result&.graphql_parent)
-            depth += 1
-          end
-          depth
-        end
-
         HALT = Object.new
         def continue_value(value, parent_type, field, is_non_null, ast_node, result_name, selection_result) # rubocop:disable Metrics/ParameterLists
           case value
@@ -953,6 +943,11 @@ module GraphQL
               lazy.value
             else
               set_result(result, result_name, lazy)
+              current_depth = 0
+              while result
+                current_depth += 1
+                result = result.graphql_parent
+              end
               @lazies_at_depth[current_depth] << lazy
               lazy
             end

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -603,7 +603,7 @@ module GraphQL
           ti = thread_info
           depth = 1
           result = ti[:current_result]
-          while (result = result.graphql_parent)
+          while (result = result&.graphql_parent)
             depth += 1
           end
           depth

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -915,8 +915,9 @@ module GraphQL
         # @return [GraphQL::Execution::Lazy, Object] If loading `object` will be deferred, it's a wrapper over it.
         def after_lazy(lazy_obj, owner:, field:, owner_object:, arguments:, ast_node:, result:, result_name:, eager: false, trace: true, &block)
           if lazy?(lazy_obj)
+            orig_result = result
             lazy = GraphQL::Execution::Lazy.new(field: field) do
-              set_all_interpreter_context(owner_object, field, arguments, result_name, result)
+              set_all_interpreter_context(owner_object, field, arguments, result_name, orig_result)
               # Wrap the execution of _this_ method with tracing,
               # but don't wrap the continuation below
               inner_obj = begin


### PR DESCRIPTION
Under some circumstances, the `thread_info` object is empty, and there is no result. In such a case, the method should return depth 1 instead of failing.

We ran into this problem after updating to `graphql` version `2.0.19` (although it also happens in `2.0.18`).
