### PR TITLE
Bump required_ruby_version to 2.7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6
+        ruby-version: 2.7
         bundler-cache: true
     - run: bundle exec rake rubocop
   system_tests:
@@ -18,12 +18,12 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.3
+        ruby-version: 2.7
         bundler-cache: true
     - run: bundle exec rake compile
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.3
+        ruby-version: 2.7
         bundler-cache: true
       env:
         BUNDLE_GEMFILE: ./spec/dummy/Gemfile

--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.authors     = ["Robert Mosolgo"]
   s.email       = ["rdmosolgo@gmail.com"]
   s.license     = "MIT"
-  s.required_ruby_version = ">= 2.4.0"
+  s.required_ruby_version = ">= 2.7.0"
   s.metadata    = {
     "homepage_uri" => "https://graphql-ruby.org",
     "changelog_uri" => "https://github.com/rmosolgo/graphql-ruby/blob/master/CHANGELOG.md",


### PR DESCRIPTION
`required_ruby_version` should be `2.7` because numbered parameters are used for blocks now.

Also I updated the Ruby versions in the CI workflow to be consistent throughout