### PR TITLE
Reduce dead_result? and non_null? checks at runtime

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -396,6 +396,7 @@ module GraphQL
 
         # @return [void]
         def evaluate_selection(result_name, field_ast_nodes_or_ast_node, owner_object, owner_type, is_eager_field, selections_result, parent_object) # rubocop:disable Metrics/ParameterLists
+          return if dead_result?(selections_result)
           # As a performance optimization, the hash key will be a `Node` if
           # there's only one selection of the field. But if there are multiple
           # selections of the field, it will be an Array of nodes
@@ -559,7 +560,7 @@ module GraphQL
         end
 
         def dead_result?(selection_result)
-          selection_result.graphql_dead || ((parent = selection_result.graphql_parent) && parent.graphql_dead)
+          selection_result.graphql_dead  # || ((parent = selection_result.graphql_parent) && parent.graphql_dead)
         end
 
         def set_result(selection_result, result_name, value)

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -396,7 +396,6 @@ module GraphQL
 
         # @return [void]
         def evaluate_selection(result_name, field_ast_nodes_or_ast_node, owner_object, owner_type, is_eager_field, selections_result, parent_object) # rubocop:disable Metrics/ParameterLists
-          return if dead_result?(selections_result)
           # As a performance optimization, the hash key will be a `Node` if
           # there's only one selection of the field. But if there are multiple
           # selections of the field, it will be an Array of nodes
@@ -429,7 +428,8 @@ module GraphQL
           # This seems janky, but we need to know
           # the field's return type at this path in order
           # to propagate `null`
-          if return_type.non_null?
+          return_type_non_null = return_type.non_null?
+          if return_type_non_null
             (selections_result.graphql_non_null_field_names ||= []).push(result_name)
           end
           # Set this before calling `run_with_directives`, so that the directive can have the latest path
@@ -447,19 +447,19 @@ module GraphQL
           total_args_count = field_defn.arguments(context).size
           if total_args_count == 0
             resolved_arguments = GraphQL::Execution::Interpreter::Arguments::EMPTY
-            evaluate_selection_with_args(resolved_arguments, field_defn, ast_node, field_ast_nodes, owner_type, object, is_eager_field, result_name, selections_result, parent_object, return_type)
+            evaluate_selection_with_args(resolved_arguments, field_defn, ast_node, field_ast_nodes, owner_type, object, is_eager_field, result_name, selections_result, parent_object, return_type, return_type_non_null)
           else
             # TODO remove all arguments(...) usages?
             @query.arguments_cache.dataload_for(ast_node, field_defn, object) do |resolved_arguments|
-              evaluate_selection_with_args(resolved_arguments, field_defn, ast_node, field_ast_nodes, owner_type, object, is_eager_field, result_name, selections_result, parent_object, return_type)
+              evaluate_selection_with_args(resolved_arguments, field_defn, ast_node, field_ast_nodes, owner_type, object, is_eager_field, result_name, selections_result, parent_object, return_type, return_type_non_null)
             end
           end
         end
 
-        def evaluate_selection_with_args(arguments, field_defn, ast_node, field_ast_nodes, owner_type, object, is_eager_field, result_name, selection_result, parent_object, return_type)  # rubocop:disable Metrics/ParameterLists
+        def evaluate_selection_with_args(arguments, field_defn, ast_node, field_ast_nodes, owner_type, object, is_eager_field, result_name, selection_result, parent_object, return_type, return_type_non_null)  # rubocop:disable Metrics/ParameterLists
           after_lazy(arguments, owner: owner_type, field: field_defn, ast_node: ast_node, owner_object: object, arguments: arguments, result_name: result_name, result: selection_result) do |resolved_arguments|
             if resolved_arguments.is_a?(GraphQL::ExecutionError) || resolved_arguments.is_a?(GraphQL::UnauthorizedError)
-              continue_value(resolved_arguments, owner_type, field_defn, return_type.non_null?, ast_node, result_name, selection_result)
+              continue_value(resolved_arguments, owner_type, field_defn, return_type_non_null, ast_node, result_name, selection_result)
               next
             end
 
@@ -813,21 +813,21 @@ module GraphQL
             inner_type = current_type.of_type
             # This is true for objects, unions, and interfaces
             use_dataloader_job = !inner_type.unwrap.kind.input?
+            inner_type_non_null = inner_type.non_null?
             response_list = GraphQLResultArray.new(result_name, selection_result)
-            response_list.graphql_non_null_list_items = inner_type.non_null?
+            response_list.graphql_non_null_list_items = inner_type_non_null
             set_result(selection_result, result_name, response_list)
             idx = 0
             list_value = begin
               value.each do |inner_value|
-                break if dead_result?(response_list)
                 this_idx = idx
                 idx += 1
                 if use_dataloader_job
                   @dataloader.append_job do
-                    resolve_list_item(inner_value, inner_type, ast_node, field, owner_object, arguments, this_idx, response_list, next_selections, owner_type)
+                    resolve_list_item(inner_value, inner_type, inner_type_non_null, ast_node, field, owner_object, arguments, this_idx, response_list, next_selections, owner_type)
                   end
                 else
-                  resolve_list_item(inner_value, inner_type, ast_node, field, owner_object, arguments, this_idx, response_list, next_selections, owner_type)
+                  resolve_list_item(inner_value, inner_type, inner_type_non_null, ast_node, field, owner_object, arguments, this_idx, response_list, next_selections, owner_type)
                 end
               end
 
@@ -857,14 +857,14 @@ module GraphQL
           end
         end
 
-        def resolve_list_item(inner_value, inner_type, ast_node, field, owner_object, arguments, this_idx, response_list, next_selections, owner_type) # rubocop:disable Metrics/ParameterLists
+        def resolve_list_item(inner_value, inner_type, inner_type_non_null, ast_node, field, owner_object, arguments, this_idx, response_list, next_selections, owner_type) # rubocop:disable Metrics/ParameterLists
           st = get_current_runtime_state
           st.current_result_name = this_idx
           st.current_result = response_list
           call_method_on_directives(:resolve_each, owner_object, ast_node.directives) do
             # This will update `response_list` with the lazy
             after_lazy(inner_value, owner: inner_type, ast_node: ast_node, field: field, owner_object: owner_object, arguments: arguments, result_name: this_idx, result: response_list) do |inner_inner_value|
-              continue_value = continue_value(inner_inner_value, owner_type, field, inner_type.non_null?, ast_node, this_idx, response_list)
+              continue_value = continue_value(inner_inner_value, owner_type, field, inner_type_non_null, ast_node, this_idx, response_list)
               if HALT != continue_value
                 continue_field(continue_value, owner_type, field, inner_type, ast_node, next_selections, false, owner_object, arguments, this_idx, response_list)
               end


### PR DESCRIPTION
- `set_result` checks for `dead_result?`, so we can get the same behavior here by removing these other checks. The only downside is that execution may continue _past_ a dead result in some cases -- but I think this is not the "happy path" and therefore an acceptable tradeoff. 
- Some checks to `non_null?` can be reduced by passing the result along.


Before: 

```
Calculating -------------------------------------
Querying for 1000 objects
                          4.079  (± 0.0%) i/s -     21.000  in   5.151335s
==================================
  Mode: wall(1)
  Samples: 876887 (70.77% miss rate)
  GC: 7711 (0.88%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     86300   (9.8%)       86300   (9.8%)     Kernel#class
     78049   (8.9%)       78049   (8.9%)     Kernel#hash
     57099   (6.5%)       57099   (6.5%)     GraphQL::Execution::Interpreter::Runtime#dead_result?
     40662   (4.6%)       40662   (4.6%)     Kernel#respond_to?
     35864   (4.1%)       35864   (4.1%)     GraphQL::Schema::NonNull#non_null?
     31803   (3.6%)       31803   (3.6%)     GraphQL::Schema.lazy_methods
```

After: 

```
Warming up --------------------------------------
Querying for 1000 objects
                         1.000  i/100ms
Calculating -------------------------------------
Querying for 1000 objects
                          4.161  (± 0.0%) i/s -     21.000  in   5.053954s
==================================
  Mode: wall(1)
  Samples: 862407 (72.03% miss rate)
  GC: 7899 (0.92%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     86084  (10.0%)       86084  (10.0%)     Kernel#class
     76190   (8.8%)       76190   (8.8%)     Kernel#hash
     40615   (4.7%)       40615   (4.7%)     Kernel#respond_to?
     31786   (3.7%)       31786   (3.7%)     GraphQL::Execution::Interpreter::Runtime#dead_result?
     31091   (3.6%)       31091   (3.6%)     GraphQL::Schema.lazy_methods
     30569   (3.5%)       30569   (3.5%)     Thread.current
     30411   (3.5%)       30411   (3.5%)     Kernel#is_a?
     28704   (3.3%)       28704   (3.3%)     GraphQL::Schema::NonNull#non_null?
```