### PR TITLE
Unsubscribe from ActionCable on link cleanup

### DIFF
--- a/javascript_client/src/subscriptions/ActionCableLink.ts
+++ b/javascript_client/src/subscriptions/ActionCableLink.ts
@@ -55,8 +55,11 @@ class ActionCableLink extends ApolloLink {
           }
         }
       })
-      // Make the ActionCable subscription behave like an Apollo subscription
-      return Object.assign(channel, {closed: false})
+
+      // The Observable should return a cleanup function
+      return () => {
+        channel.unsubscribe()
+      }
     })
   }
 }


### PR DESCRIPTION
An `Observable` should return a cleanup function.

We should return a function to unsubscribe, rather than return an object which isn't callable.