### PR TITLE
Improve runtime field lookup

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -209,12 +209,6 @@ module GraphQL
               @runtime_directive_names << name
             end
           end
-          # A cache of { Class => { String => Schema::Field } }
-          # Which assumes that MyObject.get_field("myField") will return the same field
-          # during the lifetime of a query
-          @fields_cache = Hash.new { |h, k| h[k] = {} }
-          # this can by by-identity since owners are the same object, but not the sub-hash, which uses strings.
-          @fields_cache.compare_by_identity
           # { Class => Boolean }
           @lazy_cache = {}
           @lazy_cache.compare_by_identity

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -434,22 +434,7 @@ module GraphQL
             ast_node = field_ast_nodes_or_ast_node
           end
           field_name = ast_node.name
-          # This can't use `query.get_field` because it gets confused on introspection below if `field_defn` isn't `nil`,
-          # because of how `is_dynamic` is used to call `.authorized_new` later on.
-          field_defn = @fields_cache[owner_type][field_name] ||= begin
-            f = owner_type.get_field(field_name, @context)
-            if f.nil?
-              if owner_type == schema.query && (entry_point_field = schema.introspection_system.entry_point(name: field_name))
-                entry_point_field
-              elsif (dynamic_field = schema.introspection_system.dynamic_field(name: field_name))
-                dynamic_field
-              else
-                raise "Invariant: no field for #{owner_type}.#{field_name}"
-              end
-            else
-              f
-            end
-          end
+          field_defn = query.warden.get_field(owner_type, field_name)
 
           is_dynamic = if field_defn.owner != owner_type
             field_defn.owner.graphql_name == "DynamicFields" || field_defn.owner.graphql_name == "EntryPoints"

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -430,19 +430,13 @@ module GraphQL
           field_name = ast_node.name
           field_defn = query.warden.get_field(owner_type, field_name)
 
-          is_dynamic = if field_defn.owner != owner_type
-            field_defn.owner.graphql_name == "DynamicFields" || field_defn.owner.graphql_name == "EntryPoints"
-          else
-            false
-          end
-
           # Set this before calling `run_with_directives`, so that the directive can have the latest path
           st = get_current_runtime_state
           st.current_field = field_defn
           st.current_result = selections_result
           st.current_result_name = result_name
 
-          if is_dynamic
+          if field_defn.dynamic_introspection
             owner_object = field_defn.owner.wrap(owner_object, context)
           end
 

--- a/lib/graphql/introspection/dynamic_fields.rb
+++ b/lib/graphql/introspection/dynamic_fields.rb
@@ -2,7 +2,7 @@
 module GraphQL
   module Introspection
     class DynamicFields < Introspection::BaseObject
-      field :__typename, String, "The name of this type", null: false
+      field :__typename, String, "The name of this type", null: false, dynamic_introspection: true
 
       def __typename
         object.class.graphql_name

--- a/lib/graphql/introspection/entry_points.rb
+++ b/lib/graphql/introspection/entry_points.rb
@@ -2,8 +2,8 @@
 module GraphQL
   module Introspection
     class EntryPoints < Introspection::BaseObject
-      field :__schema, GraphQL::Schema::LateBoundType.new("__Schema"), "This GraphQL schema", null: false
-      field :__type, GraphQL::Schema::LateBoundType.new("__Type"), "A type in the GraphQL system" do
+      field :__schema, GraphQL::Schema::LateBoundType.new("__Schema"), "This GraphQL schema", null: false, dynamic_introspection: true
+      field :__type, GraphQL::Schema::LateBoundType.new("__Type"), "A type in the GraphQL system", dynamic_introspection: true do
         argument :name, String
       end
 

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -659,7 +659,7 @@ module GraphQL
         method_to_call = nil
         method_args = nil
 
-        Schema::Validator.validate!(validators, application_object, query_ctx, args)
+        @own_validators && Schema::Validator.validate!(validators, application_object, query_ctx, args)
 
         query_ctx.query.after_lazy(self.authorized?(application_object, args, query_ctx)) do |is_authorized|
           if is_authorized

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -267,6 +267,7 @@ module GraphQL
         @method_sym = method_name.to_sym
         @resolver_method = (resolver_method || name_s).to_sym
         @complexity = complexity
+        @dynamic_introspection = dynamic_introspection
         @return_type_expr = type
         @return_type_null = if !null.nil?
           null
@@ -349,8 +350,6 @@ module GraphQL
 
         self.extensions.each(&:after_define_apply)
         @call_after_define = true
-        # This may be set later
-        @dynamic_introspection = dynamic_introspection
       end
 
       attr_accessor :dynamic_introspection

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -219,7 +219,7 @@ module GraphQL
       # @param method_conflict_warning [Boolean] If false, skip the warning if this field's method conflicts with a built-in method
       # @param validates [Array<Hash>] Configurations for validating this field
       # @fallback_value [Object] A fallback value if the method is not defined
-      def initialize(type: nil, name: nil, owner: nil, null: nil, description: NOT_CONFIGURED, deprecation_reason: nil, method: nil, hash_key: nil, dig: nil, resolver_method: nil, connection: nil, max_page_size: NOT_CONFIGURED, default_page_size: NOT_CONFIGURED, scope: nil, introspection: false, camelize: true, trace: nil, complexity: nil, ast_node: nil, extras: EMPTY_ARRAY, extensions: EMPTY_ARRAY, connection_extension: self.class.connection_extension, resolver_class: nil, subscription_scope: nil, relay_node_field: false, relay_nodes_field: false, method_conflict_warning: true, broadcastable: NOT_CONFIGURED, arguments: EMPTY_HASH, directives: EMPTY_HASH, validates: EMPTY_ARRAY, fallback_value: NOT_CONFIGURED, &definition_block)
+      def initialize(type: nil, name: nil, owner: nil, null: nil, description: NOT_CONFIGURED, deprecation_reason: nil, method: nil, hash_key: nil, dig: nil, resolver_method: nil, connection: nil, max_page_size: NOT_CONFIGURED, default_page_size: NOT_CONFIGURED, scope: nil, introspection: false, camelize: true, trace: nil, complexity: nil, ast_node: nil, extras: EMPTY_ARRAY, extensions: EMPTY_ARRAY, connection_extension: self.class.connection_extension, resolver_class: nil, subscription_scope: nil, relay_node_field: false, relay_nodes_field: false, method_conflict_warning: true, broadcastable: NOT_CONFIGURED, arguments: EMPTY_HASH, directives: EMPTY_HASH, validates: EMPTY_ARRAY, fallback_value: NOT_CONFIGURED, dynamic_introspection: false, &definition_block)
         if name.nil?
           raise ArgumentError, "missing first `name` argument or keyword `name:`"
         end
@@ -349,7 +349,11 @@ module GraphQL
 
         self.extensions.each(&:after_define_apply)
         @call_after_define = true
+        # This may be set later
+        @dynamic_introspection = dynamic_introspection
       end
+
+      attr_accessor :dynamic_introspection
 
       # If true, subscription updates with this field can be shared between viewers
       # @return [Boolean, nil]

--- a/lib/graphql/schema/introspection_system.rb
+++ b/lib/graphql/schema/introspection_system.rb
@@ -39,7 +39,9 @@ module GraphQL
             entry_point_fields.delete('__type') if schema.disable_type_introspection_entry_point?
             entry_point_fields
           end
+        @entry_point_fields.each { |k, v| v.dynamic_introspection = true }
         @dynamic_fields = get_fields_from_class(class_sym: :DynamicFields)
+        @dynamic_fields.each { |k, v| v.dynamic_introspection = true }
       end
 
       def entry_points

--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -133,13 +133,16 @@ module GraphQL
           def get_field(field_name, context = GraphQL::Query::NullContext)
             # Objects need to check that the interface implementation is visible, too
             warden = Warden.from_context(context)
-            for ancestor in ancestors
+            ancs = ancestors
+            i = 0
+            while (ancestor = ancs[i])
               if ancestor.respond_to?(:own_fields) &&
                   visible_interface_implementation?(ancestor, context, warden) &&
                   (f_entry = ancestor.own_fields[field_name]) &&
                   (f = Warden.visible_entry?(:visible_field?, f_entry, context, warden))
                 return f
               end
+              i += 1
             end
             nil
           end

--- a/lib/graphql/static_validation/rules/fields_will_merge.rb
+++ b/lib/graphql/static_validation/rules/fields_will_merge.rb
@@ -340,7 +340,7 @@ module GraphQL
         selections.each do |node|
           case node
           when GraphQL::Language::Nodes::Field
-            definition = context.query.get_field(owner_type, node.name)
+            definition = context.warden.get_field(owner_type, node.name)
             fields << Field.new(node, definition, owner_type, parents)
           when GraphQL::Language::Nodes::InlineFragment
             fragment_type = node.type ? context.warden.get_type(node.type.name) : owner_type

--- a/lib/graphql/static_validation/validation_context.rb
+++ b/lib/graphql/static_validation/validation_context.rb
@@ -13,12 +13,15 @@ module GraphQL
 
       attr_reader :query, :errors, :visitor,
         :on_dependency_resolve_handlers,
-        :max_errors
+        :max_errors, :warden, :schema
 
-      def_delegators :@query, :schema, :document, :fragments, :operations, :warden
+
+      def_delegators :@query, :document, :fragments, :operations
 
       def initialize(query, visitor_class, max_errors)
         @query = query
+        @warden = query.warden
+        @schema = query.schema
         @literal_validator = LiteralValidator.new(context: query.context)
         @errors = []
         @max_errors = max_errors || Float::INFINITY


### PR DESCRIPTION
I found a faster way to do this field lookup. And apparently `def_delegators` costs an allocation?!

```
EAGER=1 be rake bench:profile_small_result
```


```diff
  Calculating -------------------------------------
  Querying for 1000 objects
-                         379.826  (± 3.2%) i/s -      3.800k in  10.015388s
+                         473.957  (± 3.6%) i/s -      4.738k in  10.010388s

- Total allocated: 90240 bytes (904 objects)
+ Total allocated: 75072 bytes (788 objects)
```


But, it makes `profile_large_result` slower: 

```diff 
  Calculating -------------------------------------
  Querying for 1000 objects
-                           8.338  (± 0.0%) i/s -     84.000  in  10.079985s
+                           8.160  (± 0.0%) i/s -     82.000  in  10.070237s

- Total allocated: 3461520 bytes (16546 objects)
+ Total allocated: 3456392 bytes (16490 objects)
```

I assume it's because the large benchmark doesn't use `__typename`, which is made much faster by this change.

I checked `profile_large_introspection` too, and it was basically the same runtime with just a bit less memory usage.