### PR TITLE
Fix enum values named type

### DIFF
--- a/lib/graphql/language/parser.rb
+++ b/lib/graphql/language/parser.rb
@@ -333,7 +333,7 @@ module GraphQL
             v_loc = pos
             description = if at?(:STRING); string_value; end
             defn_loc = pos
-            enum_value = expect_token_value(:IDENTIFIER)
+            enum_value = parse_enum_name
             v_directives = parse_directives
             list << EnumValueDefinition.new(pos: v_loc, definition_pos: defn_loc, description: description, name: enum_value, directives: v_directives, filename: @filename, source_string: @graphql_str)
           end

--- a/spec/graphql/language/parser_spec.rb
+++ b/spec/graphql/language/parser_spec.rb
@@ -132,6 +132,7 @@ describe GraphQL::Language::Parser do
         enum Thing {
           "VALUE description"
           VALUE
+          type
         }
       GRAPHQL
 
@@ -142,6 +143,10 @@ describe GraphQL::Language::Parser do
       value_defn = thing_defn.values[0]
       assert_equal "VALUE", value_defn.name
       assert_equal "VALUE description", value_defn.description
+
+      value_defn = thing_defn.values[1]
+      assert_equal "type", value_defn.name
+      assert_nil value_defn.description
     end
 
     it "is parsed for directive definitions" do


### PR DESCRIPTION
Oops, there _was_ a method to parse enum names, but this code wasn't using it.

Fixes #4770 