### PR TITLE
Update homepage installation instructions

### DIFF
--- a/guides/index.html
+++ b/guides/index.html
@@ -13,7 +13,8 @@ title: Welcome
 {% highlight bash %}
 # Download the gem:
 gem install graphql
-# Setup with Rails:
+# Or, setup with Rails:
+bundle add graphql
 rails generate graphql:install
 {% endhighlight %}
       </div>


### PR DESCRIPTION
Hi!

### Problem

I was going through the quick start on the homepage, and got confused for a minute when it failed to run the generator.

Running `gem install graphql` and `rails g graphql:install` gave the error `Could not find generator 'graphql:install'.` since the gem isn't added to the Gemfile.

When I realized what was going on I felt like a dummy—so I thought it was worth calling out to save a future dev the embarrassment.

### Solution

Even though it's obvious to most, it might be helpful to give the explicit instruction to add it to the Gemfile.

### Alternative suggestion

I could see wanting to keep it as two lines, in which case it could be:

```
# Add graphql-ruby to your Gemfile:
bundle add graphql
# Setup with Rails:
rails generate graphql:install
```