### PR TITLE
Deduplicate TypeName#name and Field#name string

### DIFF
--- a/lib/graphql/language/parser.rb
+++ b/lib/graphql/language/parser.rb
@@ -608,7 +608,7 @@ module GraphQL
       end
 
       def parse_type_name
-        TypeName.new(pos: pos, name: parse_name, filename: @filename, source_string: @graphql_str)
+        TypeName.new(pos: pos, name: -parse_name, filename: @filename, source_string: @graphql_str)
       end
 
       def parse_directives

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -228,6 +228,9 @@ module GraphQL
             raise ArgumentError, "missing second `type` argument or keyword `type:`"
           end
         end
+
+        name = -name if name.is_a?(String)
+
         @original_name = name
         name_s = -name.to_s
 


### PR DESCRIPTION
Looking at deduplicated string reports from out application, GraphQL field and type are at the top:

```
Retained String Report
-----------------------------------
 203.20 kB    5080  "String"
              4902  graphql-c_parser-1.0.8/lib/graphql/c_parser.rb:73
               172  graphql-2.2.13/lib/graphql/language/lexer.rb:80
  60.77 kB    1485  "ID"
              1271  graphql-c_parser-1.0.8/lib/graphql/c_parser.rb:73
               166  graphql-2.2.13/lib/graphql/language/lexer.rb:80
                19  graphql-client-ee19269df0ee/lib/graphql/client/schema/enum_type.rb:65
  35.32 kB     883  "id"
               518  graphql-c_parser-1.0.8/lib/graphql/c_parser.rb:73
               353  graphql-2.2.13/lib/graphql/language/lexer.rb:80
  34.24 kB     856  "Int"
               800  graphql-c_parser-1.0.8/lib/graphql/c_parser.rb:73
                51  graphql-2.2.13/lib/graphql/language/lexer.rb:80
  33.08 kB     827  "Boolean"
               811  graphql-c_parser-1.0.8/lib/graphql/c_parser.rb:73
                10  graphql-2.2.13/lib/graphql/language/lexer.rb:80
```

I'm very unfamilair with the gem, but looking at which objects retain them I think I managed to locate where best to deduplicate them, but perhaps there is a better way:

```
root path to 0x7da15ef231e0:
                      ROOT (vm)
...
                      0x7da15ef02bc0 (OBJECT: GraphQL::Language::Nodes::VariableDefinition)
                      0x7da15ef6d718 (OBJECT: GraphQL::Language::Nodes::ListType)
                      0x7da15ef6d768 (OBJECT: GraphQL::Language::Nodes::NonNullType)
                      0x7da15ef6d7b8 (OBJECT: GraphQL::Language::Nodes::TypeName)
                      0x7da15ef231e0 (STRING: "String")

harb> rootpath 0x7da15da32f60
root path to 0x7da15da32f60:
                      ROOT (vm)
...
                      0x7da15d9bd7b0 (OBJECT: GraphQL::Schema::Argument)
                      0x7da15da28218 (OBJECT: GraphQL::Language::Nodes::InputValueDefinition)
                      0x7da15d9ff340 (OBJECT: GraphQL::Language::Nodes::NonNullType)
                      0x7da15d9ff390 (OBJECT: GraphQL::Language::Nodes::TypeName)
                      0x7da15da32f60 (STRING: "String")

harb> rootpath 0x7da160835c28
root path to 0x7da160835c28:
                      ROOT (vm)
...
                      0x7da16050c1c8 (OBJECT: GraphQL::Schema::Argument)
                      0x7da1606e0aa8 (OBJECT: GraphQL::Language::Nodes::InputValueDefinition)
                      0x7da160751d70 (OBJECT: GraphQL::Language::Nodes::NonNullType)
                      0x7da160751dc0 (OBJECT: GraphQL::Language::Nodes::TypeName)
                      0x7da160835c28 (STRING: "ID")

harb> rootpath 0x7da15f36ea10
root path to 0x7da15f36ea10:
                      ROOT (vm)
                      0x7da3f6ddfd20 (CLASS: Object)
...
                      0x7da15f132f80 (OBJECT: GraphQL::Schema::Field)
                      0x7da15f36ea10 (STRING: "id")

harb> rootpath 0x7da16016beb0
root path to 0x7da16016beb0:
                      ROOT (vm)
...
                      0x7da15ff16408 (OBJECT: GraphQL::Schema::Field)
                      0x7da16016beb0 (STRING: "clientMutationId")
```