### PR TITLE
Remove Fiber#transfer support

### DIFF
--- a/lib/graphql/dataloader.rb
+++ b/lib/graphql/dataloader.rb
@@ -211,9 +211,10 @@ module GraphQL
         end
       end
 
-      manager_finished = run_fiber(manager)
-      if !manager_finished
-        raise "Invariant: Manager Fiber didn't finish successfully"
+      while !(manager_finished = run_fiber(manager))
+        if !manager.alive?
+          raise "Invariant: Manager Fiber didn't finish successfully"
+        end
       end
 
       if job_fibers.any?

--- a/lib/graphql/dataloader.rb
+++ b/lib/graphql/dataloader.rb
@@ -169,7 +169,11 @@ module GraphQL
     ensure
       @pending_jobs = prev_queue
       prev_pending_keys.each do |source_instance, pending|
-        source_instance.pending.merge!(pending)
+        pending.each do |key, value|
+          if !source_instance.results.key?(key)
+            source_instance.pending[key] = value
+          end
+        end
       end
     end
 

--- a/lib/graphql/dataloader.rb
+++ b/lib/graphql/dataloader.rb
@@ -183,27 +183,37 @@ module GraphQL
       source_fibers = []
       next_source_fibers = []
       first_pass = true
+      manager = spawn_fiber do
+        while first_pass || job_fibers.any?
+          first_pass = false
 
-      while first_pass || job_fibers.any?
-        first_pass = false
-
-        while (f = job_fibers.shift || spawn_job_fiber)
-          if f.alive?
-            run_fiber(f)
-            next_job_fibers << f
-          end
-        end
-        join_queues(job_fibers, next_job_fibers)
-
-        while source_fibers.any? || @source_cache.each_value.any? { |group_sources| group_sources.each_value.any?(&:pending?) }
-          while (f = source_fibers.shift || spawn_source_fiber)
+          while (f = (job_fibers.shift || spawn_job_fiber))
             if f.alive?
-              run_fiber(f)
-              next_source_fibers << f
+              finished = run_fiber(f)
+              if !finished
+                next_job_fibers << f
+              end
             end
           end
-          join_queues(source_fibers, next_source_fibers)
+          join_queues(job_fibers, next_job_fibers)
+
+          while source_fibers.any? || @source_cache.each_value.any? { |group_sources| group_sources.each_value.any?(&:pending?) }
+            while (f = source_fibers.shift || spawn_source_fiber)
+              if f.alive?
+                finished = run_fiber(f)
+                if !finished
+                  next_source_fibers << f
+                end
+              end
+            end
+            join_queues(source_fibers, next_source_fibers)
+          end
         end
+      end
+
+      manager_finished = run_fiber(manager)
+      if !manager_finished
+        raise "Invariant: Manager Fiber didn't finish successfully"
       end
 
       if job_fibers.any?
@@ -212,7 +222,6 @@ module GraphQL
       if source_fibers.any?
         raise "Invariant: source fibers should have exited but #{source_fibers.size} remained"
       end
-
     rescue UncaughtThrowError => e
       throw e.tag, e.value
     end

--- a/lib/graphql/dataloader.rb
+++ b/lib/graphql/dataloader.rb
@@ -119,12 +119,7 @@ module GraphQL
     #
     # @return [void]
     def yield
-      if use_fiber_resume?
-        Fiber.yield
-      else
-        parent_fiber = Thread.current[:parent_fiber]
-        parent_fiber.transfer
-      end
+      Fiber.yield
       nil
     end
 
@@ -211,10 +206,10 @@ module GraphQL
         end
       end
 
-      while !(manager_finished = run_fiber(manager))
-        if !manager.alive?
-          raise "Invariant: Manager Fiber didn't finish successfully"
-        end
+      run_fiber(manager)
+
+      if manager.alive?
+        raise "Invariant: Manager fiber didn't terminate properly."
       end
 
       if job_fibers.any?
@@ -228,27 +223,17 @@ module GraphQL
     end
 
     def run_fiber(f)
-      if use_fiber_resume?
-        f.resume
-      else
-        f.transfer
-      end
+      f.resume
     end
 
     def spawn_fiber
       fiber_vars = get_fiber_variables
-      parent_fiber = use_fiber_resume? ? nil : Fiber.current
       Fiber.new(blocking: !@nonblocking) {
         set_fiber_variables(fiber_vars)
-        Thread.current[:parent_fiber] = parent_fiber
         yield
         # With `.transfer`, you have to explicitly pass back to the parent --
         # if the fiber is allowed to terminate normally, control is passed to the main fiber instead.
-        if parent_fiber
-          parent_fiber.transfer(true)
-        else
-          true
-        end
+        true
       }
     end
 
@@ -258,15 +243,6 @@ module GraphQL
       @nonblocking && Fiber.scheduler.run
       prev_queue.concat(new_queue)
       new_queue.clear
-    end
-
-    def use_fiber_resume?
-      Fiber.respond_to?(:scheduler) &&
-        (
-          (defined?(::DummyScheduler) && Fiber.scheduler.is_a?(::DummyScheduler)) ||
-          (defined?(::Evt) && ::Evt::Scheduler.singleton_class::BACKENDS.any? { |be| Fiber.scheduler.is_a?(be) }) ||
-          (defined?(::Libev) && Fiber.scheduler.is_a?(::Libev::Scheduler))
-        )
     end
 
     def spawn_job_fiber

--- a/lib/graphql/dataloader/source.rb
+++ b/lib/graphql/dataloader/source.rb
@@ -169,7 +169,7 @@ module GraphQL
         nil
       end
 
-      attr_reader :pending
+      attr_reader :pending, :results
 
       private
 

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -1018,7 +1018,11 @@ describe GraphQL::Dataloader do
           end
           all_fibers.delete(Fiber.current)
           if schema.dataloader_class == GraphQL::Dataloader::AsyncDataloader
-            skip "TODO: AsyncDataloader leaves orphan suspended fibers :'("
+            skip <<~ERR
+              TODO: AsyncDataloader leaves orphan suspended fibers :'(
+
+                - #{all_fibers.select(&:alive?).join("\n  -")}
+            ERR
           else
             assert_equal [false], all_fibers.map(&:alive?).uniq
           end

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -1017,7 +1017,11 @@ describe GraphQL::Dataloader do
             all_fibers << f
           end
           all_fibers.delete(Fiber.current)
-          assert_equal [false], all_fibers.map(&:alive?).uniq
+          if schema.dataloader_class == GraphQL::Dataloader::AsyncDataloader
+            skip "TODO: AsyncDataloader leaves orphan suspended fibers :'("
+          else
+            assert_equal [false], all_fibers.map(&:alive?).uniq
+          end
         end
 
         it "doesn't perform duplicate source fetches" do

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -1016,7 +1016,8 @@ describe GraphQL::Dataloader do
           ObjectSpace.each_object(Fiber) do |f|
             all_fibers << f
           end
-          assert_equal [Fiber.current], all_fibers
+          all_fibers.delete(Fiber.current)
+          assert_equal [false], all_fibers.map(&:alive?).uniq
         end
 
         it "doesn't perform duplicate source fetches" do

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -1004,24 +1004,19 @@ describe GraphQL::Dataloader do
         end
 
         it "works with very very large queries" do
-          schema.dataloader_class.prepend(Module.new do
-            def spawn_fiber
-              f = super
-              ALL_FIBERS << f
-              f
-            end
-          end)
           query_str = "{".dup
           1100.times do |i|
             query_str << "\n  field#{i}: lookaheadIngredient(input: { id: 1, batchKey: \"key-#{i}\"}) { name }"
           end
           query_str << "\n}"
-          ALL_FIBERS.clear
+          GC.start
           res = schema.execute(query_str)
           assert_equal 1100, res["data"].keys.size
-          if ALL_FIBERS.any?
-            assert_equal [false], ALL_FIBERS.map(&:alive?).uniq
+          all_fibers = []
+          ObjectSpace.each_object(Fiber) do |f|
+            all_fibers << f
           end
+          assert_equal [Fiber.current], all_fibers
         end
 
         it "doesn't perform duplicate source fetches" do

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -449,6 +449,9 @@ describe GraphQL::Dataloader do
     database_log.clear
   end
 
+  ALL_FIBERS = []
+
+
   class PartsSchema < GraphQL::Schema
     class FieldSource < GraphQL::Dataloader::Source
       DATA = [
@@ -1001,13 +1004,24 @@ describe GraphQL::Dataloader do
         end
 
         it "works with very very large queries" do
+          schema.dataloader_class.prepend(Module.new do
+            def spawn_fiber
+              f = super
+              ALL_FIBERS << f
+              f
+            end
+          end)
           query_str = "{".dup
           1100.times do |i|
             query_str << "\n  field#{i}: lookaheadIngredient(input: { id: 1, batchKey: \"key-#{i}\"}) { name }"
           end
           query_str << "\n}"
+          ALL_FIBERS.clear
           res = schema.execute(query_str)
           assert_equal 1100, res["data"].keys.size
+          if ALL_FIBERS.any?
+            assert_equal [false], ALL_FIBERS.map(&:alive?).uniq
+          end
         end
 
         it "doesn't perform duplicate source fetches" do

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -449,9 +449,65 @@ describe GraphQL::Dataloader do
     database_log.clear
   end
 
+  class PartsSchema < GraphQL::Schema
+    class FieldSource < GraphQL::Dataloader::Source
+      DATA = [
+        {"id" => 1, "name" => "a"},
+        {"id" => 2, "name" => "b"},
+        {"id" => 3, "name" => "c"},
+        {"id" => 4, "name" => "d"},
+      ]
+      def fetch(fields)
+        @previously_fetched ||= Set.new
+        fields.each do |f|
+          if !@previously_fetched.add?(f)
+            raise "Duplicate fetch for #{f.inspect}"
+          end
+        end
+        Array.new(fields.size, DATA)
+      end
+    end
+
+    class StringFilter < GraphQL::Schema::InputObject
+      argument :equal_to_any_of, [String]
+    end
+
+    class ComponentFilter < GraphQL::Schema::InputObject
+      argument :name, StringFilter
+    end
+
+    class FetchObjects < GraphQL::Schema::Resolver
+      argument :filter, ComponentFilter, required: false
+      def resolve(**_kwargs)
+        context.dataloader.with(FieldSource).load("#{field.path}/#{object&.fetch("id")}")
+      end
+    end
+
+    class Component < GraphQL::Schema::Object
+      field :name, String
+    end
+
+    class Part < GraphQL::Schema::Object
+      field :components, [Component], resolver: FetchObjects
+    end
+
+    class Manufacturer < GraphQL::Schema::Object
+      field :parts, [Part], resolver: FetchObjects
+    end
+
+    class Query < GraphQL::Schema::Object
+      field :manufacturers, [Manufacturer], resolver: FetchObjects
+    end
+
+    query(Query)
+    use GraphQL::Dataloader
+  end
+
   module DataloaderAssertions
     def self.included(child_class)
       child_class.class_eval do
+        let(:schema) { make_schema_from(FiberSchema) }
+        let(:parts_schema) { make_schema_from(PartsSchema) }
 
         it "Works with request(...)" do
           res = schema.execute <<-GRAPHQL
@@ -953,21 +1009,40 @@ describe GraphQL::Dataloader do
           res = schema.execute(query_str)
           assert_equal 1100, res["data"].keys.size
         end
+
+        it "doesn't perform duplicate source fetches" do
+          query = <<~QUERY
+            query {
+              manufacturers {
+                parts {
+                  components(filter: {name: {equalToAnyOf: ["c1", "c2", "c3"]}}) {
+                    name
+                  }
+                }
+              }
+            }
+          QUERY
+          response = parts_schema.execute(query).to_h
+          assert_equal [4, 4, 4, 4], response["data"]["manufacturers"].map { |parts_obj| parts_obj["parts"].size }
+        end
       end
     end
   end
 
-  let(:schema) { FiberSchema }
+  def make_schema_from(schema)
+    schema
+  end
+
   include DataloaderAssertions
 
   if RUBY_VERSION >= "3.1.1"
     require "async"
     describe "AsyncDataloader" do
-      let(:schema) {
-        Class.new(FiberSchema) {
+      def make_schema_from(schema)
+        Class.new(schema) {
           use GraphQL::Dataloader::AsyncDataloader
         }
-      }
+      end
 
       include DataloaderAssertions
     end
@@ -975,9 +1050,11 @@ describe GraphQL::Dataloader do
 
   if Fiber.respond_to?(:scheduler)
     describe "nonblocking: true" do
-      let(:schema) { Class.new(FiberSchema) do
-        use GraphQL::Dataloader, nonblocking: true
-      end }
+      def make_schema_from(schema)
+        Class.new(schema) do
+          use GraphQL::Dataloader, nonblocking: true
+        end
+      end
 
       before do
         Fiber.set_scheduler(::DummyScheduler.new)
@@ -993,9 +1070,11 @@ describe GraphQL::Dataloader do
     if RUBY_ENGINE == "ruby" && !ENV["GITHUB_ACTIONS"]
       describe "nonblocking: true with libev" do
         require "libev_scheduler"
-        let(:schema) { Class.new(FiberSchema) do
-          use GraphQL::Dataloader, nonblocking: true
-        end }
+        def make_schema_from(schema)
+          Class.new(schema) do
+            use GraphQL::Dataloader, nonblocking: true
+          end
+        end
 
         before do
           Fiber.set_scheduler(Libev::Scheduler.new)


### PR DESCRIPTION
I can't find a way to terminate a Fiber that received a transfer call, see: 

- #4745 
- #4747 
- https://bugs.ruby-lang.org/issues/20089
- https://bugs.ruby-lang.org/issues/20081

So, I'm removing it from the library until those issues are sorted out. 

Unfortunately, AsyncDataloader leaves dangling fibers anyways, I think because it uses `Fiber#transfer` under the hood. I may address that in another PR -- but I'm hoping my open issues in Ruby are addressed such that I can continue using the `async` gem!