### PR TITLE
Require resolve_type for loads:

### DIFF
--- a/guides/mutations/mutation_classes.md
+++ b/guides/mutations/mutation_classes.md
@@ -162,6 +162,10 @@ end
 
 In the above examples, `loads:` is provided a concrete type, but it also supports abstract types (i.e. interfaces and unions).
 
+### Resolving the type of loaded objects
+
+When `loads:` gets an object from {{ "Schema.object_from_id" | api_doc }}, it passes that object to {{ "Schema.resolve_type" | api_doc }} to confirm that it resolves to the same type originally configured with `loads:`.
+
 ### Handling failed loads
 
 If `loads:` fails to find an object or if the loaded object isn't resolved to the specified `loads:` type (using {{ "Schema.resolve_type" | api_doc }}), a {{ "GraphQL::LoadApplicationObjectFailedError" | api_doc }} is raised and returned to the client.

--- a/guides/schema/definition.md
+++ b/guides/schema/definition.md
@@ -92,6 +92,8 @@ class MySchema < GraphQL::Schema
 end
 ```
 
+`resolve_type` is also used by `loads:` to confirm that loaded objects match the configured type.
+
 __`object_from_id`__ is used by the `node(id: ID!): Node` field and `loads:` configuration. It receives a unique ID and must return the object for that ID, or `nil` if the object isn't found (or if it should be hidden from the current user).
 __`id_from_object`__ is used to implement `Node.id`. It should return a unique ID for the given object. This ID will later be sent to `object_from_id` to refetch the object.
 

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -931,11 +931,7 @@ module GraphQL
       end
 
       def resolve_type(type, obj, ctx)
-        if type.kind.object?
-          type
-        else
-          raise GraphQL::RequiredImplementationMissingError, "#{self.name}.resolve_type(type, obj, ctx) must be implemented to use Union types or Interface types (tried to resolve: #{type.name})"
-        end
+        raise GraphQL::RequiredImplementationMissingError, "#{self.name}.resolve_type(type, obj, ctx) must be implemented to use Union types, Interface types, or `loads:` (tried to resolve: #{type.name})"
       end
       # rubocop:enable Lint/DuplicateMethods
 

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -964,6 +964,10 @@ describe GraphQL::Dataloader do
         def self.object_from_id(id, ctx)
           ctx.dataloader.with(Example::FooSource).request(id)
         end
+
+        def self.resolve_type(type, obj, ctx)
+          type
+        end
       end
     end
 

--- a/spec/graphql/schema/argument_spec.rb
+++ b/spec/graphql/schema/argument_spec.rb
@@ -92,6 +92,10 @@ describe GraphQL::Schema::Argument do
         -> { Jazz::GloballyIdentifiableType.find(id) }
       end
 
+      def self.resolve_type(type, obj, ctx)
+        -> { type } # just for `loads:`
+      end
+
       orphan_types [Jazz::InstrumentType, UnauthorizedInstrumentType]
     end
   end

--- a/spec/graphql/schema/resolver_spec.rb
+++ b/spec/graphql/schema/resolver_spec.rb
@@ -509,6 +509,10 @@ describe GraphQL::Schema::Resolver do
         end
       end
 
+      def self.resolve_type(type, obj, ctx)
+        type # This will work for loaded objects well enough
+      end
+
       rescue_from SpecialError do |err|
         raise GraphQL::ExecutionError, "A special error was raised from #{err.id.inspect}"
       end

--- a/spec/graphql/schema/subscription_spec.rb
+++ b/spec/graphql/schema/subscription_spec.rb
@@ -176,6 +176,10 @@ describe GraphQL::Schema::Subscription do
       USERS[id]
     end
 
+    def self.resolve_type(type, obj, ctx)
+      User
+    end
+
     def self.unauthorized_field(err)
       path = err.context[:last_path]
       raise GraphQL::ExecutionError, "Can't subscribe to private user (#{path})"


### PR DESCRIPTION
`resolve_type` really _is_ part of safely using `loads:`. Make it required in GraphQL-Ruby 2.2.0. 

Fixes #4643 