### PR TITLE
Fix { backtrace: true } with @defer

### DIFF
--- a/lib/graphql/backtrace/trace.rb
+++ b/lib/graphql/backtrace/trace.rb
@@ -49,8 +49,6 @@ module GraphQL
         # This is an unhandled error from execution,
         # Re-raise it with a GraphQL trace.
         potential_context = @__backtrace_last_context
-        pp "Multiplex error #{err.message}"
-        puts err.backtrace
         if potential_context.is_a?(GraphQL::Query::Context) ||
             potential_context.is_a?(Backtrace::Frame)
           raise TracedError.new(err, potential_context)
@@ -86,7 +84,6 @@ module GraphQL
           arguments: arguments,
           parent_frame: parent_frame,
         )
-
         push_storage[push_key] = push_data
         @__backtrace_last_context = push_data
       end

--- a/lib/graphql/backtrace/trace.rb
+++ b/lib/graphql/backtrace/trace.rb
@@ -2,6 +2,12 @@
 module GraphQL
   class Backtrace
     module Trace
+      def initialize(*args, **kwargs, &block)
+        @__backtrace_contexts = {}
+        @__backtrace_last_context = nil
+        super
+      end
+
       def validate(query:, validate:)
         if query.multiplex
           push_query_backtrace_context(query)
@@ -42,36 +48,29 @@ module GraphQL
       rescue StandardError => err
         # This is an unhandled error from execution,
         # Re-raise it with a GraphQL trace.
-        multiplex_context = multiplex.context
-        potential_context = multiplex_context[:last_graphql_backtrace_context]
-
+        potential_context = @__backtrace_last_context
+        pp "Multiplex error #{err.message}"
+        puts err.backtrace
         if potential_context.is_a?(GraphQL::Query::Context) ||
             potential_context.is_a?(Backtrace::Frame)
           raise TracedError.new(err, potential_context)
         else
           raise
         end
-      ensure
-        multiplex_context = multiplex.context
-        multiplex_context.delete(:graphql_backtrace_contexts)
-        multiplex_context.delete(:last_graphql_backtrace_context)
       end
 
       private
 
       def push_query_backtrace_context(query)
         push_data = query
-        multiplex = query.multiplex
         push_key = []
-        push_storage = multiplex.context[:graphql_backtrace_contexts] ||= {}
-        push_storage[push_key] = push_data
-        multiplex.context[:last_graphql_backtrace_context] = push_data
+        @__backtrace_contexts[push_key] = push_data
+        @__backtrace_last_context = push_data
       end
 
       def push_field_backtrace_context(field, query, ast_node, arguments, object)
-        multiplex = query.multiplex
         push_key = query.context[:current_path]
-        push_storage = multiplex.context[:graphql_backtrace_contexts]
+        push_storage = @__backtrace_contexts
         parent_frame = push_storage[push_key[0..-2]]
 
         if parent_frame.is_a?(GraphQL::Query)
@@ -89,8 +88,9 @@ module GraphQL
         )
 
         push_storage[push_key] = push_data
-        multiplex.context[:last_graphql_backtrace_context] = push_data
+        @__backtrace_last_context = push_data
       end
+
     end
   end
 end

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -115,8 +115,6 @@ module GraphQL
         if schema.trace_class <= GraphQL::Tracing::CallLegacyTracers
           context_tracers += [GraphQL::Backtrace::Tracer]
           @tracers << GraphQL::Backtrace::Tracer
-        elsif !(current_trace.class <= GraphQL::Backtrace::Trace)
-          raise "Invariant: `backtrace: true` should have provided a trace class with Backtrace mixed in, but it didnt. (Found: #{current_trace.class.ancestors}). This is a bug in GraphQL-Ruby, please report it on GitHub."
         end
       end
 


### PR DESCRIPTION
Oops -- previously, the cleanup of `multiplex.context` caused this to break when `@defer` was used. It would get cleaned up, but then, when deferrals were running, there'd be no context to read or write from. 

Now, the state is not cleaned up -- and it doesn't have to be, since it's local to the Trace instance. 

I don't have a good test for this repo, but I do have a `backtrace: true` test in GraphQL-Pro's defer tests now.