### PR TITLE
Fix PrometheusTrace with multiple tracers

### DIFF
--- a/lib/graphql/tracing/prometheus_trace.rb
+++ b/lib/graphql/tracing/prometheus_trace.rb
@@ -24,7 +24,7 @@ module GraphQL
         'execute_query_lazy' => "graphql.execute",
       }.each do |trace_method, platform_key|
         module_eval <<-RUBY, __FILE__, __LINE__
-          def #{trace_method}(**data, &block)
+          def #{trace_method}(**data)
             instrument_execution("#{platform_key}", "#{trace_method}") { super }
           end
         RUBY

--- a/lib/graphql/tracing/prometheus_trace.rb
+++ b/lib/graphql/tracing/prometheus_trace.rb
@@ -25,7 +25,7 @@ module GraphQL
       }.each do |trace_method, platform_key|
         module_eval <<-RUBY, __FILE__, __LINE__
           def #{trace_method}(**data, &block)
-            instrument_execution("#{platform_key}", "#{trace_method}", &block)
+            instrument_execution("#{platform_key}", "#{trace_method}") { super }
           end
         RUBY
       end


### PR DESCRIPTION
Currently PrometheusTrace does not respect other tracers

Sample code
```ruby
# frozen_string_literal: true

require 'bundler/inline'

gemfile do
  gem 'graphql', '2.2.13'
  gem 'prometheus_exporter'
end

require 'prometheus_exporter/client'

class MySchema < GraphQL::Schema
  module TracerOne
    def execute_query(query:)
      puts 'TracerOne#execute_query.before'
      super
      puts 'TracerOne#execute_query.after'
    end
  end

  module TracerTwo
    def execute_query(query:)
      puts 'TracerTwo#execute_query.before'
      super
      puts 'TracerTwo#execute_query.after'
    end
  end

  class Query < GraphQL::Schema::Object
    field :f, Int
    def f
      puts 'f called'

      1
    end
  end
  query(Query)

  trace_with TracerOne
  trace_with TracerTwo
  trace_with GraphQL::Tracing::PrometheusTrace
end

pp MySchema.execute('{ f }').to_h
```

Before changes
```
f called
{"data"=>{"f"=>1}}
```

After changes
```
TracerTwo#execute_query.before
TracerOne#execute_query.before
f called
TracerOne#execute_query.after
TracerTwo#execute_query.after
{"data"=>{"f"=>1}}
```

Current implementation of tracers includes all modules into single anonymous class, which can lead to unexpected situations, where one gem can overwrite private helper methods of other gem if they accidentally named the same way. Do you have any thoughts how to avoid this situations?