### PR TITLE
Add install generators options that were missing in the documentation.

### DIFF
--- a/guides/schema/generators.md
+++ b/guides/schema/generators.md
@@ -42,11 +42,14 @@ After installing you can see your new schema by:
 
 ### Options
 
+- `--directory=DIRECTORY` will directory where generated files should be saved (default is `app/graphql`)
+- `--schema=MySchemaName` will be used for naming the schema (default is `#{app_name}Schema`)
+- `--skip-graphiql` will exclude `graphiql-rails` from the setup
+- `--skip-mutation-root-type` will not create of the mutation root type
 - `--relay` will add [Relay](https://facebook.github.io/relay/)-specific code to your schema
 - `--batch` will add [GraphQL::Batch](https://github.com/Shopify/graphql-batch) to your gemfile and include the setup in your schema
 - `--playground` will include `graphql_playground-rails` in the setup (mounted at `/playground`)
-- `--skip-graphiql` will exclude `graphiql-rails` from the setup
-- `--schema=MySchemaName` will be used for naming the schema (default is `#{app_name}Schema`)
+- `--api` will create smaller stack for API only apps
 
 ## Scaffolding Types
 


### PR DESCRIPTION
Hi, first of all, thank you for making this awesome gem.

When I used the generator, I noticed a discrepancy between the options listed in the documentation and the options that were actually enabled.

This PR adds the following to the documentation, which are valid options for the current generator:

- `directory`
- `skip-mutation-root-type`
- `api`

#### current excute resule

```bash
$ pwd
spec/dummy

$ bundle exec rails g graphql:install --help

Usage:
  bin/rails generate graphql:install [options]

Options:
  [--skip-namespace], [--no-skip-namespace]                    # Skip namespace (affects only isolated engines)
                                                               # Default: false
  [--skip-collision-check], [--no-skip-collision-check]        # Skip collision check
                                                               # Default: false
  [--directory=DIRECTORY]                                      # Directory where generated files should be saved
                                                               # Default: app/graphql
  [--schema=SCHEMA]                                            # Name for the schema constant (default: {app_name}Schema)
  [--skip-keeps], [--no-skip-keeps]                            # Skip .keep files for source control
                                                               # Default: false
  [--skip-graphiql], [--no-skip-graphiql]                      # Skip graphiql-rails installation
                                                               # Default: false
  [--skip-mutation-root-type], [--no-skip-mutation-root-type]  # Skip creation of the mutation root type
                                                               # Default: false
  [--relay], [--no-relay]                                      # Include installation of Relay conventions (nodes, connections, edges)
                                                               # Default: true
  [--batch], [--no-batch]                                      # Include GraphQL::Batch installation
                                                               # Default: false
  [--playground], [--no-playground]                            # Use GraphQL Playground over Graphiql as IDE
                                                               # Default: false
  [--api], [--no-api]                                          # Preconfigure smaller stack for API only apps
                                                               # Default: false

Runtime options:
  -f, [--force]                    # Overwrite files that already exist
  -p, [--pretend], [--no-pretend]  # Run but do not make any changes
  -q, [--quiet], [--no-quiet]      # Suppress status output
  -s, [--skip], [--no-skip]        # Skip files that already exist

Install GraphQL folder structure and boilerplate code
```

#### Generator souce code

https://github.com/rmosolgo/graphql-ruby/blob/master/lib/generators/graphql/install_generator.rb


