### PR TITLE
Dataloader: fix for large queries and run_isolated

### DIFF
--- a/lib/graphql/dataloader.rb
+++ b/lib/graphql/dataloader.rb
@@ -169,7 +169,11 @@ module GraphQL
     ensure
       @pending_jobs = prev_queue
       prev_pending_keys.each do |source_instance, pending|
-        source_instance.pending.merge!(pending)
+        pending.each do |key, value|
+          if !source_instance.results.key?(key)
+            source_instance.pending[key] = value
+          end
+        end
       end
     end
 

--- a/lib/graphql/dataloader.rb
+++ b/lib/graphql/dataloader.rb
@@ -183,27 +183,37 @@ module GraphQL
       source_fibers = []
       next_source_fibers = []
       first_pass = true
+      manager = spawn_fiber do
+        while first_pass || job_fibers.any?
+          first_pass = false
 
-      while first_pass || job_fibers.any?
-        first_pass = false
-
-        while (f = job_fibers.shift || spawn_job_fiber)
-          if f.alive?
-            run_fiber(f)
-            next_job_fibers << f
-          end
-        end
-        join_queues(job_fibers, next_job_fibers)
-
-        while source_fibers.any? || @source_cache.each_value.any? { |group_sources| group_sources.each_value.any?(&:pending?) }
-          while (f = source_fibers.shift || spawn_source_fiber)
+          while (f = (job_fibers.shift || spawn_job_fiber))
             if f.alive?
-              run_fiber(f)
-              next_source_fibers << f
+              finished = run_fiber(f)
+              if !finished
+                next_job_fibers << f
+              end
             end
           end
-          join_queues(source_fibers, next_source_fibers)
+          join_queues(job_fibers, next_job_fibers)
+
+          while source_fibers.any? || @source_cache.each_value.any? { |group_sources| group_sources.each_value.any?(&:pending?) }
+            while (f = source_fibers.shift || spawn_source_fiber)
+              if f.alive?
+                finished = run_fiber(f)
+                if !finished
+                  next_source_fibers << f
+                end
+              end
+            end
+            join_queues(source_fibers, next_source_fibers)
+          end
         end
+      end
+
+      manager_finished = run_fiber(manager)
+      if !manager_finished
+        raise "Invariant: Manager Fiber didn't finish successfully"
       end
 
       if job_fibers.any?
@@ -212,7 +222,6 @@ module GraphQL
       if source_fibers.any?
         raise "Invariant: source fibers should have exited but #{source_fibers.size} remained"
       end
-
     rescue UncaughtThrowError => e
       throw e.tag, e.value
     end

--- a/lib/graphql/dataloader/source.rb
+++ b/lib/graphql/dataloader/source.rb
@@ -169,7 +169,7 @@ module GraphQL
         nil
       end
 
-      attr_reader :pending
+      attr_reader :pending, :results
 
       private
 

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -449,6 +449,9 @@ describe GraphQL::Dataloader do
     database_log.clear
   end
 
+  ALL_FIBERS = []
+
+
   class PartsSchema < GraphQL::Schema
     class FieldSource < GraphQL::Dataloader::Source
       DATA = [
@@ -1001,13 +1004,24 @@ describe GraphQL::Dataloader do
         end
 
         it "works with very very large queries" do
+          schema.dataloader_class.prepend(Module.new do
+            def spawn_fiber
+              f = super
+              ALL_FIBERS << f
+              f
+            end
+          end)
           query_str = "{".dup
           1100.times do |i|
             query_str << "\n  field#{i}: lookaheadIngredient(input: { id: 1, batchKey: \"key-#{i}\"}) { name }"
           end
           query_str << "\n}"
+          ALL_FIBERS.clear
           res = schema.execute(query_str)
           assert_equal 1100, res["data"].keys.size
+          if ALL_FIBERS.any?
+            assert_equal [false], ALL_FIBERS.map(&:alive?).uniq
+          end
         end
 
         it "doesn't perform duplicate source fetches" do

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -449,9 +449,65 @@ describe GraphQL::Dataloader do
     database_log.clear
   end
 
+  class PartsSchema < GraphQL::Schema
+    class FieldSource < GraphQL::Dataloader::Source
+      DATA = [
+        {"id" => 1, "name" => "a"},
+        {"id" => 2, "name" => "b"},
+        {"id" => 3, "name" => "c"},
+        {"id" => 4, "name" => "d"},
+      ]
+      def fetch(fields)
+        @previously_fetched ||= Set.new
+        fields.each do |f|
+          if !@previously_fetched.add?(f)
+            raise "Duplicate fetch for #{f.inspect}"
+          end
+        end
+        Array.new(fields.size, DATA)
+      end
+    end
+
+    class StringFilter < GraphQL::Schema::InputObject
+      argument :equal_to_any_of, [String]
+    end
+
+    class ComponentFilter < GraphQL::Schema::InputObject
+      argument :name, StringFilter
+    end
+
+    class FetchObjects < GraphQL::Schema::Resolver
+      argument :filter, ComponentFilter, required: false
+      def resolve(**_kwargs)
+        context.dataloader.with(FieldSource).load("#{field.path}/#{object&.fetch("id")}")
+      end
+    end
+
+    class Component < GraphQL::Schema::Object
+      field :name, String
+    end
+
+    class Part < GraphQL::Schema::Object
+      field :components, [Component], resolver: FetchObjects
+    end
+
+    class Manufacturer < GraphQL::Schema::Object
+      field :parts, [Part], resolver: FetchObjects
+    end
+
+    class Query < GraphQL::Schema::Object
+      field :manufacturers, [Manufacturer], resolver: FetchObjects
+    end
+
+    query(Query)
+    use GraphQL::Dataloader
+  end
+
   module DataloaderAssertions
     def self.included(child_class)
       child_class.class_eval do
+        let(:schema) { make_schema_from(FiberSchema) }
+        let(:parts_schema) { make_schema_from(PartsSchema) }
 
         it "Works with request(...)" do
           res = schema.execute <<-GRAPHQL
@@ -953,21 +1009,40 @@ describe GraphQL::Dataloader do
           res = schema.execute(query_str)
           assert_equal 1100, res["data"].keys.size
         end
+
+        it "doesn't perform duplicate source fetches" do
+          query = <<~QUERY
+            query {
+              manufacturers {
+                parts {
+                  components(filter: {name: {equalToAnyOf: ["c1", "c2", "c3"]}}) {
+                    name
+                  }
+                }
+              }
+            }
+          QUERY
+          response = parts_schema.execute(query).to_h
+          assert_equal [4, 4, 4, 4], response["data"]["manufacturers"].map { |parts_obj| parts_obj["parts"].size }
+        end
       end
     end
   end
 
-  let(:schema) { FiberSchema }
+  def make_schema_from(schema)
+    schema
+  end
+
   include DataloaderAssertions
 
   if RUBY_VERSION >= "3.1.1"
     require "async"
     describe "AsyncDataloader" do
-      let(:schema) {
-        Class.new(FiberSchema) {
+      def make_schema_from(schema)
+        Class.new(schema) {
           use GraphQL::Dataloader::AsyncDataloader
         }
-      }
+      end
 
       include DataloaderAssertions
     end
@@ -975,9 +1050,11 @@ describe GraphQL::Dataloader do
 
   if Fiber.respond_to?(:scheduler)
     describe "nonblocking: true" do
-      let(:schema) { Class.new(FiberSchema) do
-        use GraphQL::Dataloader, nonblocking: true
-      end }
+      def make_schema_from(schema)
+        Class.new(schema) do
+          use GraphQL::Dataloader, nonblocking: true
+        end
+      end
 
       before do
         Fiber.set_scheduler(::DummyScheduler.new)
@@ -993,9 +1070,11 @@ describe GraphQL::Dataloader do
     if RUBY_ENGINE == "ruby" && !ENV["GITHUB_ACTIONS"]
       describe "nonblocking: true with libev" do
         require "libev_scheduler"
-        let(:schema) { Class.new(FiberSchema) do
-          use GraphQL::Dataloader, nonblocking: true
-        end }
+        def make_schema_from(schema)
+          Class.new(schema) do
+            use GraphQL::Dataloader, nonblocking: true
+          end
+        end
 
         before do
           Fiber.set_scheduler(Libev::Scheduler.new)


### PR DESCRIPTION
Addressing the issue from https://github.com/rmosolgo/graphql-ruby/issues/4745#issuecomment-1868101409 and #4747

TODO: 

- [ ] Backport to 2.1.10