### PR TITLE
Add more docs about security

### DIFF
--- a/guides/guides.html
+++ b/guides/guides.html
@@ -19,6 +19,7 @@ sections:
   - name: GraphQL Enterprise - Object Cache
   - name: GraphQL Enterprise - Changesets
   - name: JavaScript Client
+  - name: Security
   - name: Language Tools
   - name: Testing
   - name: Other

--- a/guides/security/Graphql.md
+++ b/guides/security/Graphql.md
@@ -1,0 +1,84 @@
+---
+layout: guide
+doc_stub: false
+search: true
+section: Security
+title: GraphQL layer
+desc: GraphQL sepecific rules
+index: 1
+---
+
+Graphql is a powerful tool for building APIs. It allows the user a lot of flexibility in how they query the data. However, this flexibility can also lead to security vulnerabilities, allowing very complex queries to be executed.
+
+This guide will help you to secure your application before it goes live.
+
+Securing an application is a very broad topic, to be secure, all the layers of the application need to be secure. This guide will focus on the GraphQL and HTTP layers, but it is important to keep in mind that the security of the application is only as strong as its weakest link.
+
+## GET Method
+
+The HTTP GET method will attach a user's browser cookies automatically. This data can be used to create requests to impersonate the user while navigating external websites. To ensure security, it is advised to disable the GET method and configure the Cross-Origin Resource Sharing (CORS) policy of the server accordingly.
+
+## Json content type
+
+The expected Content-Type for GraphQL requests is application/json. To reduce the risk of Cross-Site Request Forgery (CSRF) attacks, it is recommended to disable other Content-Types.
+
+Combined to the GET method, this can be used to create a CSRF attack. The attacker can create a link that will send a request to the GraphQL endpoint with the user's cookies. The user will be tricked into clicking on the link, and the request will be executed.
+
+## Tenant isolation
+
+Tenant isolation is a very important concept in GraphQL. It is important to ensure that a user can only access the data that belongs to them.
+
+As this is deeply related to business logic (cf. {% internal_link "authorization documentation page", "/authorization/overview.html" %}), it is not possible to provide a generic solution. However, there are some general rules that can be followed:
+
+- Token generation must be properly implemented and well tested.
+- The token must be stored in a secure way:
+  - In a cookie you may look at the [HttpOnly flag](https://owasp.org/www-community/HttpOnly)
+  - In a header you want to enforce HTTPS only
+- Be careful with third party application as they may not be able to provide the same level of security as your application (asses their security).
+- Test your application with a security scanner.
+
+Read more about this topic in the [escape's access control in multi-tenant GraphQL applications blog post](https://escape.tech/blog/access-control-in-multi-tenant-graphql-applications/).
+
+## Rate limiting
+
+Rate limiting in graphql is a bit more complicated than in REST. The reason for this is that the user can specify the amount of data they want to receive. This means that a single request can be very large or very small. To prevent a single user from flooding the server with requests, it is advised to limit the amount of requests a user can make in a given time period.
+
+But as the only endpoint is the graphql endpoint, the classical method (rate limiting at gateway level) is possible but not sufficient. GraphQL allows also the user to batch some queries in a single request. This means that a single request can contain multiple queries and mutations. This can be used to bruteforce passwords.
+
+For example the following request will be detected as a single request by the rate limiter, but mutliples at the application level:
+
+```graphql
+mutation { login(username: "admin", password: "admin") }
+mutation { login(username: "admin", password: "123456") }
+mutation { login(username: "admin", password: "qwerty") }
+```
+
+For more information about how to handle query batching, see the {% internal_link "multiplex documentation page", "/queries/multiplex.html" %}.
+
+## Depth limiting
+
+In graphql, the user can specify the amount of data they want to receive. This means that a single request can be very large or very small. To prevent a single user from flooding the server with requests, it is advised to limit the amount of data a user can request in a single request.
+
+This request can be allowed:
+
+```graphql
+query {
+  user {
+    name
+    friends {
+      name
+      friends {
+        name
+        friends {
+          name
+          friends { ... }
+        }
+      }
+    }
+  }
+}
+```
+
+Here with a depth of 20 the query will very likely ask your resolver to dump the whole database.
+
+To prevent that, you want to implement the {% internal_link "depth limiting", "queries/complexity_and_depth.html#prevent-deeply-nested-queries" %} at schema level.

--- a/guides/security/HTTP.md
+++ b/guides/security/HTTP.md
@@ -1,0 +1,62 @@
+---
+layout: guide
+doc_stub: false
+search: true
+section: Security
+title: HTTP layer
+desc: Global security settings
+index: 2
+---
+
+In this part, we will cover any security settings that are not specific to GraphQL but are still important to consider when building a secure application.
+
+There is two types of attacks that you want to mitigate :
+
+- **Attacks on your server** : You want to configure rate limiting and firewall to prevent your server from being overwhelmed an evil user.
+- **Attacks on users data** : You also want to configure your server to prevent users data from being stolen or modified.
+
+## Attacks on your server
+
+This part is a big topic and may be linked to your business cases and cloud provider. We will only cover the basics here but if you want to learn more, you can read the [OWASP Top 10](https://owasp.org/www-project-top-ten/) and the [OWASP Cheat Sheet Series](https://cheatsheetseries.owasp.org/).
+
+### Firewall
+
+You may configure a firewall to prevent your server from being overwhelmed by a malicious user.
+
+By definition, a firewall is a component that controls network traffic. It can be implemented as an external application acting as a gateway between your server and the internet or as a software running on your server.
+
+Your cloud provider may have some tools to help you with this. For example, [AWS WAF](https://aws.amazon.com/waf/) or [Google Cloud armor](https://cloud.google.com/armor/docs/cloud-armor-overview).
+
+But it can also be integrated in your application. For example, [ruby on rails has a firewall](https://guides.rubyonrails.org/security.html#firewalls) that can be configured to block requests from specific IP addresses.
+
+### Rate limiting
+
+Rate limiting is a mechanism that allows you to limit the number of requests that can be made to your API. This is useful to prevent your server from being overwhelmed by a malicious user.
+
+As graphql endpoint is the same for all requests (except for subscriptions), your HTTP rate limiting will be applied to all requests. The configured rate will be higher than on a classic REST API because endpoint is fetched mutliples times (login, logout, retrieve data...).
+
+In graphql, you can also batch multiple queries in one request. This is useful to reduce the number of requests made to the server but it can also be used to bypass rate limiting. Read the {% internal_link "Graphql rate limiting", "security/Graphql.html#rate-limiting" %} guide to learn more about this.
+
+## Secure user's data
+
+### CORS
+
+CORS stands for Cross-Origin Resource Sharing. It is a mechanism that allows restricted resources on a web page to be requested from another domain outside the domain from which the first resource was served.
+
+If you don't configure any CORS settings, the default settings will be used. This means that any domain can access your API. This is not recommended for production environments because it allows any website to impersonate the user and make requests to your API.
+
+You may want to configure your CORS settings to only allow your domain : the needed header to set is `Access-Control-Allow-Origin: my.api.example.com`.
+
+## HTTP Strict Transport Security
+
+HTTP Strict Transport Security (HSTS) is a web security policy mechanism that helps to protect websites against protocol downgrade attacks and cookie hijacking. It allows web servers to declare that web browsers (or other complying user agents) should only interact with it using secure HTTPS connections, and never via the insecure HTTP protocol.
+
+## Totally disable HTTP
+
+If there is no use cases where you need to use HTTP, you may want to configure your server to only allow HTTPS connections. It will avoid a mistake from a developer that send some data without encryption.
+
+## X-Frame-Options
+
+X-Frame-Options is a header that can be used to indicate whether or not a browser should be allowed to render a page in a `<frame>`, `<iframe>` or `<object>` . Sites can use this to avoid clickjacking attacks, by ensuring that their content is not embedded into other sites.
+
+By default your api allows your content to be embedded in any website. You may want to configure this header to only allow your domain : `X-Frame-Options: SAMEORIGIN`.

--- a/guides/security/Introduction.md
+++ b/guides/security/Introduction.md
@@ -1,0 +1,15 @@
+---
+layout: guide
+doc_stub: false
+search: true
+section: Security
+title: Introduction
+desc: Secure your application before it goes live
+index: 0
+---
+
+Graphql is a powerful tool for building APIs. It allows the user a lot of flexibility in how they query the data. However, this flexibility can also lead to security vulnerabilities, allowing very complex queries to be executed.
+
+This guide will help you to secure your application before it goes live.
+
+Securing an application is a very broad topic, to be secure, all the layers of the application need to be secure. This guide will focus on the GraphQL and HTTP layers, but it is important to keep in mind that the security of the application is only as strong as its weakest link.

--- a/guides/security/security-testing.md
+++ b/guides/security/security-testing.md
@@ -1,0 +1,27 @@
+---
+layout: guide
+doc_stub: false
+search: true
+section: Security
+title: Security testing
+desc: Assessing the security of your application
+index: 3
+---
+
+At this point you must have a good understanding of how to secure your application. However, it is important to keep in mind that security is a never ending process. It is important to keep your application up to date and to test it regularly.
+
+As the application is continuously evolving, it is important to beeing kept up to date with the latest security issues.
+
+A good way to do this is to use a DAST (Dynamic Application Security Testing) tool. This tool will automatically scan your application and report any security issues it finds.
+
+Here is a list of different DAST tools that you can use :
+
+## GraphQL security
+
+You can use [graphql.security](https://graphql.security), a free GraphQL security testing tool that quickly identifies the most common vulnerabilities in your application.
+
+## Escape
+
+Another option is [Escape](https://escape.tech), a GraphQL security SaaS platform that includes an automated pentest tool.
+
+This can be integrated into your CI/CD pipeline, such as Github Actions or Gitlab CIs. The security notifications will be automatically communicated to your CI/CD platform, allowing you to address any issues promptly.


### PR DESCRIPTION
I work as a DevSecOps at Escape, where we operate a tool for testing the security of GraphQL. Securing web applications is crucial, and our objective is to simplify the process of adopting security best practices.

To this end, we have enhanced the documentation of this GraphQL engine with our knowledge on GraphQL security measures.

I've created a new section named `Security` with 2 main focuses :

- Some Graphql specific threats like query batching or depth limit.
- Some more general HTTP security best practices like enforcing HTTPS or rate limiting.

I've also added some links to articles, reference or this docs when it's relevant.

Thanks and have a good day !