### PR TITLE
Method-based lazy resolution detection

### DIFF
--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -5,6 +5,12 @@ require "set"
 require "singleton"
 require "forwardable"
 
+class Object
+  def graphql_lazy?
+    false
+  end
+end
+
 module GraphQL
   # forwards-compat for argument handling
   module Ruby2Keywords

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -1037,9 +1037,7 @@ module GraphQL
         end
 
         def lazy?(object)
-          @lazy_cache.fetch(object.class) {
-            @lazy_cache[object.class] = @schema.lazy?(object)
-          }
+          object.graphql_lazy?
         end
       end
     end


### PR DESCRIPTION
###  Background 

GraphQL-Ruby handles _some_ objects specially. For example, when a field returns a `Promise`, GraphQL-Ruby sets it aside and continues running other fields until all that's left is `Promise`s, then it resolves those and continues again. Classes are registered for this special handling via `lazy_resolve` (for example, GraphQL-Batch: https://github.com/Shopify/graphql-batch/blob/57e7150695dc1b67381923965b366f64c25edb3d/lib/graphql/batch.rb#L30) 

Then, at runtime, GraphQL-Ruby checks each returned value to see if it needs lazy resolution. This is done by checking the object's class and looking up a registered method for that class (or a superclass). In my benchmark, this operation turns out to be the biggest time consumer: 


```
# before
Calculating -------------------------------------
Querying for 1000 objects
                          4.508  (± 0.0%) i/s -     23.000  in   5.103359s
==================================
  Mode: wall(1)
  Samples: 797053 (73.24% miss rate)
  GC: 7179 (0.90%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     77852   (9.8%)       77852   (9.8%)     Kernel#class
     73140   (9.2%)       73140   (9.2%)     Kernel#hash
     34353   (4.3%)       34353   (4.3%)     GraphQL::Execution::Interpreter::Runtime#dead_result?
     32428   (4.1%)       32428   (4.1%)     GraphQL::Schema.lazy_methods
     31782   (4.0%)       31782   (4.0%)     Thread.current
```

Usually, this lookup is a waste because the returned value is a scalar (String, number, etc), not a Promise (or other lazy object). 

So, how can it be either: 

- Eliminated in the most common case; 
- Or, sped up as to not be a problem

? 

### This idea 

Instead of maintaining a custom, class-based registry of methods, what if GraphQL-Ruby let _Ruby_ do that? That is, it could use plain ol' Ruby methods instead. For example, every lazy object must provide a `object.graphql_lazy_resolve_method` which GraphQL-Ruby would use to load its value later. 

The downside is that _every_ object must implement that method, even if it returns `nil`. This ends up "polluting" the method namespace of every object -- yuck! (Refinements could theoretically solve this problem, but unfortunately they're slow.) 

Locally, this approach provides a 6.5% speedup (Although digging in, I think it could  be  another percentage more, there are other codepaths to update to this approach :eyes:) : 

```
# after 
Calculating -------------------------------------
Querying for 1000 objects
                          4.802  (± 0.0%) i/s -     25.000  in   5.210133s
==================================
  Mode: wall(1)
  Samples: 665004 (73.03% miss rate)
  GC: 6710 (1.01%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     44396   (6.7%)       44396   (6.7%)     Object#graphql_lazy?
     39600   (6.0%)       39600   (6.0%)     Kernel#hash
     27405   (4.1%)       27405   (4.1%)     GraphQL::Execution::Interpreter::Runtime#dead_result?
     26968   (4.1%)       26968   (4.1%)     Thread.current
```

So, what do you think of this idea? Or, can you think of other options for improving this system that I might pursue? 
