### PR TITLE
Fix Warden#get_field in 1.13.x

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -502,7 +502,7 @@ module GraphQL
     # @param field_name [String]
     # @return [GraphQL::Field, nil] The field named `field_name` on `parent_type`
     # @see [GraphQL::Schema::Warden] Restricted access to members of a schema
-    def get_field(parent_type, field_name)
+    def get_field(parent_type, field_name, _context = GraphQL::Query::NullContext)
       with_definition_error_check do
         parent_type_name = case parent_type
         when GraphQL::BaseType, Class, Module

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -138,7 +138,7 @@ module GraphQL
       def get_field(parent_type, field_name)
         @visible_parent_fields ||= read_through do |type|
           read_through do |f_name|
-            field_defn = @schema.get_field(type, f_name)
+            field_defn = @schema.get_field(type, f_name, @context)
             if field_defn && visible_field?(field_defn, nil, type)
               field_defn
             else

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -138,7 +138,7 @@ module GraphQL
       def get_field(parent_type, field_name)
         @visible_parent_fields ||= read_through do |type|
           read_through do |f_name|
-            field_defn = @schema.get_field(type, f_name, @context)
+            field_defn = @schema.get_field(type, f_name)
             if field_defn && visible_field?(field_defn, nil, type)
               field_defn
             else


### PR DESCRIPTION
Fixes #4602 

Schema _class_ methods got a third parameter added, `context`, to handle dynamic schema member. Instance-based methods (like `Schema#get_field`) didn't get that new parameter. 

I'm adding it here so that the call in `Warden#get_field` won't raise an error, but the argument is unused.