### PR TITLE
Fix backtrace + default trace options

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -1182,13 +1182,15 @@ module GraphQL
             raise ArgumentError, "Can't use `context[:backtrace]` with a custom default trace mode (`#{dm.inspect}`)"
           else
             own_trace_modes[:default_backtrace] ||= build_trace_mode(:default_backtrace)
+            options_trace_mode = :default
             :default_backtrace
           end
         else
           default_trace_mode
         end
 
-        base_trace_options = trace_options_for(trace_mode)
+        options_trace_mode ||= trace_mode
+        base_trace_options = trace_options_for(options_trace_mode)
         trace_options = base_trace_options.merge(options)
         trace_class_for_mode = trace_class_for(trace_mode) || raise(ArgumentError, "#{self} has no trace class for mode: #{trace_mode.inspect}")
         trace_class_for_mode.new(**trace_options)

--- a/spec/graphql/backtrace_spec.rb
+++ b/spec/graphql/backtrace_spec.rb
@@ -25,6 +25,10 @@ describe GraphQL::Backtrace do
   end
 
   module ErrorTrace
+    def initialize(required_arg:, **_rest)
+      super(**_rest)
+    end
+
     def execute_multiplex(multiplex:)
       super
       raise "Instrumentation Boom"
@@ -144,7 +148,7 @@ describe GraphQL::Backtrace do
       assert_includes err.message, "\n" + rendered_table
       # The message includes the original error message
       assert_includes err.message, "This is broken: Boom"
-      assert_includes err.message, "spec/graphql/backtrace_spec.rb:45", "It includes the original backtrace"
+      assert_includes err.message, "spec/graphql/backtrace_spec.rb:49", "It includes the original backtrace"
       assert_includes err.message, "more lines"
     end
 
@@ -209,7 +213,7 @@ describe GraphQL::Backtrace do
 
     it "raises original exception instead of a TracedError when error does not occur during resolving" do
       instrumentation_schema = Class.new(schema) do
-        trace_with(ErrorTrace)
+        trace_with(ErrorTrace, required_arg: true)
       end
 
       assert_raises(RuntimeError) {


### PR DESCRIPTION
Oops -- this was looking for `:default_backtrace` options, but actually, it should use the default options here. 

I ran into this with GraphQL-Batch + Backtrace, and it raised an error like this: 

```
ArgumentError: missing keyword: :executor_class
    /Users/rmosolgo/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/graphql-batch-0.5.4/lib/graphql/batch/setup_multiplex.rb:17:in `initialize'
    /Users/rmosolgo/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/graphql-2.2.9/lib/graphql/backtrace/trace.rb:8:in `initialize'
    /Users/rmosolgo/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/graphql-2.2.9/lib/graphql/schema.rb:1194:in `new'
```

But the bug was here; GraphQL-Ruby wasn't passing the right options to the trace.