### PR TITLE
Set DirectiveDefinitionNode.children_method_name

### DIFF
--- a/lib/graphql/language/nodes.rb
+++ b/lib/graphql/language/nodes.rb
@@ -362,6 +362,7 @@ module GraphQL
           arguments: Nodes::Argument,
           locations: Nodes::DirectiveLocation,
         )
+        self.children_method_name = :definitions
       end
 
       # An enum value. The string is available as {#name}.

--- a/spec/graphql/language/visitor_spec.rb
+++ b/spec/graphql/language/visitor_spec.rb
@@ -200,6 +200,14 @@ describe GraphQL::Language::Visitor do
           super
         end
       end
+
+      def on_directive_definition(node, parent)
+        if node.name == "deleteMe"
+          super(DELETE_NODE, parent)
+        else
+          super
+        end
+      end
     end
 
     def get_result(query_str)
@@ -375,6 +383,10 @@ GRAPHQL
 
     it "works with SDL" do
       before_query = <<-GRAPHQL.chop
+directive @deleteMe on FIELD
+
+directive @keepMe on FIELD
+
 type Rename @doStuff {
   f: Int
   renameThis: String
@@ -383,6 +395,8 @@ type Rename @doStuff {
 GRAPHQL
 
       after_query = <<-GRAPHQL.chop
+directive @keepMe on FIELD
+
 type WasRenamed @doStuff(addedArgument2: 2) {
   f: Int
   wasRenamed: String


### PR DESCRIPTION
Fixes #4928.

This commit sets `DirectiveDefinitionNode.children_method_name` to `:definitions`. It previously defaulted to `:directive_definitions`, causing a `NoMethodError` when attempting to delete the node from the AST.

I wasn't sure how best to test this, so I added some directive definitions to the SDL test case in the visitor spec. Let me know if there's a more suitable way.