### PR TITLE
Add name to static validator

### DIFF
--- a/lib/graphql/static_validation/validator.rb
+++ b/lib/graphql/static_validation/validator.rb
@@ -17,6 +17,7 @@ module GraphQL
 
       # @param schema [GraphQL::Schema]
       # @param rules [Array<#validate(context)>] a list of rules to use when validating
+      # @param name [String] an optional instrumentation name for the ruleset
       def initialize(schema:, rules: GraphQL::StaticValidation::ALL_RULES, name: nil)
         @schema = schema
         @rules = rules

--- a/lib/graphql/static_validation/validator.rb
+++ b/lib/graphql/static_validation/validator.rb
@@ -13,11 +13,14 @@ module GraphQL
     #   errors = validator.validate(query)[:errors]
     #
     class Validator
+      attr_reader :name
+
       # @param schema [GraphQL::Schema]
       # @param rules [Array<#validate(context)>] a list of rules to use when validating
-      def initialize(schema:, rules: GraphQL::StaticValidation::ALL_RULES)
+      def initialize(schema:, rules: GraphQL::StaticValidation::ALL_RULES, name: nil)
         @schema = schema
         @rules = rules
+        @name = name
       end
 
       # Validate `query` against the schema. Returns an array of message hashes.

--- a/spec/graphql/static_validation/validator_spec.rb
+++ b/spec/graphql/static_validation/validator_spec.rb
@@ -7,6 +7,13 @@ describe GraphQL::StaticValidation::Validator do
   let(:validate) { true }
   let(:errors) { validator.validate(query, validate: validate)[:errors].map(&:to_h) }
 
+  describe "name" do
+    it "may have a name" do
+      validator = GraphQL::StaticValidation::Validator.new(schema: Dummy::Schema, name: "Some Ruleset")
+      assert_equal "Some Ruleset", validator.name
+    end
+  end
+
   describe "tracing" do
     let(:query_string) { "{ t: __typename }"}
     let(:query) { GraphQL::Query.new(Dummy::Schema, query_string, context: {tracers: [TestTracing]}) }


### PR DESCRIPTION
Now that a [query may define its own validator](https://github.com/rmosolgo/graphql-ruby/pull/4529), it would be useful for instrumentation if a static validator could also specify a ruleset name for itself.