### PR TITLE
chore: removed warning for argument deprecation

### DIFF
--- a/guides/fields/arguments.md
+++ b/guides/fields/arguments.md
@@ -92,8 +92,6 @@ field :search_posts, [PostType], null: false do
 end
 ```
 
-Note argument deprecation is a stage 2 GraphQL [proposal](https://github.com/graphql/graphql-spec/pull/525) so not all clients will leverage this information.
-
 ## Aliasing
 
 Use `as: :alternate_name` to use a different key from within your resolvers while


### PR DESCRIPTION
It is now safe to remove this warning, this is merged and isn't a proposal anymore, see more  https://github.com/graphql/graphql-spec/pull/805