### PR TITLE
Declare racc as a runtime dependency

### DIFF
--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -24,6 +24,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{lib}/**/*", "MIT-LICENSE", "readme.md", ".yardopts"]
 
+  s.add_dependency "racc", "~> 1.4"
+
   s.add_development_dependency "benchmark-ips"
   s.add_development_dependency "concurrent-ruby", "~>1.0"
   s.add_development_dependency "memory_profiler"
@@ -32,7 +34,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest", "~> 5.9.0"
   s.add_development_dependency "minitest-focus", "~> 1.1"
   s.add_development_dependency "minitest-reporters", "~>1.0"
-  s.add_development_dependency "racc", "~> 1.4"
   s.add_development_dependency "rake"
   s.add_development_dependency 'rake-compiler'
   s.add_development_dependency "rubocop", "1.12" # for Ruby 2.4 enforcement


### PR DESCRIPTION
It's used by the parser, and in Ruby 3.3 it's not longer a default gems, but was promoted as a bundled gem. So it need to be declared.

See: https://bugs.ruby-lang.org/issues/19702

Fixes #4650 