### PR TITLE
Fix alignment of a value in the "Invalid" column

### DIFF
--- a/guides/type_definitions/lists.md
+++ b/guides/type_definitions/lists.md
@@ -106,11 +106,11 @@ In this example, `scores` may not return `null`. It must _always_ return a list.
 
 Here are values the field may return:
 
-Valid | Invalid
-------|------
-`[]`  | `null`
-`[1, 2, ...]`| `[null]`
-| | `[1, null, 2, ...]`
+| Valid | Invalid |
+| ------ | ------ |
+| `[]` | `null` |
+| `[1, 2, ...]` | `[null]` |
+| | `[1, null, 2, ...]` |
 
 ### Non-null lists with nullable items
 


### PR DESCRIPTION
As highlighted in blue in the image below, that value is not aligned properly.

![image](https://github.com/rmosolgo/graphql-ruby/assets/32133198/59afd366-d3af-4623-a510-b2e2c8f60bab)

That value should be in the "Invalid" column, and the changes proposed in this PR will fix this alignment issue.