### PR TITLE
Support re-printing AST extensions

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -120,6 +120,13 @@ namespace :bench do
     GraphQLBenchmark.profile_small_result
   end
 
+  desc "Dump schema to SDL"
+  task :profile_to_definition do
+    prepare_benchmark
+    GraphQLBenchmark.profile_to_definition
+  end
+
+
   desc "Compare GraphQL-Batch and GraphQL-Dataloader"
   task :profile_batch_loaders do
     prepare_benchmark

--- a/benchmark/run.rb
+++ b/benchmark/run.rb
@@ -418,6 +418,26 @@ module GraphQLBenchmark
     GRAPHQL
   end
 
+  def self.profile_to_definition
+    require_relative "./batch_loading"
+    schema = BatchLoading::GraphQLNoBatchingSchema
+
+    Benchmark.ips do |x|
+      x.report("to_definition") { schema.to_definition }
+    end
+
+    result = StackProf.run(mode: :wall, interval: 1) do
+      schema.to_definition
+    end
+    StackProf::Report.new(result).print_text
+
+    report = MemoryProfiler.report do
+      schema.to_definition
+    end
+
+    report.pretty_print
+  end
+
   def self.profile_batch_loaders
     require_relative "./batch_loading"
     include BatchLoading

--- a/lib/graphql/language/document_from_schema_definition.rb
+++ b/lib/graphql/language/document_from_schema_definition.rb
@@ -283,9 +283,13 @@ module GraphQL
       def build_type_definition_nodes(types, type_nodes, type_extensions_nodes)
         types.each do |type|
           if !include_introspection_types && type.introspection?
-            next
+            # Nothing
           elsif !include_built_in_scalars && type.kind.scalar? && type.default_scalar?
-            next
+            if @from_ast && (exts = type.ast_extensions)
+              type_extensions_nodes.concat(exts)
+            elsif type.directives.any?
+              type_nodes << build_type_definition_node(type)
+            end
           else
             if @from_ast
               type_nodes << type.ast_node
@@ -299,6 +303,7 @@ module GraphQL
         end
 
         type_nodes.sort_by!(&:name)
+        type_extensions_nodes.sort_by!(&:name)
 
         type_nodes
       end

--- a/lib/graphql/language/document_from_schema_definition.rb
+++ b/lib/graphql/language/document_from_schema_definition.rb
@@ -55,8 +55,12 @@ module GraphQL
             mutation: (m = warden.root_type_for_operation("mutation")) && m.graphql_name,
             subscription: (s = warden.root_type_for_operation("subscription")) && s.graphql_name,
           })
+          GraphQL::Language::Nodes::SchemaDefinition.new(schema_options)
+        else
+          # A plain `schema ...` _must_ include root type definitions.
+          # If the only difference is directives, then you have to use `extend schema`
+          GraphQL::Language::Nodes::SchemaExtension.new(schema_options)
         end
-        GraphQL::Language::Nodes::SchemaDefinition.new(schema_options)
       end
 
       def build_object_type_node(object_type)

--- a/lib/graphql/language/document_from_schema_definition.rb
+++ b/lib/graphql/language/document_from_schema_definition.rb
@@ -64,9 +64,15 @@ module GraphQL
       end
 
       def build_object_type_node(object_type)
+        ints = warden.interfaces(object_type)
+        if ints.any?
+          ints.sort_by!(&:graphql_name)
+          ints.map! { |iface| build_type_name_node(iface) }
+        end
+
         GraphQL::Language::Nodes::ObjectTypeDefinition.new(
           name: object_type.graphql_name,
-          interfaces: warden.interfaces(object_type).sort_by(&:graphql_name).map { |iface| build_type_name_node(iface) },
+          interfaces: ints,
           fields: build_field_nodes(warden.fields(object_type)),
           description: object_type.description,
           directives: directives(object_type),
@@ -244,9 +250,13 @@ module GraphQL
       end
 
       def build_argument_nodes(arguments)
-        arguments
-          .map { |arg| build_argument_node(arg) }
-          .sort_by(&:name)
+        if arguments.any?
+          nodes = arguments.map { |arg| build_argument_node(arg) }
+          nodes.sort_by!(&:name)
+          nodes
+        else
+          arguments
+        end
       end
 
       def build_directive_nodes(directives)
@@ -338,7 +348,7 @@ module GraphQL
 
       def definition_directives(member, directives_method)
         dirs = if !member.respond_to?(directives_method) || member.directives.empty?
-          []
+          EmptyObjects::EMPTY_ARRAY
         else
           member.public_send(directives_method).map do |dir|
             args = []

--- a/lib/graphql/language/document_from_schema_definition.rb
+++ b/lib/graphql/language/document_from_schema_definition.rb
@@ -45,21 +45,17 @@ module GraphQL
       end
 
       def build_schema_node
-        schema_options = {
-          # `@schema.directives` is covered by `build_definition_nodes`
-          directives: definition_directives(@schema, :schema_directives),
-        }
         if !schema_respects_root_name_conventions?(@schema)
-          schema_options.merge!({
+          GraphQL::Language::Nodes::SchemaDefinition.new(
             query: (q = warden.root_type_for_operation("query")) && q.graphql_name,
             mutation: (m = warden.root_type_for_operation("mutation")) && m.graphql_name,
             subscription: (s = warden.root_type_for_operation("subscription")) && s.graphql_name,
-          })
-          GraphQL::Language::Nodes::SchemaDefinition.new(schema_options)
+            directives: definition_directives(@schema, :schema_directives)
+          )
         else
           # A plain `schema ...` _must_ include root type definitions.
           # If the only difference is directives, then you have to use `extend schema`
-          GraphQL::Language::Nodes::SchemaExtension.new(schema_options)
+          GraphQL::Language::Nodes::SchemaExtension.new(directives: definition_directives(@schema, :schema_directives))
         end
       end
 
@@ -270,7 +266,7 @@ module GraphQL
         if !include_built_in_directives
           dirs_to_build = dirs_to_build.reject { |directive| directive.default_directive? }
         end
-        dir_nodes = build_directive_nodes(dirs_to_build)
+        definitions = build_directive_nodes(dirs_to_build)
 
         type_nodes = []
         extensions_nodes = []
@@ -278,10 +274,10 @@ module GraphQL
 
         if @include_one_of
           # This may have been set to true when iterating over all types
-          dir_nodes.concat(build_directive_nodes([GraphQL::Schema::Directive::OneOf]))
+          definitions.concat(build_directive_nodes([GraphQL::Schema::Directive::OneOf]))
         end
 
-        definitions = [*dir_nodes, *type_nodes]
+        definitions.concat(type_nodes)
         if include_schema_node?
           definitions.unshift(@from_ast ? @schema.ast_node : build_schema_node)
         end
@@ -323,9 +319,9 @@ module GraphQL
       end
 
       def build_field_nodes(fields)
-        fields
-          .map { |field| build_field_node(field) }
-          .sort_by(&:name)
+        f_nodes = fields.map { |field| build_field_node(field) }
+        f_nodes.sort_by!(&:name)
+        f_nodes
       end
 
       private

--- a/lib/graphql/language/printer.rb
+++ b/lib/graphql/language/printer.rb
@@ -237,7 +237,8 @@ module GraphQL
 
       def print_object_type_definition(object_type, extension: false)
         extension ? print_string("extend ") : print_description(object_type)
-        print_string("type #{object_type.name}")
+        print_string("type ")
+        print_string(object_type.name)
         print_implements(object_type) unless object_type.interfaces.empty?
         print_directives(object_type.directives)
         print_field_definitions(object_type.fields)
@@ -248,7 +249,8 @@ module GraphQL
       end
 
       def print_input_value_definition(input_value)
-        print_string("#{input_value.name}: ")
+        print_string(input_value.name)
+        print_string(": ")
         print_node(input_value.type)
         unless input_value.default_value.nil?
           print_string(" = ")
@@ -363,11 +365,13 @@ module GraphQL
         return if fields.empty?
 
         print_string(" {\n")
-        fields.each.with_index do |field, i|
+        i = 0
+        fields.each do |field|
           print_description(field, indent: "  ", first_in_block: i == 0)
           print_string("  ")
           print_field_definition(field)
           print_string("\n")
+          i += 1
         end
         print_string("}")
       end

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -238,8 +238,8 @@ module GraphQL
       # Return the GraphQL IDL for the schema
       # @param context [Hash]
       # @return [String]
-      def to_definition(context: {})
-        GraphQL::Schema::Printer.print_schema(self, context: context)
+      def to_definition(context: {}, from_ast: false)
+        GraphQL::Schema::Printer.print_schema(self, context: context, from_ast: from_ast)
       end
 
       # Return the GraphQL::Language::Document IDL AST for the schema

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -237,6 +237,7 @@ module GraphQL
 
       # Return the GraphQL IDL for the schema
       # @param context [Hash]
+      # @param from_ast [Boolean] if true, re-print the parsed SDL definitions and extensions from each type instead of printing the schema from Ruby
       # @return [String]
       def to_definition(context: {}, from_ast: false)
         GraphQL::Schema::Printer.print_schema(self, context: context, from_ast: from_ast)

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -964,7 +964,12 @@ module GraphQL
           new_directives.flatten.each { |d| directive(d) }
         end
 
-        find_inherited_value(:directives, default_directives).merge(own_directives)
+        inherited_dirs = find_inherited_value(:directives, default_directives)
+        if own_directives.any?
+          inherited_dirs.merge(own_directives)
+        else
+          inherited_dirs
+        end
       end
 
       # Attach a single directive to this schema

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -203,6 +203,19 @@ module GraphQL
             build_scalar_type(definition, type_resolver, default_resolve: default_resolve)
           when GraphQL::Language::Nodes::InputObjectTypeDefinition
             build_input_object_type(definition, type_resolver)
+
+          when GraphQL::Language::Nodes::EnumTypeExtension
+            extend_enum_type(definition, type_resolver)
+          when GraphQL::Language::Nodes::ObjectTypeExtension
+            extend_object_type(definition, type_resolver)
+          when GraphQL::Language::Nodes::InterfaceTypeExtension
+            extend_interface_type(definition, type_resolver)
+          when GraphQL::Language::Nodes::UnionTypeExtension
+            extend_union_type(definition, type_resolver)
+          when GraphQL::Language::Nodes::ScalarTypeExtension
+            extend_scalar_type(definition, type_resolver, default_resolve: default_resolve)
+          when GraphQL::Language::Nodes::InputObjectTypeExtension
+            extend_input_object_type(definition, type_resolver)
           end
         end
 

--- a/lib/graphql/schema/member/has_ast_node.rb
+++ b/lib/graphql/schema/member/has_ast_node.rb
@@ -6,11 +6,13 @@ module GraphQL
         def self.extended(child_cls)
           super
           child_cls.ast_node = nil
+          child_cls.ast_extensions = nil
         end
 
         def inherited(child_cls)
           super
           child_cls.ast_node = nil
+          child_cls.ast_extensions = nil
         end
 
         # If this schema was parsed from a `.graphql` file (or other SDL),
@@ -18,14 +20,20 @@ module GraphQL
         def ast_node(new_ast_node = nil)
           if new_ast_node
             @ast_node = new_ast_node
-          elsif defined?(@ast_node)
-            @ast_node
           else
-            nil
+            @ast_node
           end
         end
 
-        attr_writer :ast_node
+        attr_writer :ast_node, :ast_extensions
+
+        def ast_extensions(new_exts = nil)
+          if new_exts
+            @ast_extensions = new_exts
+          else
+            @ast_extensions
+          end
+        end
       end
     end
   end

--- a/lib/graphql/schema/member/has_interfaces.rb
+++ b/lib/graphql/schema/member/has_interfaces.rb
@@ -72,9 +72,18 @@ module GraphQL
           module InheritedInterfaces
             def interfaces(context = GraphQL::Query::NullContext)
               visible_interfaces = super
-              visible_interfaces.concat(superclass.interfaces(context))
-              visible_interfaces.uniq!
-              visible_interfaces
+              inherited_interfaces = superclass.interfaces(context)
+              if visible_interfaces.any?
+                if inherited_interfaces.any?
+                  visible_interfaces.concat(inherited_interfaces)
+                  visible_interfaces.uniq!
+                end
+                visible_interfaces
+              elsif inherited_interfaces.any?
+                inherited_interfaces
+              else
+                EmptyObjects::EMPTY_ARRAY
+              end
             end
 
             def interface_type_memberships
@@ -92,23 +101,28 @@ module GraphQL
         # param context [Query::Context] If omitted, skip filtering.
         def interfaces(context = GraphQL::Query::NullContext)
           warden = Warden.from_context(context)
-          visible_interfaces = []
+          visible_interfaces = nil
           own_interface_type_memberships.each do |type_membership|
             case type_membership
             when Schema::TypeMembership
               if warden.visible_type_membership?(type_membership, context)
+                visible_interfaces ||= []
                 visible_interfaces << type_membership.abstract_type
               end
             when String, Schema::LateBoundType
               # During initialization, `type_memberships` can hold late-bound types
+              visible_interfaces ||= []
               visible_interfaces << type_membership
             else
               raise "Invariant: Unexpected type_membership #{type_membership.class}: #{type_membership.inspect}"
             end
           end
-          visible_interfaces.uniq!
-
-          visible_interfaces
+          if visible_interfaces
+            visible_interfaces.uniq!
+            visible_interfaces
+          else
+            EmptyObjects::EMPTY_ARRAY
+          end
         end
 
         private

--- a/lib/graphql/schema/printer.rb
+++ b/lib/graphql/schema/printer.rb
@@ -37,11 +37,12 @@ module GraphQL
       # @param schema [GraphQL::Schema]
       # @param context [Hash]
       # @param introspection [Boolean] Should include the introspection types in the string?
-      def initialize(schema, context: nil, introspection: false)
+      def initialize(schema, context: nil, introspection: false, from_ast: false)
         @document_from_schema = GraphQL::Language::DocumentFromSchemaDefinition.new(
           schema,
           context: context,
           include_introspection_types: introspection,
+          from_ast: from_ast
         )
 
         @document = @document_from_schema.document

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -369,7 +369,9 @@ module GraphQL
       end
 
       def read_through
-        Hash.new { |h, k| h[k] = yield(k) }
+        h = Hash.new { |h, k| h[k] = yield(k) }
+        h.compare_by_identity
+        h
       end
 
       def reachable_type_set

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -188,7 +188,16 @@ module GraphQL
       # @param argument_owner [GraphQL::Field, GraphQL::InputObjectType]
       # @return [Array<GraphQL::Argument>] Visible arguments on `argument_owner`
       def arguments(argument_owner, ctx = nil)
-        @visible_arguments ||= read_through { |o| o.arguments(@context).each_value.select { |a| visible_argument?(a, @context) } }
+        @visible_arguments ||= read_through { |o|
+          args = o.arguments(@context)
+          if args.any?
+            args = args.values
+            args.select! { |a| visible_argument?(a, @context) }
+            args
+          else
+            EmptyObjects::EMPTY_ARRAY
+          end
+        }
         @visible_arguments[argument_owner]
       end
 
@@ -211,7 +220,13 @@ module GraphQL
 
       # @return [Array<GraphQL::InterfaceType>] Visible interfaces implemented by `obj_type`
       def interfaces(obj_type)
-        @visible_interfaces ||= read_through { |t| t.interfaces(@context).select { |i| visible_type?(i) } }
+        @visible_interfaces ||= read_through { |t|
+          ints = t.interfaces(@context)
+          if ints.any?
+            ints.select! { |i| visible_type?(i) }
+          end
+          ints
+          }
         @visible_interfaces[obj_type]
       end
 

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -1847,8 +1847,5 @@ type ReachableType implements Node {
     GRAPHQL
 
     assert_equal expected_merged_schema_sdl, schema.to_definition, "It also prints the merged schema as one"
-
-
-    # assert_includes schema.to_definition, "scalar String @extra", "it prints default scalars when they've been modified"
   end
 end

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -1731,7 +1731,7 @@ type ReachableType implements Node {
     end
   end
 
-  it "works with extensions" do
+  it "works with extensions with `from_ast: true`" do
     schema_sdl = <<~EOS
     schema {
       query: CustomQuery
@@ -1759,6 +1759,6 @@ type ReachableType implements Node {
     EOS
 
     schema = GraphQL::Schema.from_definition(schema_sdl)
-    assert_equal schema_sdl, schema.to_definition
+    assert_equal schema_sdl, schema.to_definition(from_ast: true)
   end
 end

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -1574,7 +1574,7 @@ type ReachableType implements Node {
 
   it "supports extending schemas with directives" do
     schema_sdl = <<~EOS
-    schema
+    extend schema
       @link(import: ["@key", "@shareable"], url: "https://specs.apollo.dev/federation/v2.0")
 
     directive @link(as: String, for: link__Purpose, import: [link__Import], url: String!) repeatable on SCHEMA
@@ -1638,7 +1638,7 @@ type ReachableType implements Node {
       schema.schema_directives.first.arguments.to_h)
 
     expected_schema = <<~GRAPHQL
-      schema
+      extend schema
         @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@shareable"])
 
       directive @link(as: String, for: Purpose, import: Import, url: String!) repeatable on SCHEMA
@@ -1847,5 +1847,21 @@ type ReachableType implements Node {
     GRAPHQL
 
     assert_equal expected_merged_schema_sdl, schema.to_definition, "It also prints the merged schema as one"
+  end
+
+  it "reprints schema with extend when root types match" do
+    schema_str = <<~EOS
+      extend schema
+        @customDirective
+
+      directive @customDirective repeatable on SCHEMA
+
+      type Query {
+        foo: Int
+      }
+    EOS
+
+    schema = GraphQL::Schema.from_definition(schema_str)
+    assert_equal schema_str, schema.to_definition
   end
 end

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -1730,4 +1730,38 @@ type ReachableType implements Node {
       assert_equal [nil, nil], res_4.context[:nils]
     end
   end
+
+  focus
+  it "works with extensions" do
+    schema_sdl = <<~EOS
+    schema {
+      query: CustomQuery
+    }
+
+
+    type CustomQuery {
+      something: Int
+    }
+
+    extend type CustomQuery {
+      somethingElse: Float
+    }
+
+    scalar link__Import
+
+    enum link__Purpose {
+      EXECUTION
+      SECURITY
+    }
+
+    directive @link(as: String, for: link__Purpose, import: [link__Import], url: String!) repeatable on SCHEMA
+
+    extend schema
+      @link(import: ["@key", "@shareable"], url: "https://specs.apollo.dev/federation/v2.0")
+
+    EOS
+
+    schema = GraphQL::Schema.from_definition(schema_sdl)
+    assert_equal schema_sdl, schema.to_definition
+  end
 end

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -1731,20 +1731,16 @@ type ReachableType implements Node {
     end
   end
 
-  focus
   it "works with extensions" do
     schema_sdl = <<~EOS
     schema {
       query: CustomQuery
     }
 
+    directive @link(as: String, for: link__Purpose, import: [link__Import], url: String!) repeatable on SCHEMA
 
     type CustomQuery {
       something: Int
-    }
-
-    extend type CustomQuery {
-      somethingElse: Float
     }
 
     scalar link__Import
@@ -1754,11 +1750,12 @@ type ReachableType implements Node {
       SECURITY
     }
 
-    directive @link(as: String, for: link__Purpose, import: [link__Import], url: String!) repeatable on SCHEMA
-
     extend schema
       @link(import: ["@key", "@shareable"], url: "https://specs.apollo.dev/federation/v2.0")
 
+    extend type CustomQuery {
+      somethingElse: Float
+    }
     EOS
 
     schema = GraphQL::Schema.from_definition(schema_sdl)


### PR DESCRIPTION
Fixes #4635


TODO: 

- [x] Document `from_ast: true` for `to_definition` 
- [x] DRY `extend_` methods 
- ~~Support extending default scalars?~~ This turned out to be really tricky because schemas get the built-in `@skip` and `@include` directives by default, and those include the built-in String and Boolean types. But then if the schema has `extend scalar String ...`, we don't want to modify the built-in string because that might mess up another schema. So we can make a duplicate, but it will end up clashing with the built-in one which the schema already has. (Not exactly _clashing_, but it's a duplicate type with no way to choose between them, so it doesn't _work_...) 

  If it turns out someone needs that later, it could _probably_ be added somehow, but we'd have to go back and replace the built-in directives with custom ones, etc.
  
  
Along the way I also added a benchmark for printing to SDL and improved it: 

```diff
  $ be rake bench:profile_to_definition 
  Calculating -------------------------------------

-        to_definition      2.568k (± 2.3%) i/s -     13.050k in   5.084553s
+       to_definition      2.774k (± 6.4%) i/s -     13.851k in   5.015514s

- Total allocated: 43037 bytes (336 objects) 
+ Total allocated: 29229 bytes (171 objects)
```

About half as many objects and 8% faster