### PR TITLE
Improve performance of Schema::Addition

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -120,6 +120,12 @@ namespace :bench do
     GraphQLBenchmark.profile_batch_loaders
   end
 
+  desc "Run benchmarks on schema creation"
+  task :profile_boot do
+    prepare_benchmark
+    GraphQLBenchmark.profile_boot
+  end
+
   desc "Check the memory footprint of a large schema"
   task :profile_schema_memory_footprint do
     prepare_benchmark

--- a/lib/graphql/schema/addition.rb
+++ b/lib/graphql/schema/addition.rb
@@ -49,7 +49,12 @@ module GraphQL
 
       def add_type_and_traverse(new_types)
         late_types = []
-        new_types.each { |t| add_type(t, owner: nil, late_types: late_types, path: [t.graphql_name]) }
+        path = []
+        new_types.each do |t|
+          path.push(t.graphql_name)
+          add_type(t, owner: nil, late_types: late_types, path: path)
+          path.pop
+        end
         missed_late_types = 0
         while (late_type_vals = late_types.shift)
           type_owner, lt = late_type_vals
@@ -160,7 +165,9 @@ module GraphQL
           type.all_argument_definitions.each do |arg|
             arg_type = arg.type.unwrap
             references_to(arg_type, from: arg)
-            add_type(arg_type, owner: arg, late_types: late_types, path: path + [arg.graphql_name])
+            path.push(arg.graphql_name)
+            add_type(arg_type, owner: arg, late_types: late_types, path: path)
+            path.pop
             if arg.default_value?
               @arguments_with_default_values << arg
             end
@@ -181,18 +188,21 @@ module GraphQL
               name = field.graphql_name
               field_type = field.type.unwrap
               references_to(field_type, from: field)
-              field_path = path + [name]
-              add_type(field_type, owner: field, late_types: late_types, path: field_path)
+              path.push(name)
+              add_type(field_type, owner: field, late_types: late_types, path: path)
               add_directives_from(field)
               field.all_argument_definitions.each do |arg|
                 add_directives_from(arg)
                 arg_type = arg.type.unwrap
                 references_to(arg_type, from: arg)
-                add_type(arg_type, owner: arg, late_types: late_types, path: field_path + [arg.graphql_name])
+                path.push(arg.graphql_name)
+                add_type(arg_type, owner: arg, late_types: late_types, path: path)
+                path.pop
                 if arg.default_value?
                   @arguments_with_default_values << arg
                 end
               end
+              path.pop
             end
           end
           if type.kind.input_object?
@@ -200,7 +210,9 @@ module GraphQL
               add_directives_from(arg)
               arg_type = arg.type.unwrap
               references_to(arg_type, from: arg)
-              add_type(arg_type, owner: arg, late_types: late_types, path: path + [arg.graphql_name])
+              path.push(arg.graphql_name)
+              add_type(arg_type, owner: arg, late_types: late_types, path: path)
+              path.pop
               if arg.default_value?
                 @arguments_with_default_values << arg
               end
@@ -208,14 +220,18 @@ module GraphQL
           end
           if type.kind.union?
             @possible_types[type.graphql_name] = type.all_possible_types
+            path.push("possible_types")
             type.all_possible_types.each do |t|
-              add_type(t, owner: type, late_types: late_types, path: path + ["possible_types"])
+              add_type(t, owner: type, late_types: late_types, path: path)
             end
+            path.pop
           end
           if type.kind.interface?
+            path.push("orphan_types")
             type.orphan_types.each do |t|
-              add_type(t, owner: type, late_types: late_types, path: path + ["orphan_types"])
+              add_type(t, owner: type, late_types: late_types, path: path)
             end
+            path.pop
           end
           if type.kind.object?
             possible_types_for_this_name = @possible_types[type.graphql_name] ||= []
@@ -223,6 +239,7 @@ module GraphQL
           end
 
           if type.kind.object? || type.kind.interface?
+            path.push("implements")
             type.interface_type_memberships.each do |interface_type_membership|
               case interface_type_membership
               when Schema::TypeMembership
@@ -237,8 +254,9 @@ module GraphQL
               else
                 raise ArgumentError, "Invariant: unexpected type membership for #{type.graphql_name}: #{interface_type_membership.class} (#{interface_type_membership.inspect})"
               end
-              add_type(interface_type, owner: type, late_types: late_types, path: path + ["implements"])
+              add_type(interface_type, owner: type, late_types: late_types, path: path)
             end
+            path.pop
           end
         end
       end

--- a/lib/graphql/schema/addition.rb
+++ b/lib/graphql/schema/addition.rb
@@ -40,9 +40,11 @@ module GraphQL
       end
 
       def add_directives_from(owner)
-        dirs = owner.directives.map(&:class)
-        @directives.merge(dirs)
-        add_type_and_traverse(dirs)
+        if (dir_instances = owner.directives).any?
+          dirs = dir_instances.map(&:class)
+          @directives.merge(dirs)
+          add_type_and_traverse(dirs)
+        end
       end
 
       def add_type_and_traverse(new_types)

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -339,7 +339,7 @@ module GraphQL
           self.validates(validates)
         end
 
-        if definition_block
+        if block_given?
           if definition_block.arity == 1
             yield self
           else

--- a/lib/graphql/schema/member/build_type.rb
+++ b/lib/graphql/schema/member/build_type.rb
@@ -109,7 +109,14 @@ module GraphQL
               to_type_name(something.name)
             end
           when String
-            something.gsub(/\]\[\!/, "").split("::").last
+            if something.include?("]") ||
+                something.include?("[") ||
+                something.include?("!") ||
+                something.include?("::")
+              something.gsub(/\]\[\!/, "").split("::").last
+            else
+              something
+            end
           when GraphQL::Schema::NonNull, GraphQL::Schema::List
             to_type_name(something.unwrap)
           else
@@ -122,7 +129,8 @@ module GraphQL
           return string unless string.include?("_")
           camelized = string.split('_').each(&:capitalize!).join
           camelized[0] = camelized[0].downcase
-          if (match_data = string.match(/\A(_+)/))
+          if string.start_with?("_")
+            match_data = string.match(/\A(_+)/)
             camelized = "#{match_data[0]}#{camelized}"
           end
           camelized


### PR DESCRIPTION
Tighten up this part of schema boot to improve load times

This improved allocations by >25% (and a lot of them are long-lived allocations for the schema, anyways, which are already very optimized)

```diff 
-   GC: 11323 (16.40%)
+   GC: 6003 (11.23%)


- Total allocated: 14673646 bytes (105685 objects)
+ Total allocated: 13545718 bytes (76220 objects)
```