### PR TITLE
Add support for class level prepare methods on arguments

### DIFF
--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -221,8 +221,13 @@ module GraphQL
             #
             # This will have to be called later, when the runtime object _is_ available.
             value
-          else
+          elsif owner.respond_to?(@prepare)
+            owner.public_send(@prepare, value, context || obj.context)
+          elsif obj.respond_to?(@prepare)
             obj.public_send(@prepare, value)
+          else
+            raise "Invalid prepare for #{@owner.name}.name: #{@prepare.inspect}. "\
+              "Could not find prepare method #{@prepare} on #{obj.class} or #{owner}."
           end
         elsif @prepare.respond_to?(:call)
           @prepare.call(value, context || obj.context)

--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -221,10 +221,10 @@ module GraphQL
             #
             # This will have to be called later, when the runtime object _is_ available.
             value
-          elsif owner.respond_to?(@prepare)
-            owner.public_send(@prepare, value, context || obj.context)
           elsif obj.respond_to?(@prepare)
             obj.public_send(@prepare, value)
+          elsif owner.respond_to?(@prepare)
+            owner.public_send(@prepare, value, context || obj.context)
           else
             raise "Invalid prepare for #{@owner.name}.name: #{@prepare.inspect}. "\
               "Could not find prepare method #{@prepare} on #{obj.class} or #{owner}."

--- a/spec/graphql/schema/mutation_spec.rb
+++ b/spec/graphql/schema/mutation_spec.rb
@@ -81,7 +81,7 @@ describe GraphQL::Schema::Mutation do
     it "runs mutations" do
       query_str = <<-GRAPHQL
       mutation {
-        addInstrument(name: "Trombone", family: BRASS) {
+        addInstrument(name: "trombone", family: BRASS) {
           instrument {
             name
             family

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -3,7 +3,7 @@
 # Here's the "application"
 module Jazz
   module Models
-    Instrument = Struct.new(:name, :family, :alternative_name)
+    Instrument = Struct.new(:name, :family)
     Ensemble = Struct.new(:name)
     Musician = Struct.new(:name, :favorite_key)
     Key = Struct.new(:root, :sharp, :flat) do
@@ -545,16 +545,16 @@ module Jazz
 
   class AddInstrument < GraphQL::Schema::Mutation
     class << self
-      def prepare_family(value, context)
-        value.upcase
+      def prepare_name(value, context)
+        value.capitalize
       end
     end
 
     null true
     description "Register a new musical instrument in the database"
 
-    argument :name, String
-    argument :family, Family, prepare: :prepare_family
+    argument :name, String, prepare: :prepare_name
+    argument :family, Family
 
     field :instrument, InstrumentType, null: false
     # This is meaningless, but it's to test the conflict with `Hash#entries`

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -3,7 +3,7 @@
 # Here's the "application"
 module Jazz
   module Models
-    Instrument = Struct.new(:name, :family)
+    Instrument = Struct.new(:name, :family, :alternative_name)
     Ensemble = Struct.new(:name)
     Musician = Struct.new(:name, :favorite_key)
     Key = Struct.new(:root, :sharp, :flat) do
@@ -544,11 +544,17 @@ module Jazz
   end
 
   class AddInstrument < GraphQL::Schema::Mutation
+    class << self
+      def prepare_family(value, context)
+        value.upcase
+      end
+    end
+
     null true
     description "Register a new musical instrument in the database"
 
     argument :name, String
-    argument :family, Family
+    argument :family, Family, prepare: :prepare_family
 
     field :instrument, InstrumentType, null: false
     # This is meaningless, but it's to test the conflict with `Hash#entries`


### PR DESCRIPTION
Issue: https://github.com/rmosolgo/graphql-ruby/issues/4715

I _think_ this is what @eapache-opslevel was aluding to, it checks to see if the prepare method exists on the object or the owner (class method), and handles each approproiately

* For Object, don't send the context, it'll be there already
* For the Owner, send the context (like we do already for prepare blocks)
* If neither exist, give a clear error instead of a no method found error.