### PR TITLE
Include patch from #4639 in graphql_result.rb

### DIFF
--- a/lib/graphql/execution/interpreter/runtime/graphql_result.rb
+++ b/lib/graphql/execution/interpreter/runtime/graphql_result.rb
@@ -107,7 +107,7 @@ module GraphQL
               when GraphQLResultArray
                 # There's no special handling of arrays because currently, there's no way to split the execution
                 # of a list over several concurrent flows.
-                next_result.set_child_result(key, value)
+                into_result.set_child_result(key, value)
               else
                 # We have to assume that, since this passed the `fields_will_merge` selection,
                 # that the old and new values are the same.


### PR DESCRIPTION
We just updated one of our core Shopify apps to 2.1.1 yesterday, and after rebasing I got hit with the same error that https://github.com/rmosolgo/graphql-ruby/pull/4639 intended to fix. 

Due to some bad timing, https://github.com/rmosolgo/graphql-ruby/pull/4621/commits/cf081056e0c9a73f1492d57b5fd09a45855842da —which was authored before my patch—was merged the day _after_ https://github.com/rmosolgo/graphql-ruby/pull/4639, losing the change I contributed.

This PR includes the same change, but for the new `graphql_result.rb` file :D

Is it possible to cut a 2.1.2 with this patch included? It would be much appreciated! 🙏🏼 