### PR TITLE
Don't assume connection behaviors for types named Connection

### DIFF
--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -432,14 +432,12 @@ module GraphQL
           builder = self
 
           field_definitions.each do |field_definition|
-            type_name = resolve_type_name(field_definition.type)
             resolve_method_name = -"resolve_field_#{field_definition.name}"
             schema_field_defn = owner.field(
               field_definition.name,
               description: field_definition.description,
               type: type_resolver.call(field_definition.type),
               null: true,
-              connection: type_name.end_with?("Connection"),
               connection_extension: nil,
               deprecation_reason: build_deprecation_reason(field_definition.directives),
               ast_node: field_definition,
@@ -486,15 +484,6 @@ module GraphQL
             end
           }
           resolve_type_proc
-        end
-
-        def resolve_type_name(type)
-          case type
-          when GraphQL::Language::Nodes::TypeName
-            return type.name
-          else
-            resolve_type_name(type.of_type)
-          end
         end
       end
 

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -138,7 +138,7 @@ module GraphQL
             # As a last ditch, try to force loading the return type:
             type.unwrap.name
           end
-          @connection = return_type_name.end_with?("Connection")
+          @connection = return_type_name.end_with?("Connection") && return_type_name != "Connection"
         else
           @connection
         end

--- a/lib/graphql/schema/loader.rb
+++ b/lib/graphql/schema/loader.rb
@@ -186,7 +186,6 @@ module GraphQL
               null: true,
               camelize: false,
               connection_extension: nil,
-              connection: type_name.end_with?("Connection"),
             ) do
               if field_hash["args"].any?
                 loader.build_arguments(self, field_hash["args"], type_resolver)

--- a/lib/graphql/schema/loader.rb
+++ b/lib/graphql/schema/loader.rb
@@ -176,7 +176,6 @@ module GraphQL
             while (of_type = unwrapped_field_hash["ofType"])
               unwrapped_field_hash = of_type
             end
-            type_name = unwrapped_field_hash["name"]
 
             type_defn.field(
               field_hash["name"],

--- a/spec/graphql/schema/field_spec.rb
+++ b/spec/graphql/schema/field_spec.rb
@@ -841,4 +841,21 @@ This is probably a bug in GraphQL-Ruby, please report this error on GitHub: http
     res = HashDefautSchema.execute('query { example { implicitLookup explicitLookup } }').to_h
     assert_equal({ "implicitLookup" => [], "explicitLookup" => [] }, res["data"]["example"])
   end
+
+  module FieldConnectionTest
+    class SomeConnection < GraphQL::Schema::Object; end
+    class Connection < GraphQL::Schema::Object; end
+  end
+
+  it "Automatically detects connection, but can be overridden" do
+    field = GraphQL::Schema::Field.new(name: "blah", owner: nil, type: FieldConnectionTest::SomeConnection)
+    assert field.connection?
+    field = GraphQL::Schema::Field.new(name: "blah", owner: nil, type: FieldConnectionTest::SomeConnection, connection: false)
+    refute field.connection?
+
+    field = GraphQL::Schema::Field.new(name: "blah", owner: nil, type: FieldConnectionTest::Connection)
+    refute field.connection?
+    field = GraphQL::Schema::Field.new(name: "blah", owner: nil, type: FieldConnectionTest::Connection, connection: true)
+    assert field.connection?
+  end
 end


### PR DESCRIPTION
Fixes #4353  

Also, rather than clean up some areas that set `connection: ...` when building a schema, I removed it. That will make the field use the default inference in `def connection?`. 