### PR TITLE
Fix typo of pull request number in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### New features
 
-- `Schema::Object.wrap` can be used to customize how objects are (or aren't) wrapped by `GraphQL::Schema::Object` instances at runtime #5424
+- `Schema::Object.wrap` can be used to customize how objects are (or aren't) wrapped by `GraphQL::Schema::Object` instances at runtime #4524
 - `Query`: accept a `static_validator:` option in `#initialize` to use instead of the default validation configuration.
 
 ### Bug fixes


### PR DESCRIPTION
This PR fixes a typo in CHANGELOG.md.
Currently, it has a link to `#5424`, which does not exist. This PR replace the broken link with the correct PR, #4524.