### PR TITLE
Parser: Fix handling of single-token document

### DIFF
--- a/lib/graphql/language/parser.rb
+++ b/lib/graphql/language/parser.rb
@@ -62,11 +62,13 @@ module GraphQL
 
       def document
         any_tokens = advance_token
-        if !any_tokens
+        defns = []
+        if any_tokens
+          defns << definition
+        else
           # Only ignored characters is not a valid document
           raise GraphQL::ParseError.new("Unexpected end of document", nil, nil, @graphql_str)
         end
-        defns = []
         while !@lexer.eos?
           defns << definition
         end

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -651,6 +651,7 @@ describe GraphQL::Query do
         }
       GRAPHQL
     }
+
     it "adds an entry to the errors key" do
       res = schema.execute(" { ")
       assert_equal 1, res["errors"].length
@@ -660,6 +661,17 @@ describe GraphQL::Query do
         expected_err = "Expected NAME, actual: (none) (\" \") at [1, 2]"
       end
       expected_locations = [{"line" => 1, "column" => 2}]
+      assert_equal expected_err, res["errors"][0]["message"]
+      assert_equal expected_locations, res["errors"][0]["locations"]
+
+      res = schema.execute("{")
+      assert_equal 1, res["errors"].length
+      if USING_C_PARSER
+        expected_err = "syntax error, unexpected end of file at [1, 1]"
+      else
+        expected_err = "Expected NAME, actual: (none) (\"\") at [1, 1]"
+      end
+      expected_locations = [{"line" => 1, "column" => 1}]
       assert_equal expected_err, res["errors"][0]["message"]
       assert_equal expected_locations, res["errors"][0]["locations"]
 


### PR DESCRIPTION
Fixes #4746 