### PR TITLE
GraphQL::Query::NullContext support for fetch, dig, and key?

### DIFF
--- a/lib/graphql/query/null_context.rb
+++ b/lib/graphql/query/null_context.rb
@@ -20,7 +20,10 @@ module GraphQL
       class NullSchema < GraphQL::Schema
       end
 
+      extend Forwardable
+
       attr_reader :schema, :query, :warden, :dataloader
+      def_delegators GraphQL::EmptyObjects::EMPTY_HASH, :[], :fetch, :dig, :key?
 
       def initialize
         @query = NullQuery.new
@@ -33,8 +36,6 @@ module GraphQL
         )
       end
 
-      def [](key); end
-
       def interpreter?
         true
       end
@@ -42,13 +43,11 @@ module GraphQL
       class << self
         extend Forwardable
 
-        def [](key); end
-
         def instance
           @instance ||= self.new
         end
 
-        def_delegators :instance, :query, :warden, :schema, :interpreter?, :dataloader
+        def_delegators :instance, :query, :warden, :schema, :interpreter?, :dataloader, :[], :fetch, :dig, :key?
       end
     end
   end

--- a/spec/graphql/query/null_context_spec.rb
+++ b/spec/graphql/query/null_context_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::Query::NullContext do
+  describe "#[]" do
+    it "returns nil" do
+      assert_nil(GraphQL::Query::NullContext[:foo])
+    end
+  end
+
+  describe "#fetch" do
+    it "returns the default value argument" do
+      assert_equal(:default, GraphQL::Query::NullContext.fetch(:foo, :default))
+    end
+
+    it "returns the block result" do
+      assert_equal(:default, GraphQL::Query::NullContext.fetch(:foo) { :default })
+    end
+
+    it "raises a KeyError when not passed a default value or a block" do
+      assert_raises(KeyError) { GraphQL::Query::NullContext.fetch(:foo) }
+    end
+  end
+
+  describe "#key?" do
+    it "returns false" do
+      assert(!GraphQL::Query::NullContext.key?(:foo))
+    end
+  end
+
+  describe "#dig?" do
+    it "returns nil" do
+      assert_nil(GraphQL::Query::NullContext.dig(:foo, :bar, :baz))
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the `fetch`, `dig`, and `key?` methods to `GraphQL::Query::NullContext` for consistency with `GraphQL::Query::Context`