### PR TITLE
Handle context.warden being nil

### DIFF
--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -38,8 +38,9 @@ module GraphQL
     # @api private
     class Warden
       def self.from_context(context)
-        context.warden # this might be a hash which won't respond to this
-      rescue
+        context.warden || PassThruWarden
+      rescue NoMethodError
+        # this might be a hash which won't respond to #warden
         PassThruWarden
       end
 


### PR DESCRIPTION
Before https://github.com/rmosolgo/graphql-ruby/pull/4433, `from_context` returned `PassThruWarden` when `context.warden` was `nil`.

This could happen, for example, when `#warden` [falls back to query.warden](https://github.com/rmosolgo/graphql-ruby/blob/c437a55d8d865577d04c6c66d12187070721584a/lib/graphql/query/context.rb#L313-L315) which could have been initialized with [warden: nil](https://github.com/rmosolgo/graphql-ruby/blob/c437a55d8d865577d04c6c66d12187070721584a/lib/graphql/query.rb#L86).