### PR TITLE
Add typing to createAblyHandler onError handler

### DIFF
--- a/javascript_client/src/subscriptions/__tests__/createAblyHandlerTest.ts
+++ b/javascript_client/src/subscriptions/__tests__/createAblyHandlerTest.ts
@@ -1,4 +1,4 @@
-import { createAblyHandler } from "../createAblyHandler"
+import { OnErrorData, createAblyHandler } from "../createAblyHandler"
 import { Realtime, Types } from "ably"
 
 const dummyOperation = { text: "", name: "" }
@@ -383,7 +383,7 @@ describe("createAblyHandler", () => {
       const operation = {}
       const variables = {}
       const cacheConfig = {}
-      const onError = (error: Error) => {
+      const onError = (error: OnErrorData) => {
         caughtError = error
       }
       const onNext = () => {}
@@ -441,7 +441,7 @@ describe("createAblyHandler", () => {
         const operation = {}
         const variables = {}
         const cacheConfig = {}
-        const onError = (error: Error) => {
+        const onError = (error: OnErrorData) => {
           caughtError = error
         }
         const messages: any[] = []

--- a/javascript_client/src/subscriptions/createAblyHandler.ts
+++ b/javascript_client/src/subscriptions/createAblyHandler.ts
@@ -8,8 +8,17 @@ interface AblyHandlerOptions {
   fetchOperation: Function
 }
 
+interface GraphQLError {
+  message: string
+  path: (string | number)[]
+  locations: number[][]
+  extensions?: object
+}
+
+type OnErrorData = AblyError | Error| GraphQLError[]
+
 interface ApolloObserver {
-  onError: Function
+  onError: (err: OnErrorData) => void
   onNext: Function
   onCompleted: Function
 }
@@ -50,7 +59,7 @@ function createAblyHandler(options: AblyHandlerOptions) {
   ) => {
     let channel: Types.RealtimeChannelCallbacks | null = null
 
-    const dispatchResult = (result: { errors: any; data: any }) => {
+    const dispatchResult = (result: { errors?: GraphQLError[]; data: any }) => {
       if (result) {
         if (result.errors) {
           // What kind of error stuff belongs here?
@@ -140,7 +149,7 @@ function createAblyHandler(options: AblyHandlerOptions) {
         // (In that case, we want to make sure the channel is cleaned up properly.)
         dispatchResult(response.body)
       } catch (error) {
-        observer.onError(error)
+        observer.onError(error as Error)
       }
     })()
 
@@ -181,11 +190,11 @@ function createAblyHandler(options: AblyHandlerOptions) {
             ably.channels.release(disposedChannel.name)
           }
         } catch (error) {
-          observer.onError(error)
+          observer.onError(error as Error)
         }
       }
     }
   }
 }
 
-export { createAblyHandler, AblyHandlerOptions }
+export { createAblyHandler, AblyHandlerOptions, OnErrorData }


### PR DESCRIPTION
Fixes #4832 

This typing is a bit yucky, but it describes the _current_ usage of `onError`: sometimes, it receives the `errors: ...` from GraphQL; sometimes, it receives a raised error; sometimes, it receives a wrapped network error from Ably. 

cc @jscheid your thoughts?