### PR TITLE
[FIX] Update active_record_backend.md to have migration in correct order

### DIFF
--- a/guides/operation_store/active_record_backend.md
+++ b/guides/operation_store/active_record_backend.md
@@ -33,6 +33,14 @@ def change
   add_index :graphql_clients, :name, unique: true
   add_index :graphql_clients, :secret, unique: true
 
+  create_table :graphql_operations, primary_key: :id do |t|
+    t.column :digest, :string, null: false
+    t.column :body, :text, null: false
+    t.column :name, :string, null: false
+    t.timestamps
+  end
+  add_index :graphql_operations, :digest, unique: true
+
   create_table :graphql_client_operations, primary_key: :id do |t|
     t.references :graphql_client, null: false
     t.references :graphql_operation, null: false
@@ -43,14 +51,6 @@ def change
   end
   add_index :graphql_client_operations, [:graphql_client_id, :alias], unique: true, name: "graphql_client_operations_pairs"
   add_index :graphql_client_operations, :is_archived
-
-  create_table :graphql_operations, primary_key: :id do |t|
-    t.column :digest, :string, null: false
-    t.column :body, :text, null: false
-    t.column :name, :string, null: false
-    t.timestamps
-  end
-  add_index :graphql_operations, :digest, unique: true
 
   create_table :graphql_index_entries, primary_key: :id do |t|
     t.column :name, :string, null: false


### PR DESCRIPTION
The order of operations was wrong in the migration


```
Caused by:
ActiveRecord::StatementInvalid: PG::UndefinedTable: ERROR:  relation "graphql_operations" does not exist /usr/local/bundle/gems/activerecord-7.0.3.1/lib/active_record/connection_adapters/postgresql/database_statements.rb:48:in `exec' /usr/local/bundle/gems/activerecord-7.0.3.1/lib/active_record/connection_adapters/postgresql/database_statements.rb:48:in `block (2 levels) in execute' /usr/local/bundle/gems/activesupport-7.0.3.1/lib/active_support/concurrency/share_lock.rb:187:in `yield_shares' /usr/local/bundle/gems/activesupport-7.0.3.1/lib/active_support/dependencies/interlock.rb:41:in `permit_concurrent_loads' /usr/local/bundle/gems/activerecord-7.0.3.1/lib/active_record/connection_adapters/postgresql/database_statements.rb:47:in `block in execute' /usr/local/bundle/gems/activesupport-7.0.3.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt' /usr/local/bundle/gems/activesupport-7.0.3.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize' /usr/local/bundle/gems/activesupport-7.0.3.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt' /usr/local/bundle/gems/activesupport-7.0.3.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize' /usr/local/bundle/gems/activerecord-7.0.3.1/lib/active_record/connection_adapters/abstract_adapter.rb:765:in `block in log' /usr/local/bundle/gems/activesupport-7.0.3.1/lib/active_support/notifications/instrumenter.rb:24:in `instrument' /usr/local/bundle/gems/activerecord-7.0.3.1/lib/active_record/connection_adapters/abstract_adapter.rb:756:in `log' /app/config/initializers/multidb_span_logger.rb:14:in `log' /usr/local/bundle/gems/activerecord-7.0.3.1/lib/active_record/connection_adapters/postgresql/database_statements.rb:46:in `execute' /usr/local/bundle/gems/activerecord-7.0.3.1/lib/active_record/connection_adapters/abstract/schema_statements.rb:325:in `create_table' /usr/local/bundle/gems/activerecord-7.0.3.1/lib/active_record/migration.rb:932:in `block in method_missing' /usr/local/bundle/gems/activerecord-7.0.3.1/lib/active_record/migration.rb:900:in `block in say_with_time' /usr/local/bundle/gems/benchmark-0.1.1/lib/benchmark.rb:293:in `measure' /usr/local/bundle/gems/activerecord-7.0.3.1/lib/active_record/migration.rb:900:in `say_with_time' /usr/local/bundle/gems/activerecord-7.0.3.1/lib/active_record/migration.rb:921:in `method_missing' /usr/local/bundle/gems/strong_migrations-1.5.0/lib/strong_migrations/migration.rb:17:in `block (2 levels) in method_missing' /usr/local/bundle/gems/strong_migrations-1.5.0/lib/strong_migrations/checker.rb:91:in `perform' /usr/local/bundle/gems/strong_migrations-1.5.0/lib/strong_migrations/migration.rb:16:in `block in method_missing' /usr/local/bundle/gems/strong_migrations-1.5.0/lib/strong_migrations/migration.rb:15:in `catch' /usr/local/bundle/gems/strong_migrations-1.5.0/lib/strong_migrations/migration.rb:15:in `method_missing' /app/app/models/application_migration.rb:6:in `create_table' /app/db/migrate/202xxxxxxxxx_setup_operation_store.rb:11:in `change'
```