### PR TITLE
Cache resolved arguments better

### DIFF
--- a/lib/graphql/execution/interpreter/arguments_cache.rb
+++ b/lib/graphql/execution/interpreter/arguments_cache.rb
@@ -7,49 +7,48 @@ module GraphQL
         def initialize(query)
           @query = query
           @dataloader = query.context.dataloader
-          @storage = Hash.new do |h, ast_node|
-            h[ast_node] = Hash.new do |h2, arg_owner|
-              h2[arg_owner] = Hash.new do |h3, parent_object|
-                dataload_for(ast_node, arg_owner, parent_object) do |kwarg_arguments|
-                  h3[parent_object] = @query.after_lazy(kwarg_arguments) do |resolved_args|
-                    h3[parent_object] = resolved_args
-                  end
-                end
-
-                if !h3.key?(parent_object)
-                  # TODO should i bother putting anything here?
-                  h3[parent_object] = NO_ARGUMENTS
-                else
-                  h3[parent_object]
-                end
+          @storage = Hash.new do |h, argument_owner|
+            args_by_parent = if argument_owner.arguments_statically_coercible?
+              shared_values_cache = {}
+              Hash.new do |h2, ignored_parent_object|
+                h2[ignored_parent_object] = shared_values_cache
+              end
+            else
+              args_by_parent = Hash.new do |h2, parent_object|
+                h2[parent_object] = {}
               end
             end
+            args_by_parent.compare_by_identity
+            h[argument_owner] = args_by_parent
           end
+          @storage.compare_by_identity
         end
 
         def fetch(ast_node, argument_owner, parent_object)
-          # If any jobs were enqueued, run them now,
-          # since this might have been called outside of execution.
-          # (The jobs are responsible for updating `result` in-place.)
-          if !@storage.key?(ast_node) || !@storage[ast_node].key?(argument_owner)
-            @dataloader.run_isolated do
-              @storage[ast_node][argument_owner][parent_object]
+          args_hash = self.class.prepare_args_hash(@query, ast_node)
+          # This runs eagerly if no block is given
+          @storage[argument_owner][parent_object][args_hash] ||= begin
+            kwarg_arguments = argument_owner.coerce_arguments(parent_object, args_hash, @query.context)
+            @query.after_lazy(kwarg_arguments) do |resolved_args|
+              @storage[argument_owner][parent_object][args_hash] = resolved_args
             end
           end
-          # Ack, the _hash_ is updated, but the key is eventually
-          # overridden with an immutable arguments instance.
-          # The first call queues up the job,
-          # then this call fetches the result.
-          # TODO this should be better, find a solution
-          # that works with merging the runtime.rb code
-          @storage[ast_node][argument_owner][parent_object]
+
         end
 
         # @yield [Interpreter::Arguments, Lazy<Interpreter::Arguments>] The finally-loaded arguments
         def dataload_for(ast_node, argument_owner, parent_object, &block)
           # First, normalize all AST or Ruby values to a plain Ruby hash
           args_hash = self.class.prepare_args_hash(@query, ast_node)
-          argument_owner.coerce_arguments(parent_object, args_hash, @query.context, &block)
+          arg_storage = @storage[argument_owner][parent_object]
+          if (args = arg_storage[args_hash])
+            yield(args)
+          else
+            argument_owner.coerce_arguments(parent_object, args_hash, @query.context) do |resolved_args|
+              arg_storage[args_hash] = resolved_args
+              yield(resolved_args)
+            end
+          end
           nil
         end
 

--- a/lib/graphql/execution/interpreter/arguments_cache.rb
+++ b/lib/graphql/execution/interpreter/arguments_cache.rb
@@ -14,7 +14,7 @@ module GraphQL
                 h2[ignored_parent_object] = shared_values_cache
               end
             else
-              args_by_parent = Hash.new do |h2, parent_object|
+              Hash.new do |h2, parent_object|
                 args_by_node = {}
                 args_by_node.compare_by_identity
                 h2[parent_object] = args_by_node

--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -198,8 +198,8 @@ module GraphQL
 
       def statically_coercible?
         return @statically_coercible if defined?(@statically_coercible)
-
-        @statically_coercible = !@prepare.is_a?(String) && !@prepare.is_a?(Symbol)
+        requires_parent_object = @prepare.is_a?(String) || @prepare.is_a?(Symbol) || @own_validators
+        @statically_coercible = !requires_parent_object
       end
 
       # Apply the {prepare} configuration to `value`, using methods from `obj`.

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -235,7 +235,7 @@ module GraphQL
         @name = -(camelize ? Member::BuildType.camelize(name_s) : name_s)
 
         @description = description
-        @type = @owner_type = @own_validators = @own_directives = @own_arguments = nil # these will be prepared later if necessary
+        @type = @owner_type = @own_validators = @own_directives = @own_arguments = @arguments_statically_coercible = nil # these will be prepared later if necessary
 
         self.deprecation_reason = deprecation_reason
 

--- a/lib/graphql/schema/member/has_arguments.rb
+++ b/lib/graphql/schema/member/has_arguments.rb
@@ -320,9 +320,11 @@ module GraphQL
         end
 
         def arguments_statically_coercible?
-          return @arguments_statically_coercible if defined?(@arguments_statically_coercible)
-
-          @arguments_statically_coercible = all_argument_definitions.all?(&:statically_coercible?)
+          if defined?(@arguments_statically_coercible) && !@arguments_statically_coercible.nil?
+            @arguments_statically_coercible
+          else
+            @arguments_statically_coercible = all_argument_definitions.all?(&:statically_coercible?)
+          end
         end
 
         module ArgumentClassAccessor


### PR DESCRIPTION
Ugh, there's an `ArgumentsCache` class that caches arguments, but as far as I can tell, the main call in `runtime.rb`: 

https://github.com/rmosolgo/graphql-ruby/blob/a692a75384b6d446d7b7ee1355a4307871f14a63/lib/graphql/execution/interpreter/runtime.rb#L460-L462

didn't use a method that cached the results :S  

So, this PR makes it _actually_ cache and improves the caching for cases when arguments don't have a `prepare` hook or any validators by using `statically_coercible?`. 

Introspection benchmark, before: 

```
Run large introspection
                          2.157  (± 0.0%) i/s -     22.000  in  10.202996s
==================================
  Mode: wall(1000)
  Samples: 471 (1.46% miss rate)
  GC: 3 (0.64%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
        35   (7.4%)          35   (7.4%)     Kernel#class
       468  (99.4%)          24   (5.1%)     Array#each
        23   (4.9%)          23   (4.9%)     GraphQL::Schema::Member::HasValidators#validators
        22   (4.7%)          22   (4.7%)     GraphQL::Execution::Interpreter::Runtime#dead_result?
        17   (3.6%)          17   (3.6%)     GraphQL::Schema::Member::HasArguments#own_arguments
        16   (3.4%)          16   (3.4%)     Thread.current
        14   (3.0%)          14   (3.0%)     Kernel#is_a?
        14   (3.0%)          14   (3.0%)     Kernel#hash
        13   (2.8%)          13   (2.8%)     GraphQL::Schema::NonNull#non_null?

Total allocated: 15160324 bytes (113560 objects)
```

After: 

```
Calculating -------------------------------------
Run large introspection
                          2.275  (± 0.0%) i/s -     23.000  in  10.112680s
==================================
  Mode: wall(1000)
  Samples: 455 (1.52% miss rate)
  GC: 3 (0.66%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
        35   (7.7%)          35   (7.7%)     Kernel#class
        32   (7.0%)          32   (7.0%)     GraphQL::Schema::Member::HasValidators#validators
       452  (99.3%)          22   (4.8%)     Array#each
        20   (4.4%)          20   (4.4%)     Thread.current
        20   (4.4%)          20   (4.4%)     GraphQL::Execution::Interpreter::Runtime#dead_result?
        45   (9.9%)          15   (3.3%)     GraphQL::Execution::Interpreter::Runtime#gather_selections
        13   (2.9%)          13   (2.9%)     GraphQL::Schema::Member::HasArguments#own_arguments

Total allocated: 12243300 bytes (86400 objects)
```

~5% faster, but more importantly, ~19% less memory and ~24% fewer objects.

TODO: 

- [x] My first take changed the cache structure to use the Ruby hash value instead of the AST node in the cache. Is this actually faster?

   - I'm not _sure_ it's faster, but I like the idea of keeping it how it was (and not using Hashes as hash keys...)