### PR TITLE
Avoid Hash#merge on large subclass schemas

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -162,6 +162,11 @@ namespace :bench do
     GraphQLBenchmark.profile_large_introspection
   end
 
+  task :profile_small_query_on_large_schema do
+    prepare_benchmark
+    GraphQLBenchmark.profile_small_query_on_large_schema
+  end
+
   desc "Run analysis on a big query"
   task :profile_large_analysis do
     prepare_benchmark

--- a/benchmark/run.rb
+++ b/benchmark/run.rb
@@ -161,6 +161,30 @@ module GraphQLBenchmark
 
   SILLY_LARGE_SCHEMA = build_large_schema
 
+  def self.profile_small_query_on_large_schema
+    schema = Class.new(SILLY_LARGE_SCHEMA)
+    Benchmark.ips do |x|
+      x.report("Run small query") {
+        schema.execute("{ __typename }")
+      }
+    end
+
+    result = StackProf.run(mode: :wall, interval: 1) do
+      schema.execute("{ __typename }")
+    end
+    StackProf::Report.new(result).print_text
+
+    StackProf.run(mode: :wall, out: "tmp/small_query.dump", interval: 1) do
+      schema.execute("{ __typename }")
+    end
+
+    report = MemoryProfiler.report do
+      schema.execute("{ __typename }")
+    end
+    puts "\n\n"
+    report.pretty_print
+  end
+
   def self.profile_large_introspection
     schema = SILLY_LARGE_SCHEMA
     Benchmark.ips do |x|

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -536,16 +536,17 @@ module GraphQL
       attr_writer :dataloader_class
 
       def references_to(to_type = nil, from: nil)
-        @own_references_to ||= Hash.new { |h, k| h[k] = [] }
+        @own_references_to ||= {}
         if to_type
           if !to_type.is_a?(String)
             to_type = to_type.graphql_name
           end
 
           if from
-            @own_references_to[to_type] << from
+            refs = @own_references_to[to_type] ||= []
+            refs << from
           else
-            get_references_to(to_type)
+            get_references_to(to_type) || EMPTY_ARRAY
           end
         else
           # `@own_references_to` can be quite large for big schemas,
@@ -1407,8 +1408,8 @@ module GraphQL
       def get_references_to(type_name)
         own_refs = @own_references_to[type_name]
         inherited_refs = superclass.references_to(type_name)
-        if inherited_refs.any?
-          if own_refs.any?
+        if inherited_refs&.any?
+          if own_refs&.any?
             own_refs + inherited_refs
           else
             inherited_refs

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -106,7 +106,7 @@ module GraphQL
         @types = @visible_types = @reachable_types = @visible_parent_fields =
           @visible_possible_types = @visible_fields = @visible_arguments = @visible_enum_arrays =
           @visible_enum_values = @visible_interfaces = @type_visibility = @type_memberships =
-          @visible_and_reachable_type = @unions = @unfiltered_interfaces = @references_to =
+          @visible_and_reachable_type = @unions = @unfiltered_interfaces =
           @reachable_type_set =
             nil
       end

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -356,13 +356,10 @@ module GraphQL
       end
 
       def referenced?(type_defn)
-        @references_to ||= @schema.references_to
         graphql_name = type_defn.unwrap.graphql_name
-        members = @references_to[graphql_name] || NO_REFERENCES
+        members = @schema.references_to(graphql_name)
         members.any? { |m| visible?(m) }
       end
-
-      NO_REFERENCES = [].freeze
 
       def orphan_type?(type_defn)
         @schema.orphan_types.include?(type_defn)

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -164,7 +164,6 @@ describe GraphQL::Schema do
     METHODS_TO_CACHE = {
       types: 1,
       union_memberships: 1,
-      references_to: 1,
       possible_types: 5, # The number of types with fields accessed in the query
     }
 

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -456,4 +456,8 @@ describe GraphQL::Schema do
       refute_includes full_res.to_s, "oldSource"
     end
   end
+
+  it "starts with no references_to" do
+    assert_equal({}, GraphQL::Schema.references_to)
+  end
 end


### PR DESCRIPTION
It was already mentioned in the code how a large schema can incur a costly `Hash#merge` when using `.references_to`:

https://github.com/rmosolgo/graphql-ruby/blob/9eee764c074aad229ccf223de21b529dcfc0a2cd/lib/graphql/schema.rb#L553-L555

But the implementation there didn't address when a schema _did_ have some inherited types. In that case, the cost was still paid of merging the hashes, even for a very small query. 

We can re-work this, improving an existing implementation of `.references_to(type_name)`, so that the big, merged hash isn't used by GraphQL-Ruby execution, so it's never made at all. 

For a small schema with inherited types, it can make a big difference. The benchmark I added here: 

```diff 
-      Run small query      4.586k (± 8.1%) i/s -     23.256k in   5.108886s
+     Run small query      4.879k (± 5.8%) i/s -     24.735k in   5.090457s
... 
- Total allocated: 30656 bytes (278 objects)
+ Total allocated: 27248 bytes (277 objects)
```

That was _one object_ taking up 10% of memory!

Another thing I noticed was that, because the `@references_to` Hash was assigning `[]` to keys by default, `GraphQL::Schema` could _actually_ have some entries in its Hash. But they might not point at anything -- they might just be misses. So it would cause `.merge` for a bunch of empty arrays 😩 

### TODO: 

- [x] check large query benchmarks -- did this slow them down? Perhaps cache `Warden#referenced?` 
  - The other benchmarks look the same. And they didn't have any reduction in memory, presumably because they didn't have any inherited `references_to` so they weren't performing the `merge` to start with.