### PR TITLE
Pass is_non_null instead of tracking a list of non-null result names

### DIFF
--- a/benchmark/run.rb
+++ b/benchmark/run.rb
@@ -132,12 +132,13 @@ module GraphQLBenchmark
   def self.profile_large_introspection
     schema = SILLY_LARGE_SCHEMA
     Benchmark.ips do |x|
+      x.config(time: 10)
       x.report("Run large introspection") {
         schema.to_json
       }
     end
 
-    result = StackProf.run(mode: :wall, interval: 10) do
+    result = StackProf.run(mode: :wall) do
       schema.to_json
     end
     StackProf::Report.new(result).print_text


### PR DESCRIPTION
This eliminates the creation and population of the non-null result name list, reducing memory pressure and running faster, especially for queries with lots of object results which have at least one non-null field in them. (Introspection is a great example -- every type, field, and argument becomes and object result with at least one non-null field.)


```diff 
  $ be rake bench:profile_large_introspection

  Calculating -------------------------------------
  Run large introspection
-                            2.023  (± 0.0%) i/s -     21.000  in  10.407608s
+                            2.145  (± 0.0%) i/s -     22.000  in  10.262064s

- Total allocated: 16020644 bytes (125584 objects)
+ Total allocated: 15160324 bytes (113560 objects)
```
