### PR TITLE
Fix block string quote unescaping

### DIFF
--- a/lib/graphql/language/lexer.rb
+++ b/lib/graphql/language/lexer.rb
@@ -112,7 +112,7 @@ module GraphQL
           when str = scan.scan(INT)           then emit(:INT, pos, scan.pos, meta, str)
           when str = scan.scan(LIT)           then emit(LIT_NAME_LUT[str], pos, scan.pos, meta, -str)
           when str = scan.scan(IDENTIFIER)    then emit(:IDENTIFIER, pos, scan.pos, meta, str)
-          when str = scan.scan(BLOCK_STRING)  then emit_block(pos, scan.pos, meta, str.gsub(/^#{BLOCK_QUOTE}|#{BLOCK_QUOTE}$/, ''))
+          when str = scan.scan(BLOCK_STRING)  then emit_block(pos, scan.pos, meta, str.gsub(/\A#{BLOCK_QUOTE}|#{BLOCK_QUOTE}\z/, ''))
           when str = scan.scan(QUOTED_STRING) then emit_string(pos, scan.pos, meta, str.gsub(/^"|"$/, ''))
           when str = scan.scan(COMMENT)       then record_comment(pos, scan.pos, meta, str)
           when str = scan.scan(NEWLINE)

--- a/spec/graphql/language/lexer_examples.rb
+++ b/spec/graphql/language/lexer_examples.rb
@@ -184,6 +184,20 @@ GRAPHQL
           assert_equal '(RPAREN ")" [1:11])', rparen_token.inspect
         end
 
+        it "tokenizes block quotes with triple quotes correctly" do
+          doc = <<-eos
+"""
+
+string with \\"""
+
+"""
+          eos
+          tokens = subject.tokenize doc
+          token = tokens.first
+          assert_equal :STRING, token.name
+          assert_equal 'string with """', token.value
+        end
+
         it "counts block string line properly" do
           str = <<-GRAPHQL
           """


### PR DESCRIPTION
Triple quotes at the beginning and end of lines shouldn't be removed if they have been escaped.  IOW only the leading and trailing """ should be removed from the token