### PR TITLE
Add support for histograms to prometheus_tracing

### DIFF
--- a/lib/graphql/tracing/prometheus_tracing/graphql_collector.rb
+++ b/lib/graphql/tracing/prometheus_tracing/graphql_collector.rb
@@ -5,7 +5,7 @@ module GraphQL
     class PrometheusTracing < PlatformTracing
       class GraphQLCollector < ::PrometheusExporter::Server::TypeCollector
         def initialize
-          @graphql_gauge = PrometheusExporter::Metric::Summary.new(
+          @graphql_gauge = PrometheusExporter::Metric::Base.default_aggregation.new(
             'graphql_duration_seconds',
             'Time spent in GraphQL operations, in seconds'
           )


### PR DESCRIPTION
The prometheus_exporter supports histograms if enabled, but the GraphQLCollector collector always uses summary.

See: https://github.com/discourse/prometheus_exporter#histogram-mode

Similar to the [WebCollector](https://github.com/discourse/prometheus_exporter/blob/main/lib/prometheus_exporter/server/web_collector.rb#L36) this PR  use the `PrometheusExporter::Metric::Base.default_aggregation` instead of the hardcoded `Summary` metrics