### PR TITLE
Fix ActionCable fetcher

### DIFF
--- a/javascript_client/src/subscriptions/__tests__/createActionCableFetcherTest.ts
+++ b/javascript_client/src/subscriptions/__tests__/createActionCableFetcherTest.ts
@@ -28,7 +28,7 @@ describe("createActionCableFetcherTest", () => {
 
     var options = {
       consumer: (dummyActionCableConsumer as unknown) as Consumer,
-      url: "/graphql",
+      url: "/some_graphql_endpoint",
       fetch: dummyFetch as typeof fetch,
       fetchOptions: {
         custom: true,
@@ -58,7 +58,7 @@ describe("createActionCableFetcherTest", () => {
     return promise.then(() => {
       let res2 = fetcher({ operationName: null, query: "{ __typename } ", variables: {}}, {})
       const promise2 = res2.next().then(() => {
-        expect(fetchLog).toEqual([["/graphql", true]])
+        expect(fetchLog).toEqual([["/some_graphql_endpoint", true]])
       })
       return promise2
     })

--- a/javascript_client/src/subscriptions/createActionCableFetcher.ts
+++ b/javascript_client/src/subscriptions/createActionCableFetcher.ts
@@ -17,6 +17,7 @@ type SubscriptionIteratorPayload = {
 export default function createActionCableFetcher(options: ActionCableFetcherOptions) {
   let currentChannel: Subscription | null = null
   const consumer = options.consumer
+  const url = options.url
 
   const subscriptionFetcher = async function*(graphqlParams: any, fetcherOpts: any) {
     let isSubscription = false;
@@ -75,7 +76,7 @@ export default function createActionCableFetcher(options: ActionCableFetcherOpti
     } else {
       const fetchFn = options.fetch || window.fetch
       // Not a subscription fetcher, post to the given URL
-      yield fetchFn("/graphql", {
+      yield fetchFn(url, {
         method: "POST",
         body: JSON.stringify({
           query: graphqlParams.query,

--- a/javascript_client/src/subscriptions/createActionCableFetcher.ts
+++ b/javascript_client/src/subscriptions/createActionCableFetcher.ts
@@ -5,6 +5,7 @@ import type { Consumer, Subscription } from "@rails/actioncable"
 type ActionCableFetcherOptions = {
   consumer: Consumer,
   url: string,
+  channelName = "GraphqlChannel"
   fetch?: typeof fetch,
   fetchOptions?: any,
 }
@@ -18,6 +19,7 @@ export default function createActionCableFetcher(options: ActionCableFetcherOpti
   let currentChannel: Subscription | null = null
   const consumer = options.consumer
   const url = options.url
+  const channelName = options.channelName
 
   const subscriptionFetcher = async function*(graphqlParams: any, fetcherOpts: any) {
     let isSubscription = false;
@@ -33,7 +35,7 @@ export default function createActionCableFetcher(options: ActionCableFetcherOpti
 
     if (isSubscription) {
       currentChannel?.unsubscribe()
-      currentChannel = consumer.subscriptions.create("GraphqlChannel",
+      currentChannel = consumer.subscriptions.create(channelName,
         {
           connected: function() {
             currentChannel?.perform("execute", {

--- a/javascript_client/src/subscriptions/createActionCableFetcher.ts
+++ b/javascript_client/src/subscriptions/createActionCableFetcher.ts
@@ -5,7 +5,7 @@ import type { Consumer, Subscription } from "@rails/actioncable"
 type ActionCableFetcherOptions = {
   consumer: Consumer,
   url: string,
-  channelName = "GraphqlChannel"
+  channelName?: string,
   fetch?: typeof fetch,
   fetchOptions?: any,
 }
@@ -18,8 +18,8 @@ type SubscriptionIteratorPayload = {
 export default function createActionCableFetcher(options: ActionCableFetcherOptions) {
   let currentChannel: Subscription | null = null
   const consumer = options.consumer
-  const url = options.url
-  const channelName = options.channelName
+  const url = options.url || "/graphql"
+  const channelName = options.channelName || "GraphqlChannel"
 
   const subscriptionFetcher = async function*(graphqlParams: any, fetcherOpts: any) {
     let isSubscription = false;

--- a/javascript_client/src/subscriptions/createActionCableFetcher.ts
+++ b/javascript_client/src/subscriptions/createActionCableFetcher.ts
@@ -4,7 +4,7 @@ import type { Consumer, Subscription } from "@rails/actioncable"
 
 type ActionCableFetcherOptions = {
   consumer: Consumer,
-  url: String,
+  url: string,
   fetch?: typeof fetch,
   fetchOptions?: any,
 }


### PR DESCRIPTION
## Proposed Changes
- Fix Typescript type for `url`
- Use supplied `url` instead of static "/graphql" path
- Support overloading channel name. For example, our channel is "GraphQLChannel" instead of "GraphqlChannel"