### PR TITLE
Treat all connection subfields except nodes and edges as metadata

### DIFF
--- a/spec/graphql/analysis/ast/query_complexity_spec.rb
+++ b/spec/graphql/analysis/ast/query_complexity_spec.rb
@@ -522,6 +522,11 @@ describe GraphQL::Analysis::AST::QueryComplexity do
         field :name, String
       end
 
+      class CustomThingConnection < GraphQL::Types::Relay::BaseConnection
+        edge_type Thing.edge_type
+        field :something_special, String, complexity: 3
+      end
+
       class Query < GraphQL::Schema::Object
         field :complexity, SingleComplexity do
           argument :int_value, Int, required: false
@@ -543,7 +548,7 @@ describe GraphQL::Analysis::AST::QueryComplexity do
         end
 
         class ThingsCustom < GraphQL::Schema::Resolver
-          type Thing.connection_type, null: false
+          type CustomThingConnection, null: false
           complexity 100
 
           def resolve
@@ -612,11 +617,11 @@ describe GraphQL::Analysis::AST::QueryComplexity do
     end
 
     describe "when connection fields have custom complexity" do
-      let(:query_string) { "{ thingsCustom(first: 2) { nodes { name } } }"}
+      let(:query_string) { "{ thingsCustom(first: 2) { somethingSpecial nodes { name } } }"}
 
       it "uses the custom configured value" do
         complexity = reduce_result.first
-        assert_equal 103, complexity
+        assert_equal 106, complexity
       end
     end
   end


### PR DESCRIPTION
Fixes #4831 

Previously, if you added a custom field to your connection type, it would get multiplied by the number of edges or nodes to calculate complexity. 

This was mostly wrong, since it was probably a metadata field. But this patch could break your complexity calculation if you used custom field names for `edges` and `nodes`. If this applies to you, please open an issue and we can look into better handling for this. As a work-around, you can put the old implementation in your base field class: 

```ruby 
def calculate_complexity(query:, nodes:, child_complexity:)
  if connection? # get behavior from GraphQL-Ruby < 2.2.9
    arguments = query.arguments_for(nodes.first, self)
    max_possible_page_size = nil
    if arguments.respond_to?(:[]) # It might have been an error
      if arguments[:first]
        max_possible_page_size = arguments[:first]
      end

      if arguments[:last] && (max_possible_page_size.nil? || arguments[:last] > max_possible_page_size)
        max_possible_page_size = arguments[:last]
      end
    end

    if max_possible_page_size.nil?
      max_possible_page_size = default_page_size || query.schema.default_page_size || max_page_size || query.schema.default_max_page_size
    end

    if max_possible_page_size.nil?
      raise GraphQL::Error, "Can't calculate complexity for #{path}, no `first:`, `last:`, `default_page_size`, `max_page_size` or `default_max_page_size`"
    else
      metadata_complexity = 0
      lookahead = GraphQL::Execution::Lookahead.new(query: query, field: self, ast_nodes: nodes, owner_type: owner)

      if (page_info_lookahead = lookahead.selection(:page_info)).selected?
        metadata_complexity += 1 # pageInfo
        metadata_complexity += page_info_lookahead.selections.size # subfields
      end

      if lookahead.selects?(:total) || lookahead.selects?(:total_count) || lookahead.selects?(:count)
        metadata_complexity += 1
      end

      nodes_edges_complexity = 0
      nodes_edges_complexity += 1 if lookahead.selects?(:edges)
      nodes_edges_complexity += 1 if lookahead.selects?(:nodes)

      # Possible bug: selections on `edges` and `nodes` are _both_ multiplied here. Should they be?
      items_complexity = child_complexity - metadata_complexity - nodes_edges_complexity
      subfields_complexity = (max_possible_page_size * items_complexity) + metadata_complexity + nodes_edges_complexity
      # Apply this field's own complexity
      apply_own_complexity_to(subfields_complexity, query, nodes)
    end
  else 
    super # default behavior for other fields 
  end 
end 
```
