### PR TITLE
Add an option to reject numbers followed by names

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,12 +54,12 @@ jobs:
             ruby: 3.3
           - gemfile: gemfiles/rails_master.gemfile
             ruby: 3.3
-            graphql_reject_numbers_followed_by_name: 1
+            graphql_reject_numbers_followed_by_names: 1
     runs-on: ubuntu-latest
     steps:
     - run: echo BUNDLE_GEMFILE=${{ matrix.gemfile }} > $GITHUB_ENV
-    - run: echo GRAPHQL_REJECT_NUMBERS_FOLLOWED_BY_NAME=1 > $GITHUB_ENV
-      if: ${{ !!matrix.graphql_reject_numbers_followed_by_name }}
+    - run: echo GRAPHQL_REJECT_NUMBERS_FOLLOWED_BY_NAMES=1 > $GITHUB_ENV
+      if: ${{ !!matrix.graphql_reject_numbers_followed_by_names }}
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,8 @@ jobs:
             ruby: 3.3
           - gemfile: gemfiles/rails_master.gemfile
             ruby: 3.3
+            env:
+              GRAPHQL_REJECT_NUMBERS_FOLLOWED_BY_NAMES: 1
     runs-on: ubuntu-latest
     steps:
     - run: echo BUNDLE_GEMFILE=${{ matrix.gemfile }} > $GITHUB_ENV

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,11 +54,12 @@ jobs:
             ruby: 3.3
           - gemfile: gemfiles/rails_master.gemfile
             ruby: 3.3
-            env:
-              GRAPHQL_REJECT_NUMBERS_FOLLOWED_BY_NAMES: 1
+            graphql_reject_numbers_followed_by_name: 1
     runs-on: ubuntu-latest
     steps:
     - run: echo BUNDLE_GEMFILE=${{ matrix.gemfile }} > $GITHUB_ENV
+    - run: echo GRAPHQL_REJECT_NUMBERS_FOLLOWED_BY_NAME=1 > $GITHUB_ENV
+      if: ${{ !!matrix.graphql_reject_numbers_followed_by_name }}
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:

--- a/graphql-c_parser/ext/graphql_c_parser_ext/graphql_c_parser_ext.c
+++ b/graphql-c_parser/ext/graphql_c_parser_ext/graphql_c_parser_ext.c
@@ -1,7 +1,7 @@
 #include "graphql_c_parser_ext.h"
 
-VALUE GraphQL_CParser_Lexer_tokenize_with_c_internal(VALUE self, VALUE query_string, VALUE fstring_identifiers) {
-  return tokenize(query_string, RTEST(fstring_identifiers));
+VALUE GraphQL_CParser_Lexer_tokenize_with_c_internal(VALUE self, VALUE query_string, VALUE fstring_identifiers, VALUE reject_numbers_followed_by_names) {
+  return tokenize(query_string, RTEST(fstring_identifiers), RTEST(reject_numbers_followed_by_names));
 }
 
 VALUE GraphQL_CParser_Parser_c_parse(VALUE self) {
@@ -13,7 +13,7 @@ void Init_graphql_c_parser_ext() {
   VALUE GraphQL = rb_define_module("GraphQL");
   VALUE CParser = rb_define_module_under(GraphQL, "CParser");
   VALUE Lexer = rb_define_module_under(CParser, "Lexer");
-  rb_define_singleton_method(Lexer, "tokenize_with_c_internal", GraphQL_CParser_Lexer_tokenize_with_c_internal, 2);
+  rb_define_singleton_method(Lexer, "tokenize_with_c_internal", GraphQL_CParser_Lexer_tokenize_with_c_internal, 3);
   setup_static_token_variables();
 
   VALUE Parser = rb_define_class_under(CParser, "Parser", rb_cObject);

--- a/graphql-c_parser/ext/graphql_c_parser_ext/lexer.h
+++ b/graphql-c_parser/ext/graphql_c_parser_ext/lexer.h
@@ -1,6 +1,6 @@
 #ifndef Graphql_lexer_h
 #define Graphql_lexer_h
 #include <ruby.h>
-VALUE tokenize(VALUE query_rbstr, int fstring_identifiers);
+VALUE tokenize(VALUE query_rbstr, int fstring_identifiers, int reject_numbers_followed_by_names);
 void setup_static_token_variables();
 #endif

--- a/graphql-c_parser/lib/graphql/c_parser.rb
+++ b/graphql-c_parser/lib/graphql/c_parser.rb
@@ -16,7 +16,8 @@ module GraphQL
     end
 
     def self.tokenize_with_c(str)
-      tokenize_with_c_internal(str, false)
+      reject_numbers_followed_by_names = GraphQL.respond_to?(:reject_numbers_followed_by_names) && GraphQL.reject_numbers_followed_by_names
+      tokenize_with_c_internal(str, false, reject_numbers_followed_by_names)
     end
 
     def self.prepare_parse_error(message, parser)
@@ -79,7 +80,8 @@ module GraphQL
             ]
           ]
         end
-        tokenize_with_c_internal(graphql_string, intern_identifiers, GraphQL.reject_numbers_followed_by_names)
+        reject_numbers_followed_by_names = GraphQL.respond_to?(:reject_numbers_followed_by_names) && GraphQL.reject_numbers_followed_by_names
+        tokenize_with_c_internal(graphql_string, intern_identifiers, reject_numbers_followed_by_names)
       end
     end
 

--- a/graphql-c_parser/lib/graphql/c_parser.rb
+++ b/graphql-c_parser/lib/graphql/c_parser.rb
@@ -20,8 +20,10 @@ module GraphQL
     end
 
     def self.prepare_parse_error(message, parser)
+      query_str = parser.query_string
+      filename = parser.filename
       if message.start_with?("memory exhausted")
-        return GraphQL::ParseError.new("This query is too large to execute.", nil, nil, parser.query_string, filename: parser.filename)
+        return GraphQL::ParseError.new("This query is too large to execute.", nil, nil, query_str, filename: filename)
       end
       token = parser.tokens[parser.next_token_index - 1]
       if token
@@ -40,7 +42,11 @@ module GraphQL
         end
       end
 
-      GraphQL::ParseError.new(message, line, col, parser.query_string, filename: parser.filename)
+      GraphQL::ParseError.new(message, line, col, query_str, filename: filename)
+    end
+
+    def self.prepare_number_name_parse_error(line, col, query_str, number_part, name_part)
+      raise GraphQL::ParseError.new("Name after number is not allowed (in `#{number_part}#{name_part}`)", line, col, query_str)
     end
 
     def self.prepare_bad_unicode_error(parser)
@@ -73,7 +79,7 @@ module GraphQL
             ]
           ]
         end
-        tokenize_with_c_internal(graphql_string, intern_identifiers)
+        tokenize_with_c_internal(graphql_string, intern_identifiers, GraphQL.reject_numbers_followed_by_names)
       end
     end
 

--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -74,6 +74,13 @@ This is probably a bug in GraphQL-Ruby, please report this error on GitHub: http
     EMPTY_HASH = {}.freeze
     EMPTY_ARRAY = [].freeze
   end
+
+  class << self
+    # If true, the parser should raise when an integer or float is followed immediately by an identifier (instead of a space or punctuation)
+    attr_accessor :reject_numbers_followed_by_names
+  end
+
+  self.reject_numbers_followed_by_names = false
 end
 
 # Order matters for these:

--- a/lib/graphql/language.rb
+++ b/lib/graphql/language.rb
@@ -71,8 +71,21 @@ module GraphQL
       new_query_str || query_str
     end
 
+    INVALID_NUMBER_FOLLOWED_BY_NAME_REGEXP = %r{
+      (
+        ((?<num>#{Lexer::INT_REGEXP}(#{Lexer::FLOAT_EXP_REGEXP})?)(?<name>#{Lexer::IDENTIFIER_REGEXP})#{Lexer::IGNORE_REGEXP}:)
+        |
+        ((?<num>#{Lexer::INT_REGEXP}#{Lexer::FLOAT_DECIMAL_REGEXP}#{Lexer::FLOAT_EXP_REGEXP})(?<name>#{Lexer::IDENTIFIER_REGEXP})#{Lexer::IGNORE_REGEXP}:)
+        |
+        ((?<num>#{Lexer::INT_REGEXP}#{Lexer::FLOAT_DECIMAL_REGEXP})(?<name>#{Lexer::IDENTIFIER_REGEXP})#{Lexer::IGNORE_REGEXP}:)
+      )}x
+
     def self.add_space_between_numbers_and_names(query_str)
-      query_str.gsub(/(?<num>#{Lexer::NUMERIC_REGEXP})(?<name>#{Lexer::IDENTIFIER_REGEXP})/, "\\k<num> \\k<name>")
+      if query_str.match?(INVALID_NUMBER_FOLLOWED_BY_NAME_REGEXP)
+        query_str.gsub(INVALID_NUMBER_FOLLOWED_BY_NAME_REGEXP, "\\k<num> \\k<name>:")
+      else
+        query_str
+      end
     end
   end
 end

--- a/lib/graphql/language.rb
+++ b/lib/graphql/language.rb
@@ -70,5 +70,9 @@ module GraphQL
       end
       new_query_str || query_str
     end
+
+    def self.add_space_between_numbers_and_names(query_str)
+      query_str.gsub(/(?<num>#{Lexer::NUMERIC_REGEXP})(?<name>#{Lexer::IDENTIFIER_REGEXP})/, "\\k<num> \\k<name>")
+    end
   end
 end

--- a/spec/graphql/language/parser_spec.rb
+++ b/spec/graphql/language/parser_spec.rb
@@ -134,8 +134,27 @@ createRecord(data: {
   end
 
   it "can replace namestart at the end of numbers" do
-    assert_equal "{ a(b: 123 cde: 456)}", GraphQL::Language.add_space_between_numbers_and_names("{ a(b: 123cde: 456)}")
-    assert_equal "{ a(b: 12.3e5 cde: 456)}", GraphQL::Language.add_space_between_numbers_and_names("{ a(b: 12.3e5cde: 456)}")
+    ok_str1 = "{ a(b: 123 cde: 456)}"
+    assert_equal ok_str1, GraphQL::Language.add_space_between_numbers_and_names("{ a(b: 123cde: 456)}")
+    ok_str2 = "{ a(b: 12.3e5 cde: 456)}"
+    assert_equal ok_str2, GraphQL::Language.add_space_between_numbers_and_names("{ a(b: 12.3e5cde: 456)}")
+    ok_str3 = "{ a(b: 123e56 cde: 456)}"
+    assert_equal ok_str3, GraphQL::Language.add_space_between_numbers_and_names("{ a(b: 123e56cde: 456)}")
+
+    # It returns unchanged strings:
+    ok_strs = [
+      ok_str1,
+      ok_str2,
+      ok_str3,
+      "{ a(b: 123e5) }",
+      "{ a(b: 123e5 ) }",
+      "{ a(b: 12.3e5) }",
+      "{ a(b: 12.3e5 ) }",
+    ]
+    ok_strs.each do |ok_str|
+      changed_str = GraphQL::Language.add_space_between_numbers_and_names(ok_str)
+      assert ok_str.equal?(changed_str), "#{ok_str.inspect} is unchanged (was: #{changed_str.inspect})"
+    end
   end
 
   it "handles hyphens with errors" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,11 @@ else
   USING_C_PARSER = false
 end
 
+if ENV["GRAPHQL_REJECT_NUMBERS_FOLLOWED_BY_NAMES"]
+  puts "Opting into GraphQL.reject_numbers_followed_by_names"
+  GraphQL.reject_numbers_followed_by_names = true
+end
+
 require "rake"
 require "graphql/rake_task"
 require "benchmark"


### PR DESCRIPTION
Fixes #4871 

This option is off by default now but will be on by default in GraphQL-Ruby 3.0. You can opt into the new behavior with: 

```ruby
# app/graphql/my_schema.rb
GraphQL.reject_numbers_followed_by_names = true 

# ... 
```

And you can check for invalid query strings using the helper: 

```ruby 
transformed_query_str = GraphQL::Language.add_space_between_numbers_and_names(query_str) 
if transformed_query_str.equal?(query_str) 
  # The old string was returned, query_str is valid 
  # do nothing 
else 
   # A new, modified query string was returned 
   # Track this occurrence and/or use the transformed string
   BugTracer.report(:invalid_query_string, query_str)
   query_str = transformed_query_str
end 
```

TODO: 

- [x] Improve tests and implementation of string fix method to handle exponent notation
-  ~~Also make sure variable definitions are covered, eg `query($a: Int = 5$b: Int = 6) { ... }`~~
  - I think that variable definitions and values followed by directives are technically _legal_ because the following character is either `@` or `$`, not a name. I _did_ add tests for input object literals, and they were covered by the current implementation.
- [x] Are there other places where client-provided values appear, where there might be a number literal? (see above)
- [x] Add a CI build which runs with `GraphQL.reject_numbers_followed_by_names = true`