### PR TITLE
Return early if `Sentry.with_child_span` returns nil

### DIFF
--- a/lib/graphql/tracing/sentry_trace.rb
+++ b/lib/graphql/tracing/sentry_trace.rb
@@ -64,9 +64,10 @@ module GraphQL
         return yield unless Sentry.initialized?
 
         Sentry.with_child_span(op: platform_key, start_timestamp: Sentry.utc_now.to_f) do |span|
-          result = block.call
-          span.finish
+          result = yield
+          return result unless span
 
+          span.finish
           if trace_method == "execute_multiplex" && data.key?(:multiplex)
             operation_names = data[:multiplex].queries.map{|q| operation_name(q) }
             span.set_description(operation_names.join(", "))

--- a/spec/graphql/tracing/sentry_trace_spec.rb
+++ b/spec/graphql/tracing/sentry_trace_spec.rb
@@ -40,6 +40,17 @@ describe GraphQL::Tracing::SentryTrace do
     end
   end
 
+  describe "When Sentry.with_child_span returns nil" do
+    it "does not initialize any spans" do
+      Sentry.stub(:with_child_span, nil) do
+        SentryTraceTestSchema.execute("{ int thing { str } }")
+        assert_equal [], Sentry::SPAN_DATA
+        assert_equal [], Sentry::SPAN_DESCRIPTIONS
+        assert_equal [], Sentry::SPAN_OPS
+      end
+    end
+  end
+
   it "sets the expected spans" do
     SentryTraceTestSchema.execute("{ int thing { str } }")
     expected_span_ops = [


### PR DESCRIPTION
Closes https://github.com/rmosolgo/graphql-ruby/issues/4827

This adds in a guard clause to make sure we don't run any instrumentation if Sentry is initialized but `with_child_span` returns a `nil`.   This can happen if Sentry is configured but no DSN is set.