### PR TITLE
Allow precomputed analyzers to run without visitation

### DIFF
--- a/lib/graphql/analysis/ast/analyzer.rb
+++ b/lib/graphql/analysis/ast/analyzer.rb
@@ -29,6 +29,13 @@ module GraphQL
           true
         end
 
+        # Analyzer hook to decide at analysis time whether analysis
+        # requires a visitor pass; can be disabled for precomputed results.
+        # @return [Boolean] If analysis requires visitation or not
+        def visit?
+          true
+        end
+
         # The result for this analyzer. Returning {GraphQL::AnalysisError} results
         # in a query error.
         # @return [Any] The analyzer result


### PR DESCRIPTION
This PR adds a new `AST::Analyzer.visit?` hook that allows an analyzer to run without being included in visitation. This is different from the existing `AST::Analyzer.analyze?` hook that stops an analyzer from running entirely. This new hook is useful for analyzers that return precomputed/cached values.

### Why?

Analysis can be expensive, so we may want to cache some analysis results for reuse across repeat requests. For example, complexity scoring seems like it should be easy to reuse:

```ruby
class PrecomputedComplexity < GraphQL::Analysis::AST::QueryComplexity
  def result
    # seems good, but we still do all the visitation work...
    query.context[:precomputed_complexity] || super
  end
end
```

The above example isn't effective because the visitor pass itself is the primary overhead. If this were the only queued analyzer, it would still trigger a visitor pass (and save basically no time).

By adding a `visit?` hook, we can make the analyzer opt out of all visitation work. On its own, the following would not trigger an analysis visitor pass unless necessary:

```ruby
class PrecomputedComplexity < GraphQL::Analysis::AST::QueryComplexity
  def visit?
    query.context[:precomputed_complexity].nil?
  end

  def result
    query.context[:precomputed_complexity] || super
  end
end
```
