### PR TITLE
Fix typos in DataLoader testing doc + add source example

### DIFF
--- a/guides/dataloader/testing.md
+++ b/guides/dataloader/testing.md
@@ -43,7 +43,26 @@ You could also make specific assertions on the queries that are run (see the [`s
 
 ## Testing Dataloader Sources
 
-You can also test `Dataloader` behavior outside of GraphQL using {{ "GraphQL::Dataloader.with_dataloading" | api_doc }}. For example:
+You can also test `Dataloader` behavior outside of GraphQL using {{ "GraphQL::Dataloader.with_dataloading" | api_doc }}. For example, let's assuming have a `Sources::ActiveRecord` defined like so: 
+
+```ruby
+
+module Sources
+  class ActiveRecord < GraphQL::Dataloader::Source
+    def initialize(model_class)
+      @model_class = model_class
+    end
+
+    def fetch(ids)
+      records = @model_class.where(id: ids)
+      # return a list with `nil` for any ID that wasn't found, so the shape matches
+      ids.map { |id| records.find { |r| r.id == id.to_i } }
+    end
+  end
+end
+```
+
+You can test it like so: 
 
 ```ruby
 def test_it_fetches_objects_by_id
@@ -60,10 +79,10 @@ def test_it_fetches_objects_by_id
       req4 = dataloader.with(Sources::ActiveRecord).request(-1)
 
       # Validate source's matching up of records
-      expect(req1.load).to eq(user_1)
-      expect(req2.load).to eq(user_2)
-      expect(req3.load).to eq(user_3)
-      expect(req4.load).to be_nil
+      expect(req1).to eq(user_1)
+      expect(req2).to eq(user_2)
+      expect(req3).to eq(user_3)
+      expect(req4).to be_nil
     end
   end
 

--- a/guides/dataloader/testing.md
+++ b/guides/dataloader/testing.md
@@ -43,18 +43,14 @@ You could also make specific assertions on the queries that are run (see the [`s
 
 ## Testing Dataloader Sources
 
-You can also test `Dataloader` behavior outside of GraphQL using {{ "GraphQL::Dataloader.with_dataloading" | api_doc }}. For example, let's if you have a `Sources::ActiveRecord` source defined like so: 
+You can also test `Dataloader` behavior outside of GraphQL using {{ "GraphQL::Dataloader.with_dataloading" | api_doc }}. For example, let's if you have a `Sources::ActiveRecord` source defined like so:
 
 ```ruby
 
 module Sources
-  class ActiveRecord < GraphQL::Dataloader::Source
-    def initialize(model_class)
-      @model_class = model_class
-    end
-
+  class User < GraphQL::Dataloader::Source
     def fetch(ids)
-      records = @model_class.where(id: ids)
+      records = User.where(id: ids)
       # return a list with `nil` for any ID that wasn't found, so the shape matches
       ids.map { |id| records.find { |r| r.id == id.to_i } }
     end
@@ -62,7 +58,7 @@ module Sources
 end
 ```
 
-You can test it like so: 
+You can test it like so:
 
 ```ruby
 def test_it_fetches_objects_by_id
@@ -74,8 +70,8 @@ def test_it_fetches_objects_by_id
   ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
     GraphQL::Dataloader.with_dataloading do |dataloader|
       req1 = dataloader.with(Sources::ActiveRecord).request(user_1.id)
-      req2 = dataloader.with(Sources::ActiveRecord).request(user_3.id)
-      req3 = dataloader.with(Sources::ActiveRecord).request(user_2.id)
+      req2 = dataloader.with(Sources::ActiveRecord).request(user_2.id)
+      req3 = dataloader.with(Sources::ActiveRecord).request(user_3.id)
       req4 = dataloader.with(Sources::ActiveRecord).request(-1)
 
       # Validate source's matching up of records

--- a/guides/dataloader/testing.md
+++ b/guides/dataloader/testing.md
@@ -43,7 +43,7 @@ You could also make specific assertions on the queries that are run (see the [`s
 
 ## Testing Dataloader Sources
 
-You can also test `Dataloader` behavior outside of GraphQL using {{ "GraphQL::Dataloader.with_dataloading" | api_doc }}. For example, let's assuming have a `Sources::ActiveRecord` defined like so: 
+You can also test `Dataloader` behavior outside of GraphQL using {{ "GraphQL::Dataloader.with_dataloading" | api_doc }}. For example, let's if you have a `Sources::ActiveRecord` source defined like so: 
 
 ```ruby
 

--- a/guides/dataloader/testing.md
+++ b/guides/dataloader/testing.md
@@ -61,8 +61,8 @@ def test_it_fetches_objects_by_id
 
       # Validate source's matching up of records
       expect(req1.load).to eq(user_1)
-      expect(req2.load).to eq(user_3)
-      expect(req3.load).to eq(user_2)
+      expect(req2.load).to eq(user_2)
+      expect(req3.load).to eq(user_3)
       expect(req4.load).to be_nil
     end
   end


### PR DESCRIPTION
## Proposed changes:
- Fix typo with numbers of records
- Remove `load` method since the dataloader returns a record, at least according to the example here: https://graphql-ruby.org/dataloader/sources.html#example-loading-activerecord-objects-by-id.  I included that implementation in the example for reference.