### PR TITLE
Default to re-authorizing scoped items (as documented), fix skipping for connections

### DIFF
--- a/lib/graphql/schema/member/scoped.rb
+++ b/lib/graphql/schema/member/scoped.rb
@@ -21,7 +21,7 @@ module GraphQL
             if @reauthorize_scoped_objects != nil
               @reauthorize_scoped_objects
             else
-              find_inherited_value(:reauthorize_scoped_objects, nil)
+              find_inherited_value(:reauthorize_scoped_objects, true)
             end
           else
             @reauthorize_scoped_objects = new_value

--- a/lib/graphql/types/relay/connection_behaviors.rb
+++ b/lib/graphql/types/relay/connection_behaviors.rb
@@ -87,6 +87,19 @@ module GraphQL
             node_type.scope_items(items, context)
           end
 
+          # The connection will skip auth on its nodes if the node_type is configured for that
+          def reauthorize_scoped_objects(new_value = nil)
+            if new_value.nil?
+              if @reauthorize_scoped_objects != nil
+                @reauthorize_scoped_objects
+              else
+                node_type.reauthorize_scoped_objects
+              end
+            else
+              @reauthorize_scoped_objects = new_value
+            end
+          end
+
           # Add the shortcut `nodes` field to this connection and its subclasses
           def nodes_field(node_nullable: self.node_nullable, field_options: nil)
             define_nodes_field(node_nullable, field_options: field_options)


### PR DESCRIPTION
Oops -- the default behavior here didn't match the docs. I must have missed it when I switched the default to be opt-in 😖 

Since the implementation checked if `scope_items` returned a new object or not, this would have only affected people who implemented `scope_items` to return a new object and _didn't_ want that new object to be re-authorized. 

Also, I fixed the behavior for connections so that they get their `reauthorize_scoped_objects` config from the node type.

