### PR TITLE
Support early-return of falsey values from ready/authorized

### DIFF
--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -65,19 +65,20 @@ module GraphQL
       # @api private
       def resolve_with_support(**args)
         # First call the ready? hook which may raise
-        ready_val = if args.any?
+        raw_ready_val = if args.any?
           ready?(**args)
         else
           ready?
         end
-        context.query.after_lazy(ready_val) do |is_ready, ready_early_return|
-          if ready_early_return
+        context.query.after_lazy(raw_ready_val) do |ready_val|
+          if ready_val.is_a?(Array)
+            is_ready, ready_early_return = ready_val
             if is_ready != false
               raise "Unexpected result from #ready? (expected `true`, `false` or `[false, {...}]`): [#{is_ready.inspect}, #{ready_early_return.inspect}]"
             else
               ready_early_return
             end
-          elsif is_ready
+          elsif ready_val
             # Then call each prepare hook, which may return a different value
             # for that argument, or may return a lazy object
             load_arguments_val = load_arguments(args)
@@ -85,21 +86,22 @@ module GraphQL
               @prepared_arguments = loaded_args
               Schema::Validator.validate!(self.class.validators, object, context, loaded_args, as: @field)
               # Then call `authorized?`, which may raise or may return a lazy object
-              authorized_val = if loaded_args.any?
+              raw_authorized_val = if loaded_args.any?
                 authorized?(**loaded_args)
               else
                 authorized?
               end
-              context.query.after_lazy(authorized_val) do |(authorized_result, early_return)|
+              context.query.after_lazy(raw_authorized_val) do |authorized_val|
                 # If the `authorized?` returned two values, `false, early_return`,
                 # then use the early return value instead of continuing
-                if early_return
+                if authorized_val.is_a?(Array)
+                  authorized_result, early_return = authorized_val
                   if authorized_result == false
                     early_return
                   else
                     raise "Unexpected result from #authorized? (expected `true`, `false` or `[false, {...}]`): [#{authorized_result.inspect}, #{early_return.inspect}]"
                   end
-                elsif authorized_result
+                elsif authorized_val
                   # Finally, all the hooks have passed, so resolve it
                   if loaded_args.any?
                     public_send(self.class.resolve_method, **loaded_args)

--- a/spec/graphql/schema/resolver_spec.rb
+++ b/spec/graphql/schema/resolver_spec.rb
@@ -184,15 +184,15 @@ describe GraphQL::Schema::Resolver do
       end
     end
 
-    class ResolverWithNilValueReady < BaseResolver
-      type Integer, null: true
+    class ResolverWithFalseyValueReady < BaseResolver
+      type Boolean, null: true
 
       def ready?
-        return false, nil
+        return false, false
       end
 
       def resolve
-        123
+        true
       end
     end
 
@@ -329,9 +329,15 @@ describe GraphQL::Schema::Resolver do
       end
     end
 
-    class PrepResolverWithNilValueAuthorized < PrepResolver10
-      def authorized?(int1:, integer_2:)
-        return false, nil
+    class ResolverWithFalseyValueAuthorized < BaseResolver
+      type Boolean, null: true
+
+      def authorized?
+        return false, false
+      end
+
+      def resolve
+        true
       end
     end
 
@@ -469,8 +475,8 @@ describe GraphQL::Schema::Resolver do
       field :prep_resolver_12, resolver: PrepResolver12
       field :prep_resolver_13, resolver: PrepResolver13
       field :prep_resolver_14, resolver: PrepResolver14
-      field :resolver_with_nil_value_ready, resolver: ResolverWithNilValueReady
-      field :prep_resolver_with_nil_value_authorized, resolver: PrepResolverWithNilValueAuthorized
+      field :resolver_with_falsey_value_ready, resolver: ResolverWithFalseyValueReady
+      field :resolver_with_falsey_value_authorized, resolver: ResolverWithFalseyValueAuthorized
       field :resolver_with_auth_args, resolver: ResolverWithAuthArgs
       field :resolver_with_error_handler, resolver: ResolverWithErrorHandler
     end
@@ -675,9 +681,9 @@ describe GraphQL::Schema::Resolver do
         assert_equal 213, res["data"]["int"]["int"]
       end
 
-      it "can return false and nil" do
-        res = exec_query("{ int: resolverWithNilValueReady }")
-        assert_nil res["data"]["int"]
+      it "can return false and falsey data" do
+        res = exec_query("{ result: resolverWithFalseyValueReady }")
+        assert_equal false, res["data"]["result"] # must be `false`, not just falsey
         assert_nil res["errors"]
       end
 
@@ -745,9 +751,9 @@ describe GraphQL::Schema::Resolver do
           assert_equal 7, res["data"]["prepResolver12"]["value"]
         end
 
-        it "can return nil data early" do
-          res = exec_query("{ result: prepResolverWithNilValueAuthorized(int1: 9, int2: 5) }", context: { max_int: 9 })
-          assert_nil res["data"]["result"]
+        it "can return falsey data early" do
+          res = exec_query("{ result: resolverWithFalseyValueAuthorized }")
+          assert_equal false, res["data"]["result"] # must be actual `false`, not just a falsey `nil`
           assert_nil res["errors"]
         end
 


### PR DESCRIPTION
If you write a resolver's authorized method with a `return false, nil` in it (to early-return a value of `nil`), it was treating this just as `return false` and raising, because the early-return value was not truthy. Instead explicitly check for an array value before splitting it in two.

I also did `ready?` while I was here since it had the same pattern.

~~The tests are "correct" but won't fail even without my "fix" because the test schema doesn't implement `def unauthorized_object(unauthorized_error)`, and there are a bunch of tests already relying on it being not implemented. Not sure what the best approach is.~~
*edit: I realized after posting that it was easier and more correct to test for a false/nil distinction which sidesteps the `unauthorized_object` issue*

@rmosolgo @dougedey