### PR TITLE
Fix @defer with { backtrace: true } and lazy lists

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -352,6 +352,15 @@ module GraphQL
           end
 
           field_result = call_method_on_directives(:resolve, object, directives) do
+            if directives.any?
+              # This might be executed in a different context; reset this info
+              runtime_state = get_current_runtime_state
+              runtime_state.current_field = field_defn
+              runtime_state.current_object = object
+              runtime_state.current_arguments = resolved_arguments
+              runtime_state.current_result_name = result_name
+              runtime_state.current_result = selection_result
+            end
             # Actually call the field resolver and capture the result
             app_result = begin
               @current_trace.execute_field(field: field_defn, ast_node: ast_node, query: query, object: object, arguments: kwarg_arguments) do


### PR DESCRIPTION
Oops, previously this encountered: 

```
Error:
GraphQL::Schema::Directive::runtime directives#test_0003_works with backtrace: true and lazy lists:
NoMethodError: undefined method `[]' for nil:NilClass
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/backtrace/trace.rb:72:in `push_field_backtrace_context'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/backtrace/trace.rb:37:in `execute_field'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:367:in `block in evaluate_selection_with_resolved_keyword_args'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:726:in `run_directive'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/execution/interpreter/runtime.rb:744:in `block in run_directive'
    /Users/rmosolgo/code/graphql-ruby/spec/graphql/schema/directive_spec.rb:131:in `block in resolve'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/dataloader.rb:160:in `block in run_isolated'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/dataloader.rb:252:in `block in spawn_job_fiber'
    /Users/rmosolgo/code/graphql-ruby/lib/graphql/dataloader.rb:233:in `block in spawn_fiber'
```