### PR TITLE
Force UTF-8 encoding in lexer

### DIFF
--- a/lib/graphql/language/lexer.rb
+++ b/lib/graphql/language/lexer.rb
@@ -95,12 +95,14 @@ module GraphQL
           previous_token: nil,
         }
 
-        unless string.valid_encoding?
-          emit(:BAD_UNICODE_ESCAPE, 0, 0, meta, string)
+        value = string.dup.force_encoding(Encoding::UTF_8)
+
+        unless value.valid_encoding?
+          emit(:BAD_UNICODE_ESCAPE, 0, 0, meta, value)
           return meta[:tokens]
         end
 
-        scan = StringScanner.new string
+        scan = StringScanner.new value
 
         while !scan.eos?
           pos = scan.pos

--- a/spec/graphql/language/lexer_examples.rb
+++ b/spec/graphql/language/lexer_examples.rb
@@ -52,6 +52,12 @@ module LexerExamples
         |}
         let(:tokens) { subject.tokenize(query_string) }
 
+        it "force encodes to utf-8" do
+          # string that will be invalid utf-8 once force encoded
+          string = "vandflyver \xC5rhus".dup.force_encoding("ASCII-8BIT")
+          assert_equal :BAD_UNICODE_ESCAPE, subject.tokenize(string).first.name
+        end
+
         it "makes utf-8 comments" do
           tokens = subject.tokenize("# 不要!\n{")
           comment_token = tokens.first.prev_token


### PR DESCRIPTION
The rewritten lexer in https://github.com/rmosolgo/graphql-ruby/pull/4369 removed UTF8 forced encoding.

It's possible for applications to force encode document strings themselves before passing it to the GraphQL gem, but it should be done at this layer to ensure that invalid encoding is properly handled.

Two questions:
1. is there any reason not to restore this behaviour?
2. is this the proper place? Previously it was done in 3 separate places, but with the new simpler lexer I believe this should cover it.

cc @tenderlove 