### PR TITLE
Backport datadog `span_type` change  to 2.0.x

### DIFF
--- a/guides/queries/tracing.md
+++ b/guides/queries/tracing.md
@@ -148,15 +148,9 @@ To add [Datadog](https://www.datadoghq.com) instrumentation:
 
 ```ruby
 class MySchema < GraphQL::Schema
-  use(GraphQL::Tracing::DataDogTracing, options)
+  use(GraphQL::Tracing::DataDogTracing)
 end
 ```
-
-You may provide `options` as a `Hash` with the following values:
-
-| Key | Description | Default |
-| --- | ----------- | ------- |
-| `tracer` | Tracer used to perform instrumentation. Usually you don't need to set this. | `Datadog::Tracing` |
 
 For more details about Datadog's tracing API, check out the [Ruby documentation](https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md) or the [APM documentation](https://docs.datadoghq.com/tracing/) for more product information.
 

--- a/guides/queries/tracing.md
+++ b/guides/queries/tracing.md
@@ -156,8 +156,7 @@ You may provide `options` as a `Hash` with the following values:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
-| `service` | Service name used for `graphql` instrumentation | `'ruby-graphql'` |
-| `tracer` | `Datadog::Tracer` used to perform instrumentation. Usually you don't need to set this. | `Datadog.tracer` |
+| `tracer` | Tracer used to perform instrumentation. Usually you don't need to set this. | `Datadog::Tracing` |
 
 For more details about Datadog's tracing API, check out the [Ruby documentation](https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md) or the [APM documentation](https://docs.datadoghq.com/tracing/) for more product information.
 

--- a/lib/graphql/tracing/data_dog_trace.rb
+++ b/lib/graphql/tracing/data_dog_trace.rb
@@ -34,8 +34,7 @@ module GraphQL
       }.each do |trace_method, trace_key|
         module_eval <<-RUBY, __FILE__, __LINE__
           def #{trace_method}(**data)
-            @tracer.trace("#{trace_key}", service: @service_name) do |span|
-              span.span_type = 'custom'
+            @tracer.trace("#{trace_key}", service: @service_name, type: 'custom') do |span|
               if defined?(Datadog::Tracing::Metadata::Ext) # Introduced in ddtrace 1.0
                 span.set_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT, 'graphql')
                 span.set_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION, '#{trace_method}')
@@ -89,8 +88,7 @@ module GraphQL
           nil
         end
         if platform_key && trace_field
-          @tracer.trace(platform_key, service: @service_name) do |span|
-            span.span_type = 'custom'
+          @tracer.trace(platform_key, service: @service_name, type: 'custom') do |span|
             if defined?(Datadog::Tracing::Metadata::Ext) # Introduced in ddtrace 1.0
               span.set_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT, 'graphql')
               span.set_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION, span_key)
@@ -125,8 +123,7 @@ module GraphQL
 
       def authorized_span(span_key, object, type, query)
         platform_key = @platform_key_cache[DataDogTrace].platform_authorized_key_cache[type]
-        @tracer.trace(platform_key, service: @service_name) do |span|
-          span.span_type = 'custom'
+        @tracer.trace(platform_key, service: @service_name, type: 'custom') do |span|
           if defined?(Datadog::Tracing::Metadata::Ext) # Introduced in ddtrace 1.0
             span.set_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT, 'graphql')
             span.set_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION, span_key)
@@ -158,8 +155,7 @@ module GraphQL
 
       def resolve_type_span(span_key, object, type, query)
         platform_key = @platform_key_cache[DataDogTrace].platform_resolve_type_key_cache[type]
-        @tracer.trace(platform_key, service: @service_name) do |span|
-          span.span_type = 'custom'
+        @tracer.trace(platform_key, service: @service_name, type: 'custom') do |span|
           if defined?(Datadog::Tracing::Metadata::Ext) # Introduced in ddtrace 1.0
             span.set_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT, 'graphql')
             span.set_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION, span_key)

--- a/lib/graphql/tracing/data_dog_trace.rb
+++ b/lib/graphql/tracing/data_dog_trace.rb
@@ -5,18 +5,15 @@ module GraphQL
     module DataDogTrace
       # @param analytics_enabled [Boolean] Deprecated
       # @param analytics_sample_rate [Float] Deprecated
-      def initialize(tracer: nil, analytics_enabled: false, analytics_sample_rate: 1.0, service: "ruby-graphql", **rest)
+      def initialize(tracer: nil, analytics_enabled: false, analytics_sample_rate: 1.0, service: nil, **rest)
         if tracer.nil?
           tracer = defined?(Datadog::Tracing) ? Datadog::Tracing : Datadog.tracer
         end
         @tracer = tracer
 
-        analytics_available = defined?(Datadog::Contrib::Analytics) \
-            && Datadog::Contrib::Analytics.respond_to?(:enabled?) \
-            && Datadog::Contrib::Analytics.respond_to?(:set_sample_rate)
-
-        @analytics_enabled = analytics_available && Datadog::Contrib::Analytics.enabled?(analytics_enabled)
+        @analytics_enabled = analytics_enabled
         @analytics_sample_rate = analytics_sample_rate
+
         @service_name = service
         @has_prepare_span = respond_to?(:prepare_span)
         super
@@ -35,10 +32,8 @@ module GraphQL
         module_eval <<-RUBY, __FILE__, __LINE__
           def #{trace_method}(**data)
             @tracer.trace("#{trace_key}", service: @service_name, type: 'custom') do |span|
-              if defined?(Datadog::Tracing::Metadata::Ext) # Introduced in ddtrace 1.0
-                span.set_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT, 'graphql')
-                span.set_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION, '#{trace_method}')
-              end
+                span.set_tag('component', 'graphql')
+                span.set_tag('operation', '#{trace_method}')
 
               #{
                 if trace_method == 'execute_multiplex'
@@ -53,10 +48,8 @@ module GraphQL
                   end
                   span.resource = resource if resource
 
-                  # For top span of query, set the analytics sample rate tag, if available.
-                  if @analytics_enabled
-                    Datadog::Contrib::Analytics.set_sample_rate(span, @analytics_sample_rate)
-                  end
+                  # [Deprecated] will be removed in the future
+                  span.set_metric('_dd1.sr.eausr', @analytics_sample_rate) if @analytics_enabled
                   RUBY
                 elsif trace_method == 'execute_query'
                   <<-RUBY
@@ -89,10 +82,9 @@ module GraphQL
         end
         if platform_key && trace_field
           @tracer.trace(platform_key, service: @service_name, type: 'custom') do |span|
-            if defined?(Datadog::Tracing::Metadata::Ext) # Introduced in ddtrace 1.0
-              span.set_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT, 'graphql')
-              span.set_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION, span_key)
-            end
+            span.set_tag('component', 'graphql')
+            span.set_tag('operation', span_key)
+
             if @has_prepare_span
               prepare_span_data = { query: query, field: field, ast_node: ast_node, arguments: arguments, object: object }
               prepare_span(span_key, prepare_span_data, span)
@@ -124,10 +116,9 @@ module GraphQL
       def authorized_span(span_key, object, type, query)
         platform_key = @platform_key_cache[DataDogTrace].platform_authorized_key_cache[type]
         @tracer.trace(platform_key, service: @service_name, type: 'custom') do |span|
-          if defined?(Datadog::Tracing::Metadata::Ext) # Introduced in ddtrace 1.0
-            span.set_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT, 'graphql')
-            span.set_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION, span_key)
-          end
+          span.set_tag('component', 'graphql')
+          span.set_tag('operation', span_key)
+
           if @has_prepare_span
             prepare_span(span_key, {object: object, type: type, query: query}, span)
           end
@@ -156,10 +147,9 @@ module GraphQL
       def resolve_type_span(span_key, object, type, query)
         platform_key = @platform_key_cache[DataDogTrace].platform_resolve_type_key_cache[type]
         @tracer.trace(platform_key, service: @service_name, type: 'custom') do |span|
-          if defined?(Datadog::Tracing::Metadata::Ext) # Introduced in ddtrace 1.0
-            span.set_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT, 'graphql')
-            span.set_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION, span_key)
-          end
+          span.set_tag('component', 'graphql')
+          span.set_tag('operation', span_key)
+
           if @has_prepare_span
             prepare_span(span_key, {object: object, type: type, query: query}, span)
           end

--- a/lib/graphql/tracing/data_dog_trace.rb
+++ b/lib/graphql/tracing/data_dog_trace.rb
@@ -3,6 +3,7 @@
 module GraphQL
   module Tracing
     module DataDogTrace
+      # @param tracer [#trace] Deprecated
       # @param analytics_enabled [Boolean] Deprecated
       # @param analytics_sample_rate [Float] Deprecated
       def initialize(tracer: nil, analytics_enabled: false, analytics_sample_rate: 1.0, service: nil, **rest)

--- a/lib/graphql/tracing/data_dog_tracing.rb
+++ b/lib/graphql/tracing/data_dog_tracing.rb
@@ -56,6 +56,7 @@ module GraphQL
       def tracer
         default_tracer = defined?(Datadog::Tracing) ? Datadog::Tracing : Datadog.tracer
 
+        # [Deprecated] options[:tracer] will be removed in the future
         options.fetch(:tracer, default_tracer)
       end
 

--- a/lib/graphql/tracing/data_dog_tracing.rb
+++ b/lib/graphql/tracing/data_dog_tracing.rb
@@ -15,11 +15,9 @@ module GraphQL
       }
 
       def platform_trace(platform_key, key, data)
-        tracer.trace(platform_key, service: service_name, type: 'custom') do |span|
-          if defined?(Datadog::Tracing::Metadata::Ext) # Introduced in ddtrace 1.0
-            span.set_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT, 'graphql')
-            span.set_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION, key)
-          end
+        tracer.trace(platform_key, service: options[:service], type: 'custom') do |span|
+          span.set_tag('component', 'graphql')
+          span.set_tag('operation', key)
 
           if key == 'execute_multiplex'
             operations = data[:multiplex].queries.map(&:selected_operation_name).join(', ')
@@ -32,10 +30,8 @@ module GraphQL
             end
             span.resource = resource if resource
 
-            # For top span of query, set the analytics sample rate tag, if available.
-            if analytics_enabled?
-              Datadog::Contrib::Analytics.set_sample_rate(span, analytics_sample_rate)
-            end
+            # [Deprecated] will be removed in the future
+            span.set_metric('_dd1.sr.eausr', analytics_sample_rate) if analytics_enabled?
           end
 
           if key == 'execute_query'
@@ -48,10 +44,6 @@ module GraphQL
 
           yield
         end
-      end
-
-      def service_name
-        options.fetch(:service, 'ruby-graphql')
       end
 
       # Implement this method in a subclass to apply custom tags to datadog spans
@@ -67,15 +59,9 @@ module GraphQL
         options.fetch(:tracer, default_tracer)
       end
 
-      def analytics_available?
-        defined?(Datadog::Contrib::Analytics) \
-          && Datadog::Contrib::Analytics.respond_to?(:enabled?) \
-          && Datadog::Contrib::Analytics.respond_to?(:set_sample_rate)
-      end
-
       def analytics_enabled?
         # [Deprecated] options[:analytics_enabled] will be removed in the future
-        analytics_available? && Datadog::Contrib::Analytics.enabled?(options.fetch(:analytics_enabled, false))
+        options.fetch(:analytics_enabled, false)
       end
 
       def analytics_sample_rate

--- a/lib/graphql/tracing/data_dog_tracing.rb
+++ b/lib/graphql/tracing/data_dog_tracing.rb
@@ -15,8 +15,7 @@ module GraphQL
       }
 
       def platform_trace(platform_key, key, data)
-        tracer.trace(platform_key, service: service_name) do |span|
-          span.span_type = 'custom'
+        tracer.trace(platform_key, service: service_name, type: 'custom') do |span|
           if defined?(Datadog::Tracing::Metadata::Ext) # Introduced in ddtrace 1.0
             span.set_tag(Datadog::Tracing::Metadata::Ext::TAG_COMPONENT, 'graphql')
             span.set_tag(Datadog::Tracing::Metadata::Ext::TAG_OPERATION, key)

--- a/spec/support/datadog.rb
+++ b/spec/support/datadog.rb
@@ -41,7 +41,6 @@ module Datadog
       SPAN_RESOURCE_NAMES << resource_name
     end
 
-    def span_type=(*args)end
     def set_tag(key, value)
       SPAN_TAGS << [key, value]
     end

--- a/spec/support/datadog.rb
+++ b/spec/support/datadog.rb
@@ -17,19 +17,6 @@ module Datadog
     SPAN_TAGS.clear
   end
 
-
-  module Contrib
-    module Analytics
-      def self.set_sample_rate(rate)
-        rate
-      end
-
-      def self.enabled?(_bool)
-        nil
-      end
-    end
-  end
-
   class DummyTracer
     def trace(platform_key, *args)
       yield DummySpan.new
@@ -49,13 +36,6 @@ module Datadog
   module Tracing
     def self.trace(platform_key, *args)
       yield DummySpan.new
-    end
-
-    module Metadata
-      module Ext
-        TAG_COMPONENT = 'component'
-        TAG_OPERATION = 'operation'
-      end
     end
   end
 end


### PR DESCRIPTION
Backport changes from: https://github.com/rmosolgo/graphql-ruby/pull/4776