### PR TITLE
Fix SDL interface directives in new parser

### DIFF
--- a/lib/graphql/language/parser.rb
+++ b/lib/graphql/language/parser.rb
@@ -276,8 +276,8 @@ module GraphQL
           when :INTERFACE
             advance_token
             name = parse_name
-            directives = parse_directives
             interfaces = parse_implements
+            directives = parse_directives
             fields_definition = parse_field_definitions
             InterfaceTypeDefinition.new(pos: loc, definition_pos: defn_loc, description: desc, name: name, directives: directives, fields: fields_definition, interfaces: interfaces, filename: @filename, source_string: @graphql_str)
           when :UNION

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -77,10 +77,11 @@ directive @hashed repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @language(is: String!) on ENUM_VALUE
 
-type Hello implements Secret @greeting {
+type Hello implements Secret & Secret2 @greeting {
   goodbye(saying: Parting @greeting): Parting
   humbug: Int @greeting(pleasant: false)
   password: Phrase @hashed
+  password2: String
   str(in: Input): String
 }
 
@@ -95,8 +96,13 @@ enum Parting @greeting {
 
 union Phrase @greeting = Hello | Word
 
-interface Secret @greeting @greeting2 {
+interface Secret implements Secret2 @greeting @greeting2 {
   password: String
+  password2: String
+}
+
+interface Secret2 {
+  password2: String
 }
 
 type Word {


### PR DESCRIPTION
Fixes #4737 

oops, it was looking for directives _before_ `implements`, and evidently there was no test for this!