### PR TITLE
(fix) Enum_Value Directive missing from Schema IDL

### DIFF
--- a/lib/graphql/schema/addition.rb
+++ b/lib/graphql/schema/addition.rb
@@ -258,6 +258,12 @@ module GraphQL
             end
             path.pop
           end
+
+          if type.kind.enum?
+            type.all_enum_value_definitions.each do |value_definition|
+              add_directives_from(value_definition)
+            end
+          end
         end
       end
     end

--- a/spec/graphql/language/document_from_schema_definition_spec.rb
+++ b/spec/graphql/language/document_from_schema_definition_spec.rb
@@ -131,7 +131,7 @@ type Query {
         class CustomEnumValueDirective < GraphQL::Schema::Directive
           locations GraphQL::Schema::Directive::ENUM_VALUE
 
-          argument :fake_argument, String, required: true
+          argument :fake_argument, String
         end
 
         class FakeEnum < GraphQL::Schema::Enum

--- a/spec/graphql/language/document_from_schema_definition_spec.rb
+++ b/spec/graphql/language/document_from_schema_definition_spec.rb
@@ -146,7 +146,6 @@ type Query {
         end
 
         query(Query)
-        # directive(CustomEnumValueDirective)  # <-- Fails if this is not included
       end
 
       it "dumps the custom directive definition to the IDL" do


### PR DESCRIPTION
This is a bug-fix for #4594 and has been validated using the spec scenario created for triaging the initial issue.

**Summary:** Enum_Value nodes were not being traversed in the `GraphQL::Schema:Addition` AST-walk, resulting in any ENUM_VALUE targeted Directives not being added to the Schema IDL during document generation. This would produced incomplete IDL output that breaks downstream validators and codegenerators.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205346733139652