### PR TITLE
Change `INVALID_OBJECT_MESSAGE` to omit `to_h` and `to_unsafe_h`

### DIFF
--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -145,7 +145,7 @@ module GraphQL
         end
 
         # @api private
-        INVALID_OBJECT_MESSAGE = "Expected %{object} to be a key-value object responding to `to_h` or `to_unsafe_h`."
+        INVALID_OBJECT_MESSAGE = "Expected %{object} to be a key-value object."
 
         def validate_non_null_input(input, ctx, max_errors: nil)
           warden = ctx.warden


### PR DESCRIPTION
Issue:
* https://github.com/Shopify/shopify/issues/462096

Reason for change:
This message is exposed publicly [[thread](https://shopify.slack.com/archives/C04BSPBE61K/p1698868028519919?thread_ts=1698867951.169129&cid=C04BSPBE61K)].

TL;DR:

When constructing a bad input, e.g. 
```
{
  "input"=>{
    "handle"=>"new-product", 
    "title"=>"New product",
    "status"=>"ACTIVE",
    "vendor"=>"Shop 1",
    "productType"=>"",
    "descriptionHtml"=>"",
    "giftCard"=>false,
    "giftCardTemplateSuffix"=>nil, 
    "options"=>["Color", "Size"], 
    "requiresSellingPlan"=>false,
    "tags"=>[],
    "templateSuffix"=>nil,
    "optionValues"=>[
      {"name"=>"Color", "values"=>["Red"]}, 
      {"name"=>"Size", "values"=>["Small"]}
      ]
    }
}
```
for `productOptionsCreate` mutation,

the error response returned is
```
{
  "errors":[
    {
      "message": "Variable $input of type ProductInput! was provided invalid value for       optionValues.0.values.0
      (Expected \"Red\" to be a key-value object responding to `to_h` or `to_unsafe_h`.), optionValues.1.values.0 
      (Expected \"Small\" to be a key-value object responding to `to_h` or `to_unsafe_h`.)",
      "locations":[{"line":1,"column":10}
  ],
      "extensions":{"value":{"handle":"new-product","title":"New product","status":"ACTIVE","vendor":"Shop 1","productType":"","descriptionHtml":"","giftCard":false,"giftCardTemplateSuffix":null,"options":["Color","Size"],"requiresSellingPlan":false,"tags":[],"templateSuffix":null,"optionValues":[{"name":"Color","values":["Red"]},{"name":"Size","values":["Small"]}]},"problems":[{"path":["optionValues",0,"values",0],"explanation":"Expected \"Red\" to be a key-value object responding to `to_h` or `to_unsafe_h`."},{"path":["optionValues",1,"values",0],"explanation":"Expected \"Small\" to be a key-value object responding to `to_h` or `to_unsafe_h`."}]}}]}
```