### PR TITLE
Add Schema.max_query_strings_tokens limit

### DIFF
--- a/graphql-c_parser/ext/graphql_c_parser_ext/graphql_c_parser_ext.c
+++ b/graphql-c_parser/ext/graphql_c_parser_ext/graphql_c_parser_ext.c
@@ -1,7 +1,7 @@
 #include "graphql_c_parser_ext.h"
 
-VALUE GraphQL_CParser_Lexer_tokenize_with_c_internal(VALUE self, VALUE query_string, VALUE fstring_identifiers, VALUE reject_numbers_followed_by_names) {
-  return tokenize(query_string, RTEST(fstring_identifiers), RTEST(reject_numbers_followed_by_names));
+VALUE GraphQL_CParser_Lexer_tokenize_with_c_internal(VALUE self, VALUE query_string, VALUE fstring_identifiers, VALUE reject_numbers_followed_by_names, VALUE max_tokens) {
+  return tokenize(query_string, RTEST(fstring_identifiers), RTEST(reject_numbers_followed_by_names), FIX2INT(max_tokens));
 }
 
 VALUE GraphQL_CParser_Parser_c_parse(VALUE self) {
@@ -13,7 +13,7 @@ void Init_graphql_c_parser_ext() {
   VALUE GraphQL = rb_define_module("GraphQL");
   VALUE CParser = rb_define_module_under(GraphQL, "CParser");
   VALUE Lexer = rb_define_module_under(CParser, "Lexer");
-  rb_define_singleton_method(Lexer, "tokenize_with_c_internal", GraphQL_CParser_Lexer_tokenize_with_c_internal, 3);
+  rb_define_singleton_method(Lexer, "tokenize_with_c_internal", GraphQL_CParser_Lexer_tokenize_with_c_internal, 4);
   setup_static_token_variables();
 
   VALUE Parser = rb_define_class_under(CParser, "Parser", rb_cObject);

--- a/graphql-c_parser/ext/graphql_c_parser_ext/lexer.h
+++ b/graphql-c_parser/ext/graphql_c_parser_ext/lexer.h
@@ -1,6 +1,6 @@
 #ifndef Graphql_lexer_h
 #define Graphql_lexer_h
 #include <ruby.h>
-VALUE tokenize(VALUE query_rbstr, int fstring_identifiers, int reject_numbers_followed_by_names);
+VALUE tokenize(VALUE query_rbstr, int fstring_identifiers, int reject_numbers_followed_by_names, int max_tokens);
 void setup_static_token_variables();
 #endif

--- a/lib/generators/graphql/templates/schema.erb
+++ b/lib/generators/graphql/templates/schema.erb
@@ -26,6 +26,9 @@ class <%= schema_name %> < GraphQL::Schema
     raise(GraphQL::RequiredImplementationMissingError)
   end
 
+  # Limit the size of incoming queries:
+  max_query_string_tokens(5000)
+
   # Stop validating when it encounters this many errors:
   validate_max_errors(100)
 end

--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -42,8 +42,8 @@ This is probably a bug in GraphQL-Ruby, please report this error on GitHub: http
   # Turn a query string or schema definition into an AST
   # @param graphql_string [String] a GraphQL query string or schema definition
   # @return [GraphQL::Language::Nodes::Document]
-  def self.parse(graphql_string, trace: GraphQL::Tracing::NullTrace, filename: nil)
-    default_parser.parse(graphql_string, trace: trace, filename: filename)
+  def self.parse(graphql_string, trace: GraphQL::Tracing::NullTrace, filename: nil, max_tokens: nil)
+    default_parser.parse(graphql_string, trace: trace, filename: filename, max_tokens: max_tokens)
   end
 
   # Read the contents of `filename` and parse them as GraphQL

--- a/lib/graphql/language/lexer.rb
+++ b/lib/graphql/language/lexer.rb
@@ -3,7 +3,7 @@ module GraphQL
   module Language
 
     class Lexer
-      def initialize(graphql_str, filename: nil, max_tokens: Float::INFINITY)
+      def initialize(graphql_str, filename: nil, max_tokens: nil)
         if !(graphql_str.encoding == Encoding::UTF_8 || graphql_str.ascii_only?)
           graphql_str = graphql_str.dup.force_encoding(Encoding::UTF_8)
         end
@@ -11,7 +11,7 @@ module GraphQL
         @filename = filename
         @scanner = StringScanner.new(graphql_str)
         @pos = nil
-        @max_tokens = max_tokens
+        @max_tokens = max_tokens || Float::INFINITY
         @tokens_count = 0
       end
 

--- a/lib/graphql/language/lexer.rb
+++ b/lib/graphql/language/lexer.rb
@@ -3,7 +3,7 @@ module GraphQL
   module Language
 
     class Lexer
-      def initialize(graphql_str, filename: nil)
+      def initialize(graphql_str, filename: nil, max_tokens: Float::INFINITY)
         if !(graphql_str.encoding == Encoding::UTF_8 || graphql_str.ascii_only?)
           graphql_str = graphql_str.dup.force_encoding(Encoding::UTF_8)
         end
@@ -11,6 +11,8 @@ module GraphQL
         @filename = filename
         @scanner = StringScanner.new(graphql_str)
         @pos = nil
+        @max_tokens = max_tokens
+        @tokens_count = 0
       end
 
       def eos?
@@ -22,6 +24,10 @@ module GraphQL
       def advance
         @scanner.skip(IGNORE_REGEXP)
         return false if @scanner.eos?
+        @tokens_count += 1
+        if @tokens_count > @max_tokens
+          raise_parse_error("This query is too large to execute.")
+        end
         @pos = @scanner.pos
         next_byte = @string.getbyte(@pos)
         next_byte_is_for = FIRST_BYTES[next_byte]

--- a/lib/graphql/language/parser.rb
+++ b/lib/graphql/language/parser.rb
@@ -12,8 +12,8 @@ module GraphQL
       class << self
         attr_accessor :cache
 
-        def parse(graphql_str, filename: nil, trace: Tracing::NullTrace)
-          self.new(graphql_str, filename: filename, trace: trace).parse
+        def parse(graphql_str, filename: nil, trace: Tracing::NullTrace, max_tokens: nil)
+          self.new(graphql_str, filename: filename, trace: trace, max_tokens: max_tokens).parse
         end
 
         def parse_file(filename, trace: Tracing::NullTrace)
@@ -27,11 +27,11 @@ module GraphQL
         end
       end
 
-      def initialize(graphql_str, filename: nil, trace: Tracing::NullTrace)
+      def initialize(graphql_str, filename: nil, trace: Tracing::NullTrace, max_tokens: nil)
         if graphql_str.nil?
           raise GraphQL::ParseError.new("No query string was present", nil, nil, nil)
         end
-        @lexer = Lexer.new(graphql_str, filename: filename)
+        @lexer = Lexer.new(graphql_str, filename: filename, max_tokens: max_tokens)
         @graphql_str = graphql_str
         @filename = filename
         @trace = trace

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -395,7 +395,7 @@ module GraphQL
       parse_error = nil
       @document ||= begin
         if query_string
-          GraphQL.parse(query_string, trace: self.current_trace)
+          GraphQL.parse(query_string, trace: self.current_trace, max_tokens: @schema.max_query_string_tokens)
         end
       rescue GraphQL::ParseError => err
         parse_error = err

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -648,7 +648,7 @@ module GraphQL
       # @return [nil, Integer]
       def max_query_string_tokens(new_max_tokens = NOT_CONFIGURED)
         if NOT_CONFIGURED.equal?(new_max_tokens)
-          @max_query_string_tokens || find_inherited_value(:max_query_string_tokens)
+          defined?(@max_query_string_tokens) ? @max_query_string_tokens : find_inherited_value(:max_query_string_tokens)
         else
           @max_query_string_tokens = new_max_tokens
         end

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -643,6 +643,17 @@ module GraphQL
         end
       end
 
+      # A limit on the number of tokens to accept on incoming query strings.
+      # Use this to prevent parsing maliciously-large query strings.
+      # @return [nil, Integer]
+      def max_query_string_tokens(new_max_tokens = NOT_CONFIGURED)
+        if NOT_CONFIGURED.equal?(new_max_tokens)
+          @max_query_string_tokens || find_inherited_value(:max_query_string_tokens)
+        else
+          @max_query_string_tokens = new_max_tokens
+        end
+      end
+
       def default_page_size(new_default_page_size = nil)
         if new_default_page_size
           @default_page_size = new_default_page_size

--- a/spec/graphql/language/clexer_spec.rb
+++ b/spec/graphql/language/clexer_spec.rb
@@ -40,8 +40,8 @@ if defined?(GraphQL::CParser::Lexer)
 
     it "makes frozen strings when using SchemaParser" do
       str = "type Query { f1: Int }"
-      schema_ast = GraphQL::CParser::SchemaParser.new(str, nil, GraphQL::Tracing::NullTrace).result
-      default_ast = GraphQL::CParser::Parser.new(str, nil, GraphQL::Tracing::NullTrace).result
+      schema_ast = GraphQL::CParser::SchemaParser.new(str, nil, GraphQL::Tracing::NullTrace, nil).result
+      default_ast = GraphQL::CParser::Parser.new(str, nil, GraphQL::Tracing::NullTrace, nil).result
 
       # Equivalent ASTs:
       assert_equal schema_ast, default_ast

--- a/spec/graphql/language/lexer_examples.rb
+++ b/spec/graphql/language/lexer_examples.rb
@@ -243,6 +243,24 @@ string with \\"""
           assert_equal 21, type_keyword_tok_3.line
           assert_equal 21, c_name_tok.line
         end
+
+        it "halts after max_tokens" do
+          query_type = Class.new(GraphQL::Schema::Object) do
+            graphql_name "Query"
+            field :x, Integer
+          end
+          schema = Class.new(GraphQL::Schema) do
+            query(query_type)
+            max_query_string_tokens(5000)
+          end
+
+          assert_equal 5000, schema.max_query_string_tokens
+
+          query_str = "{ x } " * 5000
+          assert_equal 15000, subject.tokenize(query_str).size
+          result = schema.execute(query_str)
+          assert_equal ["This query is too large to execute."], result["errors"].map { |e| e["message"] }
+        end
       end
     end
   end

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -1091,7 +1091,7 @@ describe GraphQL::Query do
   describe "using GraphQL.default_parser" do
     module DummyParser
       DOC = GraphQL::Language::Parser.parse("{ __typename }")
-      def self.parse(query_str, trace: nil, filename: nil)
+      def self.parse(query_str, trace: nil, filename: nil, max_tokens: nil)
         DOC
       end
     end

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -48,6 +48,7 @@ describe GraphQL::Schema do
         query_analyzer Object.new
         multiplex_analyzer Object.new
         validate_timeout 100
+        max_query_string_tokens 500
         rescue_from(StandardError) { }
         use GraphQL::Backtrace
         use GraphQL::Subscriptions::ActionCableSubscriptions, action_cable: nil, action_cable_coder: JSON
@@ -69,6 +70,7 @@ describe GraphQL::Schema do
       assert_equal base_schema.orphan_types, schema.orphan_types
       assert_equal base_schema.context_class, schema.context_class
       assert_equal base_schema.directives, schema.directives
+      assert_equal base_schema.max_query_string_tokens, schema.max_query_string_tokens
       assert_equal base_schema.query_analyzers, schema.query_analyzers
       assert_equal base_schema.multiplex_analyzers, schema.multiplex_analyzers
       assert_equal base_schema.disable_introspection_entry_points?, schema.disable_introspection_entry_points?
@@ -86,6 +88,7 @@ describe GraphQL::Schema do
         use CustomSubscriptions, action_cable: nil, action_cable_coder: JSON
         query_class(custom_query_class)
         extra_types [extra_type_2]
+        max_query_string_tokens nil
       end
 
       query = Class.new(GraphQL::Schema::Object) do
@@ -128,6 +131,7 @@ describe GraphQL::Schema do
       assert_equal subscription, schema.subscription
       assert_equal introspection, schema.introspection
       assert_equal cursor_encoder, schema.cursor_encoder
+      assert_nil schema.max_query_string_tokens
 
       assert_equal context_class, schema.context_class
       assert_equal 10, schema.validate_timeout

--- a/spec/integration/rails/generators/graphql/install_generator_spec.rb
+++ b/spec/integration/rails/generators/graphql/install_generator_spec.rb
@@ -75,6 +75,9 @@ class DummySchema < GraphQL::Schema
     raise(GraphQL::RequiredImplementationMissingError)
   end
 
+  # Limit the size of incoming queries:
+  max_query_string_tokens(5000)
+
   # Stop validating when it encounters this many errors:
   validate_max_errors(100)
 end
@@ -377,6 +380,9 @@ class DummySchema < GraphQL::Schema
     # to return the correct GraphQL object type for `obj`
     raise(GraphQL::RequiredImplementationMissingError)
   end
+
+  # Limit the size of incoming queries:
+  max_query_string_tokens(5000)
 
   # Stop validating when it encounters this many errors:
   validate_max_errors(100)


### PR DESCRIPTION
This will cause the lexer to exit when receiving large query strings -- even before parsing or validation.