### PR TITLE
Accept optional channelName for ActionCable handler and subscriptions

### DIFF
--- a/javascript_client/src/subscriptions/ActionCableSubscriber.ts
+++ b/javascript_client/src/subscriptions/ActionCableSubscriber.ts
@@ -11,10 +11,12 @@ interface ApolloNetworkInterface {
 class ActionCableSubscriber {
   _cable: Consumer
   _networkInterface: ApolloNetworkInterface
+  _channelName: string
 
-  constructor(cable: Consumer, networkInterface: ApolloNetworkInterface) {
+  constructor(cable: Consumer, networkInterface: ApolloNetworkInterface, channelName?: string) {
     this._cable = cable
     this._networkInterface = networkInterface
+    this._channelName = channelName || "GraphqlChannel"
   }
 
   /**
@@ -31,7 +33,7 @@ class ActionCableSubscriber {
     // unique-ish
     var channelId = Math.round(Date.now() + Math.random() * 100000).toString(16)
     var channel = this._cable.subscriptions.create({
-      channel: "GraphqlChannel",
+      channel: this._channelName,
       channelId: channelId,
     }, {
       // After connecting, send the data over ActionCable

--- a/javascript_client/src/subscriptions/addGraphQLSubscriptions.ts
+++ b/javascript_client/src/subscriptions/addGraphQLSubscriptions.ts
@@ -48,7 +48,7 @@ interface Subscriber {
  * @param {ActionCable.Consumer} options.cable - A cable for subscribing with
  * @param {Pusher} options.pusher - A pusher client for subscribing with
 */
-function addGraphQLSubscriptions(networkInterface: any, options: { pusher?: Pusher, cable?: Consumer, subscriber?: Subscriber, decompress?: (compressed: string) => any}) {
+function addGraphQLSubscriptions(networkInterface: any, options: { pusher?: Pusher, cable?: Consumer, subscriber?: Subscriber, decompress?: (compressed: string) => any, channelName?: string }) {
   if (!options) {
     options = {}
   }
@@ -58,7 +58,7 @@ function addGraphQLSubscriptions(networkInterface: any, options: { pusher?: Push
     // Right now this is just for testing
     subscriber = options.subscriber
   } else if (options.cable) {
-    subscriber = new ActionCableSubscriber(options.cable, networkInterface)
+    subscriber = new ActionCableSubscriber(options.cable, networkInterface, options.channelName)
   } else if (options.pusher) {
     subscriber = new PusherSubscriber(options.pusher, networkInterface, options.decompress)
   } else {

--- a/javascript_client/src/subscriptions/createActionCableHandler.ts
+++ b/javascript_client/src/subscriptions/createActionCableHandler.ts
@@ -10,6 +10,7 @@ import type { Consumer } from "@rails/actioncable"
 interface ActionCableHandlerOptions {
   cable: Consumer
   operations?: { getOperationId: Function}
+  channelName?: string
 }
 
 function createActionCableHandler(options: ActionCableHandlerOptions) {
@@ -21,7 +22,7 @@ function createActionCableHandler(options: ActionCableHandlerOptions) {
 
     // Register the subscription by subscribing to the channel
     const channel = cable.subscriptions.create({
-      channel: "GraphqlChannel",
+      channel: options.channelName || "GraphqlChannel",
       channelId: channelId,
     }, {
       connected: function() {


### PR DESCRIPTION
`ActionCableSubscriber` and `createActionCableHandler` currently do not accept a configurable `channelName` for the cable. This is an effort to support passing `channelName` down to ActionCable.

Fixes #4459 