### PR TITLE
Use `all?` to check types directly

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -513,7 +513,7 @@ module GraphQL
             end
           when Array
             # It's an array full of execution errors; add them all.
-            if value.any? && value.all? { |v| v.is_a?(GraphQL::ExecutionError) }
+            if value.any? && value.all?(GraphQL::ExecutionError)
               list_type_at_all = (field && (field.type.list?))
               if selection_result.nil? || !dead_result?(selection_result)
                 value.each_with_index do |error, index|


### PR DESCRIPTION
Originally proposed in #4507 , but we don't have a Ruby 2.4 CI job anymore so it should be mergeable.