### PR TITLE
Prioritize the common case for warden lookup

### DIFF
--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -38,7 +38,9 @@ module GraphQL
     # @api private
     class Warden
       def self.from_context(context)
-        (context.respond_to?(:warden) && context.warden) || PassThruWarden
+        context.warden # this might be a hash which won't respond to this
+      rescue
+        PassThruWarden
       end
 
       # @param visibility_method [Symbol] a Warden method to call for this entry


### PR DESCRIPTION
This reduces a lot of `.respond_to?` calls at runtime and seems like it's actually faster.