### PR TITLE
Remove unused legacy connection code

### DIFF
--- a/lib/graphql/schema/field/connection_extension.rb
+++ b/lib/graphql/schema/field/connection_extension.rb
@@ -54,23 +54,9 @@ module GraphQL
                 value.edge_class = custom_t
               end
               value
-            elsif context.schema.new_connections?
+            else
               context.namespace(:connections)[:all_wrappers] ||= context.schema.connections.all_wrappers
               context.schema.connections.wrap(field, object.object, value, original_arguments, context)
-            else
-              if object.is_a?(GraphQL::Schema::Object)
-                object = object.object
-              end
-              connection_class = GraphQL::Relay::BaseConnection.connection_for_nodes(value)
-              connection_class.new(
-                value,
-                original_arguments,
-                field: field,
-                max_page_size: field.max_page_size,
-                default_page_size: field.default_page_size,
-                parent: object,
-                context: context,
-              )
             end
           end
         end

--- a/spec/integration/mongoid/star_trek/schema.rb
+++ b/spec/integration/mongoid/star_trek/schema.rb
@@ -199,23 +199,6 @@ module StarTrek
         raise GraphQL::ExecutionError.new("🔥")
       elsif ship_name == 'Scimitar'
         LazyWrapper.new { raise GraphQL::ExecutionError.new("💥")}
-      else
-        ship = DATA.create_ship(ship_name, faction_id)
-        faction = DATA["Faction"][faction_id]
-        connection_class = GraphQL::Relay::BaseConnection.connection_for_nodes(faction.ships)
-        ships_connection = connection_class.new(faction.ships, args)
-        ship_edge = GraphQL::Relay::Edge.new(ship, ships_connection)
-        result = {
-          shipEdge: ship_edge,
-          ship_edge: ship_edge, # support new-style, too
-          faction: faction,
-          aliased_faction: faction,
-        }
-        if ship_name == "Slave II"
-          LazyWrapper.new(result)
-        else
-          result
-        end
       end
     end
   end


### PR DESCRIPTION
These referenced `GraphQL::Relay::BaseConnection` which no longer exists