### PR TITLE
Fix a test failure using Ruby 3.3.0dev

### DIFF
--- a/spec/graphql/pagination/connections_spec.rb
+++ b/spec/graphql/pagination/connections_spec.rb
@@ -117,7 +117,13 @@ describe GraphQL::Pagination::Connections do
       ConnectionErrorTestSchema.execute("{ things2 { name } }")
     end
 
-    assert_includes err.message, "undefined method `no_such_method' for <BadThing!>"
+    expected_message = if RUBY_VERSION >= "3.3"
+      "undefined method `no_such_method' for an instance of ConnectionErrorTestSchema::BadThing"
+    else
+      "undefined method `no_such_method' for <BadThing!>"
+    end
+
+    assert_includes err.message, expected_message
   end
 
   it "uses a field's `max_page_size: nil` configuration" do


### PR DESCRIPTION
## Summary

This PR fixes the following test failure using Ruby 3.3.0dev:

```console
$ ruby -v
ruby 3.3.0dev (2023-06-14T23:47:25Z master 0c55ef1150) [x86_64-darwin19]
$ bundle exec ruby -Ispec spec/graphql/pagination/connections_spec.rb

# Running tests with run options --seed 51032:

F.....

Finished tests in 0.009158s, 655.1649 tests/s, 1856.3005 assertions/s.

Failure:
GraphQL::Pagination::Connections#test_0004_lets unrelated NoMethodErrors bubble up [spec/graphql/pagination/connections_spec.rb:120]
Minitest::Assertion: Expected "undefined method `no_such_method' for an instance of ConnectionErrorTestSchema::BadThing"
 to include "undefined method `no_such_method' for <BadThing!>"
.

6 tests, 17 assertions, 1 failures, 0 errors, 0 skips
```

That error message has been changed by https://github.com/ruby/ruby/commit/e7b8d32e in Ruby 3.3.0dev.

cf. https://bugs.ruby-lang.org/issues/18285

So the test error message is changed:

Ruby 3.2 or lower:

```
"undefined method `no_such_method' for <BadThing!>:ConnectionErrorTestSchema::BadThing"`
```

Ruby 3.3.0dev:

```
"undefined method `no_such_method' for an instance of ConnectionErrorTestSchema::BadThing"
```

## Additional Information

Below is a simple working example:

```ruby
# example.rb
class Foo
  def inspect
    '<Hi>'
  end
end
```

Ruby 3.2.2:

```console
% ruby -v example.rb
ruby 3.2.2 (2023-03-30 revision e51014f9c0) [x86_64-darwin19]
example.rb:8:in `<main>': undefined method `no_such_method' for <Hi>:Foo (NoMethodError)

Foo.new.no_such_method
       ^^^^^^^^^^^^^^^
```

Ruby 3.3.0dev:

```console
% ruby -v example.rb
ruby 3.3.0dev (2023-06-14T23:47:25Z master 0c55ef1150) [x86_64-darwin19]
example.rb:8:in `<main>': undefined method `no_such_method' for an instance of Foo (NoMethodError)

Foo.new.no_such_method
       ^^^^^^^^^^^^^^^
```