### PR TITLE
Fix indentation

### DIFF
--- a/guides/type_definitions/directives.md
+++ b/guides/type_definitions/directives.md
@@ -35,6 +35,7 @@ Here's how the two built-in directives work:
 
 - `@skip(if: ...)` skips the selection if the `if: ...` value is truthy ({{ "GraphQL::Schema::Directive::Skip" | api_doc }})
 - `@include(if: ...)` includes the selection if the `if: ...` value is truthy ({{ "GraphQL::Schema::Directive::Include" | api_doc }})
+
 ### Custom Runtime Directives
 
 Custom directives extend {{ "GraphQL::Schema::Directive" | api_doc }}:


### PR DESCRIPTION
As highlighted in blue in the image below, the "Custom Runtime Directives" has an accidental indent at the beginning.

![image](https://github.com/rmosolgo/graphql-ruby/assets/32133198/69324bb5-ad23-4da8-be39-41cefcbeb7c6)

This is because, as highlighted in red in the image below, that `<h3>` is inside of the `<li>`. The changes in this PR make that `<h3>` **not** inside of the `<li>`, therefore fixing the indentation issue.

![image](https://github.com/rmosolgo/graphql-ruby/assets/32133198/f48de545-1e3f-4ade-a35d-5f686d36a3ba)

