### PR TITLE
Deprecate returning `.resolve(...)` dataloader requests

### DIFF
--- a/lib/graphql/dataloader/request.rb
+++ b/lib/graphql/dataloader/request.rb
@@ -14,6 +14,11 @@ module GraphQL
       def load
         @source.load(@key)
       end
+
+      def load_with_deprecation_warning
+        warn("Returning `.request(...)` from GraphQL::Dataloader is deprecated, use `.load(...)` instead. (See usage of #{@source} with #{@key.inspect}).")
+        load
+      end
     end
   end
 end

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -1404,7 +1404,7 @@ module GraphQL
           else
             @lazy_methods = GraphQL::Execution::Lazy::LazyMethodMap.new
             @lazy_methods.set(GraphQL::Execution::Lazy, :value)
-            @lazy_methods.set(GraphQL::Dataloader::Request, :load)
+            @lazy_methods.set(GraphQL::Dataloader::Request, :load_with_deprecation_warning)
           end
         end
         @lazy_methods


### PR DESCRIPTION
This was previously supported, but it shouldn't be -- it makes Dataloader dependent on the lazy-resolve system. I'm interested in working on that system so I'd like to disentangle them first.