### PR TITLE
Connection based query splitting

### DIFF
--- a/lib/graphql/bulk/base_query_splitter.rb
+++ b/lib/graphql/bulk/base_query_splitter.rb
@@ -1,0 +1,43 @@
+module GraphQL
+  module Bulk
+    class BaseQuerySplitter
+      ConnectionQuery = Struct.new(:path_string, :query_string)
+      SplitQuery = Struct.new(:base_query, :connection_queries)
+
+      def initialize(query, schema)
+        @query = query
+        @schema = schema
+      end
+
+      def split_query
+        gql_query_tree = add_type_name_fields
+
+        connection_removal_visitor = Visitors::ConnectionRemovalVisitor.new(gql_query_tree.document)
+        base_query_document = connection_removal_visitor.visit
+
+        connection_queries = connection_removal_visitor.connections.map do |connection|
+          connection_document = Visitors::ConnectionNodeExtractionVisitor.new(gql_query_tree.document, connection)
+          query_document = connection_document.visit
+
+          ConnectionQuery.new(
+            connection.path.map{ |node| node.respond_to?(:name) ? node.name : "" }.join("."),
+            query_document.to_query_string
+          )
+        end
+
+        SplitQuery.new(
+          base_query_document.to_query_string,
+          connection_queries
+        )
+      end
+
+      private
+
+      def add_type_name_fields
+        gql_query_tree = GraphQL::Query.new(@schema, @query)
+        query_with_typename = Visitors::AddTypenameToQueryVisitor.new(gql_query_tree.document).visit
+        GraphQL::Query.new(@schema, query_with_typename.to_query_string)
+      end
+    end
+  end
+end

--- a/lib/graphql/bulk/bulk.rb
+++ b/lib/graphql/bulk/bulk.rb
@@ -1,0 +1,13 @@
+module GraphQL
+  module Bulk
+    require "graphql/bulk/visitors/add_pagination_to_query_visitor"
+    require "graphql/bulk/visitors/add_typename_to_query_visitor"
+    require "graphql/bulk/visitors/connection_node_extraction_visitor"
+    require "graphql/bulk/visitors/connection_removal_visitor"
+    require "graphql/bulk/base_query_splitter"
+    require "graphql/bulk/connection_query_splitter"
+    require "graphql/bulk/debug"
+    require "graphql/bulk/errors"
+    require "graphql/bulk/query_splitter_service"
+  end
+end

--- a/lib/graphql/bulk/connection_query_splitter.rb
+++ b/lib/graphql/bulk/connection_query_splitter.rb
@@ -1,0 +1,75 @@
+module GraphQL
+  module Bulk
+    class ConnectionQuerySplitter
+      UnrolledConnectionQuery = Struct.new(:rollup_field_name, :unrolled_query)
+      SplitConnectionQuery = Struct.new(:paginated_query, :unrolled_connection_queries)
+
+      def initialize(connection_query, schema)
+        @connection_query = connection_query
+        @schema = schema
+      end
+
+      def split_query
+        gql_query_document = GraphQL::Query.new(@schema, @connection_query.query_string).document
+
+        result = handle_nested_connections(gql_query_document)
+        paginated_query = handle_pagination_splitting(result[:base_query_without_nested_connections])
+
+        SplitConnectionQuery.new(paginated_query, result[:unrolled_connection_queries])
+      end
+
+      private
+
+      def handle_nested_connections(gql_query_document)
+        connection_removal_visitor = Visitors::ConnectionRemovalVisitor.new(gql_query_document, depth: 2)
+        base_query_document = connection_removal_visitor.visit
+
+        unrolled_connection_queries = []
+        connection_removal_visitor.connections.each do |connection|
+          connection_document = Visitors::ConnectionNodeExtractionVisitor.new(gql_query_document, connection)
+          unrolled_connection_queries << unroll_root_connection_query(connection_document.visit)
+        end
+
+        {
+          unrolled_connection_queries: unrolled_connection_queries,
+          base_query_without_nested_connections: base_query_document,
+        }
+      end
+
+      def handle_pagination_splitting(gql_query_document)
+        paginator = Visitors::AddPaginationToQueryVisitor.new(gql_query_document, root_connection_node(gql_query_document))
+        paginator.visit.to_query_string
+      end
+
+      def unroll_root_connection_query(gql_query_document)
+        root_connection_node = root_connection_node(gql_query_document)
+        query_to_inject = extract_unrolled_query(root_connection_node)
+        unrolled_query_string = "query UnrolledQuery($__appPlatformUniqueIdForUnrolling: EncodedId!) {#{root_connection_node.name.singularize}(id: $__appPlatformUniqueIdForUnrolling) { #{query_to_inject} }}"
+
+        UnrolledConnectionQuery.new("#{@connection_query.path_string}.#{root_connection_node.name}", unrolled_query_string)
+      end
+
+      def root_connection_node(gql_query_document)
+        root_connection_finder = Visitors::ConnectionRemovalVisitor.new(gql_query_document, depth: 1)
+        root_connection_finder.visit
+        root_connection_finder.connections.first.node
+      end
+
+      def extract_unrolled_query(root_connection_node)
+        field_node = root_connection_node.selections.first
+
+        if field_node.name == "nodes"
+          # nodes -> <stuff I care about>
+          return field_node.children.first.to_query_string
+        end
+
+        if field_node.name == "edges"
+          # job -> edges -> node -> <stuff I care about>
+          return field_node.children.first.children.first.to_query_string
+        end
+
+        raise Errors::BulkError, "#{root_connection_node.name} node does not have `nodes` or `edges` as it's first child"
+      end
+    end
+  end
+end

--- a/lib/graphql/bulk/debug.rb
+++ b/lib/graphql/bulk/debug.rb
@@ -1,0 +1,25 @@
+module GraphQL
+  module Bulk
+    class Debug
+      class << self
+        # rubocop:disable Rails/Output
+        def print_string(result, prefix = "")
+          puts "#{prefix}base: #{result[:base].delete("\n")}"
+          puts "#{prefix}nested:"
+          result[:nested].each do |nested|
+            puts "#{prefix}\t ========= Result ======= "
+            puts "#{prefix}\t path: #{nested[:path]}"
+            puts "#{prefix}\t paginated: #{nested[:paginated].delete("\n")}"
+            puts "#{prefix}\t unrolled:"
+            nested[:unrolled].each do |u|
+              puts "#{prefix}\t\t rollup_field: #{u[:rollup_field_name]}"
+              print_string u[:queries], "#{prefix}\t\t "
+            end
+            puts "#{prefix}\t ========================"
+          end
+          # rubocop:enable Rails/Output
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/bulk/errors.rb
+++ b/lib/graphql/bulk/errors.rb
@@ -1,0 +1,21 @@
+module GraphQL
+  module Bulk
+    module Errors
+      class BulkError < StandardError; end
+
+      class FragmentError < BulkError; end
+
+      class QueryInvalidError < BulkError
+        attr_reader :query
+
+        def initialize(query)
+          @query = query
+          errors = query.static_errors
+          message = errors.map(&:message).join(", ")
+
+          super(message)
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/bulk/query_splitter_service.rb
+++ b/lib/graphql/bulk/query_splitter_service.rb
@@ -1,0 +1,58 @@
+module GraphQL
+    module Bulk
+      class QuerySplitterService
+        class << self
+        def split(schema, query, debug: false)
+            validate(schema, query)
+
+            result = split_all_bulk_queries(schema, query)
+
+            Debug.print_string(result) if debug
+
+            result
+          end
+
+          def validate(schema, query)
+            query = GraphQL::Query.new(schema, query)
+
+            raise Errors::QueryInvalidError, query unless query.valid?
+            raise Errors::FragmentError, "Bulk operations on a query with fragments is not supported" if query.fragments.any?
+          end
+
+          private
+
+          def split_all_bulk_queries(schema, query)
+            queries = {}
+
+            base_splitter = BaseQuerySplitter.new(query, schema)
+            base_results = base_splitter.split_query
+
+            queries[:base] = base_results[:base_query]
+            queries[:nested] = []
+
+            base_results.connection_queries.each do |cq|
+              connection_splitter = ConnectionQuerySplitter.new(cq, schema)
+              connection_splitter_results = connection_splitter.split_query
+
+              paginated = connection_splitter_results[:paginated_query]
+
+              unrolled = connection_splitter_results.unrolled_connection_queries.map do |unrolled_query|
+                {
+                  rollup_field_name: unrolled_query.rollup_field_name,
+                  queries: split_all_bulk_queries(schema, unrolled_query.unrolled_query),
+                }
+              end
+
+              queries[:nested] << {
+                path: cq.path_string,
+                paginated: paginated,
+                unrolled: unrolled,
+              }
+            end
+
+            queries
+          end
+        end
+      end
+    end
+  end

--- a/lib/graphql/bulk/visitors/add_pagination_to_query_visitor.rb
+++ b/lib/graphql/bulk/visitors/add_pagination_to_query_visitor.rb
@@ -1,0 +1,63 @@
+module GraphQL
+  module Bulk
+    module Visitors
+      class AddPaginationToQueryVisitor < GraphQL::Language::Visitor
+        def initialize(document, connection_node)
+          super(document)
+          @connection_node = connection_node
+        end
+
+        def on_operation_definition(node, parent)
+          modified_node = node.merge_variable(
+            name: "__appPlatformCursor",
+            type: GraphQL::Language::Nodes::TypeName.new(name: "String!"),
+          )
+          super(modified_node, parent)
+        end
+
+        def on_field(node, parent)
+          if node == @connection_node
+            old_arguments = node.arguments
+            new_arguments = [
+              GraphQL::Language::Nodes::Argument.new(
+                name: "after",
+                value: GraphQL::Language::Nodes::VariableIdentifier.new(name: "__appPlatformCursor"),
+              ),
+              GraphQL::Language::Nodes::Argument.new(
+                name: "first",
+                value: 50,
+              ),
+            ]
+
+            old_selections = node.selections
+            new_selections = [
+              GraphQL::Language::Nodes::Field.new(
+                name: "pageInfo",
+                field_alias: "__appPlatformPageInfo",
+                selections: [
+                  GraphQL::Language::Nodes::Field.new(
+                    name: "hasNextPage"
+                  ),
+                  GraphQL::Language::Nodes::Field.new(
+                    name: "endCursor"
+                  ),
+                ]
+              ),
+            ]
+
+            modified_node = node.merge(
+              {
+                arguments: old_arguments + new_arguments,
+                selections: old_selections + new_selections,
+              }
+            )
+
+            return super(modified_node, parent)
+          end
+
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/bulk/visitors/add_typename_to_query_visitor.rb
+++ b/lib/graphql/bulk/visitors/add_typename_to_query_visitor.rb
@@ -1,0 +1,25 @@
+module GraphQL
+  module Bulk
+    module Visitors
+      class AddTypenameToQueryVisitor < GraphQL::Language::Visitor
+        def on_field(node, parent)
+          unless node.selections.empty?
+            has_typename = false
+            node.selections.each do |selection|
+              has_typename = true if selection.name == "__typename"
+            end
+
+            return super if has_typename
+
+            modified_node = node.merge_selection(
+              name: "__typename"
+            )
+            return super(modified_node, parent)
+          end
+
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/bulk/visitors/connection_node_extraction_visitor.rb
+++ b/lib/graphql/bulk/visitors/connection_node_extraction_visitor.rb
@@ -1,0 +1,23 @@
+module GraphQL
+  module Bulk
+    module Visitors
+      class ConnectionNodeExtractionVisitor < GraphQL::Language::Visitor
+        def initialize(document, connection_node)
+          super(document)
+          @connection_node = connection_node
+        end
+
+        def on_field(node, parent)
+          # Stop traversing once we find the node. No need to go any further
+          return if node == @connection_node.node
+
+          # Keep this node if it's in the path
+          return super if @connection_node.path.include?(node)
+
+          # Destroy all other nodes
+          super(DELETE_NODE, parent)
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/bulk/visitors/connection_removal_visitor.rb
+++ b/lib/graphql/bulk/visitors/connection_removal_visitor.rb
@@ -1,0 +1,90 @@
+module GraphQL
+  module Bulk
+    module Visitors
+      class ConnectionRemovalVisitor < GraphQL::Language::Visitor
+        Connection = Struct.new(:node, :path)
+
+        attr_reader :connections
+
+        GraphQL::Language::Nodes::AbstractNode.descendants.each do |descendant|
+          underscored_name = descendant.name.split("::").last.
+                             gsub(/([a-z])([A-Z])/, '\1_\2'). # insert underscores
+                             downcase
+          node_method = "on_#{underscored_name}"
+
+          class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
+            # Here's an example of what the dynamically-defined method might look like:
+            #
+            #   def on_some_node(node, parent)
+            #     @path.push(node.dup)
+            #
+            #     result = super
+            #
+            #     @path.pop
+            #
+            #     result
+            #   end
+            #
+            # The default implementation for visiting an AST node.
+            # It doesn't _do_ anything, but it continues to visiting the node's children.
+            # To customize this hook, override one of its make_visit_methods (or the base method?)
+            # in your subclasses.
+            #
+            # For compatibility, it calls hook procs, too.
+            # @param node [GraphQL::Language::Nodes::AbstractNode] the node being visited
+            # @param parent [GraphQL::Language::Nodes::AbstractNode, nil] the previously-visited node, or `nil` if this is the root node.
+            # @return [Array, nil] If there were modifications, it returns an array of new nodes, otherwise, it returns `nil`.
+            def #{node_method}(node, parent)
+              @path.push(node.dup)
+
+              result = super
+
+              @path.pop
+
+              result
+            end
+          RUBY
+        end
+
+        def initialize(document, depth: 1)
+          super(document)
+          @depth = depth
+        end
+
+        def visit
+          @path = []
+          @connections = []
+          @connection_depth = 0
+          super
+        end
+
+        def on_field(node, parent)
+          result = nil
+
+          if connection?(node)
+            @connection_depth += 1
+            if @connection_depth >= @depth
+              @connections.push(Connection.new(node, @path.dup))
+              result = super(DELETE_NODE, parent)
+            end
+          end
+
+          @path.push(node.dup)
+
+          result = super if result.nil?
+
+          @path.pop
+
+          result
+        end
+
+        def connection?(node)
+          return false if node.children.blank?
+
+          selections = node.selections
+          selections.first.name.in?(["nodes", "edges"])
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -46,6 +46,7 @@ require "graphql/schema/mutation"
 require "graphql/schema/has_single_input_argument"
 require "graphql/schema/relay_classic_mutation"
 require "graphql/schema/subscription"
+require "graphql/bulk/bulk"
 
 module GraphQL
   # A GraphQL schema which may be queried with {GraphQL::Query}.
@@ -96,6 +97,10 @@ module GraphQL
     class InvalidDocumentError < Error; end;
 
     class << self
+      def split(query)
+        GraphQL::Bulk::QuerySplitterService.split(self, query)
+      end
+
       # Create schema with the result of an introspection query.
       # @param introspection_result [Hash] A response from {GraphQL::Introspection::INTROSPECTION_QUERY}
       # @return [Class<GraphQL::Schema>] the schema described by `input`


### PR DESCRIPTION
Implementation for #4917.

## Example inputs

Note, this will only split valid queries in the schema that you are calling `split` on. For now, I'll supply example queries that are being split from our own schema. The output below was captured using the `debug` keyword argument.

### A simple query with no connections:

There are no connections in this query so nothing is split

**Query**

```
query MyQuery {
    account {
        name
        currentUser {
            fullName
        }
        maxUserCount
    }
}
```

**OurSchema.split(query)**

```
base: query MyQuery {  account {    name    currentUser {      fullName      __typename    }    maxUserCount    __typename  }}
nested:
```

### A query with no nested connections

A slightly more complex example that shows how connection fields are split

```
query MyQuery {
    invoices {
        nodes {
            id
            invoiceNet
            invoiceNumber
        }
    }
    jobs {
        nodes {
            id
        }
    }
}
```

**OurSchema.split(query)**

```
[{:path=>".MyQuery",
  :paginated=>
   "query MyQuery($__appPlatformCursor: String!) {\n  invoices(after: $__appPlatformCursor, first: 50) {\n    nodes {\n      id\n      invoiceNet\n      invoiceNumber\n      __typename\n    }\n    __typename\n    __appPlatformPageInfo: pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}",
  :unrolled=>[]},
 {:path=>".MyQuery",
  :paginated=>
   "query MyQuery($__appPlatformCursor: String!) {\n  jobs(after: $__appPlatformCursor, first: 50) {\n    nodes {\n      id\n      __typename\n    }\n    __typename\n    __appPlatformPageInfo: pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}",
  :unrolled=>[]}]
```

### A query with multiple nested connection

A query containing nested connections demonstrating how the system splits the nested connections into individual queries.

**Query**

```
query MyQuery {
    invoices {
        nodes {
            id
            invoiceNet
            invoiceNumber
            jobs {
                nodes {
                    jobNumber
                    jobStatus
                    id
                    visits {
                        nodes {
                            id
                            endAt
                            createdAt
                        }
                    }
                }
            }
            lineItems {
                edges {
                    node {
                        id
                        qty
                        name
                    }
                }
            }
        }
    }
    jobs {
        nodes {
            id
        }
    }
}
```

**OurSchema.split(query)**

```
[{:path=>".MyQuery",
  :paginated=>
   "query MyQuery($__appPlatformCursor: String!) {\n  invoices(after: $__appPlatformCursor, first: 50) {\n    nodes {\n      id\n      invoiceNet\n      invoiceNumber\n      __typename\n    }\n    __typename\n    __appPlatformPageInfo: pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}",
  :unrolled=>
   [{:rollup_field_name=>".MyQuery.invoices",
     :queries=>
      {:base=>"query UnrolledQuery($__appPlatformUniqueIdForUnrolling: EncodedId!) {\n  invoice(id: $__appPlatformUniqueIdForUnrolling) {\n    __typename\n  }\n}",
       :nested=>
        [{:path=>".UnrolledQuery.invoice",
          :paginated=>
           "query UnrolledQuery($__appPlatformUniqueIdForUnrolling: EncodedId!, $__appPlatformCursor: String!) {\n  invoice(id: $__appPlatformUniqueIdForUnrolling) {\n    jobs(after: $__appPlatformCursor, first: 50) {\n      nodes {\n        jobNumber\n        jobStatus\n        id\n        __typename\n      }\n      __typename\n      __appPlatformPageInfo: pageInfo {\n        hasNextPage\n        endCursor\n      }\n    }\n  }\n}",
          :unrolled=>
           [{:rollup_field_name=>".UnrolledQuery.invoice.jobs",
             :queries=>
              {:base=>"query UnrolledQuery($__appPlatformUniqueIdForUnrolling: EncodedId!) {\n  job(id: $__appPlatformUniqueIdForUnrolling) {\n    __typename\n  }\n}",
               :nested=>
                [{:path=>".UnrolledQuery.job",
                  :paginated=>
                   "query UnrolledQuery($__appPlatformUniqueIdForUnrolling: EncodedId!, $__appPlatformCursor: String!) {\n  job(id: $__appPlatformUniqueIdForUnrolling) {\n    visits(after: $__appPlatformCursor, first: 50) {\n      nodes {\n        id\n        endAt\n        createdAt\n        __typename\n      }\n      __typename\n      __appPlatformPageInfo: pageInfo {\n        hasNextPage\n        endCursor\n      }\n    }\n  }\n}",
                  :unrolled=>[]}]}}]}]}},
    {:rollup_field_name=>".MyQuery.invoices",
     :queries=>
      {:base=>"query UnrolledQuery($__appPlatformUniqueIdForUnrolling: EncodedId!) {\n  invoice(id: $__appPlatformUniqueIdForUnrolling) {\n    __typename\n  }\n}",
       :nested=>
        [{:path=>".UnrolledQuery.invoice",
          :paginated=>
           "query UnrolledQuery($__appPlatformUniqueIdForUnrolling: EncodedId!, $__appPlatformCursor: String!) {\n  invoice(id: $__appPlatformUniqueIdForUnrolling) {\n    lineItems(after: $__appPlatformCursor, first: 50) {\n      edges {\n        node {\n          id\n          qty\n          name\n          __typename\n        }\n        __typename\n      }\n      __typename\n      __appPlatformPageInfo: pageInfo {\n        hasNextPage\n        endCursor\n      }\n    }\n  }\n}",
          :unrolled=>[]}]}}]},
 {:path=>".MyQuery",
  :paginated=>
   "query MyQuery($__appPlatformCursor: String!) {\n  jobs(after: $__appPlatformCursor, first: 50) {\n    nodes {\n      id\n      __typename\n    }\n    __typename\n    __appPlatformPageInfo: pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}",
  :unrolled=>[]}]
```

## What broke from `2.0.24` to `2.3.0`

Not much!

```
diff --git a/app/services/app_platform/bulk/visitors/add_pagination_to_query_visitor.rb b/app/services/app_platform/bulk/visitors/add_pagination_to_query_visitor.rb
index 0ef7e740641..91e459d4ec7 100644
--- a/app/services/app_platform/bulk/visitors/add_pagination_to_query_visitor.rb
+++ b/app/services/app_platform/bulk/visitors/add_pagination_to_query_visitor.rb
@@ -9,10 +9,8 @@ module AppPlatform
 
         def on_operation_definition(node, parent)
           modified_node = node.merge_variable(
-            {
-              name: "__appPlatformCursor",
-              type: GraphQL::Language::Nodes::TypeName.new(name: "String!"),
-            }
+            name: "__appPlatformCursor",
+            type: GraphQL::Language::Nodes::TypeName.new(name: "String!"),
           )
           super(modified_node, parent)
         end
@@ -22,16 +20,12 @@ module AppPlatform
             old_arguments = node.arguments
             new_arguments = [
               GraphQL::Language::Nodes::Argument.new(
-                {
-                  name: "after",
-                  value: GraphQL::Language::Nodes::VariableIdentifier.new(name: "__appPlatformCursor"),
-                }
+                name: "after",
+                value: GraphQL::Language::Nodes::VariableIdentifier.new(name: "__appPlatformCursor"),
               ),
               GraphQL::Language::Nodes::Argument.new(
-                {
-                  name: "first",
-                  value: 50,
-                }
+                name: "first",
+                value: 50,
               ),
             ]
 
@@ -39,7 +33,7 @@ module AppPlatform
             new_selections = [
               GraphQL::Language::Nodes::Field.new(
                 name: "pageInfo",
-                alias: "__appPlatformPageInfo",
+                field_alias: "__appPlatformPageInfo",
                 selections: [
                   GraphQL::Language::Nodes::Field.new(
                     name: "hasNextPage"
diff --git a/app/services/app_platform/bulk/visitors/add_typename_to_query_visitor.rb b/app/services/app_platform/bulk/visitors/add_typename_to_query_visitor.rb
index f33e337304d..a7409a149d3 100644
--- a/app/services/app_platform/bulk/visitors/add_typename_to_query_visitor.rb
+++ b/app/services/app_platform/bulk/visitors/add_typename_to_query_visitor.rb
@@ -12,9 +12,7 @@ module AppPlatform
             return super if has_typename
 
             modified_node = node.merge_selection(
-              {
-                name: "__typename",
-              }
+              name: "__typename"
             )
             return super(modified_node, parent)
           end
```