### PR TITLE
Query-specific static validators

### DIFF
--- a/lib/graphql/query/validation_pipeline.rb
+++ b/lib/graphql/query/validation_pipeline.rb
@@ -68,7 +68,8 @@ module GraphQL
         elsif @operation_name_error
           @validation_errors << @operation_name_error
         else
-          validation_result = @schema.static_validator.validate(@query, validate: @query.validate, timeout: @schema.validate_timeout, max_errors: @schema.validate_max_errors)
+          validator = @query.static_validator || @schema.static_validator
+          validation_result = validator.validate(@query, validate: @query.validate, timeout: @schema.validate_timeout, max_errors: @schema.validate_max_errors)
           @validation_errors.concat(validation_result[:errors])
 
           if @validation_errors.empty?


### PR DESCRIPTION
### What

Adds a new `static_validator` parameter to the `Query` object. When assigned as a `StaticValidation::Validator` instance, the query will validate using its own validator rather than the schema's validator.

### Why

This allows trusted queries to be validated with fewer rules. In our case, we have external Rust-based validations available that are very fast and reliable aside from visibility checks, which still need to be run in Ruby. This option allows a subset of Ruby validations to be used for select requests.