### PR TITLE
Avoid using public_send on Context#[]

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -9,17 +9,20 @@ module GraphQL
       # @api private
       class Runtime
         class CurrentState
+          KEYS = [:current_result, :current_result_name, :current_arguments, :current_field, :current_object, :was_authorized_by_scope_items]
+
           def initialize
-            @current_object = nil
-            @current_field = nil
-            @current_arguments = nil
-            @current_result_name = nil
-            @current_result = nil
-            @was_authorized_by_scope_items = nil
+            @data = {}
           end
 
-          attr_accessor :current_result, :current_result_name,
-            :current_arguments, :current_field, :current_object, :was_authorized_by_scope_items
+          def [](key)
+            @data[key]
+          end
+
+          KEYS.each do |k|
+            define_method(k) { @data[k] }
+            define_method(:"#{k}=") {|v| @data[k] = v }
+          end
         end
 
         module GraphQLResult

--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -132,7 +132,7 @@ module GraphQL
           else
             (current_runtime_state = Thread.current[:__graphql_runtime_info]) &&
               (query_runtime_state = current_runtime_state[@query]) &&
-              (query_runtime_state.public_send(key))
+              (query_runtime_state[key])
           end
         else
           # not found


### PR DESCRIPTION
Hi, thank you for maintaining awesome library ⭐
Please feel free to close this PR if it sounds like kind of an improvement that should not be made by an external contributor, such as frozen string things in the past.

---

This PR will improve performance by 1.02x in this benchmark.

<details>
<summary>

```
$ ruby bench.rb
Warming up --------------------------------------
          with patch     1.000  i/100ms
       without patch     1.000  i/100ms
Calculating -------------------------------------
          with patch      0.814  (± 0.0%) i/s -     25.000  in  30.737210s
       without patch      0.798  (± 0.0%) i/s -     24.000  in  30.094314s

Comparison:
          with patch:        0.8 i/s
       without patch:        0.8 i/s - 1.02x  slower
```

</summary>

```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'

  gem 'benchmark-ips', require: 'benchmark/ips'
  gem 'graphql'
end

FIELD_COUNT = 100
ARTICLES_COUNT = 1000

ALL_ARTICLES = ARTICLES_COUNT.times.map do |i|
  {title: "title#{i}"}
end

module GraphQL
  module Execution
    class Interpreter
      class Runtime
        class CurrentState
          KEYS = [:current_result, :current_result_name, :current_arguments, :current_field, :current_object]

          def initialize
            @data = {}
          end

          def [](key)
            @data[key]
          end

          KEYS.each do |k|
            define_method(k) { @data[k] }
            define_method(:"#{k}=") {|v| @data[k] = v }
          end
        end
      end
    end
  end

  class Query
    class Context
      prepend(Module.new do
        def [](key)
          unless $with_patch
            return super
          end

          if @scoped_context.key?(key)
            @scoped_context[key]
          elsif @provided_values.key?(key)
            @provided_values[key]
          elsif RUNTIME_METADATA_KEYS.include?(key)
            if key == :current_path
              current_path
            else
              (current_runtime_state = Thread.current[:__graphql_runtime_info]) &&
                (query_runtime_state = current_runtime_state[@query]) &&
                (query_runtime_state[key])
            end
          else
            # not found
            nil
          end
        end
      end)
    end
  end
end

class ArticleType < GraphQL::Schema::Object
  FIELD_COUNT.times do |i|
    field "title#{i}", String, null: false do
      argument :arg, String
    end

    define_method "title#{i}" do |arg:|
      object[:title]
    end
  end
end

class QueryType < GraphQL::Schema::Object
  field :articles, [ArticleType], null: true

  def articles
    ALL_ARTICLES
  end
end

class TestSchema < GraphQL::Schema
  query QueryType
end

QUERY = <<GQL
  {
    articles { #{FIELD_COUNT.times.map {|i| "title#{i}(arg: \"a\")" }.join(",")} }
  }
GQL

Benchmark.ips do |x|
  x.time = 30

  x.report('with patch') do
    $with_patch = true
    TestSchema.execute(QUERY)
  end

  x.report('without patch') do
    $with_patch = false
    TestSchema.execute(QUERY)
  end

  x.compare!
end

__END__
$ ruby bench.rb
Warming up --------------------------------------
          with patch     1.000  i/100ms
       without patch     1.000  i/100ms
Calculating -------------------------------------
          with patch      0.814  (± 0.0%) i/s -     25.000  in  30.737210s
       without patch      0.798  (± 0.0%) i/s -     24.000  in  30.094314s

Comparison:
          with patch:        0.8 i/s
       without patch:        0.8 i/s - 1.02x  slower
```

</details>

---

I have an interest in performance improvements on graphql-ruby.

I took benchmarks for each version of the GraphQL Ruby 2 series and noticed that it has almost doubled in speed (in my example) since around 2.0.20.

![image](https://github.com/rmosolgo/graphql-ruby/assets/1796864/85b5fc62-e97c-439e-9a8a-17f32c26cee3)

https://github.com/mtsmfm/graphql-ruby-benchmark/blob/d4a390f392c01a9e1fc19ba8371787dde7452424/results/figs/result-2023-09-09T03%3A03%3A08%2B00%3A00.png

I was wondering which PR contributes most so I also took benchmark per PR.

![image](https://github.com/rmosolgo/graphql-ruby/assets/1796864/dd75e38f-2383-44a3-b9a2-0e64f4fcd8c7)

https://github.com/mtsmfm/graphql-ruby-benchmark/blob/d4a390f392c01a9e1fc19ba8371787dde7452424/results/figs/result-performance_prs-2023-09-10T03%3A38%3A18%2B00%3A00.png

I found https://github.com/rmosolgo/graphql-ruby/pull/4399 is one of the most important PR so I read the changes on the PR.
It seems the main purpose is to make a dedicated object but I found actually that part slows down the library since `public_send` is much slower than direct method call.

<details>
<summary>

```
$ ruby foo.rb 
Warming up --------------------------------------
                send   889.676k i/100ms
              direct     2.157M i/100ms
Calculating -------------------------------------
                send      8.757M (± 7.4%) i/s -     43.594M in   5.008124s
              direct     20.391M (± 7.0%) i/s -    103.546M in   5.105176s

Comparison:
              direct: 20391490.9 i/s
                send:  8756908.0 i/s - 2.33x  slower
```

</summary>

```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'

  gem 'benchmark-ips', require: 'benchmark/ips'
  gem 'graphql'
end

state = GraphQL::Execution::Interpreter::Runtime::CurrentState.new

Benchmark.ips do |x|
  x.report('send') do
    state.public_send(:current_arguments)
  end

  x.report('direct') do
    state.current_arguments
  end

  x.compare!
end

__END__
$ ruby foo.rb 
Warming up --------------------------------------
                send   889.676k i/100ms
              direct     2.157M i/100ms
Calculating -------------------------------------
                send      8.757M (± 7.4%) i/s -     43.594M in   5.008124s
              direct     20.391M (± 7.0%) i/s -    103.546M in   5.105176s

Comparison:
              direct: 20391490.9 i/s
                send:  8756908.0 i/s - 2.33x  slower
```
</details>

`Thread#[]` is fiber local variable and changing Hash object into `CurrentState` class doesn't affect the behavior in my understanding.

https://ruby-doc.org/3.2.2/Thread.html#method-i-5B-5D

I found actual improvement is done by this commit.

https://github.com/rmosolgo/graphql-ruby/pull/4399/commits/516265ebf90b65cda73433a3d07c76419e7e3137

If there's no argument on fields it can be huge improvement.

I wondered whether I should partially revert the original changes, but I decided to make the changes to keep backward compatibility.