### PR TITLE
Try removing quirks_mode: true

### DIFF
--- a/lib/graphql/language.rb
+++ b/lib/graphql/language.rb
@@ -29,7 +29,7 @@ module GraphQL
 
         "[#{serialized_array}]"
       else
-        JSON.generate(value, quirks_mode: true)
+        JSON.generate(value)
       end
     end
   end

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -151,12 +151,12 @@ module GraphQL
           warden = ctx.warden
 
           if input.is_a?(Array)
-            return GraphQL::Query::InputValidationResult.from_problem(INVALID_OBJECT_MESSAGE % { object: JSON.generate(input, quirks_mode: true) })
+            return GraphQL::Query::InputValidationResult.from_problem(INVALID_OBJECT_MESSAGE % { object: JSON.generate(input) })
           end
 
           if !(input.respond_to?(:to_h) || input.respond_to?(:to_unsafe_h))
             # We're not sure it'll act like a hash, so reject it:
-            return GraphQL::Query::InputValidationResult.from_problem(INVALID_OBJECT_MESSAGE % { object: JSON.generate(input, quirks_mode: true) })
+            return GraphQL::Query::InputValidationResult.from_problem(INVALID_OBJECT_MESSAGE % { object: JSON.generate(input) })
           end
 
           # Inject missing required arguments

--- a/lib/graphql/subscriptions/serialize.rb
+++ b/lib/graphql/subscriptions/serialize.rb
@@ -24,7 +24,7 @@ module GraphQL
       # @param obj [Object] Some subscription-related data to dump
       # @return [String] The stringified object
       def dump(obj)
-        JSON.generate(dump_value(obj), quirks_mode: true)
+        JSON.generate(dump_value(obj))
       end
 
       # This is for turning objects into subscription scopes.


### PR DESCRIPTION
I got a bug report of GraphQL::Subscriptions::Serialize not playing nice with Oj's JSON serialization when combined with ActiveSupport. It seems like removing `quirks_mode:` made it work again, so we _could_ remove it here.

But, looking back at why it was added: 

- https://github.com/rmosolgo/graphql-ruby/pull/306#issuecomment-253239424
- https://github.com/rmosolgo/graphql-ruby/pull/449

I think its _intention_ is to handle non-Hash and non-Array values properly, which I think is still needed in the codebase. So I think we should find another approach to solve the compatibility issue. 

(We also found that `controller: ...` was in context, and maybe that was causing an infinite loop in serialization.)