### PR TITLE
makes install templates more rubocop friendly.

### DIFF
--- a/lib/generators/graphql/install/templates/base_mutation.erb
+++ b/lib/generators/graphql/install/templates/base_mutation.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing_when_supported do -%>
 module Mutations
   class BaseMutation < GraphQL::Schema::RelayClassicMutation

--- a/lib/generators/graphql/install/templates/mutation_type.erb
+++ b/lib/generators/graphql/install/templates/mutation_type.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing_when_supported do -%>
 module Types
   class MutationType < Types::BaseObject

--- a/lib/generators/graphql/templates/base_argument.erb
+++ b/lib/generators/graphql/templates/base_argument.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing_when_supported do -%>
 module Types
   class BaseArgument < GraphQL::Schema::Argument

--- a/lib/generators/graphql/templates/base_connection.erb
+++ b/lib/generators/graphql/templates/base_connection.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing_when_supported do -%>
 module Types
   class BaseConnection < Types::BaseObject

--- a/lib/generators/graphql/templates/base_edge.erb
+++ b/lib/generators/graphql/templates/base_edge.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing_when_supported do -%>
 module Types
   class BaseEdge < Types::BaseObject

--- a/lib/generators/graphql/templates/base_enum.erb
+++ b/lib/generators/graphql/templates/base_enum.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing_when_supported do -%>
 module Types
   class BaseEnum < GraphQL::Schema::Enum

--- a/lib/generators/graphql/templates/base_field.erb
+++ b/lib/generators/graphql/templates/base_field.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing_when_supported do -%>
 module Types
   class BaseField < GraphQL::Schema::Field

--- a/lib/generators/graphql/templates/base_input_object.erb
+++ b/lib/generators/graphql/templates/base_input_object.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing_when_supported do -%>
 module Types
   class BaseInputObject < GraphQL::Schema::InputObject

--- a/lib/generators/graphql/templates/base_interface.erb
+++ b/lib/generators/graphql/templates/base_interface.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing_when_supported do -%>
 module Types
   module BaseInterface

--- a/lib/generators/graphql/templates/base_object.erb
+++ b/lib/generators/graphql/templates/base_object.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing_when_supported do -%>
 module Types
   class BaseObject < GraphQL::Schema::Object

--- a/lib/generators/graphql/templates/base_scalar.erb
+++ b/lib/generators/graphql/templates/base_scalar.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing_when_supported do -%>
 module Types
   class BaseScalar < GraphQL::Schema::Scalar

--- a/lib/generators/graphql/templates/base_union.erb
+++ b/lib/generators/graphql/templates/base_union.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing_when_supported do -%>
 module Types
   class BaseUnion < GraphQL::Schema::Union

--- a/lib/generators/graphql/templates/graphql_controller.erb
+++ b/lib/generators/graphql/templates/graphql_controller.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing_when_supported do -%>
 class GraphqlController < ApplicationController
   # If accessing from outside this domain, nullify the session

--- a/lib/generators/graphql/templates/loader.erb
+++ b/lib/generators/graphql/templates/loader.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing_when_supported do -%>
 module Loaders
   class <%= class_name %> < GraphQL::Batch::Loader

--- a/lib/generators/graphql/templates/mutation.erb
+++ b/lib/generators/graphql/templates/mutation.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing_when_supported do -%>
 module Mutations
   class <%= class_name %> < BaseMutation

--- a/lib/generators/graphql/templates/node_type.erb
+++ b/lib/generators/graphql/templates/node_type.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing_when_supported do -%>
 module Types
   module NodeType

--- a/lib/generators/graphql/templates/query_type.erb
+++ b/lib/generators/graphql/templates/query_type.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing_when_supported do -%>
 module Types
   class QueryType < Types::BaseObject

--- a/lib/generators/graphql/templates/schema.erb
+++ b/lib/generators/graphql/templates/schema.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing_when_supported do -%>
 class <%= schema_name %> < GraphQL::Schema
   query(Types::QueryType)


### PR DESCRIPTION
Adds `frozen_string_literal` comment to all templates that did not have it. reduce method size and complexity in the `graphql_controller` template.