### PR TITLE
ActionCable: don't use send action

### DIFF
--- a/javascript_client/src/subscriptions/__tests__/createActionCableHandlerTest.ts
+++ b/javascript_client/src/subscriptions/__tests__/createActionCableHandlerTest.ts
@@ -51,14 +51,16 @@ describe("createActionCableHandler", () => {
       {text: "", name: "", id: "abcdef"},
       {},
       {},
-      { onError: () => {}, onNext: () => {}, onCompleted: () => {} }
+      { onError: () => {}, onNext: (result: any) => { log.push(["onNext", result])}, onCompleted: () => { log.push(["onCompleted", null])} }
     )
 
     handlers.connected() // trigger the GraphQL send
+    handlers.received({ result: { data: { a: "1" } }, more: false })
 
     expect(log).toEqual([
-      ["send", { operationId: "client-1/abcdef", operationName: "", query: "", variables: {} }],
       ["execute", { operationId: "client-1/abcdef", operationName: "", query: "", variables: {} }],
+      ["onNext", { data: { a: "1" } }],
+      ["onCompleted", null],
     ])
   })
 })

--- a/javascript_client/src/subscriptions/createActionCableHandler.ts
+++ b/javascript_client/src/subscriptions/createActionCableHandler.ts
@@ -44,7 +44,6 @@ function createActionCableHandler(options: ActionCableHandlerOptions) {
             operationId: (operation.id && options.clientName ? (options.clientName + "/" + operation.id) : null),
           }
         }
-        channel.perform('send', channelParams)
         channel.perform("execute", channelParams)
       },
       // This result is sent back from ActionCable.


### PR DESCRIPTION
Oops -- somehow this entered back in https://github.com/rmosolgo/graphql-ruby/commit/cf0a3fe12f54e1ce3b3e3ae87fa78d8ee111f655#diff-9957e220f3cd45075c8bd11a71aa74970869a76e46eaff6007685295c806c6fdR45, but I don't think it should be there. 

Fixes #4792 