### PR TITLE
Fix hasNextPage when max_page_size is set

### DIFF
--- a/lib/graphql/pagination/array_connection.rb
+++ b/lib/graphql/pagination/array_connection.rb
@@ -35,10 +35,10 @@ module GraphQL
       def load_nodes
         @nodes ||= begin
           sliced_nodes = if before && after
-            end_idx = index_from_cursor(before)-1
+            end_idx = index_from_cursor(before) - 2
             end_idx < 0 ? [] : items[index_from_cursor(after)..end_idx] || []
           elsif before
-            end_idx = index_from_cursor(before)-2
+            end_idx = index_from_cursor(before) - 2
             end_idx < 0 ? [] : items[0..end_idx] || []
           elsif after
             items[index_from_cursor(after)..-1] || []
@@ -56,7 +56,7 @@ module GraphQL
             false
           end
 
-          @has_next_page = if first
+          @has_next_page = if first_value && first
             # There are more items after these items
             sliced_nodes.count > first
           elsif before

--- a/lib/graphql/pagination/relation_connection.rb
+++ b/lib/graphql/pagination/relation_connection.rb
@@ -31,7 +31,7 @@ module GraphQL
         if @has_next_page.nil?
           @has_next_page = if before_offset && before_offset > 0
             true
-          elsif first
+          elsif first && first_value
             if @nodes && @nodes.count < first
               false
             else

--- a/lib/graphql/pagination/relation_connection.rb
+++ b/lib/graphql/pagination/relation_connection.rb
@@ -29,14 +29,14 @@ module GraphQL
 
       def has_next_page
         if @has_next_page.nil?
-          @has_next_page = if before_offset && before_offset > 0
-            true
-          elsif first && first_value
+          @has_next_page = if first && first_value
             if @nodes && @nodes.count < first
               false
             else
               relation_larger_than(sliced_nodes, @sliced_nodes_offset, first)
             end
+          elsif before_offset && before_offset > 0
+            true
           else
             false
           end

--- a/spec/integration/mongoid/graphql/relay/mongo_relation_connection_spec.rb
+++ b/spec/integration/mongoid/graphql/relay/mongo_relation_connection_spec.rb
@@ -238,7 +238,7 @@ describe "GraphQL::Relay::MongoRelationConnection" do
         # Max page size is applied _without_ `first`, also
         result = star_trek_query(query_string)
         assert_equal(2, result["data"]["federation"]["bases"]["edges"].size)
-        assert_equal(true, result["data"]["federation"]["bases"]["pageInfo"]["hasNextPage"], "hasNextPage is true when first is not specified")
+        assert_equal(false, result["data"]["federation"]["bases"]["pageInfo"]["hasNextPage"], "hasNextPage is false when first is not specified")
       end
 
       it "applies to queries by `last`" do
@@ -297,7 +297,7 @@ describe "GraphQL::Relay::MongoRelationConnection" do
         # Max page size is applied _without_ `first`, also
         result = star_trek_query(query_string)
         assert_equal(3, result["data"]["federation"]["bases"]["edges"].size)
-        assert_equal(true, result["data"]["federation"]["bases"]["pageInfo"]["hasNextPage"], "hasNextPage is true when first is not specified")
+        assert_equal(false, result["data"]["federation"]["bases"]["pageInfo"]["hasNextPage"], "hasNextPage is false when first is not specified")
       end
 
       it "applies to queries by `last`" do

--- a/spec/integration/rails/graphql/relay/array_connection_spec.rb
+++ b/spec/integration/rails/graphql/relay/array_connection_spec.rb
@@ -108,12 +108,11 @@ describe "GraphQL::Relay::ArrayConnection" do
       result = star_wars_query(query_string, { "after" => first_cursor, "first" => 2 })
       assert_equal(["Y-Wing", "A-Wing"], get_names(result))
 
-      # After the last result, find the next 2:
-      second_cursor = get_last_cursor(result)
+      third_cursor = get_last_cursor(result)
 
-      # There is only 2 results between the cursors
-      result = star_wars_query(query_string, { "after" => first_cursor, "before" => second_cursor, "first" => 5 })
-      assert_equal(["Y-Wing", "A-Wing"], get_names(result))
+      # There is only 1 result between the cursors
+      result = star_wars_query(query_string, { "after" => first_cursor, "before" => third_cursor, "first" => 5 })
+      assert_equal(["Y-Wing"], get_names(result))
     end
 
     it 'handles cursors beyond the bounds of the array' do
@@ -175,7 +174,7 @@ describe "GraphQL::Relay::ArrayConnection" do
         # Max page size is applied _without_ `first`, also
         result = star_wars_query(query_string)
         assert_equal(["Yavin", "Echo Base"], get_names(result))
-        assert_equal(true, get_page_info(result)["hasNextPage"], "hasNextPage is true when first is not specified")
+        assert_equal(false, get_page_info(result)["hasNextPage"], "hasNextPage is false when first is not specified")
       end
 
       it "applies to queries by `last`" do
@@ -235,7 +234,7 @@ describe "GraphQL::Relay::ArrayConnection" do
         # Max page size is applied _without_ `first`, also
         result = star_wars_query(query_string)
         assert_equal(["Yavin", "Echo Base", "Secret Hideout"], get_names(result))
-        assert_equal(true, get_page_info(result)["hasNextPage"], "hasNextPage is true when first is not specified")
+        assert_equal(false, get_page_info(result)["hasNextPage"], "hasNextPage is false when first is not specified")
       end
 
       it "applies to queries by `last`" do

--- a/spec/integration/rails/graphql/relay/relation_connection_spec.rb
+++ b/spec/integration/rails/graphql/relay/relation_connection_spec.rb
@@ -287,7 +287,7 @@ describe "GraphQL::Relay::RelationConnection" do
         # Max page size is applied _without_ `first`, also
         result = star_wars_query(query_string)
         assert_equal(2, result["data"]["empire"]["bases"]["edges"].size)
-        assert_equal(true, result["data"]["empire"]["bases"]["pageInfo"]["hasNextPage"], "hasNextPage is true when first is not specified")
+        assert_equal(false, result["data"]["empire"]["bases"]["pageInfo"]["hasNextPage"], "hasNextPage is false when first is not specified")
       end
 
       it "applies to queries by `last`" do
@@ -346,7 +346,7 @@ describe "GraphQL::Relay::RelationConnection" do
         # Max page size is applied _without_ `first`, also
         result = star_wars_query(query_string)
         assert_equal(3, result["data"]["empire"]["bases"]["edges"].size)
-        assert_equal(true, result["data"]["empire"]["bases"]["pageInfo"]["hasNextPage"], "hasNextPage is true when first is not specified")
+        assert_equal(false, result["data"]["empire"]["bases"]["pageInfo"]["hasNextPage"], "hasNextPage is false when first is not specified")
       end
 
       it "applies to queries by `last`" do

--- a/spec/support/connection_assertions.rb
+++ b/spec/support/connection_assertions.rb
@@ -253,6 +253,11 @@ module ConnectionAssertions
           assert_equal true, get_page_info(res, "hasNextPage")
           assert_equal true, get_page_info(res, "hasPreviousPage")
           assert_names [], res
+
+          res = exec_query(query_str, after: after_cursor, before: before_cursor, first: 3)
+          assert_equal false, get_page_info(res, "hasNextPage")
+          assert_equal true, get_page_info(res, "hasPreviousPage")
+          assert_names [], res
         end
 
         it "handles out-of-bounds cursors" do

--- a/spec/support/connection_assertions.rb
+++ b/spec/support/connection_assertions.rb
@@ -243,6 +243,18 @@ module ConnectionAssertions
           refute get_page_info(res3, "hasPreviousPage")
         end
 
+        it "returns empty lists for `after: 1` and `before: 2`" do
+          res = exec_query(query_str, first: 2)
+          assert_names(["Avocado", "Beet"], res)
+          after_cursor = get_page_info(res, "startCursor")
+          before_cursor = get_page_info(res, "endCursor")
+
+          res = exec_query(query_str, after: after_cursor, before: before_cursor)
+          assert_equal true, get_page_info(res, "hasNextPage")
+          assert_equal true, get_page_info(res, "hasPreviousPage")
+          assert_names [], res
+        end
+
         it "handles out-of-bounds cursors" do
           # It treats negative cursors like zero
           bogus_negative_cursor = NonceEnabledEncoder.encode("-10")
@@ -300,7 +312,7 @@ module ConnectionAssertions
           res = exec_query(query_str, {})
           # Neither first nor last was provided, so default_page_size was applied.
           assert_names(["Avocado", "Beet", "Cucumber", "Dill"], res)
-          assert_equal true, get_page_info(res, "hasNextPage")
+          assert_equal false, get_page_info(res, "hasNextPage")
           assert_equal false, get_page_info(res, "hasPreviousPage")
         end
 


### PR DESCRIPTION
About hasNextPage, the relay spec says: 

> [HasNextPage](https://relay.dev/graphql/connections.htm#HasNextPage())(allEdges, before, after, first, last)
> 
>     If first is set:
>         Let edges be the result of calling [ApplyCursorsToEdges](https://relay.dev/graphql/connections.htm#ApplyCursorsToEdges())(allEdges, before, after).
>         If edges contains more than first elements return true, otherwise false.
>     If before is set:
>         If the server can efficiently determine that elements exist following before, return true.
>     Return false.

But GraphQL-Ruby's `max_page_size` was causing it to take the "if first is set..." branch even when the client didn't provide `first`. 

After this change, it will fall down to the "Return false" branch of that spec unless `first` is explicitly provided by the client.

Fixes #4765