### PR TITLE
add `execute_multiplex.graphql` to NotificationsTrace

### DIFF
--- a/lib/graphql/tracing.rb
+++ b/lib/graphql/tracing.rb
@@ -14,6 +14,7 @@ require "graphql/tracing/statsd_tracing"
 require "graphql/tracing/prometheus_tracing"
 
 # New Tracing:
+require "graphql/tracing/active_support_notifications_trace"
 require "graphql/tracing/platform_trace"
 require "graphql/tracing/appoptics_trace"
 require "graphql/tracing/appsignal_trace"

--- a/lib/graphql/tracing/notifications_trace.rb
+++ b/lib/graphql/tracing/notifications_trace.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "graphql/tracing/platform_trace"
+
 module GraphQL
   module Tracing
     # This implementation forwards events to a notification handler (i.e.
@@ -20,6 +22,7 @@ module GraphQL
         "validate" => "validate.graphql",
         "analyze_multiplex" => "analyze_multiplex.graphql",
         "analyze_query" => "analyze_query.graphql",
+        "execute_multiplex" => "execute_multiplex.graphql",
         "execute_query" => "execute_query.graphql",
         "execute_query_lazy" => "execute_query_lazy.graphql",
         "execute_field" => "execute_field.graphql",

--- a/spec/graphql/tracing/notifications_trace_spec.rb
+++ b/spec/graphql/tracing/notifications_trace_spec.rb
@@ -19,9 +19,24 @@ describe GraphQL::Tracing::NotificationsTrace do
 
   describe "Observing" do
     it "dispatchs the event to the notifications engine with suffixed key" do
-      dispatched_events = trigger_fake_notifications_tracer(NotificationsTraceTest::Schema)
+      dispatched_events = trigger_fake_notifications_tracer(NotificationsTraceTest::Schema).to_h
 
       assert dispatched_events.length > 0
+
+      expected_event_keys = [
+        'execute_multiplex.graphql',
+        'analyze_multiplex.graphql',
+        'lex.graphql',
+        'parse.graphql',
+        'validate.graphql',
+        'analyze_query.graphql',
+        'execute_query.graphql',
+        'authorized.graphql',
+        'execute_field.graphql',
+        'execute_query_lazy.graphql'
+      ]
+
+      assert_equal expected_event_keys, dispatched_events.keys
 
       dispatched_events.each do |event, payload|
         assert event.end_with?(".graphql")


### PR DESCRIPTION
Legacy tracing fired `execute_multiplex.graphql` to ActiveSupport::Notifications; this PR restores that behavior for the new `ActiveSupportNotificationsTrace` mixin, and adds a few missing requires (to bring it into parity with the rest of the new Trace modules).