### PR TITLE
Remove mention of graphql-libgraphqlparser

### DIFF
--- a/guides/related_projects.md
+++ b/guides/related_projects.md
@@ -15,7 +15,6 @@ Want to add something? Please open a pull request [on GitHub](https://github.com
 - `graphql-ruby` + Sinatra demo ([src](https://github.com/robinjmurphy/ruby-graphql-server-example) / [heroku](https://ruby-graphql-server-example.herokuapp.com/))
 - [`graphql-batch`](https://github.com/shopify/graphql-batch), a batched query execution strategy
 - [`graphql-cache`](https://github.com/stackshareio/graphql-cache), a resolver-level caching solution
-- [`graphql-libgraphqlparser`](https://github.com/rmosolgo/graphql-libgraphqlparser-ruby), bindings to [libgraphqlparser](https://github.com/graphql/libgraphqlparser), a C-level parser.
 - [`graphql-devise`](https://github.com/graphql-devise/graphql_devise), a gql interface to handle authentication with Devise
 - [`graphql-docs`](https://github.com/gjtorikian/graphql-docs), a tool to automatically generate static HTML documentation from your GraphQL implementation
 - [`graphql-metrics`](https://github.com/Shopify/graphql-metrics), a plugin to extract fine-grain metrics of GraphQL queries received by your server


### PR DESCRIPTION
It hasn't been compatible since graphql-ruby < 1.9, and is no longer supported, as mentioned here: https://github.com/rmosolgo/graphql-ruby/issues/2398#issuecomment-515049940