### PR TITLE
Fix ActionCable subscriptions channel example

### DIFF
--- a/lib/graphql/subscriptions/action_cable_subscriptions.rb
+++ b/lib/graphql/subscriptions/action_cable_subscriptions.rb
@@ -35,7 +35,7 @@ module GraphQL
     #       }
     #
     #       result = MySchema.execute(
-    #         query: query,
+    #         query,
     #         context: context,
     #         variables: variables,
     #         operation_name: operation_name


### PR DESCRIPTION
Query is the first positional argument for `Schema#execute`, not a kwarg.

At least 2 instances of users trying to use the example and bumping into cryptic errors, [this guy](https://stackoverflow.com/questions/66877742/ruby-graphql-and-or-actioncable-dumping-core-on-subscription) and myself ha.