### PR TITLE
Fix tracer compatibility with inheritance

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -102,7 +102,7 @@ module GraphQL
 
       # Support `ctx[:backtrace] = true` for wrapping backtraces
       if context && context[:backtrace] && !@tracers.include?(GraphQL::Backtrace::Tracer)
-        if schema.trace_class <= GraphQL::Tracing::LegacyTrace
+        if schema.trace_class <= GraphQL::Tracing::CallLegacyTracers
           context_tracers += [GraphQL::Backtrace::Tracer]
           @tracers << GraphQL::Backtrace::Tracer
         elsif !(current_trace.class <= GraphQL::Backtrace::Trace)
@@ -110,8 +110,8 @@ module GraphQL
         end
       end
 
-      if context_tracers.any? && !(schema.trace_class <= GraphQL::Tracing::LegacyTrace)
-        raise ArgumentError, "context[:tracers] are not supported without `trace_class(GraphQL::Tracing::LegacyTrace)` in the schema configuration, please add it."
+      if context_tracers.any? && !(schema.trace_class <= GraphQL::Tracing::CallLegacyTracers)
+        raise ArgumentError, "context[:tracers] are not supported without `trace_with(GraphQL::Tracing::CallLegacyTracers)` in the schema configuration, please add it."
       end
 
 

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -961,10 +961,8 @@ module GraphQL
       end
 
       def tracer(new_tracer)
-        if defined?(@trace_modes) && !(trace_class_for(:default) < GraphQL::Tracing::LegacyTrace)
-          raise ArgumentError, "Can't add tracer after configuring a `trace_class`, use GraphQL::Tracing::LegacyTrace to merge legacy tracers into a trace class instead."
-        else
-          trace_mode(:default, Class.new(GraphQL::Tracing::LegacyTrace))
+        if !(trace_class_for(:default) < GraphQL::Tracing::CallLegacyTracers)
+          trace_with(GraphQL::Tracing::CallLegacyTracers)
         end
 
         own_tracers << new_tracer

--- a/lib/graphql/tracing/legacy_trace.rb
+++ b/lib/graphql/tracing/legacy_trace.rb
@@ -4,7 +4,7 @@ module GraphQL
     # This trace class calls legacy-style tracer with payload hashes.
     # New-style `trace_with` modules significantly reduce the overhead of tracing,
     # but that advantage is lost when legacy-style tracers are also used (since the payload hashes are still constructed).
-    class LegacyTrace < Trace
+    module CallLegacyTracers
       def lex(query_string:)
         (@multiplex || @query).trace("lex", { query_string: query_string }) { super }
       end
@@ -60,6 +60,10 @@ module GraphQL
       def resolve_type_lazy(query:, type:, object:)
         query.trace("resolve_type_lazy", { context: query.context, type: type, object: object, path: query.context[:current_path] }) { super }
       end
+    end
+
+    class LegacyTrace < Trace
+      include CallLegacyTracers
     end
   end
 end

--- a/spec/graphql/backtrace_spec.rb
+++ b/spec/graphql/backtrace_spec.rb
@@ -212,7 +212,6 @@ describe GraphQL::Backtrace do
     it "raises original exception instead of a TracedError when error does not occur during resolving" do
       instrumentation_schema = Class.new(schema) do
         instrument(:query, ErrorInstrumentation)
-        trace_class(GraphQL::Tracing::LegacyTrace)
       end
 
       assert_raises(RuntimeError) {

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -151,9 +151,9 @@ describe GraphQL::Schema do
       assert_equal base_schema.multiplex_analyzers + [multiplex_analyzer], schema.multiplex_analyzers
       assert_equal [GraphQL::Backtrace, GraphQL::Subscriptions::ActionCableSubscriptions, CustomSubscriptions], schema.plugins.map(&:first)
       assert_equal [GraphQL::Tracing::DataDogTracing], base_schema.tracers
-      assert_includes base_schema.trace_class.ancestors, GraphQL::Tracing::LegacyTrace
+      assert_includes base_schema.trace_class.ancestors, GraphQL::Tracing::CallLegacyTracers
       assert_equal [GraphQL::Tracing::DataDogTracing, GraphQL::Tracing::NewRelicTracing], schema.tracers
-      assert_includes schema.trace_class.ancestors, GraphQL::Tracing::LegacyTrace
+      assert_includes schema.trace_class.ancestors, GraphQL::Tracing::CallLegacyTracers
 
 
       assert_instance_of CustomSubscriptions, schema.subscriptions

--- a/spec/graphql/tracing/legacy_trace_spec.rb
+++ b/spec/graphql/tracing/legacy_trace_spec.rb
@@ -76,6 +76,6 @@ describe GraphQL::Tracing::LegacyTrace do
 
     res2 = child_schema.execute("{ int }")
     assert_equal true, res2.context[:trace_module_ran]
-    assert_equal true, res1.context[:tracer_ran]
+    assert_equal true, res2.context[:tracer_ran]
   end
 end

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -517,7 +517,7 @@ module Dummy
     subscription Subscription
     max_depth 5
     orphan_types Honey, Beverage
-    trace_class GraphQL::Tracing::LegacyTrace
+    trace_with GraphQL::Tracing::CallLegacyTracers
 
     rescue_from(NoSuchDairyError) { |err| raise GraphQL::ExecutionError, err.message  }
 


### PR DESCRIPTION
Previously, using a legacy `tracer ...` would silently attach a new `trace_class` called `LegacyTrace` whose only job was to call legacy tracers. However, if the parent class has new-style `trace_with` modules attached, `LegacyTrace` wouldn't call them because those modules weren't in `LegacyTrace`'s inheritace. 

This branch takes the behavior of calling legacy tracers and puts it in a _module_ instead, so that it can be added to an intact inheritance chain when it's needed, without disrupting `trace_with` setups from the parent class. (The old `LegacyTrace` class is left in place for compatibility, but error messages point to this new module now.) 

Fixes #4486 