### PR TITLE
Fix field usage on prepared input types with original value

### DIFF
--- a/lib/graphql/analysis/ast/field_usage.rb
+++ b/lib/graphql/analysis/ast/field_usage.rb
@@ -41,7 +41,9 @@ module GraphQL
               @used_deprecated_arguments << argument.definition.path
             end
 
-            next if argument.value.nil?
+            arg_val = argument.value
+
+            next if arg_val.nil?
 
             argument_type = argument.definition.type
             if argument_type.non_null?
@@ -49,18 +51,18 @@ module GraphQL
             end
 
             if argument_type.kind.input_object?
-              extract_deprecated_arguments(argument.value.arguments.argument_values) # rubocop:disable Development/ContextIsPassedCop -- runtime args instance
+              extract_deprecated_arguments(argument.original_value.arguments.argument_values) # rubocop:disable Development/ContextIsPassedCop -- runtime args instance
             elsif argument_type.kind.enum?
-              extract_deprecated_enum_value(argument_type, argument.value)
+              extract_deprecated_enum_value(argument_type, arg_val)
             elsif argument_type.list?
               inner_type = argument_type.unwrap
               case inner_type.kind
               when TypeKinds::INPUT_OBJECT
-                argument.value.each do |value|
+                argument.original_value.each do |value|
                   extract_deprecated_arguments(value.arguments.argument_values) # rubocop:disable Development/ContextIsPassedCop -- runtime args instance
                 end
               when TypeKinds::ENUM
-                argument.value.each do |value|
+                arg_val.each do |value|
                   extract_deprecated_enum_value(inner_type, value)
                 end
               else

--- a/lib/graphql/execution/interpreter/argument_value.rb
+++ b/lib/graphql/execution/interpreter/argument_value.rb
@@ -6,14 +6,18 @@ module GraphQL
       # A container for metadata regarding arguments present in a GraphQL query.
       # @see Interpreter::Arguments#argument_values for a hash of these objects.
       class ArgumentValue
-        def initialize(definition:, value:, default_used:)
+        def initialize(definition:, value:, original_value:, default_used:)
           @definition = definition
           @value = value
+          @original_value = original_value
           @default_used = default_used
         end
 
         # @return [Object] The Ruby-ready value for this Argument
         attr_reader :value
+
+        # @return [Object] The value of this argument _before_ `prepare` is applied.
+        attr_reader :original_value
 
         # @return [GraphQL::Schema::Argument] The definition instance for this argument
         attr_reader :definition

--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -290,6 +290,7 @@ module GraphQL
             # TODO code smell to access such a deeply-nested constant in a distant module
             argument_values[arg_key] = GraphQL::Execution::Interpreter::ArgumentValue.new(
               value: resolved_loaded_value,
+              original_value: resolved_coerced_value,
               definition: self,
               default_used: default_used,
             )

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -215,8 +215,7 @@ module GraphQL
             if resolved_arguments.is_a?(GraphQL::Error)
               raise resolved_arguments
             else
-              input_obj_instance = self.new(resolved_arguments, ruby_kwargs: resolved_arguments.keyword_arguments, context: ctx, defaults_used: nil)
-              input_obj_instance.prepare
+              self.new(resolved_arguments, ruby_kwargs: resolved_arguments.keyword_arguments, context: ctx, defaults_used: nil)
             end
           end
         end

--- a/spec/graphql/analysis/ast/field_usage_spec.rb
+++ b/spec/graphql/analysis/ast/field_usage_spec.rb
@@ -254,6 +254,17 @@ describe GraphQL::Analysis::AST::FieldUsage do
     end
   end
 
+  describe "mutation with deprecated arguments with prepared values" do
+    let(:query_string) {%|
+      mutation {
+        pushValue(preparedTestInput: { deprecatedDate: "2020-10-10" })
+      }
+    |}
+
+    it "keeps track of nested deprecated arguments" do
+      assert_equal ['PreparedDateInput.deprecatedDate'], result[:used_deprecated_arguments]
+    end
+  end
 
   describe "when an argument prepare raises a GraphQL::ExecutionError" do
     class ArgumentErrorFieldUsageSchema < GraphQL::Schema

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -265,6 +265,18 @@ module Dummy
     argument :old_source, String, required: false, deprecation_reason: "No longer supported"
   end
 
+  class PreparedDateInput < BaseInputObject
+    description "Input with prepared value"
+    argument :date, String, description: "date as a string", required: false
+    argument :deprecated_date, String, description: "date as a string", required: false, deprecation_reason: "Use date"
+
+    def prepare
+      return nil unless date || deprecated_date
+
+      Date.parse(date || deprecated_date)
+    end
+  end
+
   class DeepNonNull < BaseObject
     field :non_null_int, Integer, null: false do
       argument :returning, Integer, required: false
@@ -492,6 +504,7 @@ module Dummy
     field :push_value, [Integer], null: false, description: "Push a value onto a global array :D" do
       argument :value, Integer, as: :val
       argument :deprecated_test_input, DairyProductInput, required: false
+      argument :prepared_test_input, PreparedDateInput, required: false
     end
     def push_value(val:)
       GLOBAL_VALUES << val


### PR DESCRIPTION
Fixes #4864 

Along the way, I noticed that `InputObject#prepare` was called twice when that method returned itself. By removing the first call, this solution worked out nicely.