### PR TITLE
Tidy chained array transforms

### DIFF
--- a/lib/graphql/analysis/ast.rb
+++ b/lib/graphql/analysis/ast.rb
@@ -74,7 +74,7 @@ module GraphQL
       end
 
       def analysis_errors(results)
-        results.flatten.select { |r| r.is_a?(GraphQL::AnalysisError) }
+        results.flatten.tap { _1.select! { |r| r.is_a?(GraphQL::AnalysisError) } }
       end
     end
   end

--- a/lib/graphql/execution/lookahead.rb
+++ b/lib/graphql/execution/lookahead.rb
@@ -102,7 +102,7 @@ module GraphQL
             @query.warden
               .possible_types(selected_type)
               .map { |t| @query.warden.fields(t) }
-              .flatten
+              .tap(&:flatten!)
           end
 
           if (match_by_orig_name = all_fields.find { |f| f.original_name == field_name })

--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -323,7 +323,7 @@ module GraphQL
         #   @return [String, Float, Integer, Boolean, Array, InputObject, VariableIdentifier] The value passed for this key
 
         def children
-          @children ||= Array(value).flatten.select { |v| v.is_a?(AbstractNode) }
+          @children ||= Array(value).flatten.tap { _1.select! { |v| v.is_a?(AbstractNode) } }
         end
       end
 

--- a/lib/graphql/static_validation/literal_validator.rb
+++ b/lib/graphql/static_validation/literal_validator.rb
@@ -111,7 +111,7 @@ module GraphQL
         # that required fields are missing
         required_field_names = @warden.arguments(type)
           .select { |argument| argument.type.kind.non_null? && @warden.get_argument(type, argument.name) }
-          .map(&:name)
+          .map!(&:name)
 
         present_field_names = ast_node.arguments.map(&:name)
         missing_required_field_names = required_field_names - present_field_names

--- a/lib/graphql/static_validation/rules/required_arguments_are_present.rb
+++ b/lib/graphql/static_validation/rules/required_arguments_are_present.rb
@@ -21,7 +21,7 @@ module GraphQL
         present_argument_names = ast_node.arguments.map(&:name)
         required_argument_names = context.warden.arguments(defn)
           .select { |a| a.type.kind.non_null? && !a.default_value? && context.warden.get_argument(defn, a.name) }
-          .map(&:name)
+          .map!(&:name)
 
         missing_names = required_argument_names - present_argument_names
         if missing_names.any?

--- a/lib/graphql/static_validation/rules/required_input_object_attributes_are_present.rb
+++ b/lib/graphql/static_validation/rules/required_input_object_attributes_are_present.rb
@@ -36,7 +36,7 @@ module GraphQL
 
         required_fields = context.warden.arguments(parent_type)
           .select{|arg| arg.type.kind.non_null?}
-          .map(&:graphql_name)
+          .map!(&:graphql_name)
 
         present_fields = ast_node.arguments.map(&:name)
         missing_fields = required_fields - present_fields

--- a/lib/graphql/tracing/appoptics_trace.rb
+++ b/lib/graphql/tracing/appoptics_trace.rb
@@ -195,7 +195,7 @@ module GraphQL
           else
             [key, data[key]]
           end
-        end.flatten(2).each_slice(2).to_h.merge(Spec: 'graphql')
+        end.tap { _1.flatten!(2) }.each_slice(2).to_h.merge(Spec: 'graphql')
       end
       # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
@@ -226,7 +226,7 @@ module GraphQL
       end
 
       def graphql_multiplex(data)
-        names = data.queries.map(&:operations).map(&:keys).flatten.compact
+        names = data.queries.map(&:operations).map!(&:keys).tap(&:flatten!).tap(&:compact!)
         multiplex_transaction_name(names) if names.size > 1
 
         [:Operations, names.join(', ')]

--- a/lib/graphql/tracing/appoptics_tracing.rb
+++ b/lib/graphql/tracing/appoptics_tracing.rb
@@ -117,7 +117,7 @@ module GraphQL
           else
             [key, data[key]]
           end
-        end.flatten(2).each_slice(2).to_h.merge(Spec: 'graphql')
+        end.tap { _1.flatten!(2) }.each_slice(2).to_h.merge(Spec: 'graphql')
       end
       # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
@@ -148,7 +148,7 @@ module GraphQL
       end
 
       def graphql_multiplex(data)
-        names = data.queries.map(&:operations).map(&:keys).flatten.compact
+        names = data.queries.map(&:operations).map!(&:keys).tap(&:flatten!).tap(&:compact!)
         multiplex_transaction_name(names) if names.size > 1
 
         [:Operations, names.join(', ')]


### PR DESCRIPTION
Cleans up some pedantic details that reminded me of a Shopify Readme titled **"Ruby code that looks silly to a low-level programmer"**...

> 3. _Always_ use inline operations. Which means, prefer the use of `map! {...}` versus `map {...}`. Without the `!`, the interpreter will create a new Array. Only use the `map{...}` if the creation of a new array is desired. The same applies for other methods like `select!`, `filter!`, `rotate!`, `reverse!` and etc.

This is generally a pretty easy pattern to spot: when chaining multiple array transforms, all the later transforms should inline.