### PR TITLE
Fix DataDogTrace LocalJumpError

### DIFF
--- a/lib/graphql/tracing/data_dog_trace.rb
+++ b/lib/graphql/tracing/data_dog_trace.rb
@@ -106,8 +106,8 @@ module GraphQL
         end
       end
 
-      def execute_field_lazy(query:, field:, ast_node:, arguments:, object:)
-        execute_field("execute_field_lazy", query: query, field: field, ast_node: ast_node, arguments: arguments, object: object)
+      def execute_field_lazy(query:, field:, ast_node:, arguments:, object:, &block)
+        execute_field("execute_field_lazy", query: query, field: field, ast_node: ast_node, arguments: arguments, object: object, &block)
       end
 
       def authorized(object:, type:, query:, span_key: "authorized")

--- a/spec/graphql/tracing/data_dog_trace_spec.rb
+++ b/spec/graphql/tracing/data_dog_trace_spec.rb
@@ -4,10 +4,17 @@ require "spec_helper"
 
 describe GraphQL::Tracing::DataDogTrace do
   module DataDogTraceTest
+    class Box
+      def initialize(value)
+        @value = value
+      end
+      attr_reader :value
+    end
+
     class Thing < GraphQL::Schema::Object
       field :str, String
 
-      def str; "blah"; end
+      def str; Box.new("blah"); end
     end
 
     class Query < GraphQL::Schema::Object
@@ -26,6 +33,7 @@ describe GraphQL::Tracing::DataDogTrace do
     class TestSchema < GraphQL::Schema
       query(Query)
       trace_with(GraphQL::Tracing::DataDogTrace)
+      lazy_resolve(Box, :value)
     end
 
     class CustomTracerTestSchema < GraphQL::Schema
@@ -37,6 +45,7 @@ describe GraphQL::Tracing::DataDogTrace do
       end
       query(Query)
       trace_with(CustomDataDogTracing)
+      lazy_resolve(Box, :value)
     end
   end
 


### PR DESCRIPTION
Fixes #4578  

I replicated the error in the test: 

```

# Running tests with run options --seed 30235:

..E..

Finished tests in 0.004136s, 1208.8974 tests/s, 1692.4564 assertions/s.


Error:
GraphQL::Tracing::DataDogTrace#test_0005_sets custom tags tags:
LocalJumpError: no block given (yield)
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing/trace.rb:51:in `execute_field'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing/data_dog_trace.rb:105:in `execute_field'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing/data_dog_trace.rb:110:in `execute_field_lazy'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:976:in `block in after_lazy'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/lazy.rb:30:in `value'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/resolve.rb:23:in `each'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/resolve.rb:23:in `block in resolve_each_depth'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/dataloader/null_dataloader.rb:19:in `append_job'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/resolve.rb:22:in `resolve_each_depth'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:99:in `block (5 levels) in run_all'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing/trace.rb:47:in `execute_query_lazy'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing/data_dog_trace.rb:47:in `block in execute_query_lazy'
    /Users/rmosolgo/code/graphql-ruby/spec/support/datadog.rb:52:in `trace'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing/data_dog_trace.rb:36:in `execute_query_lazy'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:98:in `block (4 levels) in run_all'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/dataloader/null_dataloader.rb:19:in `append_job'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:89:in `block (3 levels) in run_all'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:171:in `block (2 levels) in each_query_call_hooks'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:166:in `each_query_call_hooks'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:170:in `block in each_query_call_hooks'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:197:in `call_hooks'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:169:in `each_query_call_hooks'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:46:in `block (2 levels) in run_all'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:197:in `call_hooks'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:45:in `block in run_all'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing/trace.rb:39:in `execute_multiplex'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing/data_dog_trace.rb:61:in `block in execute_multiplex'
    /Users/rmosolgo/code/graphql-ruby/spec/support/datadog.rb:52:in `trace'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/tracing/data_dog_trace.rb:36:in `execute_multiplex'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter.rb:37:in `run_all'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1138:in `multiplex'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/schema.rb:1114:in `execute'
    /Users/rmosolgo/code/graphql-ruby/spec/graphql/tracing/data_dog_trace_spec.rb:81:in `block (2 levels) in <top (required)>'

5 tests, 7 assertions, 0 failures, 1 errors, 0 skips
```

And I was a bit surprised to find that passing `&block` _just_ in `def execute_field_lazy` was enough to fix it -- is the block passed implicitly by `super`? 