### PR TITLE
Add Schema.default_trace_mode

### DIFF
--- a/spec/graphql/tracing/trace_modes_spec.rb
+++ b/spec/graphql/tracing/trace_modes_spec.rb
@@ -125,7 +125,6 @@ describe "Trace modes for schemas" do
     end
 
     class ChildCustomDefaultSchema < CustomDefaultSchema
-      trace_mode :custom_default, CustomDefaultTrace
     end
 
     it "inherits configuration" do


### PR DESCRIPTION
Fixes #4632 

TODO: 

Currently, a child schema class _rebuilds_ a special modes out of inherited modules + its own default base class. So the child class in the test needs to re-call `trace_mode ...` with a class to override that created class. 

Can that be made to work _right_?