### PR TITLE
Reference correct variable in #merge-into

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -125,7 +125,7 @@ module GraphQL
               when GraphQLResultArray
                 # There's no special handling of arrays because currently, there's no way to split the execution
                 # of a list over several concurrent flows.
-                next_result.set_child_result(key, value)
+                into_result.set_child_result(key, value)
               else
                 # We have to assume that, since this passed the `fields_will_merge` selection,
                 # that the old and new values are the same.


### PR DESCRIPTION
👋🏼 Hey @rmosolgo. I don't think we've crossed paths since the Batman.js days :)

I'm in the process of writing a new directive, and got hit by this little bug in testing. It looks like it was introduced as part of https://github.com/rmosolgo/graphql-ruby/pull/4425, which was merged relatively recently.