### PR TITLE
Disable `Minitest::Reporters` for RubyMine

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,10 @@ require "minitest/autorun"
 require "minitest/focus"
 require "minitest/reporters"
 
-Minitest::Reporters.use! Minitest::Reporters::DefaultReporter.new(color: true)
+running_in_rubymine = ENV["RM_INFO"]
+unless running_in_rubymine
+  Minitest::Reporters.use! Minitest::Reporters::DefaultReporter.new(color: true)
+end
 
 Minitest::Spec.make_my_diffs_pretty!
 


### PR DESCRIPTION
RubyMine uses its own internal reporter, and needs `Minitest::Reporters` to be disabled to function properly. This change will let RubyMine users run tests in this repo out-of-the-box without needing to patch this themselves.

I know it's editor-specific, so I'd understand if this is rejected on those grounds, but it's a small just just to the spec_helper, so it won't hurt regular consumers of the gem.