### PR TITLE
Fix Marshal with parsed documents

### DIFF
--- a/lib/graphql/language/parser.rb
+++ b/lib/graphql/language/parser.rb
@@ -478,7 +478,7 @@ module GraphQL
         end
 
         if at?(:BANG)
-          type = Nodes::NonNullType.new(pos: pos, of_type: type)
+          type = Nodes::NonNullType.new(pos: pos, of_type: type, source: self)
           expect_token(:BANG)
         end
         type
@@ -487,7 +487,7 @@ module GraphQL
       def list_type
         loc = pos
         expect_token(:LBRACKET)
-        type = Nodes::ListType.new(pos: loc, of_type: self.type)
+        type = Nodes::ListType.new(pos: loc, of_type: self.type, source: self)
         expect_token(:RBRACKET)
         type
       end

--- a/spec/graphql/language/nodes_spec.rb
+++ b/spec/graphql/language/nodes_spec.rb
@@ -26,6 +26,41 @@ describe GraphQL::Language::Nodes::AbstractNode do
     end
   end
 
+  describe "Marshal" do
+    it "marshals and unmarshals parsed ASTs" do
+      str = "query($var: [Int!] = [100001]) {
+  f1(arg: {input: $var, nullInput: null}) @stuff {
+    ...F2
+  }
+}
+
+fragment F2 on SomeType {
+  ... {
+    someField(arg1: true, arg2: THING, arg3: 5.01234) {
+      a @someDirective @anotherDirective @yetAnother
+      b
+      c
+    }
+  }
+}"
+      doc = GraphQL.parse(str)
+      data = Marshal.dump(doc)
+      new_doc = Marshal.load(data)
+      assert_equal doc, new_doc
+      assert_equal str, doc.to_query_string
+      assert_equal str, new_doc.to_query_string
+
+      # also test schema definition nodes:
+      str2 = Dummy::Schema.to_definition.strip
+      doc2 = GraphQL.parse(str2)
+      data2 = Marshal.dump(doc2)
+      new_doc2 = Marshal.load(data2)
+      assert_equal doc, new_doc
+      assert_equal str2, doc2.to_query_string
+      assert_equal str2, new_doc2.to_query_string
+    end
+  end
+
   describe "#filename" do
     it "is set after .parse_file" do
       filename = "spec/support/parser/filename_example.graphql"


### PR DESCRIPTION
Also fixes a bug where `ListType` and `NonNullType` would raise an error when you asked for their `line` or `col`.

Fixes #4955 