### PR TITLE
Fewer result objects

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -52,7 +52,6 @@ module GraphQL
         class GraphQLResultHash < Hash
           def initialize(_result_name, _parent_result, _is_non_null_in_parent)
             super
-            @storing_graphql_metadata = false
             @graphql_result_data = {}
           end
 
@@ -75,7 +74,7 @@ module GraphQL
 
             @graphql_result_data[key] = value
             # keep this up-to-date if it's being used
-            if @storing_graphql_metadata
+            if any?
               self[key] = value
             end
 
@@ -88,8 +87,7 @@ module GraphQL
             end
             # If we encounter some part of this response that requires metadata tracking,
             # then create the metadata hash if necessary. It will be kept up-to-date after this.
-            if !@storing_graphql_metadata
-              @storing_graphql_metadata = true
+            if !any?
               self.merge!(@graphql_result_data)
             end
 
@@ -104,19 +102,19 @@ module GraphQL
           end
 
           def each(&block)
-            @storing_graphql_metadata ? super(&block) : @graphql_result_data.each(&block)
+            any? ? super(&block) : @graphql_result_data.each(&block)
           end
 
           def values
-            @storing_graphql_metadata ? super : @graphql_result_data.values
+            any? ? super : @graphql_result_data.values
           end
 
           def key?(k)
-            @storing_graphql_metadata ? super : @graphql_result_data.key?(k)
+            any? ? super : @graphql_result_data.key?(k)
           end
 
           def [](k)
-            @storing_graphql_metadata ? super : @graphql_result_data[k]
+            any? ? super : @graphql_result_data[k]
           end
 
           def merge_into(into_result)


### PR DESCRIPTION
I thought I  could get a win here because it would reduce the number of objects used for tracking results during execution, but in fact, it got slower: 

```diff 
  Calculating -------------------------------------
  Run large introspection
-                           2.199  (± 0.0%) i/s -     22.000  in  10.006654s
+                           2.015  (± 0.0%) i/s -     21.000  in  10.436912s

- Total allocated: 15160324 bytes (113560 objects)
+ Total allocated: 14992884 bytes (106969 objects)
```

My guess is that it's because Ruby has optimizations for Hash methods on Hash instances, but by making a subclass, I lose that advantage. (I remember learning about that sometime in the past, anyways...)