### PR TITLE
Revert hasNextPage change when first isn't present

### DIFF
--- a/lib/graphql/pagination/array_connection.rb
+++ b/lib/graphql/pagination/array_connection.rb
@@ -56,12 +56,12 @@ module GraphQL
             false
           end
 
-          @has_next_page = if first_value && first
-            # There are more items after these items
-            sliced_nodes.count > first
-          elsif before
+          @has_next_page = if before
             # The original array is longer than the `before` index
             index_from_cursor(before) < items.length + 1
+          elsif first
+            # There are more items after these items
+            sliced_nodes.count > first
           else
             false
           end

--- a/lib/graphql/pagination/relation_connection.rb
+++ b/lib/graphql/pagination/relation_connection.rb
@@ -29,14 +29,14 @@ module GraphQL
 
       def has_next_page
         if @has_next_page.nil?
-          @has_next_page = if first && first_value
+          @has_next_page = if before_offset && before_offset > 0
+            true
+          elsif first
             if @nodes && @nodes.count < first
               false
             else
               relation_larger_than(sliced_nodes, @sliced_nodes_offset, first)
             end
-          elsif before_offset && before_offset > 0
-            true
           else
             false
           end

--- a/spec/integration/rails/graphql/relay/array_connection_spec.rb
+++ b/spec/integration/rails/graphql/relay/array_connection_spec.rb
@@ -174,7 +174,7 @@ describe "GraphQL::Relay::ArrayConnection" do
         # Max page size is applied _without_ `first`, also
         result = star_wars_query(query_string)
         assert_equal(["Yavin", "Echo Base"], get_names(result))
-        assert_equal(false, get_page_info(result)["hasNextPage"], "hasNextPage is false when first is not specified")
+        assert_equal(true, get_page_info(result)["hasNextPage"], "hasNextPage is false when first is not specified")
       end
 
       it "applies to queries by `last`" do

--- a/spec/integration/rails/graphql/relay/relation_connection_spec.rb
+++ b/spec/integration/rails/graphql/relay/relation_connection_spec.rb
@@ -287,7 +287,7 @@ describe "GraphQL::Relay::RelationConnection" do
         # Max page size is applied _without_ `first`, also
         result = star_wars_query(query_string)
         assert_equal(2, result["data"]["empire"]["bases"]["edges"].size)
-        assert_equal(false, result["data"]["empire"]["bases"]["pageInfo"]["hasNextPage"], "hasNextPage is false when first is not specified")
+        assert_equal(true, result["data"]["empire"]["bases"]["pageInfo"]["hasNextPage"], "hasNextPage is false when first is not specified")
       end
 
       it "applies to queries by `last`" do
@@ -346,7 +346,7 @@ describe "GraphQL::Relay::RelationConnection" do
         # Max page size is applied _without_ `first`, also
         result = star_wars_query(query_string)
         assert_equal(3, result["data"]["empire"]["bases"]["edges"].size)
-        assert_equal(false, result["data"]["empire"]["bases"]["pageInfo"]["hasNextPage"], "hasNextPage is false when first is not specified")
+        assert_equal(true, result["data"]["empire"]["bases"]["pageInfo"]["hasNextPage"], "hasNextPage is false when first is not specified")
       end
 
       it "applies to queries by `last`" do

--- a/spec/support/connection_assertions.rb
+++ b/spec/support/connection_assertions.rb
@@ -255,7 +255,7 @@ module ConnectionAssertions
           assert_names [], res
 
           res = exec_query(query_str, after: after_cursor, before: before_cursor, first: 3)
-          assert_equal false, get_page_info(res, "hasNextPage")
+          assert_equal true, get_page_info(res, "hasNextPage")
           assert_equal true, get_page_info(res, "hasPreviousPage")
           assert_names [], res
         end
@@ -317,7 +317,7 @@ module ConnectionAssertions
           res = exec_query(query_str, {})
           # Neither first nor last was provided, so default_page_size was applied.
           assert_names(["Avocado", "Beet", "Cucumber", "Dill"], res)
-          assert_equal false, get_page_info(res, "hasNextPage")
+          assert_equal true, get_page_info(res, "hasNextPage")
           assert_equal false, get_page_info(res, "hasPreviousPage")
         end
 


### PR DESCRIPTION
This is a PR to revert the behavior change to `hasNextPage` from #4780. 

That PR made it so that `hasNextPage` was always `false` when `first:` wasn't provided. This reverts to the old behavior that `max_page_size` counts as an implicit `first:`, and `hasNextPage` may be true when `max_page_size` is applied.

I'm interested in some :+1: / :-1: on this for your situation.