### PR TITLE
Fix runtime state when fields run nested queries

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -1018,7 +1018,12 @@ module GraphQL
 
         def delete_all_interpreter_context
           per_query_state = Thread.current[:__graphql_runtime_info]
-          per_query_state && per_query_state.delete(@query)
+          if per_query_state
+            per_query_state.delete(@query)
+            if per_query_state.size == 0
+              Thread.current[:__graphql_runtime_info] = nil
+            end
+          end
           nil
         end
 

--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -227,7 +227,8 @@ module GraphQL
             current_path
           else
             (current_runtime_state = Thread.current[:__graphql_runtime_info]) &&
-              (current_runtime_state.public_send(key))
+              (query_runtime_state = current_runtime_state[@query]) &&
+              (query_runtime_state.public_send(key))
           end
         else
           # not found
@@ -237,10 +238,12 @@ module GraphQL
 
       def current_path
         current_runtime_state = Thread.current[:__graphql_runtime_info]
-        path = current_runtime_state &&
-          (result = current_runtime_state.current_result) &&
+        query_runtime_state = current_runtime_state && current_runtime_state[@query]
+
+        path = query_runtime_state &&
+          (result = query_runtime_state.current_result) &&
           (result.path)
-        if path && (rn = current_runtime_state.current_result_name)
+        if path && (rn = query_runtime_state.current_result_name)
           path = path.dup
           path.push(rn)
         end
@@ -260,7 +263,8 @@ module GraphQL
       def fetch(key, default = UNSPECIFIED_FETCH_DEFAULT)
         if RUNTIME_METADATA_KEYS.include?(key)
           (runtime = Thread.current[:__graphql_runtime_info]) &&
-            (runtime.public_send(key))
+            (query_runtime_state = runtime[@query]) &&
+            (query_runtime_state.public_send(key))
         elsif @scoped_context.key?(key)
           scoped_context[key]
         elsif @provided_values.key?(key)
@@ -277,7 +281,8 @@ module GraphQL
       def dig(key, *other_keys)
         if RUNTIME_METADATA_KEYS.include?(key)
           (current_runtime_state = Thread.current[:__graphql_runtime_info]) &&
-            (obj = current_runtime_state.public_send(key)) &&
+            (query_runtime_state = current_runtime_state[@query]) &&
+            (obj = query_runtime_state.public_send(key)) &&
             obj.dig(*other_keys)
         elsif @scoped_context.key?(key)
           @scoped_context.dig(key, *other_keys)

--- a/spec/graphql/query/context_spec.rb
+++ b/spec/graphql/query/context_spec.rb
@@ -94,7 +94,7 @@ describe GraphQL::Query::Context do
 
     it "allows you to read values of contexts using dig" do
       assert_equal(1, context.dig(:a, :b))
-      Thread.current[:__graphql_runtime_info] = OpenStruct.new(current_arguments: {c: 1})
+      Thread.current[:__graphql_runtime_info] = { context.query => OpenStruct.new(current_arguments: {c: 1}) }
       assert_equal 1, context.dig(:current_arguments, :c)
     end
   end
@@ -111,7 +111,7 @@ describe GraphQL::Query::Context do
 
   it "can override values set by runtime" do
     context = GraphQL::Query::Context.new(query: OpenStruct.new(schema: schema), values: {a: {b: 1}}, object: nil)
-    Thread.current[:__graphql_runtime_info] = OpenStruct.new({ current_object: :runtime_value })
+    Thread.current[:__graphql_runtime_info] = { context.query => OpenStruct.new({ current_object: :runtime_value }) }
     assert_equal :runtime_value, context[:current_object]
     context[:current_object] = :override_value
     assert_equal :override_value, context[:current_object]
@@ -384,7 +384,7 @@ describe GraphQL::Query::Context do
     it "always retrieves a scoped context value if set" do
       context = GraphQL::Query::Context.new(query: OpenStruct.new(schema: schema), values: nil, object: nil)
       dummy_runtime = OpenStruct.new(current_result: nil)
-      Thread.current[:__graphql_runtime_info] = dummy_runtime
+      Thread.current[:__graphql_runtime_info] = { context.query => dummy_runtime }
       dummy_runtime.current_result = OpenStruct.new(path: ["somewhere"])
       expected_key = :a
       expected_value = :test
@@ -446,7 +446,7 @@ describe GraphQL::Query::Context do
     it "has a #current_path method" do
       context = GraphQL::Query::Context.new(query: OpenStruct.new(schema: schema), values: nil, object: nil)
       current_result = OpenStruct.new(path: ["somewhere", "child", "grandchild"])
-      Thread.current[:__graphql_runtime_info] = OpenStruct.new(current_result: current_result)
+      Thread.current[:__graphql_runtime_info] = { context.query => OpenStruct.new(current_result: current_result) }
       assert_equal ["somewhere", "child", "grandchild"], context.scoped_context.current_path
     end
   end

--- a/spec/graphql/query/context_spec.rb
+++ b/spec/graphql/query/context_spec.rb
@@ -2,6 +2,12 @@
 require "spec_helper"
 
 describe GraphQL::Query::Context do
+  after do
+    # Clean up test fixtures so they don't pollute later tests
+    # (Usually this is cleaned up by execution code, but many tests here don't actually execute queries)
+    Thread.current[:__graphql_runtime_info] = nil
+  end
+
   class ContextTestSchema < GraphQL::Schema
     class Query < GraphQL::Schema::Object
       field :context, String, resolver_method: :fetch_context_key do


### PR DESCRIPTION
Oops, if a field ran another graphql query inside its resolver body, then the inner query would clobber the thread context for the outer field. This change makes it so that the outer field will still have its runtime context after the inner query is finished. 

The performance impact looks negligible: 

```diff
  Calculating -------------------------------------
  Querying for 1000 objects
-                           4.562  (± 0.0%) i/s -     23.000  in   5.043385s
+                           4.447  (± 0.0%) i/s -     23.000  in   5.174162s
```

Plus two more objects allocated 🤷 