### PR TITLE
Fix fragment skip/include tracking during analysis visitation

### DIFF
--- a/lib/graphql/analysis/ast/visitor.rb
+++ b/lib/graphql/analysis/ast/visitor.rb
@@ -118,8 +118,12 @@ module GraphQL
         def on_inline_fragment(node, parent)
           on_fragment_with_type(node) do
             @path.push("...#{node.type ? " on #{node.type.name}" : ""}")
+            @skipping = @skip_stack.last || skip?(node)
+            @skip_stack << @skipping
+
             call_on_enter_inline_fragment(node, parent)
             super
+            @skipping = @skip_stack.pop
             call_on_leave_inline_fragment(node, parent)
           end
         end
@@ -187,9 +191,13 @@ module GraphQL
 
         def on_fragment_spread(node, parent)
           @path.push("... #{node.name}")
+          @skipping = @skip_stack.last || skip?(node)
+          @skip_stack << @skipping
+
           call_on_enter_fragment_spread(node, parent)
           enter_fragment_spread_inline(node)
           super
+          @skipping = @skip_stack.pop
           leave_fragment_spread_inline(node)
           call_on_leave_fragment_spread(node, parent)
           @path.pop


### PR DESCRIPTION
### What

Fixes a bug in the analysis visitor to make inline fragments and fragment spreads respond to `@skip/include` directives, [per the spec](https://spec.graphql.org/October2021/#sec--skip). This is another piece of housekeeping that may need to go into the `v3` milestone... It's a clear-cut bug to fix, though I suppose it could have implications on custom analyzer expectations out in the wild.

### Why?

At present, analysis visitation only responds to field conditions. Ignoring fragment conditions manifests numerous analysis bugs, not the least of which is over-costing our old friend complexity analysis (where a skipped fragment tree gets included in the query cost). Fixing this issue for complexity is non-breaking, because costs will only go down.
