### PR TITLE
Proof on concept, Allow conditional introspection

### DIFF
--- a/lib/graphql/execution/interpreter.rb
+++ b/lib/graphql/execution/interpreter.rb
@@ -22,6 +22,14 @@ module GraphQL
         # @param max_complexity [Integer, nil]
         # @return [Array<Hash>] One result per query
         def run_all(schema, query_options, context: {}, max_complexity: schema.max_complexity)
+          # Remove 'enable_introspection_entry_points' from the options hash
+          # before passing it to the query.
+          # This is a hack to avoid breaking the public API.
+          query_options = query_options.map do |opts|
+            opts = opts.dup
+            opts.delete(:enable_introspection_entry_points)
+            opts
+          end
           queries = query_options.map do |opts|
             case opts
             when Hash

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -97,7 +97,7 @@ module GraphQL
     # @param max_complexity [Numeric] the maximum field complexity for this query (falls back to schema-level value)
     # @param except [<#call(schema_member, context)>] If provided, objects will be hidden from the schema when `.call(schema_member, context)` returns truthy
     # @param only [<#call(schema_member, context)>] If provided, objects will be hidden from the schema when `.call(schema_member, context)` returns false
-    def initialize(schema, query_string = nil, query: nil, document: nil, context: nil, variables: nil, validate: true, static_validator: nil, subscription_topic: nil, operation_name: nil, root_value: nil, max_depth: schema.max_depth, max_complexity: schema.max_complexity, except: nil, only: nil, warden: nil)
+    def initialize(schema, query_string = nil, query: nil, document: nil, context: nil, variables: nil, validate: true, static_validator: nil, subscription_topic: nil, operation_name: nil, root_value: nil, max_depth: schema.max_depth, max_complexity: schema.max_complexity, except: nil, only: nil, warden: nil, disable_introspection_entry_points: true)
       # Even if `variables: nil` is passed, use an empty hash for simpler logic
       variables ||= {}
       @schema = schema
@@ -114,6 +114,7 @@ module GraphQL
       self.static_validator = static_validator if static_validator
       context_tracers = (context ? context.fetch(:tracers, []) : [])
       @tracers = schema.tracers + context_tracers
+      @disable_introspection_entry_points = disable_introspection_entry_points
 
       # Support `ctx[:backtrace] = true` for wrapping backtraces
       if context && context[:backtrace] && !@tracers.include?(GraphQL::Backtrace::Tracer)

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -712,6 +712,11 @@ module GraphQL
         @introspection_system = nil
       end
 
+      def enable_introspection_entry_points
+        @disable_introspection_entry_points = false
+        introspection_system
+      end
+
       def disable_schema_introspection_entry_point
         @disable_schema_introspection_entry_point = true
         # TODO: this clears the cache made in `def types`. But this is not a great solution.
@@ -1045,6 +1050,7 @@ module GraphQL
         if query_str
           kwargs[:query] = query_str
         end
+        enable_introspection_entry_points if kwargs[:enable_introspection_entry_points]
         # Some of the query context _should_ be passed to the multiplex, too
         multiplex_context = if (ctx = kwargs[:context])
           {


### PR DESCRIPTION
This demonstrates one way to enable introspection at runtime. In our case, admin users provided by context should be able to introspect queries to make tools such as GraphiQL useful.

Fix for https://github.com/rmosolgo/graphql-ruby/issues/4262