### PR TITLE
Use compare_by_identity on some runtime caches

### DIFF
--- a/lib/graphql/execution/interpreter/arguments_cache.rb
+++ b/lib/graphql/execution/interpreter/arguments_cache.rb
@@ -11,7 +11,7 @@ module GraphQL
             h[ast_node] = Hash.new do |h2, arg_owner|
               h2[arg_owner] = Hash.new do |h3, parent_object|
                 dataload_for(ast_node, arg_owner, parent_object) do |kwarg_arguments|
-                  h3[parent_object] = @query.schema.after_lazy(kwarg_arguments) do |resolved_args|
+                  h3[parent_object] = @query.after_lazy(kwarg_arguments) do |resolved_args|
                     h3[parent_object] = resolved_args
                   end
                 end

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -951,6 +951,18 @@ module GraphQL
           Thread.current[:__graphql_runtime_info] ||= CurrentState.new
         end
 
+        def minimal_after_lazy(value, &block)
+          if lazy?(value)
+            GraphQL::Execution::Lazy.new do
+              result = @schema.sync_lazy(value)
+              # The returned result might also be lazy, so check it, too
+              minimal_after_lazy(result, &block)
+            end
+          else
+            yield(value)
+          end
+        end
+
         # @param obj [Object] Some user-returned value that may want to be batched
         # @param field [GraphQL::Schema::Field]
         # @param eager [Boolean] Set to `true` for mutation root fields only

--- a/lib/graphql/execution/lookahead.rb
+++ b/lib/graphql/execution/lookahead.rb
@@ -55,7 +55,7 @@ module GraphQL
           @arguments
         else
           @arguments = if @field
-            @query.schema.after_lazy(@query.arguments_for(@ast_nodes.first, @field)) do |args|
+            @query.after_lazy(@query.arguments_for(@ast_nodes.first, @field)) do |args|
               args.is_a?(Execution::Interpreter::Arguments) ? args.keyword_arguments : args
             end
           else

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -361,6 +361,10 @@ module GraphQL
       schema.handle_or_reraise(context, err)
     end
 
+    def after_lazy(value, &block)
+      @schema.after_lazy(value, &block)
+    end
+
     private
 
     def find_operation(operations, operation_name)

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -362,7 +362,15 @@ module GraphQL
     end
 
     def after_lazy(value, &block)
-      @schema.after_lazy(value, &block)
+      if !defined?(@runtime_instance)
+        @runtime_instance = context.namespace(:interpreter_runtime)[:runtime]
+      end
+
+      if @runtime_instance
+        @runtime_instance.minimal_after_lazy(value, &block)
+      else
+        @schema.after_lazy(value, &block)
+      end
     end
 
     private

--- a/lib/graphql/query/null_context.rb
+++ b/lib/graphql/query/null_context.rb
@@ -12,6 +12,9 @@ module GraphQL
       end
 
       class NullQuery
+        def after_lazy(value)
+          yield(value)
+        end
       end
 
       class NullSchema < GraphQL::Schema

--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -264,7 +264,7 @@ module GraphQL
 
         # If this isn't lazy, then the block returns eagerly and assigns the result here
         # If it _is_ lazy, then we write the lazy to the hash, then update it later
-        argument_values[arg_key] = context.schema.after_lazy(coerced_value) do |resolved_coerced_value|
+        argument_values[arg_key] = context.query.after_lazy(coerced_value) do |resolved_coerced_value|
           owner.validate_directive_argument(self, resolved_coerced_value)
           prepared_value = begin
             prepare_value(parent_object, resolved_coerced_value, context: context)
@@ -281,7 +281,7 @@ module GraphQL
           end
 
           maybe_loaded_value = loaded_value || prepared_value
-          context.schema.after_lazy(maybe_loaded_value) do |resolved_loaded_value|
+          context.query.after_lazy(maybe_loaded_value) do |resolved_loaded_value|
             # TODO code smell to access such a deeply-nested constant in a distant module
             argument_values[arg_key] = GraphQL::Execution::Interpreter::ArgumentValue.new(
               value: resolved_loaded_value,
@@ -303,7 +303,7 @@ module GraphQL
           else
             load_method_owner.public_send(arg_load_method, coerced_value)
           end
-          context.schema.after_lazy(custom_loaded_value) do |custom_value|
+          context.query.after_lazy(custom_loaded_value) do |custom_value|
             if loads
               if type.list?
                 loaded_values = custom_value.each_with_index.map { |custom_val, idx|

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -661,7 +661,7 @@ module GraphQL
 
         Schema::Validator.validate!(validators, application_object, query_ctx, args)
 
-        query_ctx.schema.after_lazy(self.authorized?(application_object, args, query_ctx)) do |is_authorized|
+        query_ctx.query.after_lazy(self.authorized?(application_object, args, query_ctx)) do |is_authorized|
           if is_authorized
             with_extensions(object, args, query_ctx) do |obj, ruby_kwargs|
               method_args = ruby_kwargs
@@ -833,7 +833,7 @@ ERR
           extended_args = extended[:args]
           memos = extended[:memos] || EMPTY_HASH
 
-          ctx.schema.after_lazy(value) do |resolved_value|
+          ctx.query.after_lazy(value) do |resolved_value|
             idx = 0
             @extensions.each do |ext|
               memo = memos[idx]

--- a/lib/graphql/schema/field/connection_extension.rb
+++ b/lib/graphql/schema/field/connection_extension.rb
@@ -26,7 +26,7 @@ module GraphQL
           # rename some inputs to avoid conflicts inside the block
           maybe_lazy = value
           value = nil
-          context.schema.after_lazy(maybe_lazy) do |resolved_value|
+          context.query.after_lazy(maybe_lazy) do |resolved_value|
             value = resolved_value
             if value.is_a? GraphQL::ExecutionError
               # This isn't even going to work because context doesn't have ast_node anymore

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -211,7 +211,7 @@ module GraphQL
 
           arguments = coerce_arguments(nil, value, ctx)
 
-          ctx.schema.after_lazy(arguments) do |resolved_arguments|
+          ctx.query.after_lazy(arguments) do |resolved_arguments|
             if resolved_arguments.is_a?(GraphQL::Error)
               raise resolved_arguments
             else

--- a/lib/graphql/schema/member/has_arguments.rb
+++ b/lib/graphql/schema/member/has_arguments.rb
@@ -51,7 +51,7 @@ module GraphQL
               class_eval <<-RUBY, __FILE__, __LINE__ + 1
               def #{method_owner}load_#{arg_defn.keyword}(values, context = nil)
                 argument = get_argument("#{arg_defn.graphql_name}")
-                (context || self.context).schema.after_lazy(values) do |values2|
+                (context || self.context).query.after_lazy(values) do |values2|
                   GraphQL::Execution::Lazy.all(values2.map { |value| load_application_object(argument, value, context || self.context) })
                 end
               end
@@ -363,7 +363,7 @@ module GraphQL
           end
 
           def authorize_application_object(argument, id, context, loaded_application_object)
-            context.schema.after_lazy(loaded_application_object) do |application_object|
+            context.query.after_lazy(loaded_application_object) do |application_object|
               if application_object.nil?
                 err = GraphQL::LoadApplicationObjectFailedError.new(argument: argument, id: id, object: application_object)
                 load_application_object_failed(err)
@@ -371,7 +371,7 @@ module GraphQL
               # Double-check that the located object is actually of this type
               # (Don't want to allow arbitrary access to objects this way)
               maybe_lazy_resolve_type = context.schema.resolve_type(argument.loads, application_object, context)
-              context.schema.after_lazy(maybe_lazy_resolve_type) do |resolve_type_result|
+              context.query.after_lazy(maybe_lazy_resolve_type) do |resolve_type_result|
                 if resolve_type_result.is_a?(Array) && resolve_type_result.size == 2
                   application_object_type, application_object = resolve_type_result
                 else
@@ -386,7 +386,7 @@ module GraphQL
                   # This object was loaded successfully
                   # and resolved to the right type,
                   # now apply the `.authorized?` class method if there is one
-                  context.schema.after_lazy(application_object_type.authorized?(application_object, context)) do |authed|
+                  context.query.after_lazy(application_object_type.authorized?(application_object, context)) do |authed|
                     if authed
                       application_object
                     else

--- a/lib/graphql/schema/object.rb
+++ b/lib/graphql/schema/object.rb
@@ -68,7 +68,7 @@ module GraphQL
             maybe_lazy_auth_val
           end
 
-          context.schema.after_lazy(auth_val) do |is_authorized|
+          context.query.after_lazy(auth_val) do |is_authorized|
             if is_authorized
               self.new(object, context)
             else

--- a/lib/graphql/schema/relay_classic_mutation.rb
+++ b/lib/graphql/schema/relay_classic_mutation.rb
@@ -60,7 +60,7 @@ module GraphQL
           super()
         end
 
-        context.schema.after_lazy(return_value) do |return_hash|
+        context.query.after_lazy(return_value) do |return_hash|
           # It might be an error
           if return_hash.is_a?(Hash)
             return_hash[:client_mutation_id] = client_mutation_id

--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -70,7 +70,7 @@ module GraphQL
         else
           ready?
         end
-        context.schema.after_lazy(ready_val) do |is_ready, ready_early_return|
+        context.query.after_lazy(ready_val) do |is_ready, ready_early_return|
           if ready_early_return
             if is_ready != false
               raise "Unexpected result from #ready? (expected `true`, `false` or `[false, {...}]`): [#{is_ready.inspect}, #{ready_early_return.inspect}]"
@@ -81,7 +81,7 @@ module GraphQL
             # Then call each prepare hook, which may return a different value
             # for that argument, or may return a lazy object
             load_arguments_val = load_arguments(args)
-            context.schema.after_lazy(load_arguments_val) do |loaded_args|
+            context.query.after_lazy(load_arguments_val) do |loaded_args|
               @prepared_arguments = loaded_args
               Schema::Validator.validate!(self.class.validators, object, context, loaded_args, as: @field)
               # Then call `authorized?`, which may raise or may return a lazy object
@@ -90,7 +90,7 @@ module GraphQL
               else
                 authorized?
               end
-              context.schema.after_lazy(authorized_val) do |(authorized_result, early_return)|
+              context.query.after_lazy(authorized_val) do |(authorized_result, early_return)|
                 # If the `authorized?` returned two values, `false, early_return`,
                 # then use the early return value instead of continuing
                 if early_return
@@ -185,7 +185,7 @@ module GraphQL
           if arg_defn
             prepped_value = prepared_args[key] = arg_defn.load_and_authorize_value(self, value, context)
             if context.schema.lazy?(prepped_value)
-              prepare_lazies << context.schema.after_lazy(prepped_value) do |finished_prepped_value|
+              prepare_lazies << context.query.after_lazy(prepped_value) do |finished_prepped_value|
                 prepared_args[key] = finished_prepped_value
               end
             end

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -98,6 +98,7 @@ module GraphQL
         @subscription = @schema.subscription
         @context = context
         @visibility_cache = read_through { |m| filter.call(m, context) }
+        @visibility_cache.compare_by_identity
         # Initialize all ivars to improve object shape consistency:
         @types = @visible_types = @reachable_types = @visible_parent_fields =
           @visible_possible_types = @visible_fields = @visible_arguments = @visible_enum_arrays =


### PR DESCRIPTION
Some hashes in GraphQL-Ruby are by-type caches of things. Those will always have the _same objects_ (Classes) as keys, so we could use compare_by_identity for them (suggested in https://github.com/rmosolgo/graphql-ruby/pull/4431#discussion_r1163159395)

Initial results are good: 


```diff
  Warming up --------------------------------------
  Querying for 1000 objects
-                           4.333  (± 0.0%) i/s -     22.000  in   5.082679s
+                           4.848  (± 0.0%) i/s -     25.000  in   5.158312s

  # ... 
  ==================================
       TOTAL    (pct)     SAMPLES    (pct)     FRAME
-      26656   (9.4%)       26656   (9.4%)     Kernel#hash
+      17766   (2.7%)       17766   (2.7%)     Kernel#hash


-      26300   (9.3%)       26300   (9.3%)     Kernel#class
+      68174  (10.4%)       68174  (10.4%)     Kernel#class
```

TODO: 

- [x] Address some usages of `schema.after_lazy` to use this runtime method instead (perhaps by adding `query.` or `context.after_lazy`?) which uses a better cache