### PR TITLE
Hardcoding runtime metadata calls in Context#[]

### DIFF
--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -306,7 +306,7 @@ module GraphQL
 
       def query_runtime_state
         (current_runtime_state = Thread.current[:__graphql_runtime_info]) &&
-          (query_runtime_state = current_runtime_state[@query])
+          current_runtime_state[@query]
       end
     end
   end


### PR DESCRIPTION
Another try at #4631 

Interestingly, in this context, it makes little difference to the gem's benchmarks. 


IPS:

|Benchmark | master | master, YJIT | branch | branch, YJIT |
|---|---|---|---|---|
|`profile_large_result`| 5.672 | 11.916 | 5.590 | 12.040 | 
|`profile_small_result`| 390.810 | 854.469 | 388.769 | 852.65 |
|Benchmark from #4631 | 1.281 | 3.763 | 1.284  | 3.929 |

