### PR TITLE
[1.13.x] require ostruct which was previously required by rake

### DIFF
--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -4,6 +4,7 @@ require "json"
 require "set"
 require "singleton"
 require "forwardable"
+require "ostruct"
 
 module GraphQL
   # forwards-compat for argument handling


### PR DESCRIPTION
Fixes #4900 

Not needed in 2.x because the file using it isn't present. 

There _is_ another use of OpenStruct in the gem, but it will only run in applications which already use OpenStruct: 

https://github.com/rmosolgo/graphql-ruby/blob/ec1ae00fdd36d5292096e40adb7401c4832bb7ee/lib/graphql/subscriptions/serialize.rb#L85-L87