### PR TITLE
Add small query benchmark, fix field args check

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -114,6 +114,12 @@ namespace :bench do
     GraphQLBenchmark.profile_large_result
   end
 
+  desc "Run benchmarks on a small result"
+  task :profile_small_result do
+    prepare_benchmark
+    GraphQLBenchmark.profile_small_result
+  end
+
   desc "Compare GraphQL-Batch and GraphQL-Dataloader"
   task :profile_batch_loaders do
     prepare_benchmark

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -438,8 +438,7 @@ module GraphQL
             owner_object = field_defn.owner.wrap(owner_object, context)
           end
           return_type = field_defn.type
-          total_args_count = field_defn.arguments(context).size
-          if total_args_count == 0
+          if !field_defn.any_arguments?
             resolved_arguments = GraphQL::Execution::Interpreter::Arguments::EMPTY
             if field_defn.extras.size == 0
               evaluate_selection_with_resolved_keyword_args(

--- a/lib/graphql/schema/member/has_arguments.rb
+++ b/lib/graphql/schema/member/has_arguments.rb
@@ -122,6 +122,10 @@ module GraphQL
           own_arguments_that_apply || own_arguments
         end
 
+        def any_arguments?
+          own_arguments.any?
+        end
+
         module ClassConfigured
           def inherited(child_class)
             super
@@ -143,6 +147,10 @@ module GraphQL
               else
                 inherited_arguments
               end
+            end
+
+            def any_arguments?
+              super || superclass.any_arguments?
             end
 
             def all_argument_definitions

--- a/lib/graphql/schema/member/has_arguments.rb
+++ b/lib/graphql/schema/member/has_arguments.rb
@@ -183,7 +183,7 @@ module GraphQL
         module FieldConfigured
           def arguments(context = GraphQL::Query::NullContext)
             own_arguments = super
-            if defined?(@resolver_class) && @resolver_class
+            if @resolver_class
               inherited_arguments = @resolver_class.field_arguments(context)
               if own_arguments.any?
                 if inherited_arguments.any?
@@ -199,8 +199,12 @@ module GraphQL
             end
           end
 
+          def any_arguments?
+            super || (@resolver_class && @resolver_class.any_field_arguments?)
+          end
+
           def all_argument_definitions
-            if defined?(@resolver_class) && @resolver_class
+            if @resolver_class
               all_defns = {}
               @resolver_class.all_field_argument_definitions.each do |arg_defn|
                 key = arg_defn.graphql_name

--- a/lib/graphql/schema/relay_classic_mutation.rb
+++ b/lib/graphql/schema/relay_classic_mutation.rb
@@ -92,6 +92,10 @@ module GraphQL
           dummy.own_arguments
         end
 
+        def any_field_arguments?
+          dummy.any_arguments?
+        end
+
         def all_field_argument_definitions
           dummy.all_argument_definitions
         end

--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -214,6 +214,10 @@ module GraphQL
           arguments(context)
         end
 
+        def any_field_arguments?
+          any_arguments?
+        end
+
         def get_field_argument(name, context = GraphQL::Query::NullContext)
           get_argument(name, context)
         end


### PR DESCRIPTION
So far, my benchmarks have all been for really big queries. But small queries shed light on other performance bottlenecks, like this one. 

```diff 
  Calculating -------------------------------------
  Querying for 1000 objects
-                         327.533  (± 2.7%) i/s -      3.300k in  10.083216s
+                         359.747  (± 3.6%) i/s -      3.605k in  10.035778s

...
- Total allocated: 108864 bytes (1012 objects)
+ Total allocated: 97896 bytes (949 objects)
```