### PR TITLE
Accept trace instances during query execution

### DIFF
--- a/guides/queries/tracing.md
+++ b/guides/queries/tracing.md
@@ -32,6 +32,8 @@ end
 
 For a full list of methods and their arguments, see {{ "GraphQL::Tracing::Trace" | api_doc }}.
 
+By default, GraphQL-Ruby makes a new trace instance when it runs a query. You can pass an existing instance as `context: { trace: ... }`. Also, `GraphQL.parse( ..., trace: ...)` accepts a trace instance.
+
 ## ActiveSupport::Notifications
 
 You can emit events to `ActiveSupport::Notifications` with an experimental tracer, `ActiveSupportNotificationsTrace`.

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -168,7 +168,7 @@ module GraphQL
 
     # @return [GraphQL::Tracing::Trace]
     def current_trace
-      @current_trace ||= multiplex ? multiplex.current_trace : schema.new_trace(multiplex: multiplex, query: self)
+      @current_trace ||= context[:trace] || (multiplex ? multiplex.current_trace : schema.new_trace(multiplex: multiplex, query: self))
     end
 
     def subscription_update?

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -1047,6 +1047,7 @@ module GraphQL
           {
             backtrace: ctx[:backtrace],
             tracers: ctx[:tracers],
+            trace: ctx[:trace],
             dataloader: ctx[:dataloader],
           }
         else

--- a/spec/graphql/execution/multiplex_spec.rb
+++ b/spec/graphql/execution/multiplex_spec.rb
@@ -242,4 +242,41 @@ describe GraphQL::Execution::Multiplex do
       assert_equal unhandled_err_json, InspectQueryInstrumentation.last_json
     end
   end
+
+  describe "context[:trace]" do
+    class MultiplexTraceSchema < GraphQL::Schema
+      class Query < GraphQL::Schema::Object
+        field :int, Integer
+        def int; 1; end
+      end
+
+      class Trace < GraphQL::Tracing::Trace
+        def execute_multiplex(multiplex:)
+          @execute_multiplex_count ||= 0
+          @execute_multiplex_count += 1
+          super
+        end
+
+        def execute_query(query:)
+          @execute_query_count ||= 0
+          @execute_query_count += 1
+          super
+        end
+
+        attr_reader :execute_multiplex_count, :execute_query_count
+      end
+
+      query(Query)
+    end
+
+    it "uses it instead of making a new trace" do
+      query_str = "{ int }"
+      trace_instance = MultiplexTraceSchema::Trace.new
+      res = MultiplexTraceSchema.multiplex([{query: query_str}, {query: query_str}], context: { trace: trace_instance })
+      assert_equal [1, 1], res.map { |r| r["data"]["int"]}
+
+      assert_equal 1, trace_instance.execute_multiplex_count
+      assert_equal 2, trace_instance.execute_query_count
+    end
+  end
 end

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -1016,4 +1016,49 @@ describe GraphQL::Query do
       assert_equal "Query", res["data"]["__typename"]
     end
   end
+
+  describe "context[:trace]" do
+    class QueryTraceSchema < GraphQL::Schema
+      class Query < GraphQL::Schema::Object
+        field :int, Integer
+        def int; 1; end
+      end
+
+      class Trace < GraphQL::Tracing::Trace
+        def execute_multiplex(multiplex:)
+          @execute_multiplex_count ||= 0
+          @execute_multiplex_count += 1
+          super
+        end
+
+        def execute_query(query:)
+          @execute_query_count ||= 0
+          @execute_query_count += 1
+          super
+        end
+
+        def execute_field(**rest)
+          @execute_field_count ||= 0
+          @execute_field_count += 1
+          super
+        end
+
+        attr_reader :execute_multiplex_count, :execute_query_count, :execute_field_count
+      end
+
+      query(Query)
+    end
+
+    it "uses it instead of making a new trace" do
+      query_str = "{ int __typename }"
+      trace_instance = QueryTraceSchema::Trace.new
+      res = QueryTraceSchema.execute(query_str, context: { trace: trace_instance })
+
+      assert_equal 1, res["data"]["int"]
+
+      assert_equal 1, trace_instance.execute_multiplex_count
+      assert_equal 1, trace_instance.execute_query_count
+      assert_equal 2, trace_instance.execute_field_count
+    end
+  end
 end


### PR DESCRIPTION
This way, you can take a trace instance passed to `GraphQL.parse` and provide it for query execution. (The same thing was posssible with `context[:tracers]` but it hadn't been totally added for the new Trace API.)