### PR TITLE
Accept dataload: true for fields that need batching

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -550,8 +550,15 @@ module GraphQL
                 ex_err
               end
             end
-            after_lazy(app_result, field: field_defn, ast_node: ast_node, owner_object: object, arguments: resolved_arguments, result_name: result_name, result: selection_result) do |inner_result|
-              continue_value = continue_value(inner_result, owner_type, field_defn, return_type_non_null, ast_node, result_name, selection_result)
+            if field_defn.dataload?
+              after_lazy(app_result, field: field_defn, ast_node: ast_node, owner_object: object, arguments: resolved_arguments, result_name: result_name, result: selection_result) do |inner_result|
+                continue_value = continue_value(inner_result, owner_type, field_defn, return_type_non_null, ast_node, result_name, selection_result)
+                if HALT != continue_value
+                  continue_field(continue_value, owner_type, field_defn, return_type, ast_node, next_selections, false, object, resolved_arguments, result_name, selection_result)
+                end
+              end
+            else
+              continue_value = continue_value(app_result, owner_type, field_defn, return_type_non_null, ast_node, result_name, selection_result)
               if HALT != continue_value
                 continue_field(continue_value, owner_type, field_defn, return_type, ast_node, next_selections, false, object, resolved_arguments, result_name, selection_result)
               end

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -32,6 +32,18 @@ module GraphQL
       attr_reader :hash_key
       attr_reader :dig_keys
 
+      def dataload?
+        @dataload
+      end
+
+      def self.dataload_by_default(new_value = NOT_CONFIGURED)
+        if NOT_CONFIGURED == new_value
+          defined?(@dataload_by_default) ? @dataload_by_default : (superclass.respond_to?(:dataload_by_default) ? superclass.dataload_by_default : true)
+        else
+          @dataload_by_default = new_value
+        end
+      end
+
       # @return [Symbol] The method on the type to look up
       def resolver_method
         if @resolver_class
@@ -218,8 +230,9 @@ module GraphQL
       # @param ast_node [Language::Nodes::FieldDefinition, nil] If this schema was parsed from definition, this AST node defined the field
       # @param method_conflict_warning [Boolean] If false, skip the warning if this field's method conflicts with a built-in method
       # @param validates [Array<Hash>] Configurations for validating this field
-      # @fallback_value [Object] A fallback value if the method is not defined
-      def initialize(type: nil, name: nil, owner: nil, null: nil, description: NOT_CONFIGURED, deprecation_reason: nil, method: nil, hash_key: nil, dig: nil, resolver_method: nil, connection: nil, max_page_size: NOT_CONFIGURED, default_page_size: NOT_CONFIGURED, scope: nil, introspection: false, camelize: true, trace: nil, complexity: nil, ast_node: nil, extras: EMPTY_ARRAY, extensions: EMPTY_ARRAY, connection_extension: self.class.connection_extension, resolver_class: nil, subscription_scope: nil, relay_node_field: false, relay_nodes_field: false, method_conflict_warning: true, broadcastable: NOT_CONFIGURED, arguments: EMPTY_HASH, directives: EMPTY_HASH, validates: EMPTY_ARRAY, fallback_value: NOT_CONFIGURED, &definition_block)
+      # @param dataload [Boolean] If true, use GraphQL-Ruby's batch loading mechanism to resolve this field's return value
+      # @param fallback_value [Object] A fallback value if the method is not defined
+      def initialize(type: nil, name: nil, owner: nil, null: nil, description: NOT_CONFIGURED, deprecation_reason: nil, method: nil, hash_key: nil, dig: nil, resolver_method: nil, connection: nil, max_page_size: NOT_CONFIGURED, default_page_size: NOT_CONFIGURED, scope: nil, introspection: false, camelize: true, trace: nil, complexity: nil, ast_node: nil, extras: EMPTY_ARRAY, extensions: EMPTY_ARRAY, connection_extension: self.class.connection_extension, resolver_class: nil, subscription_scope: nil, relay_node_field: false, relay_nodes_field: false, method_conflict_warning: true, dataload: self.class.dataload_by_default, broadcastable: NOT_CONFIGURED, arguments: EMPTY_HASH, directives: EMPTY_HASH, validates: EMPTY_ARRAY, fallback_value: NOT_CONFIGURED, &definition_block)
         if name.nil?
           raise ArgumentError, "missing first `name` argument or keyword `name:`"
         end
@@ -275,6 +288,9 @@ module GraphQL
         else
           true
         end
+
+        @dataload = dataload
+
         @connection = connection
         @max_page_size = max_page_size
         @default_page_size = default_page_size


### PR DESCRIPTION
Currently, _every_ object returned by a graphql field is checked to see if it needs lazy resolution. This wastes a lot of time (~5% of runtime in one benchmark). We could make this faster by _not_ always checking, and a first attempt would be to require opt-in for dataloaded values. (This could be more ergonomic, see below.) This only reduces overhead in fields that _don't_ require batch loading, but in my experience, that's _most_ fields (most fields are leaf fields; leaf fields don't usually use batch loading). 

### TODO 

- [ ] Make a "development mode" where it _still_ checks for lazy values and reports them, so that the config can be added 
- [ ] Could there even be a diagnostic output + Rubocop correction for automatically migrating?
- [ ] Lazy values from `resolve_type`, `authorized?`, and argument `prepare`s can "pollute" downstream, making some fields require `dataload: true` even though the field has nothing to do with that. Gotta fix this somehow. 
