### PR TITLE
fix: onCompleted typo in createRelaySubscriptionHandler

### DIFF
--- a/javascript_client/src/subscriptions/createRelaySubscriptionHandler.ts
+++ b/javascript_client/src/subscriptions/createRelaySubscriptionHandler.ts
@@ -60,7 +60,7 @@ function createRelaySubscriptionHandler(options: ActionCableHandlerOptions | Pus
               }
               observer.next(res);
             },
-            onComplete: observer.complete,
+            onCompleted: observer.complete,
           }
         );
 


### PR DESCRIPTION
When using this handle with the `createActionCableHandler`, , an error is thrown because it expects the observer object to have an `onCompleted` method, but `onComplete` is currently passed from the `createRelaySubscriptionHandler`. 

For reference: https://github.com/rmosolgo/graphql-ruby/blob/master/javascript_client/src/subscriptions/createActionCableHandler.ts#L60

Fixes https://github.com/rmosolgo/graphql-ruby/issues/4604