### PR TITLE
Use `all?` to check types directly

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -705,7 +705,7 @@ module GraphQL
             end
           when Array
             # It's an array full of execution errors; add them all.
-            if value.any? && value.all? { |v| v.is_a?(GraphQL::ExecutionError) }
+            if value.any? && value.all?(GraphQL::ExecutionError)
               list_type_at_all = (field && (field.type.list?))
               if selection_result.nil? || !dead_result?(selection_result)
                 value.each_with_index do |error, index|


### PR DESCRIPTION
`all?` can take a "pattern" (anything that responds to `#===`).

In a synthetic benchmark, it's marginally faster to let `all?` call `Class#===` (which has the same semantics as `is_a?`) than to provide a block explicitly:

<details>
<summary>Benchmark</summary>

```ruby
#!/usr/bin/ruby

require "benchmark/ips"

a = [true, false, nil, 1, 2.3, "abc", :abc, [], {}, Object.new] * 10


def found_it!; end

Benchmark.ips do |x|
  x.time = 30
  x.warmup = 10
# x.time = 1
# x.warmup = 1
  
  x.report("all? + is_a?") do |times|
    i = 0
    while i < times
      i += 1
      
      a.all? { |v| v.is_a?(BasicObject) }
      
    end
  end
  
  x.report("just all?") do |times|
    i = 0
    while i < times
      i += 1
      
      a.all?(BasicObject)
      
    end
  end
  
  x.compare!
end
```

</details>

Result:

```
Warming up --------------------------------------
        all? + is_a?    20.952k i/100ms
           just all?    50.146k i/100ms
Calculating -------------------------------------
        all? + is_a?    218.217k (± 1.3%) i/s -      6.558M in  30.057723s
           just all?    502.744k (± 1.5%) i/s -     15.094M in  30.030166s

Comparison:
           just all?:   502744.2 i/s
        all? + is_a?:   218217.2 i/s - 2.30x  slower
```