### PR TITLE
Faster `GraphQL::Language::Printer` with `truncate_size` option

### DIFF
--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -517,7 +517,7 @@ module GraphQL
       # @example Creating a custom string from a document
       #  class VariableScrubber < GraphQL::Language::Printer
       #    def print_argument(arg)
-      #      "#{arg.name}: <HIDDEN>"
+      #      print_string("#{arg.name}: <HIDDEN>")
       #    end
       #  end
       #

--- a/lib/graphql/language/printer.rb
+++ b/lib/graphql/language/printer.rb
@@ -40,7 +40,7 @@ module GraphQL
       #
       #  class MyPrinter < GraphQL::Language::Printer
       #    def print_argument(arg)
-      #      "#{arg.name}: <HIDDEN>"
+      #      print_string("#{arg.name}: <HIDDEN>")
       #    end
       #  end
       #
@@ -62,68 +62,72 @@ module GraphQL
 
       protected
 
+      def print_string(str)
+        @out.append(str)
+      end
+
       def print_document(document)
         document.definitions.each_with_index do |d, i|
           print_node(d)
-          @out.append("\n\n") if i < document.definitions.size - 1
+          print_string("\n\n") if i < document.definitions.size - 1
         end
       end
 
       def print_argument(argument)
-        @out.append("#{argument.name}: ")
+        print_string("#{argument.name}: ")
         print_node(argument.value)
       end
 
       def print_input_object(input_object)
-        @out.append("{")
+        print_string("{")
         input_object.arguments.each_with_index do |a, i|
           print_argument(a)
-          @out.append(", ") if i < input_object.arguments.size - 1
+          print_string(", ") if i < input_object.arguments.size - 1
         end
-        @out.append("}")
+        print_string("}")
       end
 
       def print_directive(directive)
-        @out.append("@#{directive.name}")
+        print_string("@#{directive.name}")
 
         if directive.arguments.any?
-          @out.append("(")
+          print_string("(")
           directive.arguments.each_with_index do |a, i|
             print_argument(a)
-            @out.append(", ") if i < directive.arguments.size - 1
+            print_string(", ") if i < directive.arguments.size - 1
           end
-          @out.append(")")
+          print_string(")")
         end
       end
 
       def print_enum(enum)
-        @out.append(enum.name)
+        print_string(enum.name)
       end
 
       def print_null_value
-        @out.append("null")
+        print_string("null")
       end
 
       def print_field(field, indent: "")
-        @out.append(indent)
-        @out.append("#{field.alias}: ") if field.alias
-        @out.append(field.name)
+        print_string(indent)
+        print_string("#{field.alias}: ") if field.alias
+        print_string(field.name)
         if field.arguments.any?
-          @out.append("(")
+          print_string("(")
           field.arguments.each_with_index do |a, i|
             print_argument(a)
-            @out.append(", ") if i < field.arguments.size - 1
+            print_string(", ") if i < field.arguments.size - 1
           end
-          @out.append(")")
+          print_string(")")
         end
         print_directives(field.directives)
         print_selections(field.selections, indent: indent)
       end
 
       def print_fragment_definition(fragment_def, indent: "")
-        @out.append("#{indent}fragment #{fragment_def.name}")
+        print_string("#{indent}fragment #{fragment_def.name}")
         if fragment_def.type
-          @out.append(" on ")
+          print_string(" on ")
           print_node(fragment_def.type)
         end
         print_directives(fragment_def.directives)
@@ -131,14 +135,14 @@ module GraphQL
       end
 
       def print_fragment_spread(fragment_spread, indent: "")
-        @out.append("#{indent}...#{fragment_spread.name}")
+        print_string("#{indent}...#{fragment_spread.name}")
         print_directives(fragment_spread.directives)
       end
 
       def print_inline_fragment(inline_fragment, indent: "")
-        @out.append("#{indent}...")
+        print_string("#{indent}...")
         if inline_fragment.type
-          @out.append(" on ")
+          print_string(" on ")
           print_node(inline_fragment.type)
         end
         print_directives(inline_fragment.directives)
@@ -146,27 +150,27 @@ module GraphQL
       end
 
       def print_list_type(list_type)
-        @out.append("[")
+        print_string("[")
         print_node(list_type.of_type)
-        @out.append("]")
+        print_string("]")
       end
 
       def print_non_null_type(non_null_type)
         print_node(non_null_type.of_type)
-        @out.append("!")
+        print_string("!")
       end
 
       def print_operation_definition(operation_definition, indent: "")
-        @out.append("#{indent}#{operation_definition.operation_type}")
-        @out.append(" #{operation_definition.name}") if operation_definition.name
+        print_string("#{indent}#{operation_definition.operation_type}")
+        print_string(" #{operation_definition.name}") if operation_definition.name
 
         if operation_definition.variables.any?
-          @out.append("(")
+          print_string("(")
           operation_definition.variables.each_with_index do |v, i|
             print_variable_definition(v)
-            @out.append(", ") if i < operation_definition.variables.size - 1
+            print_string(", ") if i < operation_definition.variables.size - 1
           end
-          @out.append(")")
+          print_string(")")
         end
 
         print_directives(operation_definition.directives)
@@ -174,20 +178,20 @@ module GraphQL
       end
 
       def print_type_name(type_name)
-        @out.append(type_name.name)
+        print_string(type_name.name)
       end
 
       def print_variable_definition(variable_definition)
-        @out.append("$#{variable_definition.name}: ")
+        print_string("$#{variable_definition.name}: ")
         print_node(variable_definition.type)
         unless variable_definition.default_value.nil?
-          @out.append(" = ")
+          print_string(" = ")
           print_node(variable_definition.default_value)
         end
       end
 
       def print_variable_identifier(variable_identifier)
-        @out.append("$#{variable_identifier.name}")
+        print_string("$#{variable_identifier.name}")
       end
 
 
@@ -201,54 +205,54 @@ module GraphQL
           return
         end
 
-        @out.append("schema")
+        print_string("schema")
 
         if schema.directives.any?
           schema.directives.each do |dir|
-            @out.append("\n  ")
+            print_string("\n  ")
             print_node(dir)
           end
 
           if !has_conventional_names
-            @out.append("\n")
+            print_string("\n")
           end
         end
 
         if !has_conventional_names
           if schema.directives.empty?
-            @out.append(" ")
+            print_string(" ")
           end
-          @out.append("{\n")
-          @out.append("  query: #{schema.query}\n") if schema.query
-          @out.append("  mutation: #{schema.mutation}\n") if schema.mutation
-          @out.append("  subscription: #{schema.subscription}\n") if schema.subscription
-          @out.append("}")
+          print_string("{\n")
+          print_string("  query: #{schema.query}\n") if schema.query
+          print_string("  mutation: #{schema.mutation}\n") if schema.mutation
+          print_string("  subscription: #{schema.subscription}\n") if schema.subscription
+          print_string("}")
         end
       end
 
       def print_scalar_type_definition(scalar_type)
         print_description(scalar_type)
-        @out.append("scalar #{scalar_type.name}")
+        print_string("scalar #{scalar_type.name}")
         print_directives(scalar_type.directives)
       end
 
       def print_object_type_definition(object_type)
         print_description(object_type)
-        @out.append("type #{object_type.name}")
+        print_string("type #{object_type.name}")
         print_implements(object_type) unless object_type.interfaces.empty?
         print_directives(object_type.directives)
         print_field_definitions(object_type.fields)
       end
 
       def print_implements(type)
-        @out.append(" implements #{type.interfaces.map(&:name).join(" & ")}")
+        print_string(" implements #{type.interfaces.map(&:name).join(" & ")}")
       end
 
       def print_input_value_definition(input_value)
-        @out.append("#{input_value.name}: ")
+        print_string("#{input_value.name}: ")
         print_node(input_value.type)
         unless input_value.default_value.nil?
-          @out.append(" = ")
+          print_string(" = ")
           print_node(input_value.default_value)
         end
         print_directives(input_value.directives)
@@ -256,38 +260,38 @@ module GraphQL
 
       def print_arguments(arguments, indent: "")
         if arguments.all? { |arg| !arg.description }
-          @out.append("(")
+          print_string("(")
           arguments.each_with_index do |arg, i|
             print_input_value_definition(arg)
-            @out.append(", ") if i < arguments.size - 1
+            print_string(", ") if i < arguments.size - 1
           end
-          @out.append(")")
+          print_string(")")
           return
         end
 
-        @out.append("(\n")
+        print_string("(\n")
         arguments.each_with_index do |arg, i|
           print_description(arg, indent: "  " + indent, first_in_block: i == 0)
-          @out.append("  #{@indent}")
+          print_string("  #{indent}")
           print_input_value_definition(arg)
-          @out.append("\n") if i < arguments.size - 1
+          print_string("\n") if i < arguments.size - 1
         end
-        @out.append("\n#{@indent})")
+        print_string("\n#{indent})")
       end
 
       def print_field_definition(field)
-        @out.append(field.name)
+        print_string(field.name)
         unless field.arguments.empty?
           print_arguments(field.arguments, indent: "  ")
         end
-        @out.append(": ")
+        print_string(": ")
         print_node(field.type)
         print_directives(field.directives)
       end
 
       def print_interface_type_definition(interface_type)
         print_description(interface_type)
-        @out.append("interface #{interface_type.name}")
+        print_string("interface #{interface_type.name}")
         print_implements(interface_type) if interface_type.interfaces.any?
         print_directives(interface_type.directives)
         print_field_definitions(interface_type.fields)
@@ -295,83 +299,85 @@ module GraphQL
 
       def print_union_type_definition(union_type)
         print_description(union_type)
-        @out.append("union #{union_type.name}")
+        print_string("union #{union_type.name}")
         print_directives(union_type.directives)
-        @out.append(" = #{union_type.types.map(&:name).join(" | ")}")
+        print_string(" = #{union_type.types.map(&:name).join(" | ")}")
       end
 
       def print_enum_type_definition(enum_type)
         print_description(enum_type)
-        @out.append("enum #{enum_type.name}")
+        print_string("enum #{enum_type.name}")
         print_directives(enum_type.directives)
-        @out.append(" {\n")
+        print_string(" {\n")
         enum_type.values.each.with_index do |value, i|
           print_description(value, indent: "  ", first_in_block: i == 0)
           print_enum_value_definition(value)
         end
-        @out.append("}")
+        print_string("}")
       end
 
       def print_enum_value_definition(enum_value)
-        @out.append("  #{enum_value.name}")
+        print_string("  #{enum_value.name}")
         print_directives(enum_value.directives)
-        @out.append("\n")
+        print_string("\n")
       end
 
       def print_input_object_type_definition(input_object_type)
         print_description(input_object_type)
-        @out.append("input #{input_object_type.name}")
+        print_string("input #{input_object_type.name}")
         print_directives(input_object_type.directives)
         if !input_object_type.fields.empty?
-          @out.append(" {\n")
+          print_string(" {\n")
           input_object_type.fields.each.with_index do |field, i|
             print_description(field, indent: "  ", first_in_block: i == 0)
-            @out.append("  ")
+            print_string("  ")
             print_input_value_definition(field)
-            @out.append("\n")
+            print_string("\n")
           end
-          @out.append("}")
+          print_string("}")
         end
       end
 
       def print_directive_definition(directive)
         print_description(directive)
-        @out.append("directive @#{directive.name}")
+        print_string("directive @#{directive.name}")
 
         if directive.arguments.any?
           print_arguments(directive.arguments)
         end
 
         if directive.repeatable
-          @out.append(" repeatable")
+          print_string(" repeatable")
         end
 
-        @out.append(" on #{directive.locations.map(&:name).join(" | ")}")
+        print_string(" on #{directive.locations.map(&:name).join(" | ")}")
       end
 
       def print_description(node, indent: "", first_in_block: true)
         return unless node.description
 
-        @out.append("\n") if indent != "" && !first_in_block
-        @out.append(GraphQL::Language::BlockString.print(node.description, indent: indent))
+        print_string("\n") if indent != "" && !first_in_block
+        print_string(GraphQL::Language::BlockString.print(node.description, indent: indent))
       end
 
       def print_field_definitions(fields)
-        @out.append(" {\n")
+        return if fields.empty?
+
+        print_string(" {\n")
         fields.each.with_index do |field, i|
           print_description(field, indent: "  ", first_in_block: i == 0)
-          @out.append("  ")
+          print_string("  ")
           print_field_definition(field)
-          @out.append("\n")
+          print_string("\n")
         end
-        @out.append("}")
+        print_string("}")
       end
 
       def print_directives(directives)
         return if directives.empty?
 
         directives.each do |d|
-          @out.append(" ")
+          print_string(" ")
           print_directive(d)
         end
       end
@@ -379,12 +385,12 @@ module GraphQL
       def print_selections(selections, indent: "")
         return if selections.empty?
 
-        @out.append(" {\n")
+        print_string(" {\n")
         selections.each do |selection|
           print_node(selection, indent: indent + "  ")
-          @out.append("\n")
+          print_string("\n")
         end
-        @out.append("#{indent}}")
+        print_string("#{indent}}")
       end
 
       def print_node(node, indent: "")
@@ -444,24 +450,24 @@ module GraphQL
         when Nodes::DirectiveDefinition
           print_directive_definition(node)
         when FalseClass, Float, Integer, NilClass, String, TrueClass, Symbol
-          @out.append(GraphQL::Language.serialize(node))
+          print_string(GraphQL::Language.serialize(node))
         when Array
-          @out.append("[")
+          print_string("[")
           node.each_with_index do |v, i|
             print_node(v)
-            @out.append(", ") if i < node.length - 1
+            print_string(", ") if i < node.length - 1
           end
-          @out.append("]")
+          print_string("]")
         when Hash
-          @out.append("{")
+          print_string("{")
           node.each_with_index do |(k, v), i|
-            @out.append("#{k}: ")
+            print_string("#{k}: ")
             print_node(v)
-            @out.append(", ") if i < node.length - 1
+            print_string(", ") if i < node.length - 1
           end
-          @out.append("}")
+          print_string("}")
         else
-          @out.append(GraphQL::Language.serialize(node.to_s))
+          print_string(GraphQL::Language.serialize(node.to_s))
         end
       end
     end

--- a/lib/graphql/language/printer.rb
+++ b/lib/graphql/language/printer.rb
@@ -14,7 +14,7 @@ module GraphQL
           @truncate_size = truncate_size
         end
 
-        def <<(other)
+        def append(other)
           if @truncate_size && (@out.size + other.size) > @truncate_size
             @out << other.slice(0, @truncate_size - @out.size)
             raise(TruncateSizeReached, "Truncate size reached")
@@ -65,65 +65,65 @@ module GraphQL
       def print_document(document)
         document.definitions.each_with_index do |d, i|
           print_node(d)
-          @out << "\n\n" if i < document.definitions.size - 1
+          @out.append("\n\n") if i < document.definitions.size - 1
         end
       end
 
       def print_argument(argument)
-        @out << "#{argument.name}: "
+        @out.append("#{argument.name}: ")
         print_node(argument.value)
       end
 
       def print_input_object(input_object)
-        @out << "{"
+        @out.append("{")
         input_object.arguments.each_with_index do |a, i|
           print_argument(a)
-          @out << ", " if i < input_object.arguments.size - 1
+          @out.append(", ") if i < input_object.arguments.size - 1
         end
-        @out << "}"
+        @out.append("}")
       end
 
       def print_directive(directive)
-        @out << "@#{directive.name}"
+        @out.append("@#{directive.name}")
 
         if directive.arguments.any?
-          @out << "("
+          @out.append("(")
           directive.arguments.each_with_index do |a, i|
             print_argument(a)
-            @out << ", " if i < directive.arguments.size - 1
+            @out.append(", ") if i < directive.arguments.size - 1
           end
-          @out << ")"
+          @out.append(")")
         end
       end
 
       def print_enum(enum)
-        @out << enum.name
+        @out.append(enum.name)
       end
 
       def print_null_value
-        @out << "null"
+        @out.append("null")
       end
 
       def print_field(field, indent: "")
-        @out << indent
-        @out << "#{field.alias}: " if field.alias
-        @out << field.name
+        @out.append(indent)
+        @out.append("#{field.alias}: ") if field.alias
+        @out.append(field.name)
         if field.arguments.any?
-          @out << "("
+          @out.append("(")
           field.arguments.each_with_index do |a, i|
             print_argument(a)
-            @out << ", " if i < field.arguments.size - 1
+            @out.append(", ") if i < field.arguments.size - 1
           end
-          @out << ")"
+          @out.append(")")
         end
         print_directives(field.directives)
         print_selections(field.selections, indent: indent)
       end
 
       def print_fragment_definition(fragment_def, indent: "")
-        @out << "#{indent}fragment #{fragment_def.name}"
+        @out.append("#{indent}fragment #{fragment_def.name}")
         if fragment_def.type
-          @out << " on "
+          @out.append(" on ")
           print_node(fragment_def.type)
         end
         print_directives(fragment_def.directives)
@@ -131,14 +131,14 @@ module GraphQL
       end
 
       def print_fragment_spread(fragment_spread, indent: "")
-        @out << "#{indent}...#{fragment_spread.name}"
+        @out.append("#{indent}...#{fragment_spread.name}")
         print_directives(fragment_spread.directives)
       end
 
       def print_inline_fragment(inline_fragment, indent: "")
-        @out << "#{indent}..."
+        @out.append("#{indent}...")
         if inline_fragment.type
-          @out << " on "
+          @out.append(" on ")
           print_node(inline_fragment.type)
         end
         print_directives(inline_fragment.directives)
@@ -146,27 +146,27 @@ module GraphQL
       end
 
       def print_list_type(list_type)
-        @out << "["
+        @out.append("[")
         print_node(list_type.of_type)
-        @out << "]"
+        @out.append("]")
       end
 
       def print_non_null_type(non_null_type)
         print_node(non_null_type.of_type)
-        @out << "!"
+        @out.append("!")
       end
 
       def print_operation_definition(operation_definition, indent: "")
-        @out << "#{indent}#{operation_definition.operation_type}"
-        @out << " #{operation_definition.name}" if operation_definition.name
+        @out.append("#{indent}#{operation_definition.operation_type}")
+        @out.append(" #{operation_definition.name}") if operation_definition.name
 
         if operation_definition.variables.any?
-          @out << "("
+          @out.append("(")
           operation_definition.variables.each_with_index do |v, i|
             print_variable_definition(v)
-            @out << ", " if i < operation_definition.variables.size - 1
+            @out.append(", ") if i < operation_definition.variables.size - 1
           end
-          @out << ")"
+          @out.append(")")
         end
 
         print_directives(operation_definition.directives)
@@ -174,20 +174,20 @@ module GraphQL
       end
 
       def print_type_name(type_name)
-        @out << type_name.name
+        @out.append(type_name.name)
       end
 
       def print_variable_definition(variable_definition)
-        @out << "$#{variable_definition.name}: "
+        @out.append("$#{variable_definition.name}: ")
         print_node(variable_definition.type)
         unless variable_definition.default_value.nil?
-          @out << " = "
+          @out.append(" = ")
           print_node(variable_definition.default_value)
         end
       end
 
       def print_variable_identifier(variable_identifier)
-        @out << "$#{variable_identifier.name}"
+        @out.append("$#{variable_identifier.name}")
       end
 
 
@@ -201,54 +201,54 @@ module GraphQL
           return
         end
 
-        @out << "schema"
+        @out.append("schema")
 
         if schema.directives.any?
           schema.directives.each do |dir|
-            @out << "\n  "
+            @out.append("\n  ")
             print_node(dir)
           end
 
           if !has_conventional_names
-            @out << "\n"
+            @out.append("\n")
           end
         end
 
         if !has_conventional_names
           if schema.directives.empty?
-            @out << " "
+            @out.append(" ")
           end
-          @out << "{\n"
-          @out << "  query: #{schema.query}\n" if schema.query
-          @out << "  mutation: #{schema.mutation}\n" if schema.mutation
-          @out << "  subscription: #{schema.subscription}\n" if schema.subscription
-          @out << "}"
+          @out.append("{\n")
+          @out.append("  query: #{schema.query}\n") if schema.query
+          @out.append("  mutation: #{schema.mutation}\n") if schema.mutation
+          @out.append("  subscription: #{schema.subscription}\n") if schema.subscription
+          @out.append("}")
         end
       end
 
       def print_scalar_type_definition(scalar_type)
         print_description(scalar_type)
-        @out << "scalar #{scalar_type.name}"
+        @out.append("scalar #{scalar_type.name}")
         print_directives(scalar_type.directives)
       end
 
       def print_object_type_definition(object_type)
         print_description(object_type)
-        @out << "type #{object_type.name}"
+        @out.append("type #{object_type.name}")
         print_implements(object_type) unless object_type.interfaces.empty?
         print_directives(object_type.directives)
         print_field_definitions(object_type.fields)
       end
 
       def print_implements(type)
-        @out << " implements #{type.interfaces.map(&:name).join(" & ")}"
+        @out.append(" implements #{type.interfaces.map(&:name).join(" & ")}")
       end
 
       def print_input_value_definition(input_value)
-        @out << "#{input_value.name}: "
+        @out.append("#{input_value.name}: ")
         print_node(input_value.type)
         unless input_value.default_value.nil?
-          @out << " = "
+          @out.append(" = ")
           print_node(input_value.default_value)
         end
         print_directives(input_value.directives)
@@ -256,38 +256,38 @@ module GraphQL
 
       def print_arguments(arguments, indent: "")
         if arguments.all? { |arg| !arg.description }
-          @out << "("
+          @out.append("(")
           arguments.each_with_index do |arg, i|
             print_input_value_definition(arg)
-            @out << ", " if i < arguments.size - 1
+            @out.append(", ") if i < arguments.size - 1
           end
-          @out << ")"
+          @out.append(")")
           return
         end
 
-        @out << "(\n"
+        @out.append("(\n")
         arguments.each_with_index do |arg, i|
           print_description(arg, indent: "  " + indent, first_in_block: i == 0)
-          @out << "  #{@indent}"
+          @out.append("  #{@indent}")
           print_input_value_definition(arg)
-          @out << "\n" if i < arguments.size - 1
+          @out.append("\n") if i < arguments.size - 1
         end
-        @out << "\n#{@indent})"
+        @out.append("\n#{@indent})")
       end
 
       def print_field_definition(field)
-        @out << field.name
+        @out.append(field.name)
         unless field.arguments.empty?
           print_arguments(field.arguments, indent: "  ")
         end
-        @out << ": "
+        @out.append(": ")
         print_node(field.type)
         print_directives(field.directives)
       end
 
       def print_interface_type_definition(interface_type)
         print_description(interface_type)
-        @out << "interface #{interface_type.name}"
+        @out.append("interface #{interface_type.name}")
         print_implements(interface_type) if interface_type.interfaces.any?
         print_directives(interface_type.directives)
         print_field_definitions(interface_type.fields)
@@ -295,83 +295,83 @@ module GraphQL
 
       def print_union_type_definition(union_type)
         print_description(union_type)
-        @out << "union #{union_type.name}"
+        @out.append("union #{union_type.name}")
         print_directives(union_type.directives)
-        @out << " = " + union_type.types.map(&:name).join(" | ")
+        @out.append(" = #{union_type.types.map(&:name).join(" | ")}")
       end
 
       def print_enum_type_definition(enum_type)
         print_description(enum_type)
-        @out << "enum #{enum_type.name}"
+        @out.append("enum #{enum_type.name}")
         print_directives(enum_type.directives)
-        @out << " {\n"
+        @out.append(" {\n")
         enum_type.values.each.with_index do |value, i|
           print_description(value, indent: "  ", first_in_block: i == 0)
           print_enum_value_definition(value)
         end
-        @out << "}"
+        @out.append("}")
       end
 
       def print_enum_value_definition(enum_value)
-        @out << "  #{enum_value.name}"
+        @out.append("  #{enum_value.name}")
         print_directives(enum_value.directives)
-        @out << "\n"
+        @out.append("\n")
       end
 
       def print_input_object_type_definition(input_object_type)
         print_description(input_object_type)
-        @out << "input #{input_object_type.name}"
+        @out.append("input #{input_object_type.name}")
         print_directives(input_object_type.directives)
         if !input_object_type.fields.empty?
-          @out << " {\n"
+          @out.append(" {\n")
           input_object_type.fields.each.with_index do |field, i|
             print_description(field, indent: "  ", first_in_block: i == 0)
-            @out << "  "
+            @out.append("  ")
             print_input_value_definition(field)
-            @out << "\n"
+            @out.append("\n")
           end
-          @out << "}"
+          @out.append("}")
         end
       end
 
       def print_directive_definition(directive)
         print_description(directive)
-        @out << "directive @#{directive.name}"
+        @out.append("directive @#{directive.name}")
 
         if directive.arguments.any?
           print_arguments(directive.arguments)
         end
 
         if directive.repeatable
-          @out << " repeatable"
+          @out.append(" repeatable")
         end
 
-        @out << " on #{directive.locations.map(&:name).join(" | ")}"
+        @out.append(" on #{directive.locations.map(&:name).join(" | ")}")
       end
 
       def print_description(node, indent: "", first_in_block: true)
         return unless node.description
 
-        @out << "\n" if indent != "" && !first_in_block
-        @out << GraphQL::Language::BlockString.print(node.description, indent: indent)
+        @out.append("\n") if indent != "" && !first_in_block
+        @out.append(GraphQL::Language::BlockString.print(node.description, indent: indent))
       end
 
       def print_field_definitions(fields)
-        @out << " {\n"
+        @out.append(" {\n")
         fields.each.with_index do |field, i|
           print_description(field, indent: "  ", first_in_block: i == 0)
-          @out << "  "
+          @out.append("  ")
           print_field_definition(field)
-          @out << "\n"
+          @out.append("\n")
         end
-        @out << "}"
+        @out.append("}")
       end
 
       def print_directives(directives)
         return if directives.empty?
 
         directives.each do |d|
-          @out << " "
+          @out.append(" ")
           print_directive(d)
         end
       end
@@ -379,12 +379,12 @@ module GraphQL
       def print_selections(selections, indent: "")
         return if selections.empty?
 
-        @out << " {\n"
+        @out.append(" {\n")
         selections.each do |selection|
           print_node(selection, indent: indent + "  ")
-          @out << "\n"
+          @out.append("\n")
         end
-        @out << "#{indent}}"
+        @out.append("#{indent}}")
       end
 
       def print_node(node, indent: "")
@@ -444,24 +444,24 @@ module GraphQL
         when Nodes::DirectiveDefinition
           print_directive_definition(node)
         when FalseClass, Float, Integer, NilClass, String, TrueClass, Symbol
-          @out << GraphQL::Language.serialize(node)
+          @out.append(GraphQL::Language.serialize(node))
         when Array
-          @out << "["
+          @out.append("[")
           node.each_with_index do |v, i|
             print_node(v)
-            @out << ", " if i < node.length - 1
+            @out.append(", ") if i < node.length - 1
           end
-          @out << "]"
+          @out.append("]")
         when Hash
-          @out << "{"
+          @out.append("{")
           node.each_with_index do |(k, v), i|
-            @out << "#{k}: "
+            @out.append("#{k}: ")
             print_node(v)
-            @out << ", " if i < node.length - 1
+            @out.append(", ") if i < node.length - 1
           end
-          @out << "}"
+          @out.append("}")
         else
-          @out << GraphQL::Language.serialize(node.to_s)
+          @out.append(GraphQL::Language.serialize(node.to_s))
         end
       end
     end

--- a/lib/graphql/language/printer.rb
+++ b/lib/graphql/language/printer.rb
@@ -54,7 +54,7 @@ module GraphQL
       def print(node, indent: "", truncate_size: nil)
         truncate_size = truncate_size ? [truncate_size - OMISSION.size, 0].max : nil
         @out = TruncatableBuffer.new(truncate_size:)
-        print_node(node, indent:)
+        print_node(node, indent: indent)
         @out.to_string
       rescue TruncatableBuffer::TruncateSizeReached
         @out.to_string << OMISSION
@@ -117,7 +117,7 @@ module GraphQL
           @out << ")"
         end
         print_directives(field.directives)
-        print_selections(field.selections, indent:)
+        print_selections(field.selections, indent: indent)
       end
 
       def print_fragment_definition(fragment_def, indent: "")
@@ -127,7 +127,7 @@ module GraphQL
           print_node(fragment_def.type)
         end
         print_directives(fragment_def.directives)
-        print_selections(fragment_def.selections, indent:)
+        print_selections(fragment_def.selections, indent: indent)
       end
 
       def print_fragment_spread(fragment_spread, indent: "")
@@ -142,7 +142,7 @@ module GraphQL
           print_node(inline_fragment.type)
         end
         print_directives(inline_fragment.directives)
-        print_selections(inline_fragment.selections, indent:)
+        print_selections(inline_fragment.selections, indent: indent)
       end
 
       def print_list_type(list_type)
@@ -170,7 +170,7 @@ module GraphQL
         end
 
         print_directives(operation_definition.directives)
-        print_selections(operation_definition.selections, indent:)
+        print_selections(operation_definition.selections, indent: indent)
       end
 
       def print_type_name(type_name)

--- a/lib/graphql/language/printer.rb
+++ b/lib/graphql/language/printer.rb
@@ -53,7 +53,7 @@ module GraphQL
       # @return [String] Valid GraphQL for `node`
       def print(node, indent: "", truncate_size: nil)
         truncate_size = truncate_size ? [truncate_size - OMISSION.size, 0].max : nil
-        @out = TruncatableBuffer.new(truncate_size:)
+        @out = TruncatableBuffer.new(truncate_size: truncate_size)
         print_node(node, indent: indent)
         @out.to_string
       rescue TruncatableBuffer::TruncateSizeReached

--- a/lib/graphql/language/printer.rb
+++ b/lib/graphql/language/printer.rb
@@ -53,7 +53,7 @@ module GraphQL
       # @return [String] Valid GraphQL for `node`
       def print(node, indent: "", truncate_size: nil)
         truncate_size = truncate_size ? [truncate_size - OMISSION.size, 0].max : nil
-        @out = TruncatableBuffer.new(truncate_size: @truncate_size)
+        @out = TruncatableBuffer.new(truncate_size:)
         print_node(node, indent:)
         @out.to_string
       rescue TruncatableBuffer::TruncateSizeReached

--- a/lib/graphql/language/sanitized_printer.rb
+++ b/lib/graphql/language/sanitized_printer.rb
@@ -40,7 +40,7 @@ module GraphQL
         case node
         when FalseClass, Float, Integer, String, TrueClass
           if @current_argument && redact_argument_value?(@current_argument, node)
-            redacted_argument_value(@current_argument)
+            print_string(redacted_argument_value(@current_argument))
           else
             super
           end
@@ -51,9 +51,8 @@ module GraphQL
             @current_input_type = @current_input_type.of_type if @current_input_type.non_null?
           end
 
-          res = super
+          super
           @current_input_type = old_input_type
-          res
         else
           super
         end
@@ -89,11 +88,12 @@ module GraphQL
         else
           argument.value
         end
-        res = "#{argument.name}: #{print_node(argument_value)}".dup
+
+        print_string("#{argument.name}: ")
+        print_node(argument_value)
 
         @current_input_type = old_input_type
         @current_argument = old_current_argument
-        res
       end
 
       def coerce_argument_value_to_list?(type, value)
@@ -116,9 +116,8 @@ module GraphQL
         @current_field = query.get_field(@current_type, field.name)
         old_type = @current_type
         @current_type = @current_field.type.unwrap
-        res = super
+        super
         @current_type = old_type
-        res
       end
 
       def print_inline_fragment(inline_fragment, indent: "")
@@ -128,31 +127,26 @@ module GraphQL
           @current_type = query.get_type(inline_fragment.type.name)
         end
 
-        res = super
+        super
 
         @current_type = old_type
-
-        res
       end
 
       def print_fragment_definition(fragment_def, indent: "")
         old_type = @current_type
         @current_type = query.get_type(fragment_def.type.name)
 
-        res = super
+        super
 
         @current_type = old_type
-
-        res
       end
 
       def print_directive(directive)
         @current_directive = query.schema.directives[directive.name]
 
-        res = super
+        super
 
         @current_directive = nil
-        res
       end
 
       # Print the operation definition but do not include the variable
@@ -162,16 +156,15 @@ module GraphQL
         @current_type = query.schema.public_send(operation_definition.operation_type)
 
         if @inline_variables
-          out = "#{indent}#{operation_definition.operation_type}".dup
-          out << " #{operation_definition.name}" if operation_definition.name
-          out << print_directives(operation_definition.directives)
-          out << print_selections(operation_definition.selections, indent: indent)
+          print_string("#{indent}#{operation_definition.operation_type}")
+          print_string(" #{operation_definition.name}") if operation_definition.name
+          print_directives(operation_definition.directives)
+          print_selections(operation_definition.selections, indent: indent)
         else
-          out = super
+          super
         end
 
         @current_type = old_type
-        out
       end
 
       private

--- a/lib/graphql/schema/printer.rb
+++ b/lib/graphql/schema/printer.rb
@@ -92,7 +92,7 @@ module GraphQL
 
       class IntrospectionPrinter < GraphQL::Language::Printer
         def print_schema_definition(schema)
-          "schema {\n  query: Root\n}"
+          print_string("schema {\n  query: Root\n}")
         end
       end
     end

--- a/spec/graphql/language/generation_spec.rb
+++ b/spec/graphql/language/generation_spec.rb
@@ -10,7 +10,7 @@ describe GraphQL::Language::Generation do
     let(:custom_printer_class) {
       Class.new(GraphQL::Language::Printer) {
         def print_field_definition(print_field_definition)
-          "<Field Hidden>"
+          print_string("<Field Hidden>")
         end
       }
     }

--- a/spec/graphql/language/nodes_spec.rb
+++ b/spec/graphql/language/nodes_spec.rb
@@ -30,7 +30,7 @@ describe GraphQL::Language::Nodes::AbstractNode do
     let(:custom_printer_class) {
       Class.new(GraphQL::Language::Printer) {
         def print_field_definition(print_field_definition)
-          "<Field Hidden>"
+          print_string("<Field Hidden>")
         end
       }
     }

--- a/spec/graphql/language/printer_spec.rb
+++ b/spec/graphql/language/printer_spec.rb
@@ -31,6 +31,16 @@ describe GraphQL::Language::Printer do
       assert_equal query_string.gsub(/^    /, "").strip, printer.print(document)
     end
 
+    it "prints a truncated query string" do
+      expected = query_string.gsub(/^    /, "").strip[0, 50 - GraphQL::Language::Printer::OMISSION.size]
+      expected = "#{expected}#{GraphQL::Language::Printer::OMISSION}"
+
+      assert_equal(
+        expected,
+        printer.print(document, truncate_size: 50),
+      )
+    end
+
     describe "inputs" do
       let(:query_string) {%|
         query {


### PR DESCRIPTION
Rewrites the `GraphQL::Language::Printer` to make it more efficient and allow consumers to pass a `truncate_size` option.

Some benchmarks we ran with large queries indicated a ~2x speedup compared to the original implementation.

![image](https://user-images.githubusercontent.com/5751476/226683094-e0494454-70da-4ae3-a3ba-eedfca9c5868.png)

Even with the optimized implementation, printing large queries can fairly expensive. The `truncate_size:` option can be used by consumers that don't necessarily need to print the whole document to stop printing when the `truncate_size` is reached.
