### PR TITLE
Fix run_graphql_field with missing query string on dummy query

### DIFF
--- a/lib/graphql/testing/helpers.rb
+++ b/lib/graphql/testing/helpers.rb
@@ -41,7 +41,7 @@ module GraphQL
 
       def run_graphql_field(schema, field_path, object, arguments: {}, context: {})
         type_name, *field_names = field_path.split(".")
-        dummy_query = GraphQL::Query.new(schema, "query {}", context: context)
+        dummy_query = GraphQL::Query.new(schema, "{ __typename }", context: context)
         query_context = dummy_query.context
         object_type = dummy_query.get_type(type_name) # rubocop:disable Development/ContextIsPassedCop
         if object_type

--- a/lib/graphql/testing/helpers.rb
+++ b/lib/graphql/testing/helpers.rb
@@ -41,7 +41,7 @@ module GraphQL
 
       def run_graphql_field(schema, field_path, object, arguments: {}, context: {})
         type_name, *field_names = field_path.split(".")
-        dummy_query = GraphQL::Query.new(schema, context: context)
+        dummy_query = GraphQL::Query.new(schema, "query {}", context: context)
         query_context = dummy_query.context
         object_type = dummy_query.get_type(type_name) # rubocop:disable Development/ContextIsPassedCop
         if object_type

--- a/spec/graphql/testing/helpers_spec.rb
+++ b/spec/graphql/testing/helpers_spec.rb
@@ -28,6 +28,10 @@ describe GraphQL::Testing::Helpers do
     end
 
     class Student < GraphQL::Schema::Object
+      def self.authorized?(object, context)
+        context.errors.empty?
+      end
+
       field :name, String do
         argument :full_name, Boolean, required: false
         argument :prefix, String, required: false, default_value: "Mc", prepare: ->(val, ctx) { -> { val.capitalize } }


### PR DESCRIPTION
Bug: The `dummy_query` object created as part of `run_graphql_field` doesn't set a query string, which results in a `query_context` object that has validation errors.

Later when `object_type.wrap(inner_object, query_context)` is called with that `query_context`, it checks that the field is authorized.

If as part of checking `self.authorized?` on an object, we first ensure that the context is valid i.e. that `context.errors.empty?`, we will find that it isn't because of this missing query string.

Even if this query string isn't used, the `GraphQL::Query` object should be valid, in case there are validations that are done on these objects in a client's code. This is what we are doing in our code, which led me to this bug.

This PR sets a dummy query string value to fix this issue, and adds a simple `self.authorized?` check which ensures that the context is valid i.e. that `context.errors.empty?`