### PR TITLE
Improve test helper docs

### DIFF
--- a/guides/testing/helpers.md
+++ b/guides/testing/helpers.md
@@ -49,7 +49,7 @@ Additionally, it accepts some keyword arguments:
 You can use {{ "Testing::Helpers#with_resolution_context" | api_doc }} to use the same type, runtime object, and GraphQL context for multiple field resolutions. For example:
 
 ```ruby
-with_resolution_context("Post", example_post, context: { current_user: author }) do |rc|
+with_resolution_context(type: "Post", object: example_post, context: { current_user: author }) do |rc|
   assert_equal "100 Great Ideas", rc.run_graphql_field("title")
   assert_equal true, rc.run_graphql_field("viewerIsAuthor")
   assert_equal 5, rc.run_graphql_field("commentsCount")


### PR DESCRIPTION
Very excited about the new test helpers. I ran into a few issues getting it wired up and would love to help improve the documentation more. 

For instance, it would be great to document any additional set up / context required to use `with_resolution_context`. For example, the `with_resolution_context` method is erroring in the Object Cache Tracer:

```sh
NoMethodError: undefined method `[]' for nil
from .../graphql-enterprise-1.3.2/lib/graphql/enterprise/object_cache.rb:521:in `trace'
```
