### PR TITLE
docs: fix example given for GraphQL::Schema::Enum

### DIFF
--- a/lib/graphql/schema/enum.rb
+++ b/lib/graphql/schema/enum.rb
@@ -14,7 +14,7 @@ module GraphQL
     #   #   ONIONS
     #   #   PEPPERS
     #   # }
-    #   class PizzaTopping < GraphQL::Enum
+    #   class PizzaTopping < GraphQL::Schema::Enum
     #     value :MUSHROOMS
     #     value :ONIONS
     #     value :PEPPERS


### PR DESCRIPTION
The example inherited from `GraphQL::Enum` - a constant that doesn't exist. 
Update the example to inherit from `GraphQL::Schema::Enum` instead.