### PR TITLE
Support serializing ActiveRecord::Relations as Arrays

### DIFF
--- a/lib/graphql/subscriptions/serialize.rb
+++ b/lib/graphql/subscriptions/serialize.rb
@@ -148,6 +148,8 @@ module GraphQL
             { TIMESTAMP_KEY => [obj.class.name, obj.strftime(TIMESTAMP_FORMAT)] }
           elsif obj.is_a?(OpenStruct)
             { OPEN_STRUCT_KEY => dump_value(obj.to_h) }
+          elsif defined?(ActiveRecord::Relation) && obj.is_a?(ActiveRecord::Relation)
+            dump_value(obj.to_a)
           else
             obj
           end

--- a/spec/graphql/pagination/active_record_relation_connection_spec.rb
+++ b/spec/graphql/pagination/active_record_relation_connection_spec.rb
@@ -3,10 +3,6 @@ require "spec_helper"
 
 if testing_rails?
   describe GraphQL::Pagination::ActiveRecordRelationConnection do
-    if Food.count == 0 # Backwards-compat version of `.none?`
-      ConnectionAssertions::NAMES.each { |n| Food.create!(name: n) }
-    end
-
     class RelationConnectionWithTotalCount < GraphQL::Pagination::ActiveRecordRelationConnection
       def total_count
         if items.respond_to?(:unscope)
@@ -35,6 +31,12 @@ if testing_rails?
     let(:limit) { nil }
 
     include ConnectionAssertions
+
+    before do
+      if Food.count == 0 # Backwards-compat version of `.none?`
+        ConnectionAssertions::NAMES.each { |n| Food.create!(name: n) }
+      end
+    end
 
     it "maintains an application-provided offset" do
       results = schema.execute("{

--- a/spec/graphql/pagination/mongoid_relation_connection_spec.rb
+++ b/spec/graphql/pagination/mongoid_relation_connection_spec.rb
@@ -8,9 +8,11 @@ if testing_mongoid?
       field :name, type: String
     end
 
-    # Populate the DB
-    Food.collection.drop
-    ConnectionAssertions::NAMES.each { |n| Food.create(name: n) }
+    before do
+      # Populate the DB
+      Food.collection.drop
+      ConnectionAssertions::NAMES.each { |n| Food.create(name: n) }
+    end
 
     class MongoidRelationConnectionWithTotalCount < GraphQL::Pagination::MongoidRelationConnection
       def total_count

--- a/spec/graphql/pagination/sequel_dataset_connection_spec.rb
+++ b/spec/graphql/pagination/sequel_dataset_connection_spec.rb
@@ -6,8 +6,10 @@ if testing_rails?
     class SequelFood < Sequel::Model(:foods)
     end
 
-    if SequelFood.empty? # Can overlap with ActiveRecordRelationConnection test
-      ConnectionAssertions::NAMES.each { |n| SequelFood.create(name: n) }
+    before do
+      if SequelFood.empty? # Can overlap with ActiveRecordRelationConnection test
+        ConnectionAssertions::NAMES.each { |n| SequelFood.create(name: n) }
+      end
     end
 
     class SequelDatasetConnectionWithTotalCount < GraphQL::Pagination::SequelDatasetConnection

--- a/spec/graphql/subscriptions/serialize_spec.rb
+++ b/spec/graphql/subscriptions/serialize_spec.rb
@@ -98,6 +98,27 @@ describe GraphQL::Subscriptions::Serialize do
     end
   end
 
+  if testing_rails?
+    describe "ActiveRecord::Relations" do
+      before do
+        Food.destroy_all
+        Food.create!(name: "Peanut Butter")
+        Food.create!(name: "Jelly")
+      end
+
+      after do
+        Food.destroy_all
+      end
+
+      it "turns them into Arrays and can reload them with GlobalID" do
+        assert_equal 2, Food.count
+        serialized = serialize_dump(Food.all)
+        reloaded = serialize_load(serialized)
+        assert_equal reloaded, Food.all.to_a
+      end
+    end
+  end
+
   it "can deserialize openstructs" do
     os = OpenStruct.new(a: 1.2, b: :c, d: Time.new, e: OpenStruct.new(f: [1, 2, 3]))
     serialized = serialize_dump(os)

--- a/spec/support/active_record_setup.rb
+++ b/spec/support/active_record_setup.rb
@@ -53,5 +53,6 @@ if testing_rails?
   end
 
   class Food < ActiveRecord::Base
+    include GlobalID::Identification
   end
 end


### PR DESCRIPTION
Fixes #4719 

In order for this to actually reload records, the records have to include `GlobalID::Identification` as shown in this diff.