### PR TITLE
Handle nil query_string in fingerprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ Gemfile.lock
 gemfiles/*.lock
 # Test database
 *.db
+*.db-shm
+*.db-wal
+.byebug_history
 .bundle/
 vendor/
 .idea/
@@ -17,7 +20,6 @@ _site
 .jekyll-cache
 gh-pages/
 tmp/*
-__*.db
 node_modules/
 yarn.lock
 OperationStoreClient.js

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -304,7 +304,7 @@ module GraphQL
 
     # @return [String] An opaque hash for identifying this query's given query string and selected operation
     def operation_fingerprint
-      @operation_fingerprint ||= "#{selected_operation_name || "anonymous"}/#{Fingerprint.generate(query_string)}"
+      @operation_fingerprint ||= "#{selected_operation_name || "anonymous"}/#{Fingerprint.generate(query_string || "")}"
     end
 
     # @return [String] An opaque hash for identifying this query's given a variable values (not including defaults)

--- a/spec/graphql/query/fingerprint_spec.rb
+++ b/spec/graphql/query/fingerprint_spec.rb
@@ -40,6 +40,14 @@ describe GraphQL::Query::Fingerprint do
     assert_equal op_name_expected_fingerprint, build_query(str3, {}).operation_fingerprint
   end
 
+  it "returns a fingerprint when the query string is blank or nil" do
+    nil_query = build_query(nil, {})
+    blank_query = build_query("", {})
+
+    assert_equal "anonymous/47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU=", blank_query.operation_fingerprint
+    assert_equal "anonymous/47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU=", nil_query.operation_fingerprint
+  end
+
   it "makes combined fingerprints" do
     str1a = "{ __typename }"
     str1b = "{ __typename }"


### PR DESCRIPTION
Now a `nil` query string is fingerprinted as if it was an empty string. 

Fixes #4942 