### PR TITLE
Fix sentry trace super calls

### DIFF
--- a/lib/graphql/tracing/sentry_trace.rb
+++ b/lib/graphql/tracing/sentry_trace.rb
@@ -16,8 +16,8 @@ module GraphQL
         "execute_query_lazy" => "graphql.execute"
       }.each do |trace_method, platform_key|
         module_eval <<-RUBY, __FILE__, __LINE__
-        def #{trace_method}(**data, &block)
-          instrument_execution("#{platform_key}", "#{trace_method}", data, &block)
+        def #{trace_method}(**data)
+          instrument_execution("#{platform_key}", "#{trace_method}", data) { super }
         end
         RUBY
       end

--- a/spec/graphql/tracing/sentry_trace_spec.rb
+++ b/spec/graphql/tracing/sentry_trace_spec.rb
@@ -22,11 +22,23 @@ describe GraphQL::Tracing::SentryTrace do
 
     query(Query)
 
+    module OtherTrace
+      def execute_query(query:)
+        query.context[:other_trace_ran] = true
+        super
+      end
+    end
+    trace_with OtherTrace
     trace_with GraphQL::Tracing::SentryTrace
   end
 
   before do
     Sentry.clear_all
+  end
+
+  it "works with other trace modules" do
+    res = SentryTraceTestSchema.execute("{ int }")
+    assert res.context[:other_trace_ran]
   end
 
   describe "When Sentry is not configured" do


### PR DESCRIPTION
Fixes #4826 


Oops, these methods should have called `super`, since PlatformTrace doesn't modify them. (The `platform_*` methods yield to PlatformTrace code.) This change puts the SentryTrace in line with other traces:

https://github.com/rmosolgo/graphql-ruby/blob/18f3deda9944febcbd97a84a4943362f68c8a373/lib/graphql/tracing/data_dog_trace.rb#L66

https://github.com/rmosolgo/graphql-ruby/blob/18f3deda9944febcbd97a84a4943362f68c8a373/lib/graphql/tracing/statsd_trace.rb#L27

https://github.com/rmosolgo/graphql-ruby/blob/18f3deda9944febcbd97a84a4943362f68c8a373/lib/graphql/tracing/new_relic_trace.rb#L38