### PR TITLE
Handle unknown trace modes at runtime

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -167,7 +167,7 @@ module GraphQL
           backtrace_class.include(GraphQL::Backtrace::Trace)
           trace_mode(:default_backtrace, backtrace_class)
         end
-        trace_class_for(:default)
+        trace_class_for(:default, build: true)
       end
 
       # @return [Class] Return the trace class to use for this mode, looking one up on the superclass if this Schema doesn't have one defined.
@@ -218,14 +218,14 @@ module GraphQL
             include DefaultTraceClass
           end
         when :default_backtrace
-          schema_base_class = trace_class_for(:default)
+          schema_base_class = trace_class_for(:default, build: true)
           Class.new(schema_base_class) do
             include(GraphQL::Backtrace::Trace)
           end
         else
           # First, see if the superclass has a custom-defined class for this.
           # Then, if it doesn't, use this class's default trace
-          base_class = (superclass.respond_to?(:trace_class_for) && superclass.trace_class_for(mode, build: false)) || trace_class_for(:default)
+          base_class = (superclass.respond_to?(:trace_class_for) && superclass.trace_class_for(mode)) || trace_class_for(:default, build: true)
           # Prepare the default trace class if it hasn't been initialized yet
           base_class ||= (own_trace_modes[:default] = build_trace_mode(:default))
           mods = trace_modules_for(mode)
@@ -1118,7 +1118,7 @@ module GraphQL
       end
 
       def tracer(new_tracer)
-        default_trace = trace_class_for(:default)
+        default_trace = trace_class_for(:default, build: true)
         if default_trace.nil? || !(default_trace < GraphQL::Tracing::CallLegacyTracers)
           trace_with(GraphQL::Tracing::CallLegacyTracers)
         end

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -171,9 +171,16 @@ module GraphQL
       end
 
       # @return [Class] Return the trace class to use for this mode, looking one up on the superclass if this Schema doesn't have one defined.
-      def trace_class_for(mode, build: true)
-        own_trace_modes[mode] ||
-          (superclass.respond_to?(:trace_class_for) ? superclass.trace_class_for(mode, build: build) : (build ? (own_trace_modes[mode] = build_trace_mode(mode)) : nil))
+      def trace_class_for(mode, build: false)
+        if (trace_class = own_trace_modes[mode])
+          trace_class
+        elsif superclass.respond_to?(:trace_class_for) && (trace_class = superclass.trace_class_for(mode, build: false))
+          trace_class
+        elsif build
+          own_trace_modes[mode] = build_trace_mode(mode)
+        else
+          nil
+        end
       end
 
       # Configure `trace_class` to be used whenever `context: { trace_mode: mode_name }` is requested.
@@ -1163,10 +1170,14 @@ module GraphQL
       def trace_options_for(mode)
         @trace_options_for_mode ||= {}
         @trace_options_for_mode[mode] ||= begin
+          # It may be time to create an options hash for a mode that wasn't registered yet.
+          # Mix in the default options in that case.
+          default_options = mode == :default ? EMPTY_HASH : trace_options_for(:default)
+          # Make sure this returns a new object so that other hashes aren't modified later
           if superclass.respond_to?(:trace_options_for)
-            superclass.trace_options_for(mode).dup
+            superclass.trace_options_for(mode).merge(default_options)
           else
-            {}
+            default_options.dup
           end
         end
       end
@@ -1199,7 +1210,7 @@ module GraphQL
         options_trace_mode ||= trace_mode
         base_trace_options = trace_options_for(options_trace_mode)
         trace_options = base_trace_options.merge(options)
-        trace_class_for_mode = trace_class_for(trace_mode) || raise(ArgumentError, "#{self} has no trace class for mode: #{trace_mode.inspect}")
+        trace_class_for_mode = trace_class_for(trace_mode, build: true)
         trace_class_for_mode.new(**trace_options)
       end
 

--- a/spec/graphql/tracing/trace_modes_spec.rb
+++ b/spec/graphql/tracing/trace_modes_spec.rb
@@ -36,7 +36,7 @@ describe "Trace modes for schemas" do
 
       query(Query)
 
-      trace_with GlobalTrace
+      trace_with GlobalTrace, global_arg: 1
       trace_with SpecialTrace, mode: :special
       trace_with OptionsTrace, mode: :options, configured_option: :was_configured
     end
@@ -76,6 +76,19 @@ describe "Trace modes for schemas" do
     res = TraceModesTest::GrandchildSchema.execute("{ greeting }")
     assert res.context[:global_trace]
     assert res.context[:grandchild_default]
+  end
+
+  it "uses the default trace class and trace options for unknown modes" do
+    assert_nil TraceModesTest::ParentSchema.trace_class_for(:who_knows_what2)
+    constructed_trace_class = TraceModesTest::ParentSchema.trace_class_for(:who_knows_what2, build: true)
+    assert_equal TraceModesTest::ParentSchema.trace_class_for(:default), constructed_trace_class.superclass
+
+    assert_equal({global_arg: 1}, TraceModesTest::ParentSchema.trace_options_for(:who_know_what3))
+  end
+
+  it "uses the default trace mode when an unknown mode is given" do
+    res = TraceModesTest::ParentSchema.execute("{ greeting }", context: { trace_mode: :who_knows_what })
+    assert res.context[:global_trace]
   end
 
   it "inherits special modes" do


### PR DESCRIPTION
Oops, there was some code here to handle unexpected mode names, but it didn't really work (and wasn't tested, etc). This makes it so that, when a Schema receives an unknown trace mode at runtime, it treats it like a `:default` mode. It creates a class and options hash for it just like it was registered ahead of time, both derived from `:default`.

Fixes #4855