### PR TITLE
Fix execution errors raised by fields in tracing

### DIFF
--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -752,6 +752,8 @@ module GraphQL
         end
         # if the line above doesn't raise, re-raise
         raise
+      rescue GraphQL::ExecutionError => err
+        err
       end
 
       # @param ctx [GraphQL::Query::Context]

--- a/spec/graphql/tracing/platform_tracing_spec.rb
+++ b/spec/graphql/tracing/platform_tracing_spec.rb
@@ -30,7 +30,11 @@ describe GraphQL::Tracing::PlatformTracing do
 
     def platform_trace(platform_key, key, data)
       TRACE << platform_key
-      yield
+      res = yield
+      if res.is_a?(GraphQL::ExecutionError)
+        TRACE << "returned error"
+      end
+      res
     end
   end
 
@@ -92,6 +96,12 @@ describe GraphQL::Tracing::PlatformTracing do
       # Then execute
       query.result
       assert_equal expected_trace, CustomPlatformTracer::TRACE
+    end
+
+    it "gets execution errors raised from field resolution" do
+      scalar_schema = Class.new(Dummy::Schema) { use(CustomPlatformTracer, trace_scalars: true) }
+      scalar_schema.execute("{ executionError }")
+      assert_includes CustomPlatformTracer::TRACE, "returned error"
     end
 
     it "traces resolve_type calls" do


### PR DESCRIPTION
Oops -- this changed a while back where this error handling happened at another level. Tracing that expected to run code _after_ resolve wasn't getting run anymore. This puts it back the way it was.