### PR TITLE
Move runtime state into result objects

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -279,7 +279,6 @@ module GraphQL
           after_lazy(arguments, field: field_defn, ast_node: ast_node, owner_object: object, arguments: arguments, result_name: result_name, result: selection_result, runtime_state: runtime_state) do |resolved_arguments, runtime_state|
             return_type_non_null = return_type.non_null?
             if resolved_arguments.is_a?(GraphQL::ExecutionError) || resolved_arguments.is_a?(GraphQL::UnauthorizedError)
-              owner_type = selection_result.graphql_result_type
               continue_value(resolved_arguments, field_defn, return_type_non_null, ast_node, result_name, selection_result)
               next
             end

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -210,7 +210,7 @@ module GraphQL
           gathered_selections.each do |result_name, field_ast_nodes_or_ast_node|
             @dataloader.append_job {
               runtime_state = get_current_runtime_state
-              field_result = evaluate_selection(
+              evaluate_selection(
                 result_name, field_ast_nodes_or_ast_node, is_eager_selection, selections_result, parent_object, runtime_state
               )
               finished_jobs += 1
@@ -384,15 +384,11 @@ module GraphQL
               end
             end
           end
-
           # If this field is a root mutation field, immediately resolve
           # all of its child fields before moving on to the next root mutation field.
           # (Subselections of this mutation will still be resolved level-by-level.)
           if is_eager_field
             Interpreter::Resolve.resolve_all([field_result], @dataloader)
-          else
-            # Return this from `after_lazy` because it might be another lazy that needs to be resolved
-            field_result
           end
         end
 

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -245,7 +245,7 @@ module GraphQL
           end
           field_name = ast_node.name
           owner_type = selections_result.graphql_result_type
-          field_defn = query.warden.get_field(owner_type, field_name) || binding.pry
+          field_defn = query.warden.get_field(owner_type, field_name)
 
           # Set this before calling `run_with_directives`, so that the directive can have the latest path
           runtime_state = get_current_runtime_state

--- a/lib/graphql/execution/interpreter/runtime/graphql_result.rb
+++ b/lib/graphql/execution/interpreter/runtime/graphql_result.rb
@@ -5,8 +5,10 @@ module GraphQL
     class Interpreter
       class Runtime
         module GraphQLResult
-          def initialize(result_name, parent_result, is_non_null_in_parent)
+          def initialize(result_name, result_type, application_value, parent_result, is_non_null_in_parent)
             @graphql_parent = parent_result
+            @graphql_application_value = application_value
+            @graphql_result_type = result_type
             if parent_result && parent_result.graphql_dead
               @graphql_dead = true
             end
@@ -26,14 +28,14 @@ module GraphQL
           end
 
           attr_accessor :graphql_dead
-          attr_reader :graphql_parent, :graphql_result_name, :graphql_is_non_null_in_parent
+          attr_reader :graphql_parent, :graphql_result_name, :graphql_is_non_null_in_parent, :graphql_application_value, :graphql_result_type
 
           # @return [Hash] Plain-Ruby result data (`@graphql_metadata` contains Result wrapper objects)
           attr_accessor :graphql_result_data
         end
 
         class GraphQLResultHash
-          def initialize(_result_name, _parent_result, _is_non_null_in_parent)
+          def initialize(_result_name, _result_type, _application_value, _parent_result, _is_non_null_in_parent)
             super
             @graphql_result_data = {}
           end
@@ -121,7 +123,7 @@ module GraphQL
         class GraphQLResultArray
           include GraphQLResult
 
-          def initialize(_result_name, _parent_result, _is_non_null_in_parent)
+          def initialize(_result_name, _result_type, _application_value, _parent_result, _is_non_null_in_parent)
             super
             @graphql_result_data = []
           end


### PR DESCRIPTION
This is an experiment in managing runtime state. 

We already have a lot of per-field metadata in `current_runtime_state`, and most of it is derived from `GraphQLResult` objects. I think it should be possible to: 

- Move per-object state to `GraphQLResult` objects (not _everything_ -- can't be per-field since leaf values don't get `GraphQLResult` objects)
- Remove per-object state values from runtime method signatures, since they're accessible from the passed-in `GraphQLResult` 
- Update `current_runtime_state` to use GraphQLResult in more cases (it already does for path, at least) 

If _that_ works, then I'm hoping that `GraphQLResult` can be the basis for a run-and-return (trampoline) -style execution instead of a recursive one, where the `GraphQLResult` itself contains information about what needs to be done to it next.