### PR TITLE
Speed up lookup of possible types for Fragments

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -343,12 +343,8 @@ module GraphQL
                 if node.type
                   type_defn = schema.get_type(node.type.name, context)
 
-                  # Faster than .map{}.include?()
-                  query.warden.possible_types(type_defn).each do |t|
-                    if t == owner_type
-                      gather_selections(owner_object, owner_type, node.selections, selections_to_run, next_selections)
-                      break
-                    end
+                  if query.warden.possible_types(type_defn).include?(owner_type)
+                    gather_selections(owner_object, owner_type, node.selections, selections_to_run, next_selections)
                   end
                 else
                   # it's an untyped fragment, definitely continue
@@ -357,12 +353,8 @@ module GraphQL
               when GraphQL::Language::Nodes::FragmentSpread
                 fragment_def = query.fragments[node.name]
                 type_defn = query.get_type(fragment_def.type.name)
-                possible_types = query.warden.possible_types(type_defn)
-                possible_types.each do |t|
-                  if t == owner_type
-                    gather_selections(owner_object, owner_type, fragment_def.selections, selections_to_run, next_selections)
-                    break
-                  end
+                if query.warden.possible_types(type_defn).include?(owner_type)
+                  gather_selections(owner_object, owner_type, fragment_def.selections, selections_to_run, next_selections)
                 end
               else
                 raise "Invariant: unexpected selection class: #{node.class}"


### PR DESCRIPTION
Really this is just a readability improvement, but there's a nice perf side effect, too :)

This change speeds up `rake bench:profile_large_result` benchmark by about 1.8%.

Baseline (master at cbdae7612372ac5d4edf04c5e6a2404f8471671c)

```
Warming up --------------------------------------
Querying for 1000 objects
                         1.000  i/100ms
Calculating -------------------------------------
Querying for 1000 objects
                          8.149  (± 0.0%) i/s -    815.000  in 100.061220s
```

After this change:

```
Warming up --------------------------------------
Querying for 1000 objects
                         1.000  i/100ms
Calculating -------------------------------------
Querying for 1000 objects
                          8.295  (± 0.0%) i/s -    830.000  in 100.093047s
```

<hr>

This logic used to be more complicated (`t.metadata[:type_class] == owner_type`), but has since been [simplified](https://github.com/rmosolgo/graphql-ruby/commit/3383586f2cf15b345cebdfba6f2a4f7a24122e60#diff-8398a090ccfa07b5ba0482e924606c920a38f2b329ffd1d6246d29e65c9ef6a8R91) to doing a search for an exact-match (`t == owner_type`).

https://github.com/rmosolgo/graphql-ruby/blob/aec347f11f33a3b118612d57a27a723ab497d7b3/lib/graphql/execution/interpreter/runtime.rb#L83-L89

`include?` can do this more expressively than `each` + `break`, and has the added benefit of being way faster (since it can run the loop body in C code, rather than needing to call into a Ruby block). Here's a dumb little synthetic benchmark to demonstrate that:

<details>
<summary>Benchmark</summary>

```ruby
#!/usr/bin/ruby

require "benchmark/ips"

a = Array(1...100)

def found_it!; end

Benchmark.ips do |x|
  x.time = 30
  x.warmup = 10
  x.time = 1
  x.warmup = 1
  
  x.report("each+break") do |times|
    i = 0
    while i < times
      i += 1
    
      a.each do |x|
        if x == 90
          found_it!
          break
        end
      end
    
    end
  end
  
  x.report("include?") do |times|
    i = 0
    while i < times
      i += 1
      
      if a.include?(90)
        found_it!
      end
      
    end
  end
  
  x.compare!
end
```

</details>

```
Warming up --------------------------------------
          each+break    32.413k i/100ms
            include?   264.562k i/100ms
Calculating -------------------------------------
          each+break    322.606k (± 2.6%) i/s -    324.130k in   1.005439s
            include?      2.631M (± 1.1%) i/s -      2.646M in   1.005860s

Comparison:
            include?:  2630515.3 i/s
          each+break:   322606.5 i/s - 8.15x  slower

```