### PR TITLE
Apply validate_timeout to analysis, too

### DIFF
--- a/guides/queries/timeout.md
+++ b/guides/queries/timeout.md
@@ -63,16 +63,17 @@ class MySchema < GraphQL::Schema
 end
 ```
 
-## Validation
+## Validation and Analysis
 
 Queries can originate from a user, and may be crafted in a manner to take a long time to validate against the schema.
 
-It is possible to limit how many seconds the static validation rules are allowed to run before returning a validation timeout error. The default is no timeout.
+It is possible to limit how many seconds the static validation rules and analysers are allowed to run before returning a validation timeout error. The default is no timeout.
 
 For example:
 
 ```ruby
 class MySchema < GraphQL::Schema
+  # Applies to static validation and query analysis
   validate_timeout 10
 end
 ```

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -317,7 +317,7 @@ module GraphQL
     end
 
     def_delegators :validation_pipeline, :validation_errors,
-                   :analyzers, :ast_analyzers, :max_depth, :max_complexity
+                   :analyzers, :ast_analyzers, :max_depth, :max_complexity, :validate_timeout_remaining
 
     attr_accessor :analysis_errors
     def valid?

--- a/lib/graphql/query/validation_pipeline.rb
+++ b/lib/graphql/query/validation_pipeline.rb
@@ -14,7 +14,7 @@ module GraphQL
     #
     # @api private
     class ValidationPipeline
-      attr_reader :max_depth, :max_complexity
+      attr_reader :max_depth, :max_complexity, :validate_timeout_remaining
 
       def initialize(query:, parse_error:, operation_name_error:, max_depth:, max_complexity:)
         @validation_errors = []
@@ -71,7 +71,7 @@ module GraphQL
           validator = @query.static_validator || @schema.static_validator
           validation_result = validator.validate(@query, validate: @query.validate, timeout: @schema.validate_timeout, max_errors: @schema.validate_max_errors)
           @validation_errors.concat(validation_result[:errors])
-
+          @validate_timeout_remaining = validation_result[:remaining_timeout]
           if @validation_errors.empty?
             @validation_errors.concat(@query.variables.errors)
           end

--- a/lib/graphql/static_validation/validator.rb
+++ b/lib/graphql/static_validation/validator.rb
@@ -28,6 +28,7 @@ module GraphQL
       # @return [Array<Hash>]
       def validate(query, validate: true, timeout: nil, max_errors: nil)
         query.current_trace.validate(validate: validate, query: query) do
+          begin_t = Time.now
           errors = if validate == false
             []
           else
@@ -52,11 +53,13 @@ module GraphQL
           end
 
           {
+            remaining_timeout: timeout ? (timeout - (Time.now - begin_t)) : nil,
             errors: errors,
           }
         end
       rescue GraphQL::ExecutionError => e
         {
+          remaining_timeout: nil,
           errors: [e],
         }
       end


### PR DESCRIPTION
Fixes #4629 

I think this will be fair to apply to analysis too, since that's usually CPU work, like static validation. Please leave a comment here if you have a concern about it -- another implementation would be to add a separate `analysis_timeout ...` option. 