### PR TITLE
Fixing new_trace not using parent's trace_options

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -988,9 +988,7 @@ module GraphQL
       end
 
       def new_trace(**options)
-        if defined?(@trace_options)
-          options = trace_options.merge(options)
-        end
+        options = trace_options.merge(options)
         trace_mode = if (target = options[:query] || options[:multiplex]) && target.context[:backtrace]
           :default_backtrace
         else

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -359,6 +359,20 @@ describe GraphQL::Schema do
       assert_kind_of NewTrace2, child_trace
       assert_kind_of GraphQL::Tracing::Trace, child_trace
     end
+
+    it "returns an instance of the parent configured trace_class with trace_options" do
+      parent_schema = Class.new(GraphQL::Schema) do
+        trace_with NewTrace1, a: 1
+      end
+
+      child_schema = Class.new(parent_schema) do
+      end
+
+      child_trace = child_schema.new_trace
+      assert_equal({a: 1}, child_trace.trace_opts)
+      assert_kind_of NewTrace1, child_trace
+      assert_kind_of GraphQL::Tracing::Trace, child_trace
+    end
   end
 
   describe ".possible_types" do


### PR DESCRIPTION
### Background

When inheriting from Schema the trace options is not used. Since `#trace_options` is never called it will not use the `superclass.trace_options`.

One practical instance of this issue is the following:
```
class BaseSchema < GraphQL::Schema
    use(GraphQL::Schema::Timeout)
    # ...
end

class AnotherSchema < BaseSchema
    # ...
end
```

This will raise the following trace:
```
ArgumentError: missing keyword: :timeout
    .../gems/graphql-2.0.21/lib/graphql/schema/timeout.rb:47:in `initialize'
    .../gems/graphql-2.0.21/lib/graphql/schema.rb:999:in `new'
    .../gems/graphql-2.0.21/lib/graphql/schema.rb:999:in `new_trace'
    .../gems/graphql-2.0.21/lib/graphql/execution/multiplex.rb:35:in `initialize'
    .../gems/graphql-2.0.21/lib/graphql/execution/interpreter.rb:36:in `new'
    .../gems/graphql-2.0.21/lib/graphql/execution/interpreter.rb:36:in `run_all'
    .../gems/graphql-2.0.21/lib/graphql/schema.rb:1069:in `multiplex'
    ...gems/graphql-2.0.21/lib/graphql/schema.rb:1045:in `execute'
```