### PR TITLE
Fix `BlockString.trim_whitespace` to conform to spec.

### DIFF
--- a/lib/graphql/language/block_string.rb
+++ b/lib/graphql/language/block_string.rb
@@ -47,10 +47,10 @@ module GraphQL
         end
 
         # Remove leading & trailing blank lines
-        while lines.size > 0 && lines[0].empty?
+        while lines.size > 0 && contains_only_whitespace?(lines.first)
           lines.shift
         end
-        while lines.size > 0 && lines[-1].empty?
+        while lines.size > 0 && contains_only_whitespace?(lines.last)
           lines.pop
         end
 
@@ -105,6 +105,10 @@ module GraphQL
         end
 
         nil
+      end
+
+      def self.contains_only_whitespace?(line)
+        line.match?(/^\s*$/)
       end
     end
   end

--- a/spec/graphql/language/block_string_spec.rb
+++ b/spec/graphql/language/block_string_spec.rb
@@ -63,6 +63,18 @@ describe GraphQL::Language::BlockString do
           # Doesn't crash when the string is only a newline
           "\n",
           ""
+        ],
+        [
+          # Removes long blank lines
+          "  \n                                     \n
+          Hello,
+            World!
+
+          Yours,
+            GraphQL.
+
+          \n                                        \n",
+          "Hello,\n  World!\n\nYours,\n  GraphQL."
         ]
       ]
 


### PR DESCRIPTION
GraphQL spec requires to strip lines which are not empty but contain only whitespace. The current implementation doesn't remove such lines. This probably doesn't matter in practice, but it's always nice to be spec-compliant.

 Quoting the [block string spec](https://spec.graphql.org/October2021/#BlockStringValue()):
```
4. While the first item line in lines contains only WhiteSpace:
    a. Remove the first item from lines.

5. While the last item line in lines contains only WhiteSpace:
    a. Remove the last item from lines.
```