### PR TITLE
Rescue printing Infinity

### DIFF
--- a/lib/graphql/language.rb
+++ b/lib/graphql/language.rb
@@ -33,6 +33,12 @@ module GraphQL
       else
         JSON.generate(value, quirks_mode: true)
       end
+    rescue JSON::GeneratorError
+      if Float::INFINITY == value
+        "Infinity"
+      else
+        raise
+      end
     end
 
     # Returns a new string if any single-quoted newlines were escaped.

--- a/lib/graphql/language/lexer.rb
+++ b/lib/graphql/language/lexer.rb
@@ -156,6 +156,7 @@ module GraphQL
       INT_REGEXP =        /-?(?:[0]|[1-9][0-9]*)/
       FLOAT_DECIMAL_REGEXP = /[.][0-9]+/
       FLOAT_EXP_REGEXP =     /[eE][+-]?[0-9]+/
+      # TODO: FLOAT_EXP_REGEXP should not be allowed to follow INT_REGEXP, integers are not allowed to have exponent parts.
       NUMERIC_REGEXP =  /#{INT_REGEXP}(#{FLOAT_DECIMAL_REGEXP}#{FLOAT_EXP_REGEXP}|#{FLOAT_DECIMAL_REGEXP}|#{FLOAT_EXP_REGEXP})?/
 
       KEYWORDS = [

--- a/spec/graphql/language/printer_spec.rb
+++ b/spec/graphql/language/printer_spec.rb
@@ -278,7 +278,7 @@ describe GraphQL::Language::Printer do
     schema = Class.new(GraphQL::Schema) do
       query(query_type)
     end
-    query_str = "query {\n  issue(number: 9999e999)\n}"
+    query_str = "query {\n  issue(number: 9999.9e999)\n}"
     printed_query_str = "query {\n  issue(number: Infinity)\n}"
 
     assert_equal printed_query_str, GraphQL.parse(query_str).to_query_string


### PR DESCRIPTION
When clients provide numbers that are too big for Ruby, query execution returns an error. This handles the query printer to print _something_ when that happens -- it used to raise an error. 

Technically, the right thing to do would be to raise a parse error.

Part of #4922 

