### PR TITLE
Cache the result of gathered selections for later re-use

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -304,10 +304,11 @@ module GraphQL
           nil
         end
 
-        def gather_selections(owner_object, owner_type, ast_node_for_caching, selections, selections_to_run = nil, selections_by_name = {})
+        def gather_selections(owner_object, owner_type, ast_node_for_caching, selections, selections_to_run = nil, selections_by_name = nil)
           if ast_node_for_caching && (cached_selections = @gathered_selections_cache[ast_node_for_caching])
             return cached_selections
           end
+          selections_by_name ||= {} # allocate this default here so we check the cache first
 
           should_cache = true
 

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -359,18 +359,18 @@ module GraphQL
                   type_defn = schema.get_type(node.type.name, context)
 
                   if query.warden.possible_types(type_defn).include?(owner_type)
-                    gather_selections(owner_object, owner_type, node, node.selections, selections_to_run, next_selections)
+                    gather_selections(owner_object, owner_type, nil, node.selections, selections_to_run, next_selections)
                   end
                 else
                   # it's an untyped fragment, definitely continue
-                  gather_selections(owner_object, owner_type, node, node.selections, selections_to_run, next_selections)
+                  gather_selections(owner_object, owner_type, nil, node.selections, selections_to_run, next_selections)
                 end
               when GraphQL::Language::Nodes::FragmentSpread
                 should_cache = false
                 fragment_def = query.fragments[node.name]
                 type_defn = query.get_type(fragment_def.type.name)
                 if query.warden.possible_types(type_defn).include?(owner_type)
-                  gather_selections(owner_object, owner_type, node, fragment_def.selections, selections_to_run, next_selections)
+                  gather_selections(owner_object, owner_type, nil, fragment_def.selections, selections_to_run, next_selections)
                 end
               else
                 raise "Invariant: unexpected selection class: #{node.class}"

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -315,6 +315,7 @@ module GraphQL
           selections.each do |node|
             # Skip gathering this if the directive says so
             if !directives_include?(node, owner_object, owner_type)
+              should_cache = false
               next
             end
 

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -218,6 +218,9 @@ module GraphQL
           # { Class => Boolean }
           @lazy_cache = {}
           @lazy_cache.compare_by_identity
+
+          @gathered_selections_cache = {}
+          @gathered_selections_cache.compare_by_identity
         end
 
         def final_result
@@ -257,7 +260,7 @@ module GraphQL
             @response = nil
           else
             call_method_on_directives(:resolve, runtime_object, root_operation.directives) do # execute query level directives
-              gathered_selections = gather_selections(runtime_object, root_type, root_operation.selections)
+              gathered_selections = gather_selections(runtime_object, root_type, nil, root_operation.selections)
               # This is kind of a hack -- `gathered_selections` is an Array if any of the selections
               # require isolation during execution (because of runtime directives). In that case,
               # make a new, isolated result hash for writing the result into. (That isolated response
@@ -301,7 +304,13 @@ module GraphQL
           nil
         end
 
-        def gather_selections(owner_object, owner_type, selections, selections_to_run = nil, selections_by_name = {})
+        def gather_selections(owner_object, owner_type, ast_node_for_caching, selections, selections_to_run = nil, selections_by_name = {})
+          if ast_node_for_caching && (cached_selections = @gathered_selections_cache[ast_node_for_caching])
+            return cached_selections
+          end
+
+          should_cache = true
+
           selections.each do |node|
             # Skip gathering this if the directive says so
             if !directives_include?(node, owner_object, owner_type)
@@ -329,6 +338,7 @@ module GraphQL
               if @runtime_directive_names.any? && node.directives.any? { |d| @runtime_directive_names.include?(d.name) }
                 next_selections = {}
                 next_selections[:graphql_directives] = node.directives
+                should_cache = false
                 if selections_to_run
                   selections_to_run << next_selections
                 else
@@ -343,27 +353,33 @@ module GraphQL
               case node
               when GraphQL::Language::Nodes::InlineFragment
                 if node.type
+                  should_cache = false
                   type_defn = schema.get_type(node.type.name, context)
 
                   if query.warden.possible_types(type_defn).include?(owner_type)
-                    gather_selections(owner_object, owner_type, node.selections, selections_to_run, next_selections)
+                    gather_selections(owner_object, owner_type, node, node.selections, selections_to_run, next_selections)
                   end
                 else
                   # it's an untyped fragment, definitely continue
-                  gather_selections(owner_object, owner_type, node.selections, selections_to_run, next_selections)
+                  gather_selections(owner_object, owner_type, node, node.selections, selections_to_run, next_selections)
                 end
               when GraphQL::Language::Nodes::FragmentSpread
+                should_cache = false
                 fragment_def = query.fragments[node.name]
                 type_defn = query.get_type(fragment_def.type.name)
                 if query.warden.possible_types(type_defn).include?(owner_type)
-                  gather_selections(owner_object, owner_type, fragment_def.selections, selections_to_run, next_selections)
+                  gather_selections(owner_object, owner_type, node, fragment_def.selections, selections_to_run, next_selections)
                 end
               else
                 raise "Invariant: unexpected selection class: #{node.class}"
               end
             end
           end
-          selections_to_run || selections_by_name
+          result = selections_to_run || selections_by_name
+          if should_cache
+            @gathered_selections_cache[ast_node_for_caching] = result
+          end
+          result
         end
 
         NO_ARGS = GraphQL::EmptyObjects::EMPTY_HASH
@@ -780,7 +796,8 @@ module GraphQL
               if HALT != continue_value
                 response_hash = GraphQLResultHash.new(result_name, selection_result, is_non_null)
                 set_result(selection_result, result_name, response_hash, true, is_non_null)
-                gathered_selections = gather_selections(continue_value, current_type, next_selections)
+
+                gathered_selections = gather_selections(continue_value, current_type, ast_node, next_selections)
                 # There are two possibilities for `gathered_selections`:
                 # 1. All selections of this object should be evaluated together (there are no runtime directives modifying execution).
                 #    This case is handled below, and the result can be written right into the main `response_hash` above.

--- a/spec/graphql/schema/list_spec.rb
+++ b/spec/graphql/schema/list_spec.rb
@@ -156,7 +156,7 @@ describe GraphQL::Schema::List do
         value "A"
         value "B"
       end
-      
+
       class Query < GraphQL::Schema::Object
         field :items, [Item], null: false do
           argument :ids, [Int]


### PR DESCRIPTION
I noticed that this code was getting called over and over again, and this makes sense in some cases, because fragments may apply conditionally and directives depend on the runtime object. But in the simplest case, it was doing repeat work, over and over. So I added a cache for that simplest case. ~~(It could probably be improved to cache based on `type`, too.)~~ I went ahead and did it because it covers the built-in introspection query much better.

- `~/code/graphql-ruby $ EAGER=1 be rake bench:profile_large_result`
  
  ```diff 
    Calculating -------------------------------------
    Querying for 1000 objects
  -                         358.825  (± 6.1%) i/s -      3.600k in  10.082144s
  +                         376.938  (± 3.2%) i/s -      3.774k in  10.023754s

  -        117   (2.1%)          72   (1.3%)     GraphQL::Execution::Interpreter::Runtime#gather_selections
  +         12   (0.2%)          12   (0.2%)     GraphQL::Execution::Interpreter::Runtime#gather_selections

  - Total allocated: 97896 bytes (949 objects)
  + Total allocated: 89232 bytes (895 objects)
  ```


- `~/code/graphql-ruby $ EAGER=1 be rake bench:profile_small_result`

  ```diff
    Calculating -------------------------------------
    Querying for 1000 objects
  -                           7.852  (± 0.0%) i/s -     79.000  in  10.071959s
  +                           8.244  (± 0.0%) i/s -     83.000  in  10.078467s

  -       6425   (2.8%)        3318   (1.4%)     GraphQL::Execution::Interpreter::Runtime#gather_selections
  +        109   (0.0%)          88   (0.0%)     GraphQL::Execution::Interpreter::Runtime#gather_selections
 
  - Total allocated: 4427896 bytes (18540 objects)
  + Total allocated: 3461056 bytes (16543 objects)
  ```

  (Weirdly in the `large` benchmark, on master, it records 1000 allocations from here: https://github.com/rmosolgo/graphql-ruby/blob/fd15d0b93a7c3177eab34c142007e2f50b438f07/lib/graphql/schema/directive/skip.rb#L20 . I don't know why that would different between these branches...)

- `be rake bench:profile_large_introspection`

  ```diff 
    Calculating -------------------------------------
    Run large introspection
  -                       2.336  (± 0.0%) i/s -     24.000  in  10.280001s
  +                       2.706  (± 0.0%) i/s -     28.000  in  10.350335s
    
  -         46  (10.4%)          30   (6.8%)     GraphQL::Execution::Interpreter::Runtime#gather_selections
  +          4   (1.1%)           4   (1.1%)     GraphQL::Execution::Interpreter::Runtime#gather_selections


  - Total allocated: 11898855 bytes (84486 objects)
  + Total allocated: 9556496 bytes (64699 objects)
  ```