### PR TITLE
Memoize current trace

### DIFF
--- a/lib/graphql/execution/interpreter.rb
+++ b/lib/graphql/execution/interpreter.rb
@@ -87,7 +87,6 @@ module GraphQL
 
                   # Then, work through lazy results in a breadth-first way
                   multiplex.dataloader.append_job {
-                    tracer = multiplex
                     query = multiplex.queries.length == 1 ? multiplex.queries[0] : nil
                     queries = multiplex ? multiplex.queries : [query]
                     final_values = queries.map do |query|
@@ -96,7 +95,7 @@ module GraphQL
                       runtime ? runtime.final_result : nil
                     end
                     final_values.compact!
-                    tracer.current_trace.execute_query_lazy(multiplex: multiplex, query: query) do
+                    multiplex.current_trace.execute_query_lazy(multiplex: multiplex, query: query) do
                       Interpreter::Resolve.resolve_each_depth(lazies_at_depth, multiplex.dataloader)
                     end
                     queries.each do |query|

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -197,11 +197,11 @@ module GraphQL
 
         def initialize(query:, lazies_at_depth:)
           @query = query
+          @current_trace = query.current_trace
           @dataloader = query.multiplex.dataloader
           @lazies_at_depth = lazies_at_depth
           @schema = query.schema
           @context = query.context
-          @multiplex_context = query.multiplex.context
           @response = GraphQLResultHash.new(nil, nil, false)
           # Identify runtime directives by checking which of this schema's directives have overridden `def self.resolve`
           @runtime_directive_names = []
@@ -543,7 +543,7 @@ module GraphQL
           field_result = call_method_on_directives(:resolve, object, directives) do
             # Actually call the field resolver and capture the result
             app_result = begin
-              query.current_trace.execute_field(field: field_defn, ast_node: ast_node, query: query, object: object, arguments: kwarg_arguments) do
+              @current_trace.execute_field(field: field_defn, ast_node: ast_node, query: query, object: object, arguments: kwarg_arguments) do
                 field_defn.resolve(object, kwarg_arguments, context)
               end
             rescue GraphQL::ExecutionError => err
@@ -974,7 +974,7 @@ module GraphQL
               # but don't wrap the continuation below
               inner_obj = begin
                 if trace
-                  query.current_trace.execute_field_lazy(field: field, query: query, object: owner_object, arguments: arguments, ast_node: ast_node) do
+                  @current_trace.execute_field_lazy(field: field, query: query, object: owner_object, arguments: arguments, ast_node: ast_node) do
                     schema.sync_lazy(lazy_obj)
                   end
                 else
@@ -1031,13 +1031,13 @@ module GraphQL
         end
 
         def resolve_type(type, value)
-          resolved_type, resolved_value = query.current_trace.resolve_type(query: query, type: type, object: value) do
+          resolved_type, resolved_value = @current_trace.resolve_type(query: query, type: type, object: value) do
             query.resolve_type(type, value)
           end
 
           if lazy?(resolved_type)
             GraphQL::Execution::Lazy.new do
-              query.current_trace.resolve_type_lazy(query: query, type: type, object: value) do
+              @current_trace.resolve_type_lazy(query: query, type: type, object: value) do
                 schema.sync_lazy(resolved_type)
               end
             end


### PR DESCRIPTION
This is hit a lot at runtime, but it shouldn't change after `query.multiplex = ...` is assigned, so we can safely memoize it. 

```diff
  Calculating -------------------------------------
  Run large introspection
-                           2.059  (± 0.0%) i/s -     21.000  in  10.204161s
+                           2.077  (± 0.0%) i/s -     21.000  in  10.132087s
       TOTAL    (pct)     SAMPLES    (pct)     FRAME
          39   (8.0%)          39   (8.0%)     Kernel#class
         480  (98.2%)          22   (4.5%)     Array#each
          18   (3.7%)          18   (3.7%)     NilClass#===
          17   (3.5%)          17   (3.5%)     GraphQL::Schema::Member::HasValidators#validators
          16   (3.3%)          16   (3.3%)     GraphQL::Execution::Interpreter::Runtime#dead_result?
          14   (2.9%)          14   (2.9%)     Kernel#hash
-         13   (2.7%)          13   (2.7%)     GraphQL::Query#current_trace
          13   (2.7%)          13   (2.7%)     Thread.current
```