### PR TITLE
Fix typo

### DIFF
--- a/guides/queries/executing_queries.md
+++ b/guides/queries/executing_queries.md
@@ -127,7 +127,7 @@ Note that `context` is _not_ the hash that you passed it. It's an instance of {{
 
 `context` is shared by the whole query. Anything you add to `context` will be accessible by any other field in the query (although GraphQL-Ruby's order of execution can vary).
 
-However, "scoped context" is can be used to assign values into `context` that are only available in the current field and the _children_ of the current field. For example, in this query:
+However, "scoped context" can be used to assign values into `context` that are only available in the current field and the _children_ of the current field. For example, in this query:
 
 ```graphql
 {


### PR DESCRIPTION
The typo is highlighted in blue in the image below:

![image](https://github.com/rmosolgo/graphql-ruby/assets/32133198/cf7f428e-1be3-4f44-8bd7-10189f84c734)
