### PR TITLE
Deprecate execution strategy methods

### DIFF
--- a/lib/graphql/execution/interpreter.rb
+++ b/lib/graphql/execution/interpreter.rb
@@ -47,7 +47,7 @@ module GraphQL
             begin
               # Since this is basically the batching context,
               # share it for a whole multiplex
-              multiplex.context[:interpreter_instance] ||= multiplex.schema.query_execution_strategy.new
+              multiplex.context[:interpreter_instance] ||= multiplex.schema.query_execution_strategy(deprecation_warning: false).new
               # Do as much eager evaluation of the query as possible
               results = []
               queries.each_with_index do |query, idx|

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -63,10 +63,6 @@ module GraphQL
   # Schemas can restrict large incoming queries with `max_depth` and `max_complexity` configurations.
   # (These configurations can be overridden by specific calls to {Schema#execute})
   #
-  # Schemas can specify how queries should be executed against them.
-  # `query_execution_strategy`, `mutation_execution_strategy` and `subscription_execution_strategy`
-  # each apply to corresponding root types.
-  #
   # @example defining a schema
   #   class MySchema < GraphQL::Schema
   #     query QueryType
@@ -651,27 +647,39 @@ module GraphQL
         end
       end
 
-      def query_execution_strategy(new_query_execution_strategy = nil)
+      def query_execution_strategy(new_query_execution_strategy = nil, deprecation_warning: true)
+        if deprecation_warning
+          warn "GraphQL::Schema.query_execution_strategy is deprecated without replacement. Use `GraphQL::Query.new` directly to create and execute a custom query instead."
+          warn "  #{caller(1, 1).first}"
+        end
         if new_query_execution_strategy
           @query_execution_strategy = new_query_execution_strategy
         else
-          @query_execution_strategy || find_inherited_value(:query_execution_strategy, self.default_execution_strategy)
+          @query_execution_strategy || (superclass.respond_to?(:query_execution_strategy) ? superclass.query_execution_strategy(deprecation_warning: false) : self.default_execution_strategy)
         end
       end
 
-      def mutation_execution_strategy(new_mutation_execution_strategy = nil)
+      def mutation_execution_strategy(new_mutation_execution_strategy = nil, deprecation_warning: true)
+        if deprecation_warning
+          warn "GraphQL::Schema.mutation_execution_strategy is deprecated without replacement. Use `GraphQL::Query.new` directly to create and execute a custom query instead."
+            warn "  #{caller(1, 1).first}"
+        end
         if new_mutation_execution_strategy
           @mutation_execution_strategy = new_mutation_execution_strategy
         else
-          @mutation_execution_strategy || find_inherited_value(:mutation_execution_strategy, self.default_execution_strategy)
+          @mutation_execution_strategy || (superclass.respond_to?(:mutation_execution_strategy) ? superclass.mutation_execution_strategy(deprecation_warning: false) : self.default_execution_strategy)
         end
       end
 
-      def subscription_execution_strategy(new_subscription_execution_strategy = nil)
+      def subscription_execution_strategy(new_subscription_execution_strategy = nil, deprecation_warning: true)
+        if deprecation_warning
+          warn "GraphQL::Schema.subscription_execution_strategy is deprecated without replacement. Use `GraphQL::Query.new` directly to create and execute a custom query instead."
+          warn "  #{caller(1, 1).first}"
+        end
         if new_subscription_execution_strategy
           @subscription_execution_strategy = new_subscription_execution_strategy
         else
-          @subscription_execution_strategy || find_inherited_value(:subscription_execution_strategy, self.default_execution_strategy)
+          @subscription_execution_strategy || (superclass.respond_to?(:subscription_execution_strategy) ? superclass.subscription_execution_strategy(deprecation_warning: false) : self.default_execution_strategy)
         end
       end
 

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -42,9 +42,6 @@ describe GraphQL::Schema do
         orphan_types Jazz::Ensemble
         introspection Module.new
         cursor_encoder Object.new
-        query_execution_strategy Object.new
-        mutation_execution_strategy Object.new
-        subscription_execution_strategy Object.new
         context_class Class.new
         directives [DummyFeature1]
         tracer GraphQL::Tracing::DataDogTracing
@@ -64,9 +61,6 @@ describe GraphQL::Schema do
       assert_equal base_schema.subscription, schema.subscription
       assert_equal base_schema.introspection, schema.introspection
       assert_equal base_schema.cursor_encoder, schema.cursor_encoder
-      assert_equal base_schema.query_execution_strategy, schema.query_execution_strategy
-      assert_equal base_schema.mutation_execution_strategy, schema.mutation_execution_strategy
-      assert_equal base_schema.subscription_execution_strategy, schema.subscription_execution_strategy
       assert_equal base_schema.validate_timeout, schema.validate_timeout
       assert_equal base_schema.max_complexity, schema.max_complexity
       assert_equal base_schema.max_depth, schema.max_depth
@@ -114,15 +108,6 @@ describe GraphQL::Schema do
       schema.introspection(introspection)
       cursor_encoder = Object.new
       schema.cursor_encoder(cursor_encoder)
-      query_execution_strategy = Object.new
-      schema.query_execution_strategy(query_execution_strategy)
-      mutation_execution_strategy = Object.new
-      schema.mutation_execution_strategy(mutation_execution_strategy)
-      subscription_execution_strategy = Object.new
-      schema.subscription_execution_strategy(subscription_execution_strategy)
-      assert_equal query_execution_strategy, schema.query_execution_strategy
-      assert_equal mutation_execution_strategy, schema.mutation_execution_strategy
-      assert_equal subscription_execution_strategy, schema.subscription_execution_strategy
 
       context_class = Class.new
       schema.context_class(context_class)


### PR DESCRIPTION
In fact, `mutation_...` and `subscription_...` have been unused for a long time, and I don't expect any integrations with this method to actually work. But for completeness's sake, I'll start with a formal deprecation before I remove these methods in 3.0.