### PR TITLE
add a note to the Operation Store AR guide about test environments

### DIFF
--- a/guides/operation_store/active_record_backend.md
+++ b/guides/operation_store/active_record_backend.md
@@ -93,3 +93,10 @@ use GraphQL::Pro::OperationStore, update_last_used_at_every: 1 # seconds
 ```
 
 To update that column inline each time an operation is accessed, pass `0`.
+
+**Note:** It is recommended to set this to `0` in test environments, to avoid delayed updates in another thread that can cause intermittent test hangs and failures. For example:
+
+```ruby
+# Update immediately in Test, wait 5 seconds in other environments:
+use GraphQL::Pro::OperationStore, update_last_used_at_every: Rails.env.test? ? 0 : 5
+```


### PR DESCRIPTION
By default, `last_used_at` timestamps are updated every 5 seconds in a background thread. However, in a test environment, this can cause some surprising and unintended side effects when the background thread update is delayed until after a test finishes, and the test transaction has been rolled back.

We were intermittently running into hanging tests in our suite, which has 1 test that checks that the operation store is set up correctly. t took awhile, but we were able to track it down, but eventually we were able to get some stacktrace details on where our test suite was getting stuck:

```
	from [...]/vendor/bundle/ruby/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/connection_adapters/postgresql_adapter.rb:894:in `block (2 levels) in exec_no_cache'
	from [...]/vendor/bundle/ruby/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/connection_adapters/abstract_adapter.rb:1028:in `block in with_raw_connection'
	from [...]/vendor/bundle/ruby/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
	from [...]/vendor/bundle/ruby/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/connection_adapters/abstract_adapter.rb:1000:in `with_raw_connection'
	from [...]/vendor/bundle/ruby/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/connection_adapters/postgresql_adapter.rb:893:in `block in exec_no_cache'
	from [...]/vendor/bundle/ruby/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
	from [...]/vendor/bundle/ruby/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/connection_adapters/abstract_adapter.rb:1143:in `log'
	from [...]/vendor/bundle/ruby/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/connection_adapters/postgresql_adapter.rb:892:in `exec_no_cache'
	from [...]/vendor/bundle/ruby/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/connection_adapters/postgresql_adapter.rb:872:in `execute_and_clear'
	from [...]/vendor/bundle/ruby/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/connection_adapters/postgresql/database_statements.rb:77:in `exec_delete'
	from [...]/vendor/bundle/ruby/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/connection_adapters/abstract/database_statements.rb:202:in `update'
	from [...]/vendor/bundle/ruby/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/connection_adapters/abstract/query_cache.rb:25:in `update'
	from [...]/vendor/bundle/ruby/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/relation.rb:530:in `update_all'
	from [...]/vendor/bundle/ruby/3.3.0/gems/graphql-pro-1.26.5/lib/graphql/pro/operation_store/active_record_backend.rb:255:in `block in update_last_used_ats'
	from [...]/vendor/bundle/ruby/3.3.0/gems/graphql-pro-1.26.5/lib/graphql/pro/operation_store/active_record_backend.rb:252:in `each'
	from [...]/vendor/bundle/ruby/3.3.0/gems/graphql-pro-1.26.5/lib/graphql/pro/operation_store/active_record_backend.rb:252:in `update_last_used_ats'
	from /opt/hostedtoolcache/Ruby/3.3.0/x64/lib/ruby/3.3.0/forwardable.rb:240:in `update_last_used_ats'
	from [...]/vendor/bundle/ruby/3.3.0/gems/graphql-pro-1.26.5/lib/graphql/pro/operation_store.rb:211:in `block in flush_pending_last_used_ats'
	from [...]/vendor/bundle/ruby/3.3.0/gems/graphql-pro-1.26.5/lib/graphql/pro/operation_store.rb:209:in `synchronize'
	from [...]/vendor/bundle/ruby/3.3.0/gems/graphql-pro-1.26.5/lib/graphql/pro/operation_store.rb:209:in `flush_pending_last_used_ats'
	from [...]/vendor/bundle/ruby/3.3.0/gems/graphql-pro-1.26.5/lib/graphql/pro/operation_store.rb:126:in `block in touch_last_used_at'
```

A simple change to this completely eliminated these test hangs / failures:

```ruby
use GraphQL::Pro::OperationStore, update_last_used_at_every: Rails.env.test? ? 0 : 15
```

I thought it might be helpful to note that in the operation store AR backend guide.