### PR TITLE
Set GraphQL cache regardless of bootsnap

### DIFF
--- a/guides/parser_cache.md
+++ b/guides/parser_cache.md
@@ -1,0 +1,12 @@
+---
+layout: guide
+doc_stub: false
+search: true
+title: GraphQL Parser cache
+section: Other
+desc: How to make parsing GraphQL faster with caching
+---
+
+Parser caching may be optionally enabled by setting `config.graphql.parser_cache = true` in your Rails application. The cache may be manually built by assigning `GraphQL::Language::Parser.cache = GraphQL::Language::Cache.new("some_dir")`. This will create a directory (`tmp/cache/graphql` by default) that stores a cache of parsed files.
+
+Much like [bootsnap](https://github.com/Shopify/bootsnap), the parser cache needs to be cleaned up manually. You will need to clear the cache directory for each new deployment of your application. Also note that the parser cache will grow as your schema is loaded, so the cache directory must be writable.

--- a/lib/graphql/railtie.rb
+++ b/lib/graphql/railtie.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
+
 module GraphQL
   class Railtie < Rails::Railtie
-    config.before_configuration do
-      # Bootsnap compile cache has similar expiration properties,
-      # so we assume that if the user has bootsnap setup it's ok
-      # to piggy back on it.
-      if ::Object.const_defined?("Bootsnap::CompileCache::ISeq") && Bootsnap::CompileCache::ISeq.cache_dir
-        Language::Parser.cache ||= Language::Cache.new(Pathname.new(Bootsnap::CompileCache::ISeq.cache_dir).join('graphql'))
+    config.graphql = ActiveSupport::OrderedOptions.new
+    config.graphql.parser_cache = false
+
+    initializer("graphql.cache") do |app|
+      if config.graphql.parser_cache
+        Language::Parser.cache ||= Language::Cache.new(
+          app.root.join("tmp/cache/graphql")
+        )
       end
     end
   end


### PR DESCRIPTION
👋 I noticed recently that this gem uses the bootsnap iseq cache dir as a basis to enable caching or not. This doesn't make much sense to me because the parser cache has nothing to do with bootsnap. This was causing problems for me on an app that precompiled bootsnap cache on CI, and marked the cache as readonly. Naturally, this caused problems when the GraphQL parser cache got written to.

Since we can't precompile this cache, and it isn't dependent on bootsnap, I think we can simply use a different directory and avoid these conditionals. This will prevent bootsnap cache to be polluted/extended by the graphql gem, and allow more apps to leverage GraphQL caching. WDYT?