### PR TITLE
Use resolver classes for queries by default

### DIFF
--- a/guides/fields/resolvers.md
+++ b/guides/fields/resolvers.md
@@ -99,24 +99,13 @@ So, if there are other, better options, why does `Resolver` exist? Here are a fe
 
 ## Using `resolver`
 
-To add resolvers to your project, make a base class:
-
-```ruby
-# app/graphql/resolvers/base.rb
-module Resolvers
-  class Base < GraphQL::Schema::Resolver
-    # if you have a custom argument class, you can attach it:
-    argument_class Arguments::Base
-  end
-end
-```
-
-Then, extend it as needed:
+Use the base resolver class:
 
 ```ruby
 module Resolvers
-  class RecommendedItems < Resolvers::Base
+  class RecommendedItems < BaseResolver
     type [Types::Item], null: false
+    description "Items this user might like"
 
     argument :order_by, Types::ItemOrder, required: false
     argument :category, Types::ItemCategory, required: false
@@ -140,9 +129,7 @@ And attach it to your field:
 
 ```ruby
 class Types::User < Types::BaseObject
-  field :recommended_items,
-    resolver: Resolvers::RecommendedItems,
-    description: "Items this user might like"
+  field :recommended_items, resolver: Resolvers::RecommendedItems
 end
 ```
 
@@ -173,7 +160,7 @@ end
 # app/graphql/resolvers/tasks_resolver.rb
 
 module Resolvers
-  class TasksResolver < GraphQL::Schema::Resolver
+  class TasksResolver < BaseResolver
     type [Types::TaskType], null: false
 
     def resolve
@@ -189,7 +176,7 @@ A simple solution is to express the type as a string in the resolver:
 
 ```ruby
 module Resolvers
-  class TasksResolver < GraphQL::Schema::Resolver
+  class TasksResolver < BaseResolver
     type "[Types::TaskType]", null: false
 
     def resolve

--- a/guides/getting_started.md
+++ b/guides/getting_started.md
@@ -78,14 +78,24 @@ Before building a schema, you have to define an [entry point to your system, the
 class QueryType < GraphQL::Schema::Object
   description "The query root of this schema"
 
-  # First describe the field signature:
-  field :post, PostType, "Find a post by ID" do
-    argument :id, ID
-  end
+  field :post, resolver: Resolvers::Post
+end
+```
 
-  # Then provide an implementation:
-  def post(id:)
-    Post.find(id)
+Define how this field is resolved by creating a resolver class:
+
+```ruby
+# app/graphql/types/resolvers/post.rb
+module Types
+  module Resolvers
+    class Post < BaseResolver
+      type PostType
+      argument :id, ID
+
+      def resolve(id:)
+        Post.find(id)
+      end
+    end
   end
 end
 ```

--- a/lib/generators/graphql/install_generator.rb
+++ b/lib/generators/graphql/install_generator.rb
@@ -105,6 +105,9 @@ module Graphql
           template("#{base_type}.erb", "#{options[:directory]}/types/#{base_type}.rb")
         end
 
+        # All resolvers are defined as living in their own module, including this class.
+        template("base_resolver.erb", "#{options[:directory]}/resolvers/base.rb")
+
         # Note: You can't have a schema without the query type, otherwise introspection breaks
         template("query_type.erb", "#{options[:directory]}/types/query_type.rb")
         insert_root_type('query', 'QueryType')

--- a/lib/generators/graphql/templates/base_resolver.erb
+++ b/lib/generators/graphql/templates/base_resolver.erb
@@ -1,0 +1,6 @@
+<% module_namespacing_when_supported do -%>
+module Types
+  class BaseResolver < GraphQL::Schema::Resolver
+  end
+end
+<% end -%>


### PR DESCRIPTION
After raising #4468 and getting a thumbs-up from @rmosolgo about it, I've finally gotten around to issuing this PR.

I've updated the install generator to generate a base resolver class, and directed readers of the Getting Started guide to use this class when defining fields. Similar changes have been made elsewhere in the documentation as well.

Ultimately, the goal of this change is to alter the way types such as `QueryType` are defined. Currently, the suggestion is:

```ruby
module Types
  class QueryType < Types::BaseObject
    # Add `node(id: ID!) and `nodes(ids: [ID!]!)`
    include GraphQL::Types::Relay::HasNodeField
    include GraphQL::Types::Relay::HasNodesField

    field :repos, [RepoType], null: false

    def repos
      Repo.all
    end

    field :repo, RepoResult, null: false do
      argument :id, ID, required: true
    end

    def repo(id:)
      Repo.find(id)
    end

    field :category, CategoryType, null: false do
      argument :id, ID, required: true
    end

    def category(id:)
      Category.find(id)
    end
  end
end
```

After this change, it will be:

```ruby
module Types
  class QueryType < Types::BaseObject
    # Add `node(id: ID!) and `nodes(ids: [ID!]!)`
    include GraphQL::Types::Relay::HasNodeField
    include GraphQL::Types::Relay::HasNodesField

    field :repos, resolver: Resolvers::Repo::List
    field :repo, resolver: Resolvers::Repo::Find
    field :category, resolver: Resolvers::Category::Find
```

With each of those resolver classes defining the types, arguments and resolution techniques for the fields themselves. 

I've intentionally left the definition and structure of those resolvers "loose", as I think it's one of those areas where every developer would have an opinion about The One True Way(tm) to structure these classes.

Where I work, we follow this pattern with some decent success, with those resolver classes typically having resolution methods that pass the GraphQL args down to operations, which then resolve however they need to. The operations themselves are tested in isolation and also with GraphQL request specs. Seems to work for us!
