### PR TITLE
Don't require a filter for Warden

### DIFF
--- a/lib/graphql/filter.rb
+++ b/lib/graphql/filter.rb
@@ -6,7 +6,8 @@ module GraphQL
   class Filter
     def initialize(only: nil, except: nil, silence_deprecation_warning: false)
       if !silence_deprecation_warning
-        GraphQL::Deprecation.warn("GraphQL::Filter, `only:`, `except:`, and `.merge_filters` are deprecated and will be removed in v2.1.0. Implement `visible?` on your schema members instead (https://graphql-ruby.org/authorization/visibility.html).")
+        line = caller(2, 10).find { |l| !l.include?("lib/graphql") }
+        GraphQL::Deprecation.warn("GraphQL::Filter, `only:`, `except:`, and `.merge_filters` are deprecated and will be removed in v2.1.0. Implement `visible?` on your schema members instead (https://graphql-ruby.org/authorization/visibility.html).\n  #{line}")
       end
       @only = only
       @except = except

--- a/lib/graphql/filter.rb
+++ b/lib/graphql/filter.rb
@@ -6,7 +6,7 @@ module GraphQL
   class Filter
     def initialize(only: nil, except: nil, silence_deprecation_warning: false)
       if !silence_deprecation_warning
-        GraphQL::Deprecation.warn("GraphQL::Filter, `only:`, and `except:` are deprecated and will be removed in v2.1.0. Implement `visible?` on your schema members instead (https://graphql-ruby.org/authorization/visibility.html).")
+        GraphQL::Deprecation.warn("GraphQL::Filter, `only:`, `except:`, and `.merge_filters` are deprecated and will be removed in v2.1.0. Implement `visible?` on your schema members instead (https://graphql-ruby.org/authorization/visibility.html).")
       end
       @only = only
       @except = except

--- a/lib/graphql/filter.rb
+++ b/lib/graphql/filter.rb
@@ -6,7 +6,7 @@ module GraphQL
   class Filter
     def initialize(only: nil, except: nil, silence_deprecation_warning: false)
       if !silence_deprecation_warning
-        GraphQL::Deprecation.warn("GraphQL::Filter is deprecated and will be removed in v2.1.0. Implement `visible?` on your schema members instead (https://graphql-ruby.org/authorization/visibility.html).")
+        GraphQL::Deprecation.warn("GraphQL::Filter, `only:`, and `except:` are deprecated and will be removed in v2.1.0. Implement `visible?` on your schema members instead (https://graphql-ruby.org/authorization/visibility.html).")
       end
       @only = only
       @except = except

--- a/lib/graphql/language/document_from_schema_definition.rb
+++ b/lib/graphql/language/document_from_schema_definition.rb
@@ -24,17 +24,21 @@ module GraphQL
         @include_built_in_directives = include_built_in_directives
         @include_one_of = false
 
-        filter = GraphQL::Filter.new(only: only, except: except, silence_deprecation_warning: true)
-        if @schema.respond_to?(:visible?)
-          filter = filter.merge(only: @schema.method(:visible?))
+        schema_context = schema.context_class.new(query: nil, object: nil, schema: schema, values: context)
+
+        @warden = if only || except
+          filter = GraphQL::Filter
+            .new(only: only, except: except)
+            .merge(only: @schema.method(:visible?))
+          GraphQL::Schema::Warden.new(
+              filter,
+              schema: @schema,
+              context: schema_context,
+            )
+        else
+          GraphQL::Schema::Warden.new(schema: @schema, context: schema_context)
         end
 
-        schema_context = schema.context_class.new(query: nil, object: nil, schema: schema, values: context)
-        @warden = GraphQL::Schema::Warden.new(
-          filter,
-          schema: @schema,
-          context: schema_context,
-        )
         schema_context.warden = @warden
       end
 

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -87,7 +87,11 @@ module GraphQL
       # Even if `variables: nil` is passed, use an empty hash for simpler logic
       variables ||= {}
       @schema = schema
-      @filter = schema.default_filter.merge(except: except, only: only)
+      @filter = if only || except
+        schema.default_filter.merge(except: except, only: only)
+      else
+        nil
+      end
       @context = schema.context_class.new(query: self, object: root_value, values: context)
       @warden = warden
       @subscription_topic = subscription_topic
@@ -151,11 +155,6 @@ module GraphQL
 
       @result_values = nil
       @executed = false
-
-      # TODO add a general way to define schema-level filters
-      if @schema.respond_to?(:visible?)
-        merge_filters(only: @schema.method(:visible?))
-      end
     end
 
     # If a document was provided to `GraphQL::Schema#execute` instead of the raw query string, we will need to get it from the document

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -346,6 +346,7 @@ module GraphQL
       if @prepared_ast
         raise "Can't add filters after preparing the query"
       else
+        @filter ||= GraphQL::Filter.new(only: ->(m, ctx){ @schema.visible?(m, ctx) })
         @filter = @filter.merge(only: only, except: except)
       end
       nil

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -87,10 +87,8 @@ module GraphQL
       # Even if `variables: nil` is passed, use an empty hash for simpler logic
       variables ||= {}
       @schema = schema
-      @filter = if only || except
-        schema.default_filter.merge(except: except, only: only)
-      else
-        nil
+      if only || except
+        merge_filters(except: except, only: only)
       end
       @context = schema.context_class.new(query: self, object: root_value, values: context)
       @warden = warden
@@ -346,7 +344,7 @@ module GraphQL
       if @prepared_ast
         raise "Can't add filters after preparing the query"
       else
-        @filter ||= GraphQL::Filter.new(only: ->(m, ctx){ @schema.visible?(m, ctx) })
+        @filter ||= @schema.default_filter
         @filter = @filter.merge(only: only, except: except)
       end
       nil

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -244,11 +244,13 @@ module GraphQL
       end
 
       def default_filter
-        GraphQL::Filter.new(except: default_mask, silence_deprecation_warning: true)
+        GraphQL::Filter.new(except: default_mask)
       end
 
       def default_mask(new_mask = nil)
         if new_mask
+          line = caller(2, 10).find { |l| !l.include?("lib/graphql") }
+          GraphQL::Deprecation.warn("GraphQL::Filter and Schema.mask are deprecated and will be removed in v2.1.0. Implement `visible?` on your schema members instead (https://graphql-ruby.org/authorization/visibility.html).\n  #{line}")
           @own_default_mask = new_mask
         else
           @own_default_mask || find_inherited_value(:default_mask, Schema::NullMask)

--- a/lib/graphql/schema/printer.rb
+++ b/lib/graphql/schema/printer.rb
@@ -57,12 +57,14 @@ module GraphQL
         query_root = Class.new(GraphQL::Schema::Object) do
           graphql_name "Root"
           field :throwaway_field, String
+          def self.visible?(ctx)
+            false
+          end
         end
         schema = Class.new(GraphQL::Schema) { query(query_root) }
 
         introspection_schema_ast = GraphQL::Language::DocumentFromSchemaDefinition.new(
           schema,
-          except: ->(member, _) { member.graphql_name == "Root" },
           include_introspection_types: true,
           include_built_in_directives: true,
         ).document

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -90,14 +90,19 @@ module GraphQL
       # @param filter [<#call(member)>] Objects are hidden when `.call(member, ctx)` returns true
       # @param context [GraphQL::Query::Context]
       # @param schema [GraphQL::Schema]
-      def initialize(filter, context:, schema:)
+      def initialize(filter = nil, context:, schema:)
         @schema = schema
         # Cache these to avoid repeated hits to the inheritance chain when one isn't present
         @query = @schema.query
         @mutation = @schema.mutation
         @subscription = @schema.subscription
         @context = context
-        @visibility_cache = read_through { |m| filter.call(m, context) }
+        @visibility_cache = if filter
+          read_through { |m| filter.call(m, context) }
+        else
+          read_through { |m| schema.visible?(m, context) }
+        end
+
         @visibility_cache.compare_by_identity
         # Initialize all ivars to improve object shape consistency:
         @types = @visible_types = @reachable_types = @visible_parent_fields =

--- a/spec/graphql/language/document_from_schema_definition_spec.rb
+++ b/spec/graphql/language/document_from_schema_definition_spec.rb
@@ -324,10 +324,13 @@ type Query {
       }
 
       let(:document) {
-        subject.new(
-          schema,
-          except: ->(m, _ctx) { m.respond_to?(:graphql_name) && m.graphql_name == "Type" }
-        ).document
+        doc_schema = Class.new(schema) do
+          def self.visible?(m, _ctx)
+            m.respond_to?(:graphql_name) && m.graphql_name != "Type"
+          end
+        end
+
+        subject.new(doc_schema).document
       }
 
       it "returns the IDL minus the filtered members" do
@@ -375,10 +378,13 @@ type Query {
       }
 
       let(:document) {
-        subject.new(
-          schema,
-          only: ->(m, _ctx) { !(m.respond_to?(:kind) && m.kind.scalar? && m.name == "CustomScalar") }
-        ).document
+        doc_schema = Class.new(schema) do
+          def self.visible?(m, _ctx)
+            !(m.respond_to?(:kind) && m.kind.scalar? && m.name == "CustomScalar")
+          end
+        end
+
+        subject.new(doc_schema).document
       }
 
       it "returns the IDL minus the filtered members" do

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -836,7 +836,7 @@ describe GraphQL::Query do
 
   it "Accepts a passed-in warden" do
     schema_class = Class.new(Jazz::Schema) do
-      def self.visible?(ctx)
+      def self.visible?(member, ctx)
         false
       end
     end

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -835,7 +835,13 @@ describe GraphQL::Query do
   end
 
   it "Accepts a passed-in warden" do
-    warden = GraphQL::Schema::Warden.new(->(t, ctx) { false }, schema: Jazz::Schema, context: nil)
+    schema_class = Class.new(Jazz::Schema) do
+      def self.visible?(ctx)
+        false
+      end
+    end
+
+    warden = GraphQL::Schema::Warden.new(schema: schema_class, context: nil)
     res = Jazz::Schema.execute("{ __typename } ", warden: warden)
     assert_equal ["Schema is not configured for queries"], res["errors"].map { |e| e["message"] }
   end

--- a/spec/graphql/schema/warden_spec.rb
+++ b/spec/graphql/schema/warden_spec.rb
@@ -477,10 +477,11 @@ describe GraphQL::Schema::Warden do
         query(Query)
 
         def self.visible?(member, context)
-          super(member, context) && if context[:except]
+          res = super(member, context)
+          if res && context[:except]
             !context[:except].call(member, context)
           else
-            true
+            res
           end
         end
       end
@@ -539,10 +540,11 @@ describe GraphQL::Schema::Warden do
 
       schema = GraphQL::Schema.from_definition(sdl)
       schema.define_singleton_method(:visible?) do |member, context|
-        super(member, context) && if context[:except]
+        res = super(member, context)
+        if res && context[:except]
           !context[:except].call(member, context)
         else
-          true
+          res
         end
       end
 

--- a/spec/graphql/schema/warden_spec.rb
+++ b/spec/graphql/schema/warden_spec.rb
@@ -220,6 +220,7 @@ module MaskHelpers
   end
 
   def self.query_with_mask(str, mask, variables: {})
+    # TODO Why isn't this warning?
     run_query(str, except: mask, root_value: Data, variables: variables)
   end
 

--- a/spec/graphql/schema/warden_spec.rb
+++ b/spec/graphql/schema/warden_spec.rb
@@ -187,19 +187,6 @@ module MaskHelpers
     end
   end
 
-  module FilterInstrumentation
-    def self.before_query(query)
-      if query.context[:filters]
-        query.merge_filters(
-          only: query.context[:filters][:only],
-          except: query.context[:filters][:except],
-        )
-      end
-    end
-
-    def self.after_query(q); end
-  end
-
   class Schema < GraphQL::Schema
     query QueryType
     mutation MutationType
@@ -209,7 +196,18 @@ module MaskHelpers
       PhonemeType
     end
 
-    instrument :query, FilterInstrumentation
+    def self.visible?(member, context)
+      result = super(member, context)
+      if result && (f = context[:filters])
+        if f[:only] && !Array(f[:only]).all? { |func| func.call(member, context) }
+          return false
+        end
+        if f[:except] && Array(f[:except]).any? { |func| func.call(member, context) }
+          return false
+        end
+      end
+      result
+    end
   end
 
   module Data
@@ -220,11 +218,21 @@ module MaskHelpers
   end
 
   def self.query_with_mask(str, mask, variables: {})
-    # TODO Why isn't this warning?
-    run_query(str, except: mask, root_value: Data, variables: variables)
+    run_query(str, context: { filters: { except: mask } }, root_value: Data, variables: variables)
   end
 
   def self.run_query(str, **kwargs)
+    filters = {}
+    if (only = kwargs.delete(:only))
+      filters[:only] = only
+    end
+    if (except = kwargs.delete(:except))
+      filters[:except] = except
+    end
+    if filters.any?
+      context = kwargs[:context] ||= {}
+      context[:filters] = filters
+    end
     Schema.execute(str, **kwargs.merge(root_value: Data))
   end
 end
@@ -433,6 +441,9 @@ describe GraphQL::Schema::Warden do
       |
 
       schema = GraphQL::Schema.from_definition(sdl)
+      schema.define_singleton_method(:visible?) do |member, ctx|
+        super(member, ctx) && (ctx[:hiding] ? member.graphql_name != "Repository" : true)
+      end
 
       query_string = %|
         {
@@ -442,7 +453,7 @@ describe GraphQL::Schema::Warden do
       res = schema.execute(query_string)
       assert res["data"]["Node"]
 
-      res = schema.execute(query_string, except: ->(m, _) { m.graphql_name == "Repository" })
+      res = schema.execute(query_string, context: { hiding: true })
       assert_nil res["data"]["Node"]
     end
 
@@ -464,6 +475,14 @@ describe GraphQL::Schema::Warden do
         end
 
         query(Query)
+
+        def self.visible?(member, context)
+          super(member, context) && if context[:except]
+            !context[:except].call(member, context)
+          else
+            true
+          end
+        end
       end
 
       schema = PossibleTypesSchema
@@ -480,17 +499,17 @@ describe GraphQL::Schema::Warden do
       assert_equal ["bag"], res["data"]["Query"]["fields"].map { |f| f["name"] }
 
       # Hide the union when all its possible types are gone. This will cause the field to be hidden too.
-      res = schema.execute(query_string, except: ->(m, _) { ["A", "B", "C"].include?(m.graphql_name) })
+      res = schema.execute(query_string, context: { except: ->(m, _) { ["A", "B", "C"].include?(m.graphql_name) } })
       assert_nil res["data"]["BagOfThings"]
       assert_equal [], res["data"]["Query"]["fields"]
 
-      res = schema.execute(query_string, except: ->(m, _) { m.graphql_name == "bag" })
+      res = schema.execute(query_string, context: { except: ->(m, _) { m.graphql_name == "bag" } })
       assert_nil res["data"]["BagOfThings"]
       assert_equal [], res["data"]["Query"]["fields"]
 
       # Unreferenced but still visible because orphan type
       schema.orphan_types([schema.find("BagOfThings")])
-      res = schema.execute(query_string, except: ->(m, _) { m.graphql_name == "bag" })
+      res = schema.execute(query_string, context: { except: ->(m, _) { m.graphql_name == "bag" } })
       assert res["data"]["BagOfThings"]
     end
 
@@ -519,6 +538,13 @@ describe GraphQL::Schema::Warden do
       "
 
       schema = GraphQL::Schema.from_definition(sdl)
+      schema.define_singleton_method(:visible?) do |member, context|
+        super(member, context) && if context[:except]
+          !context[:except].call(member, context)
+        else
+          true
+        end
+      end
 
       query_string = %|
         {
@@ -532,13 +558,13 @@ describe GraphQL::Schema::Warden do
       assert_equal ["a", "node"], res["data"]["Query"]["fields"].map { |f| f["name"] }
 
       # When the possible types are all hidden, hide the interface and fields pointing to it
-      res = schema.execute(query_string, except: ->(m, _) { ["A", "B", "C"].include?(m.graphql_name) })
+      res = schema.execute(query_string, context: { except: ->(m, _) { ["A", "B", "C"].include?(m.graphql_name) } })
       assert_nil res["data"]["Node"]
       assert_equal [], res["data"]["Query"]["fields"]
 
       # Even when it's not the return value of a field,
       # still show the interface since it allows code reuse
-      res = schema.execute(query_string, except: ->(m, _) { m.graphql_name == "node" })
+      res = schema.execute(query_string, context: { except: ->(m, _) { m.graphql_name == "node" } })
       assert_equal "Node", res["data"]["Node"]["name"]
       assert_equal [{"name" => "a"}], res["data"]["Query"]["fields"]
     end
@@ -854,33 +880,6 @@ describe GraphQL::Schema::Warden do
       assert_raises(expected_class) {
         MaskHelpers.query_with_mask(query_string, mask)
       }
-    end
-  end
-
-  describe "default_mask" do
-    let(:default_mask) {
-      ->(member, ctx) { MaskHelpers.has_flag?(member, :hidden_enum_value) }
-    }
-    let(:schema) {
-      m = default_mask
-      Class.new(MaskHelpers::Schema) do
-        default_mask(m)
-      end
-    }
-    let(:query_str) { <<-GRAPHQL
-      {
-        enum: __type(name: "Manner") { enumValues { name } }
-        input: __type(name: "WithinInput") { name }
-      }
-    GRAPHQL
-    }
-
-    it "is additive with query filters" do
-      query_except = ->(member, ctx) { MaskHelpers.has_flag?(member, :hidden_input_object_type) }
-      res = schema.execute(query_str, except: query_except)
-      assert_nil res["data"]["input"]
-      enum_values = res["data"]["enum"]["enumValues"].map { |v| v["name"] }
-      refute_includes enum_values, "TRILL"
     end
   end
 


### PR DESCRIPTION
As part of deprecating `GraphQL::Filter`, it should be possible to make a warden without one.

TODO: 

- [ ] address deprecation warnings in test (make sure they're useful, then fix the calls)