### PR TITLE
Use `extend schema` when the schema has directives

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -126,6 +126,12 @@ namespace :bench do
     GraphQLBenchmark.profile_small_introspection
   end
 
+  desc "Dump schema to SDL"
+  task :profile_to_definition do
+    prepare_benchmark
+    GraphQLBenchmark.profile_to_definition
+  end
+
   desc "Compare GraphQL-Batch and GraphQL-Dataloader"
   task :profile_batch_loaders do
     prepare_benchmark

--- a/Rakefile
+++ b/Rakefile
@@ -60,7 +60,7 @@ end
 
 desc "Use Racc to regenerate parser.rb from configuration files"
 task :build_parser do
-  assert_dependency_version("Racc", "1.6.2", %|ruby -e "require 'racc'; puts Racc::VERSION"|)
+  assert_dependency_version("Racc", "1.7.1", %|ruby -e "require 'racc'; puts Racc::VERSION"|)
 
   `rm -f lib/graphql/language/parser.rb `
   `racc lib/graphql/language/parser.y -o lib/graphql/language/parser.rb`

--- a/benchmark/run.rb
+++ b/benchmark/run.rb
@@ -442,6 +442,26 @@ module GraphQLBenchmark
     GRAPHQL
   end
 
+  def self.profile_to_definition
+    require_relative "./batch_loading"
+    schema = BatchLoading::GraphQLNoBatchingSchema
+
+    Benchmark.ips do |x|
+      x.report("to_definition") { schema.to_definition }
+    end
+
+    result = StackProf.run(mode: :wall, interval: 1) do
+      schema.to_definition
+    end
+    StackProf::Report.new(result).print_text
+
+    report = MemoryProfiler.report do
+      schema.to_definition
+    end
+
+    report.pretty_print
+  end
+
   def self.profile_batch_loaders
     require_relative "./batch_loading"
     include BatchLoading

--- a/benchmark/run.rb
+++ b/benchmark/run.rb
@@ -444,7 +444,8 @@ module GraphQLBenchmark
 
   def self.profile_to_definition
     require_relative "./batch_loading"
-    schema = BatchLoading::GraphQLNoBatchingSchema
+    schema = ProfileLargeResult::Schema
+    schema.to_definition
 
     Benchmark.ips do |x|
       x.report("to_definition") { schema.to_definition }

--- a/lib/graphql/language/block_string.rb
+++ b/lib/graphql/language/block_string.rb
@@ -59,40 +59,52 @@ module GraphQL
       end
 
       def self.print(str, indent: '')
-        lines = str.split("\n")
+        line_length = 120 - indent.length
+        block_str = "".dup
+        triple_quotes = "\"\"\"\n"
+        block_str << indent
+        block_str << triple_quotes
 
-        block_str = "#{indent}\"\"\"\n".dup
-
-        lines.each do |line|
-          if line == ''
-            block_str << "\n"
-          else
-            sublines = break_line(line, 120 - indent.length)
-            sublines.each do |subline|
-              block_str << "#{indent}#{subline}\n"
+        if str.include?("\n")
+          str.split("\n") do |line|
+            if line == ''
+              block_str << "\n"
+            else
+              break_line(line, line_length) do |subline|
+                block_str << indent
+                block_str << subline
+                block_str << "\n"
+              end
             end
+          end
+        else
+          break_line(str, line_length) do |subline|
+            block_str << indent
+            block_str << subline
+            block_str << "\n"
           end
         end
 
-        block_str << "#{indent}\"\"\"\n".dup
+        block_str << indent
+        block_str << triple_quotes
       end
 
       private
 
       def self.break_line(line, length)
-        return [line] if line.length < length + 5
+        return yield(line) if line.length < length + 5
 
         parts = line.split(Regexp.new("((?: |^).{15,#{length - 40}}(?= |$))"))
-        return [line] if parts.length < 4
+        return yield(line) if parts.length < 4
 
-        sublines = [parts.slice!(0, 3).join]
+        yield(parts.slice!(0, 3).join)
 
         parts.each_with_index do |part, i|
           next if i % 2 == 1
-          sublines << "#{part[1..-1]}#{parts[i + 1]}"
+          yield "#{part[1..-1]}#{parts[i + 1]}"
         end
 
-        sublines
+        nil
       end
     end
   end

--- a/lib/graphql/language/document_from_schema_definition.rb
+++ b/lib/graphql/language/document_from_schema_definition.rb
@@ -52,8 +52,12 @@ module GraphQL
             mutation: (m = warden.root_type_for_operation("mutation")) && m.graphql_name,
             subscription: (s = warden.root_type_for_operation("subscription")) && s.graphql_name,
           })
+          GraphQL::Language::Nodes::SchemaDefinition.new(schema_options)
+        else
+          # A plain `schema ...` _must_ include root type definitions.
+          # If the only difference is directives, then you have to use `extend schema`
+          GraphQL::Language::Nodes::SchemaExtension.new(schema_options)
         end
-        GraphQL::Language::Nodes::SchemaDefinition.new(schema_options)
       end
 
       def build_object_type_node(object_type)

--- a/lib/graphql/language/document_from_schema_definition.rb
+++ b/lib/graphql/language/document_from_schema_definition.rb
@@ -186,7 +186,8 @@ module GraphQL
             of_type: build_type_name_node(type.of_type)
           )
         else
-          GraphQL::Language::Nodes::TypeName.new(name: type.graphql_name)
+          @cached_type_name_nodes ||= {}
+          @cached_type_name_nodes[type.graphql_name] ||= GraphQL::Language::Nodes::TypeName.new(name: type.graphql_name)
         end
       end
 

--- a/lib/graphql/language/document_from_schema_definition.rb
+++ b/lib/graphql/language/document_from_schema_definition.rb
@@ -42,21 +42,17 @@ module GraphQL
       end
 
       def build_schema_node
-        schema_options = {
-          # `@schema.directives` is covered by `build_definition_nodes`
-          directives: definition_directives(@schema, :schema_directives),
-        }
         if !schema_respects_root_name_conventions?(@schema)
-          schema_options.merge!({
+          GraphQL::Language::Nodes::SchemaDefinition.new(
             query: (q = warden.root_type_for_operation("query")) && q.graphql_name,
             mutation: (m = warden.root_type_for_operation("mutation")) && m.graphql_name,
             subscription: (s = warden.root_type_for_operation("subscription")) && s.graphql_name,
-          })
-          GraphQL::Language::Nodes::SchemaDefinition.new(schema_options)
+            directives: definition_directives(@schema, :schema_directives)
+          )
         else
           # A plain `schema ...` _must_ include root type definitions.
           # If the only difference is directives, then you have to use `extend schema`
-          GraphQL::Language::Nodes::SchemaExtension.new(schema_options)
+          GraphQL::Language::Nodes::SchemaExtension.new(directives: definition_directives(@schema, :schema_directives))
         end
       end
 
@@ -267,16 +263,16 @@ module GraphQL
         if !include_built_in_directives
           dirs_to_build = dirs_to_build.reject { |directive| directive.default_directive? }
         end
-        dir_nodes = build_directive_nodes(dirs_to_build)
+        definitions = build_directive_nodes(dirs_to_build)
 
         type_nodes = build_type_definition_nodes(warden.reachable_types)
 
         if @include_one_of
           # This may have been set to true when iterating over all types
-          dir_nodes.concat(build_directive_nodes([GraphQL::Schema::Directive::OneOf]))
+          definitions.concat(build_directive_nodes([GraphQL::Schema::Directive::OneOf]))
         end
 
-        definitions = [*dir_nodes, *type_nodes]
+        definitions.concat(type_nodes)
         if include_schema_node?
           definitions.unshift(build_schema_node)
         end
@@ -299,9 +295,9 @@ module GraphQL
       end
 
       def build_field_nodes(fields)
-        fields
-          .map { |field| build_field_node(field) }
-          .sort_by(&:name)
+        f_nodes = fields.map { |field| build_field_node(field) }
+        f_nodes.sort_by!(&:name)
+        f_nodes
       end
 
       private

--- a/lib/graphql/language/printer.rb
+++ b/lib/graphql/language/printer.rb
@@ -237,7 +237,8 @@ module GraphQL
 
       def print_object_type_definition(object_type, extension: false)
         extension ? print_string("extend ") : print_description(object_type)
-        print_string("type #{object_type.name}")
+        print_string("type ")
+        print_string(object_type.name)
         print_implements(object_type) unless object_type.interfaces.empty?
         print_directives(object_type.directives)
         print_field_definitions(object_type.fields)
@@ -248,7 +249,8 @@ module GraphQL
       end
 
       def print_input_value_definition(input_value)
-        print_string("#{input_value.name}: ")
+        print_string(input_value.name)
+        print_string(": ")
         print_node(input_value.type)
         unless input_value.default_value.nil?
           print_string(" = ")
@@ -363,11 +365,13 @@ module GraphQL
         return if fields.empty?
 
         print_string(" {\n")
-        fields.each.with_index do |field, i|
+        i = 0
+        fields.each do |field|
           print_description(field, indent: "  ", first_in_block: i == 0)
           print_string("  ")
           print_field_definition(field)
           print_string("\n")
+          i += 1
         end
         print_string("}")
       end

--- a/lib/graphql/language/printer.rb
+++ b/lib/graphql/language/printer.rb
@@ -74,7 +74,8 @@ module GraphQL
       end
 
       def print_argument(argument)
-        print_string("#{argument.name}: ")
+        print_string(argument.name)
+        print_string(": ")
         print_node(argument.value)
       end
 
@@ -88,7 +89,8 @@ module GraphQL
       end
 
       def print_directive(directive)
-        print_string("@#{directive.name}")
+        print_string("@")
+        print_string(directive.name)
 
         if directive.arguments.any?
           print_string("(")
@@ -110,7 +112,10 @@ module GraphQL
 
       def print_field(field, indent: "")
         print_string(indent)
-        print_string("#{field.alias}: ") if field.alias
+        if field.alias
+          print_string(field.alias)
+          print_string(": ")
+        end
         print_string(field.name)
         if field.arguments.any?
           print_string("(")
@@ -125,7 +130,13 @@ module GraphQL
       end
 
       def print_fragment_definition(fragment_def, indent: "")
-        print_string("#{indent}fragment #{fragment_def.name}")
+        print_string(indent)
+        print_string("fragment")
+        if fragment_def.name
+          print_string(" ")
+          print_string(fragment_def.name)
+        end
+
         if fragment_def.type
           print_string(" on ")
           print_node(fragment_def.type)
@@ -135,12 +146,15 @@ module GraphQL
       end
 
       def print_fragment_spread(fragment_spread, indent: "")
-        print_string("#{indent}...#{fragment_spread.name}")
+        print_string(indent)
+        print_string("...")
+        print_string(fragment_spread.name)
         print_directives(fragment_spread.directives)
       end
 
       def print_inline_fragment(inline_fragment, indent: "")
-        print_string("#{indent}...")
+        print_string(indent)
+        print_string("...")
         if inline_fragment.type
           print_string(" on ")
           print_node(inline_fragment.type)
@@ -161,8 +175,12 @@ module GraphQL
       end
 
       def print_operation_definition(operation_definition, indent: "")
-        print_string("#{indent}#{operation_definition.operation_type}")
-        print_string(" #{operation_definition.name}") if operation_definition.name
+        print_string(indent)
+        print_string(operation_definition.operation_type)
+        if operation_definition.name
+          print_string(" ")
+          print_string(operation_definition.name)
+        end
 
         if operation_definition.variables.any?
           print_string("(")
@@ -182,7 +200,9 @@ module GraphQL
       end
 
       def print_variable_definition(variable_definition)
-        print_string("$#{variable_definition.name}: ")
+        print_string("$")
+        print_string(variable_definition.name)
+        print_string(": ")
         print_node(variable_definition.type)
         unless variable_definition.default_value.nil?
           print_string(" = ")
@@ -191,7 +211,8 @@ module GraphQL
       end
 
       def print_variable_identifier(variable_identifier)
-        print_string("$#{variable_identifier.name}")
+        print_string("$")
+        print_string(variable_identifier.name)
       end
 
       def print_schema_definition(schema, extension: false)
@@ -231,7 +252,8 @@ module GraphQL
 
       def print_scalar_type_definition(scalar_type, extension: false)
         extension ? print_string("extend ") : print_description(scalar_type)
-        print_string("scalar #{scalar_type.name}")
+        print_string("scalar ")
+        print_string(scalar_type.name)
         print_directives(scalar_type.directives)
       end
 
@@ -245,7 +267,15 @@ module GraphQL
       end
 
       def print_implements(type)
-        print_string(" implements #{type.interfaces.map(&:name).join(" & ")}")
+        print_string(" implements ")
+        i = 0
+        type.interfaces.each do |int|
+          if i > 0
+            print_string(" & ")
+          end
+          print_string(int.name)
+          i += 1
+        end
       end
 
       def print_input_value_definition(input_value)
@@ -273,11 +303,14 @@ module GraphQL
         print_string("(\n")
         arguments.each_with_index do |arg, i|
           print_description(arg, indent: "  " + indent, first_in_block: i == 0)
-          print_string("  #{indent}")
+          print_string("  ")
+          print_string(indent)
           print_input_value_definition(arg)
           print_string("\n") if i < arguments.size - 1
         end
-        print_string("\n#{indent})")
+        print_string("\n")
+        print_string(indent)
+        print_string(")")
       end
 
       def print_field_definition(field)
@@ -292,7 +325,8 @@ module GraphQL
 
       def print_interface_type_definition(interface_type, extension: false)
         extension ? print_string("extend ") : print_description(interface_type)
-        print_string("interface #{interface_type.name}")
+        print_string("interface ")
+        print_string(interface_type.name)
         print_implements(interface_type) if interface_type.interfaces.any?
         print_directives(interface_type.directives)
         print_field_definitions(interface_type.fields)
@@ -300,14 +334,24 @@ module GraphQL
 
       def print_union_type_definition(union_type, extension: false)
         extension ? print_string("extend ") : print_description(union_type)
-        print_string("union #{union_type.name}")
+        print_string("union ")
+        print_string(union_type.name)
         print_directives(union_type.directives)
-        print_string(" = #{union_type.types.map(&:name).join(" | ")}")
+        print_string(" = ")
+        i = 0
+        union_type.types.each do |t|
+          if i > 0
+            print_string(" | ")
+          end
+          print_string(t.name)
+          i += 1
+        end
       end
 
       def print_enum_type_definition(enum_type, extension: false)
         extension ? print_string("extend ") : print_description(enum_type)
-        print_string("enum #{enum_type.name}")
+        print_string("enum ")
+        print_string(enum_type.name)
         print_directives(enum_type.directives)
         print_string(" {\n")
         enum_type.values.each.with_index do |value, i|
@@ -318,14 +362,16 @@ module GraphQL
       end
 
       def print_enum_value_definition(enum_value)
-        print_string("  #{enum_value.name}")
+        print_string("  ")
+        print_string(enum_value.name)
         print_directives(enum_value.directives)
         print_string("\n")
       end
 
       def print_input_object_type_definition(input_object_type, extension: false)
         extension ? print_string("extend ") : print_description(input_object_type)
-        print_string("input #{input_object_type.name}")
+        print_string("input ")
+        print_string(input_object_type.name)
         print_directives(input_object_type.directives)
         if !input_object_type.fields.empty?
           print_string(" {\n")
@@ -341,7 +387,8 @@ module GraphQL
 
       def print_directive_definition(directive)
         print_description(directive)
-        print_string("directive @#{directive.name}")
+        print_string("directive @")
+        print_string(directive.name)
 
         if directive.arguments.any?
           print_arguments(directive.arguments)
@@ -351,7 +398,15 @@ module GraphQL
           print_string(" repeatable")
         end
 
-        print_string(" on #{directive.locations.map(&:name).join(" | ")}")
+        print_string(" on ")
+        i = 0
+        directive.locations.each do |loc|
+          if i > 0
+            print_string(" | ")
+          end
+          print_string(loc.name)
+          i += 1
+        end
       end
 
       def print_description(node, indent: "", first_in_block: true)
@@ -393,7 +448,8 @@ module GraphQL
           print_node(selection, indent: indent + "  ")
           print_string("\n")
         end
-        print_string("#{indent}}")
+        print_string(indent)
+        print_string("}")
       end
 
       def print_node(node, indent: "")
@@ -478,7 +534,8 @@ module GraphQL
         when Hash
           print_string("{")
           node.each_with_index do |(k, v), i|
-            print_string("#{k}: ")
+            print_string(k)
+            print_string(": ")
             print_node(v)
             print_string(", ") if i < node.length - 1
           end

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -963,7 +963,12 @@ module GraphQL
           new_directives.flatten.each { |d| directive(d) }
         end
 
-        find_inherited_value(:directives, default_directives).merge(own_directives)
+        inherited_dirs = find_inherited_value(:directives, default_directives)
+        if own_directives.any?
+          inherited_dirs.merge(own_directives)
+        else
+          inherited_dirs
+        end
       end
 
       # Attach a single directive to this schema

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -761,7 +761,16 @@ module GraphQL
           own_orphan_types.concat(new_orphan_types.flatten)
         end
 
-        find_inherited_value(:orphan_types, EMPTY_ARRAY) + own_orphan_types
+        inherited_ot = find_inherited_value(:orphan_types, nil)
+        if inherited_ot
+          if own_orphan_types.any?
+            inherited_ot + own_orphan_types
+          else
+            inherited_ot
+          end
+        else
+          own_orphan_types
+        end
       end
 
       def default_execution_strategy

--- a/lib/graphql/schema/member/base_dsl_methods.rb
+++ b/lib/graphql/schema/member/base_dsl_methods.rb
@@ -102,7 +102,8 @@ module GraphQL
         def default_graphql_name
           @default_graphql_name ||= begin
             raise GraphQL::RequiredImplementationMissingError, 'Anonymous class should declare a `graphql_name`' if name.nil?
-            -name.split("::").last.sub(/Type\Z/, "")
+            g_name = -name.split("::").last
+            g_name.end_with?("Type") ? g_name.sub(/Type\Z/, "") : g_name
           end
         end
 

--- a/lib/graphql/schema/member/has_interfaces.rb
+++ b/lib/graphql/schema/member/has_interfaces.rb
@@ -72,9 +72,18 @@ module GraphQL
           module InheritedInterfaces
             def interfaces(context = GraphQL::Query::NullContext)
               visible_interfaces = super
-              visible_interfaces.concat(superclass.interfaces(context))
-              visible_interfaces.uniq!
-              visible_interfaces
+              inherited_interfaces = superclass.interfaces(context)
+              if visible_interfaces.any?
+                if inherited_interfaces.any?
+                  visible_interfaces.concat(inherited_interfaces)
+                  visible_interfaces.uniq!
+                end
+                visible_interfaces
+              elsif inherited_interfaces.any?
+                inherited_interfaces
+              else
+                EmptyObjects::EMPTY_ARRAY
+              end
             end
 
             def interface_type_memberships
@@ -92,23 +101,28 @@ module GraphQL
         # param context [Query::Context] If omitted, skip filtering.
         def interfaces(context = GraphQL::Query::NullContext)
           warden = Warden.from_context(context)
-          visible_interfaces = []
+          visible_interfaces = nil
           own_interface_type_memberships.each do |type_membership|
             case type_membership
             when Schema::TypeMembership
               if warden.visible_type_membership?(type_membership, context)
+                visible_interfaces ||= []
                 visible_interfaces << type_membership.abstract_type
               end
             when String, Schema::LateBoundType
               # During initialization, `type_memberships` can hold late-bound types
+              visible_interfaces ||= []
               visible_interfaces << type_membership
             else
               raise "Invariant: Unexpected type_membership #{type_membership.class}: #{type_membership.inspect}"
             end
           end
-          visible_interfaces.uniq!
-
-          visible_interfaces
+          if visible_interfaces
+            visible_interfaces.uniq!
+            visible_interfaces
+          else
+            EmptyObjects::EMPTY_ARRAY
+          end
         end
 
         private

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -369,7 +369,9 @@ module GraphQL
       end
 
       def read_through
-        Hash.new { |h, k| h[k] = yield(k) }
+        h = Hash.new { |h, k| h[k] = yield(k) }
+        h.compare_by_identity
+        h
       end
 
       def reachable_type_set

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -226,7 +226,7 @@ module GraphQL
             ints.select! { |i| visible_type?(i) }
           end
           ints
-          }
+        }
         @visible_interfaces[obj_type]
       end
 

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -188,7 +188,16 @@ module GraphQL
       # @param argument_owner [GraphQL::Field, GraphQL::InputObjectType]
       # @return [Array<GraphQL::Argument>] Visible arguments on `argument_owner`
       def arguments(argument_owner, ctx = nil)
-        @visible_arguments ||= read_through { |o| o.arguments(@context).each_value.select { |a| visible_argument?(a, @context) } }
+        @visible_arguments ||= read_through { |o|
+          args = o.arguments(@context)
+          if args.any?
+            args = args.values
+            args.select! { |a| visible_argument?(a, @context) }
+            args
+          else
+            EmptyObjects::EMPTY_ARRAY
+          end
+        }
         @visible_arguments[argument_owner]
       end
 
@@ -211,7 +220,13 @@ module GraphQL
 
       # @return [Array<GraphQL::InterfaceType>] Visible interfaces implemented by `obj_type`
       def interfaces(obj_type)
-        @visible_interfaces ||= read_through { |t| t.interfaces(@context).select { |i| visible_type?(i) } }
+        @visible_interfaces ||= read_through { |t|
+          ints = t.interfaces(@context)
+          if ints.any?
+            ints.select! { |i| visible_type?(i) }
+          end
+          ints
+          }
         @visible_interfaces[obj_type]
       end
 

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -1574,7 +1574,7 @@ type ReachableType implements Node {
 
   it "supports extending schemas with directives" do
     schema_sdl = <<~EOS
-    schema
+    extend schema
       @link(import: ["@key", "@shareable"], url: "https://specs.apollo.dev/federation/v2.0")
 
     directive @link(as: String, for: link__Purpose, import: [link__Import], url: String!) repeatable on SCHEMA
@@ -1638,7 +1638,7 @@ type ReachableType implements Node {
       schema.schema_directives.first.arguments.to_h)
 
     expected_schema = <<~GRAPHQL
-      schema
+      extend schema
         @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@shareable"])
 
       directive @link(as: String, for: Purpose, import: Import, url: String!) repeatable on SCHEMA
@@ -1729,5 +1729,21 @@ type ReachableType implements Node {
       assert_equal({ "abc" => nil, "def" => 7, "ghi"=>{"jkl"=>nil} }, res_4["data"]["echoJsonValue"])
       assert_equal [nil, nil], res_4.context[:nils]
     end
+  end
+
+  it "reprints schema with extend when root types match" do
+    schema_str = <<~EOS
+      extend schema
+        @customDirective
+
+      directive @customDirective repeatable on SCHEMA
+
+      type Query {
+        foo: Int
+      }
+    EOS
+
+    schema = GraphQL::Schema.from_definition(schema_str)
+    assert_equal schema_str, schema.to_definition
   end
 end


### PR DESCRIPTION
Fixes #4635 

Includes some speedups to the SDL printer: 


```diff
  $ be rake bench:profile_to_definition 
  Calculating -------------------------------------

-        to_definition      1.481k (± 3.6%) i/s -      7.398k in   5.001939s
+        to_definition      1.695k (± 5.1%) i/s -      8.550k in   5.058730s

- Total allocated: 81119 bytes (672 objects)
+ Total allocated: 54327 bytes (345 objects)
```

About half as many objects and 14% faster