### PR TITLE
Use type objects, not names, in references_to hash

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,11 +89,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-      - gemfile: gemfiles/rails_master.gemfile
-        ruby: 3.3
-        isolation_level_fiber: 1
-      - gemfile: gemfiles/rails_7.1_postgresql.gemfile
-        ruby: 3.3
+        include:
+        - gemfile: gemfiles/rails_master.gemfile
+          ruby: 3.3
+          isolation_level_fiber: 1
+        - gemfile: gemfiles/rails_7.1_postgresql.gemfile
+          ruby: 3.3
     services:
       postgres:
         image: postgres:latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,10 +50,6 @@ jobs:
             ruby: 3.1
           - gemfile: gemfiles/rails_7.0.gemfile
             ruby: 3.2
-          - gemfile: gemfiles/rails_7.0.gemfile
-            ruby: 3.2
-          - gemfile: gemfiles/rails_7.1.gemfile
-            ruby: 3.3
           - gemfile: gemfiles/rails_7.1.gemfile
             ruby: 3.3
           - gemfile: gemfiles/rails_master.gemfile
@@ -62,11 +58,14 @@ jobs:
           - gemfile: gemfiles/rails_master.gemfile
             ruby: 3.3
             graphql_reject_numbers_followed_by_names: 1
+            isolation_level_fiber: 1
     runs-on: ubuntu-latest
     steps:
     - run: echo BUNDLE_GEMFILE=${{ matrix.gemfile }} > $GITHUB_ENV
     - run: echo GRAPHQL_REJECT_NUMBERS_FOLLOWED_BY_NAMES=1 > $GITHUB_ENV
       if: ${{ !!matrix.graphql_reject_numbers_followed_by_names }}
+    - run: echo ISOLATION_LEVEL_FIBER=1 > $GITHUB_ENV
+      if: ${{ !!matrix.isolation_level_fiber }}
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,26 +52,21 @@ jobs:
             ruby: 3.2
           - gemfile: gemfiles/rails_7.0.gemfile
             ruby: 3.2
-            isolation_level_fiber: 1
           - gemfile: gemfiles/rails_7.1.gemfile
             ruby: 3.3
           - gemfile: gemfiles/rails_7.1.gemfile
             ruby: 3.3
-            isolation_level_fiber: 1
           - gemfile: gemfiles/rails_master.gemfile
             ruby: 3.3
             graphql_reject_numbers_followed_by_names: 1
           - gemfile: gemfiles/rails_master.gemfile
             ruby: 3.3
             graphql_reject_numbers_followed_by_names: 1
-            isolation_level_fiber: 1
     runs-on: ubuntu-latest
     steps:
     - run: echo BUNDLE_GEMFILE=${{ matrix.gemfile }} > $GITHUB_ENV
     - run: echo GRAPHQL_REJECT_NUMBERS_FOLLOWED_BY_NAMES=1 > $GITHUB_ENV
       if: ${{ !!matrix.graphql_reject_numbers_followed_by_names }}
-    - run: echo ISOLATION_LEVEL_FIBER=1 > $GITHUB_ENV
-      if: ${{ !!matrix.isolation_level_fiber }}
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
@@ -113,6 +108,7 @@ jobs:
     - run: echo DATABASE='POSTGRESQL' > $GITHUB_ENV
     - run: echo PGPASSWORD='postgres' > $GITHUB_ENV
     - run: echo GRAPHQL_CPARSER=1 > $GITHUB_ENV
+    - run: echo ISOLATION_LEVEL_FIBER=1 > $GITHUB_ENV
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,6 +87,13 @@ jobs:
       working-directory: ./javascript_client
   postgres_test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+      - gemfile: gemfiles/rails_master.gemfile
+        ruby: 3.3
+        isolation_level_fiber: 1
+      - gemfile: gemfiles/rails_7.1_postgresql.gemfile
+        ruby: 3.3
     services:
       postgres:
         image: postgres:latest
@@ -103,11 +110,12 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-    - run: echo BUNDLE_GEMFILE='gemfiles/rails_7.1_postgresql.gemfile' > $GITHUB_ENV
+    - run: echo BUNDLE_GEMFILE='' > $GITHUB_ENV
     - run: echo DATABASE='POSTGRESQL' > $GITHUB_ENV
     - run: echo PGPASSWORD='postgres' > $GITHUB_ENV
     - run: echo GRAPHQL_CPARSER=1 > $GITHUB_ENV
     - run: echo ISOLATION_LEVEL_FIBER=1 > $GITHUB_ENV
+      if: ${{ !!matrix.isolation_level_fiber }}
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -7,7 +7,7 @@ gem "ruby-prof", platform: :ruby
 gem "pry"
 gem "pry-stack_explorer", platform: :ruby
 gem "rails", "~> 7.0.0", require: "rails/all"
-gem "sqlite3"
+gem "sqlite3", "~> 1.4", platform: :ruby
 gem "sequel"
 gem "evt"
 gem "async"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -7,8 +7,7 @@ gem "ruby-prof", platform: :ruby
 gem "pry"
 gem "pry-stack_explorer", platform: :ruby
 gem "rails", "~> 7.0.0", require: "rails/all"
-gem "sqlite3", "~> 1.4", platform: :ruby
-gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
+gem "sqlite3"
 gem "sequel"
 gem "evt"
 gem "async"

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -7,7 +7,7 @@ gem "ruby-prof", platform: :ruby
 gem "pry"
 gem "pry-stack_explorer", platform: :ruby
 gem "rails", "~> 7.1.0", require: "rails/all"
-gem "sqlite3"
+gem "sqlite3", "~>1.4"
 gem "pg", platform: :ruby
 gem "sequel"
 gem "evt"

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -7,9 +7,8 @@ gem "ruby-prof", platform: :ruby
 gem "pry"
 gem "pry-stack_explorer", platform: :ruby
 gem "rails", "~> 7.1.0", require: "rails/all"
-gem "sqlite3", "~> 1.4", platform: :ruby
+gem "sqlite3"
 gem "pg", platform: :ruby
-gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sequel"
 gem "evt"
 gem "async"

--- a/gemfiles/rails_master.gemfile
+++ b/gemfiles/rails_master.gemfile
@@ -7,8 +7,8 @@ gem "ruby-prof", platform: :ruby
 gem "pry"
 gem "pry-stack_explorer", platform: :ruby
 gem "rails", github: "rails/rails", require: "rails/all", ref: "main"
-gem 'sqlite3', "~> 1.4", platform: :ruby
-gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
+gem 'sqlite3'
+gem 'pg'
 gem "sequel"
 gem "evt"
 if RUBY_ENGINE == "ruby" # This doesn't work on truffle-ruby becuase there's no `IO::READABLE`

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -553,12 +553,8 @@ module GraphQL
       attr_writer :dataloader_class
 
       def references_to(to_type = nil, from: nil)
-        @own_references_to ||= {}
+        @own_references_to ||= {}.tap(&:compare_by_identity)
         if to_type
-          if !to_type.is_a?(String)
-            to_type = to_type.graphql_name
-          end
-
           if from
             refs = @own_references_to[to_type] ||= []
             refs << from
@@ -1529,15 +1525,15 @@ module GraphQL
       end
 
       # This is overridden in subclasses to check the inheritance chain
-      def get_references_to(type_name)
-        @own_references_to[type_name]
+      def get_references_to(type_defn)
+        @own_references_to[type_defn]
       end
     end
 
     module SubclassGetReferencesTo
-      def get_references_to(type_name)
-        own_refs = @own_references_to[type_name]
-        inherited_refs = superclass.references_to(type_name)
+      def get_references_to(type_defn)
+        own_refs = @own_references_to[type_defn]
+        inherited_refs = superclass.references_to(type_defn)
         if inherited_refs&.any?
           if own_refs&.any?
             own_refs + inherited_refs

--- a/lib/graphql/schema/late_bound_type.rb
+++ b/lib/graphql/schema/late_bound_type.rb
@@ -25,6 +25,10 @@ module GraphQL
         @to_list_type ||= GraphQL::Schema::List.new(self)
       end
 
+      def to_type_signature
+        name
+      end
+
       def inspect
         "#<LateBoundType @name=#{name}>"
       end

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -363,8 +363,7 @@ module GraphQL
       end
 
       def referenced?(type_defn)
-        graphql_name = type_defn.unwrap.graphql_name
-        members = @schema.references_to(graphql_name)
+        members = @schema.references_to(type_defn)
         members.any? { |m| visible?(m) }
       end
 

--- a/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
+++ b/spec/graphql/static_validation/rules/argument_literals_are_compatible_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require "spec_helper"
-
+require "uri"
 describe GraphQL::StaticValidation::ArgumentLiteralsAreCompatible do
   include StaticValidationHelpers
 

--- a/spec/integration/rails/graphql/dataloader/async_dataloader_spec.rb
+++ b/spec/integration/rails/graphql/dataloader/async_dataloader_spec.rb
@@ -21,6 +21,7 @@ describe GraphQL::Dataloader::AsyncDataloader do
       def set_fiber_variables(vars)
         connection_config = vars.delete(:connected_to)
         StarWars::StarWarsModel.connecting_to(**connection_config)
+        pp [Fiber.current.object_id, :SET_fiber_variables_tables, StarWars::StarWarsModel.connection.tables, StarWars::StarWarsModel.connection_db_config]
         super(vars)
       end
     end

--- a/spec/integration/rails/graphql/dataloader/async_dataloader_spec.rb
+++ b/spec/integration/rails/graphql/dataloader/async_dataloader_spec.rb
@@ -9,13 +9,13 @@ describe GraphQL::Dataloader::AsyncDataloader do
 
       def get_fiber_variables
         vars = super
-        pp [Fiber.current.object_id, :get_fiber_variables_tables, StarWars::StarWarsModel.connection.tables]
+        pp [Fiber.current.object_id, :get_fiber_variables_tables, StarWars::StarWarsModel.connection.tables, StarWars::StarWarsModel.connection.current_database]
+        pp StarWars::StarWarsModel.connection.raw_connection.conninfo_hash
         vars[:connected_to] = {
           role: StarWars::StarWarsModel.current_role,
           shard: StarWars::StarWarsModel.current_shard,
           prevent_writes: StarWars::StarWarsModel.current_preventing_writes
         }
-        pp [:connected_to, vars[:connected_to]]
         vars
       end
 
@@ -56,7 +56,9 @@ describe GraphQL::Dataloader::AsyncDataloader do
       end
 
       def inline_base_name(id:)
-        p [Fiber.current.object_id, :inline_base_name_tables, StarWars::Base.connection.tables]
+        p [Fiber.current.object_id, :inline_base_name_tables, StarWars::StarWarsModel.connection.tables, StarWars::StarWarsModel.connection.current_database]
+        pp StarWars::StarWarsModel.connection.raw_connection.conninfo_hash
+
         StarWars::Base.where(id: id).first&.name
       end
 
@@ -77,7 +79,7 @@ describe GraphQL::Dataloader::AsyncDataloader do
 
   before {
     skip("Only test when isolation_level = :fiber") unless ENV["ISOLATION_LEVEL_FIBER"]
-    [Fiber.current.object_id, :before_tables, StarWars::StarWarsModel.connection.tables]
+    p [Fiber.current.object_id, :before_tables, StarWars::StarWarsModel.connection.tables, StarWars::StarWarsModel.connection.current_database]
     if Rails::VERSION::STRING.start_with?("7.0")
       ActiveRecord.legacy_connection_handling = false
     end

--- a/spec/integration/rails/graphql/dataloader/async_dataloader_spec.rb
+++ b/spec/integration/rails/graphql/dataloader/async_dataloader_spec.rb
@@ -54,6 +54,8 @@ describe GraphQL::Dataloader::AsyncDataloader do
       end
 
       def inline_base_name(id:)
+        pp StarWars::Base.connection.tables
+        pp ActiveRecord::Base.connection.tables
         StarWars::Base.where(id: id).first&.name
       end
 

--- a/spec/integration/rails/graphql/dataloader/async_dataloader_spec.rb
+++ b/spec/integration/rails/graphql/dataloader/async_dataloader_spec.rb
@@ -9,11 +9,13 @@ describe GraphQL::Dataloader::AsyncDataloader do
 
       def get_fiber_variables
         vars = super
+        pp [:before_tables, StarWars::StarWarsModel.connection.tables]
         vars[:connected_to] = {
           role: StarWars::StarWarsModel.current_role,
           shard: StarWars::StarWarsModel.current_shard,
           prevent_writes: StarWars::StarWarsModel.current_preventing_writes
         }
+        pp [:connected_to, vars[:connected_to]]
         vars
       end
 

--- a/spec/integration/rails/graphql/dataloader/async_dataloader_spec.rb
+++ b/spec/integration/rails/graphql/dataloader/async_dataloader_spec.rb
@@ -9,7 +9,6 @@ describe GraphQL::Dataloader::AsyncDataloader do
 
       def get_fiber_variables
         vars = super
-        pp [Fiber.current.object_id, :get_fiber_variables_tables, StarWars::StarWarsModel.connection.tables, StarWars::StarWarsModel.connection_db_config]
         vars[:connected_to] = {
           role: StarWars::StarWarsModel.current_role,
           shard: StarWars::StarWarsModel.current_shard,
@@ -21,7 +20,6 @@ describe GraphQL::Dataloader::AsyncDataloader do
       def set_fiber_variables(vars)
         connection_config = vars.delete(:connected_to)
         StarWars::StarWarsModel.connecting_to(**connection_config)
-        pp [Fiber.current.object_id, :SET_fiber_variables_tables, StarWars::StarWarsModel.connection.tables, StarWars::StarWarsModel.connection_db_config]
         super(vars)
       end
     end
@@ -56,7 +54,6 @@ describe GraphQL::Dataloader::AsyncDataloader do
       end
 
       def inline_base_name(id:)
-        p [Fiber.current.object_id, :inline_base_name_tables, StarWars::StarWarsModel.connection.tables, StarWars::StarWarsModel.connection_db_config]
         StarWars::Base.where(id: id).first&.name
       end
 
@@ -77,16 +74,6 @@ describe GraphQL::Dataloader::AsyncDataloader do
 
   before {
     skip("Only test when isolation_level = :fiber") unless ENV["ISOLATION_LEVEL_FIBER"]
-    p [Fiber.current.object_id, :before_tables, StarWars::StarWarsModel.connection.tables, StarWars::StarWarsModel.connection_db_config]
-    if Rails::VERSION::STRING.start_with?("7.0")
-      ActiveRecord.legacy_connection_handling = false
-    end
-  }
-
-  after {
-    if Rails::VERSION::STRING.start_with?("7.0")
-      ActiveRecord.legacy_connection_handling = true
-    end
   }
 
   it "cleans up database connections" do

--- a/spec/integration/rails/graphql/dataloader/async_dataloader_spec.rb
+++ b/spec/integration/rails/graphql/dataloader/async_dataloader_spec.rb
@@ -9,7 +9,7 @@ describe GraphQL::Dataloader::AsyncDataloader do
 
       def get_fiber_variables
         vars = super
-        pp [:before_tables, StarWars::StarWarsModel.connection.tables]
+        pp [Fiber.current.object_id, :get_fiber_variables_tables, StarWars::StarWarsModel.connection.tables]
         vars[:connected_to] = {
           role: StarWars::StarWarsModel.current_role,
           shard: StarWars::StarWarsModel.current_shard,
@@ -56,8 +56,7 @@ describe GraphQL::Dataloader::AsyncDataloader do
       end
 
       def inline_base_name(id:)
-        pp StarWars::Base.connection.tables
-        pp ActiveRecord::Base.connection.tables
+        p [Fiber.current.object_id, :inline_base_name_tables, StarWars::Base.connection.tables]
         StarWars::Base.where(id: id).first&.name
       end
 
@@ -78,6 +77,7 @@ describe GraphQL::Dataloader::AsyncDataloader do
 
   before {
     skip("Only test when isolation_level = :fiber") unless ENV["ISOLATION_LEVEL_FIBER"]
+    [Fiber.current.object_id, :before_tables, StarWars::StarWarsModel.connection.tables]
     if Rails::VERSION::STRING.start_with?("7.0")
       ActiveRecord.legacy_connection_handling = false
     end

--- a/spec/integration/rails/graphql/dataloader/async_dataloader_spec.rb
+++ b/spec/integration/rails/graphql/dataloader/async_dataloader_spec.rb
@@ -9,8 +9,7 @@ describe GraphQL::Dataloader::AsyncDataloader do
 
       def get_fiber_variables
         vars = super
-        pp [Fiber.current.object_id, :get_fiber_variables_tables, StarWars::StarWarsModel.connection.tables, StarWars::StarWarsModel.connection.current_database]
-        pp StarWars::StarWarsModel.connection.raw_connection.conninfo_hash
+        pp [Fiber.current.object_id, :get_fiber_variables_tables, StarWars::StarWarsModel.connection.tables, StarWars::StarWarsModel.connection_db_config]
         vars[:connected_to] = {
           role: StarWars::StarWarsModel.current_role,
           shard: StarWars::StarWarsModel.current_shard,
@@ -56,9 +55,7 @@ describe GraphQL::Dataloader::AsyncDataloader do
       end
 
       def inline_base_name(id:)
-        p [Fiber.current.object_id, :inline_base_name_tables, StarWars::StarWarsModel.connection.tables, StarWars::StarWarsModel.connection.current_database]
-        pp StarWars::StarWarsModel.connection.raw_connection.conninfo_hash
-
+        p [Fiber.current.object_id, :inline_base_name_tables, StarWars::StarWarsModel.connection.tables, StarWars::StarWarsModel.connection_db_config]
         StarWars::Base.where(id: id).first&.name
       end
 
@@ -79,7 +76,7 @@ describe GraphQL::Dataloader::AsyncDataloader do
 
   before {
     skip("Only test when isolation_level = :fiber") unless ENV["ISOLATION_LEVEL_FIBER"]
-    p [Fiber.current.object_id, :before_tables, StarWars::StarWarsModel.connection.tables, StarWars::StarWarsModel.connection.current_database]
+    p [Fiber.current.object_id, :before_tables, StarWars::StarWarsModel.connection.tables, StarWars::StarWarsModel.connection_db_config]
     if Rails::VERSION::STRING.start_with?("7.0")
       ActiveRecord.legacy_connection_handling = false
     end

--- a/spec/integration/rails/graphql/schema_spec.rb
+++ b/spec/integration/rails/graphql/schema_spec.rb
@@ -43,11 +43,12 @@ describe GraphQL::Schema do
   describe "#references_to" do
     it "returns a list of Field and Arguments of that type" do
       cow_field = schema.get_field("Query", "cow")
-      assert_equal [cow_field], schema.references_to("Cow")
+      cow_t = schema.get_type("Cow")
+      assert_equal [cow_field], schema.references_to(cow_t)
     end
 
     it "returns an empty list when type is not referenced by any field or argument" do
-      assert_equal [], schema.references_to("Goat")
+      assert_equal [], schema.references_to(Jazz::InstrumentType)
     end
   end
 

--- a/spec/support/active_record_setup.rb
+++ b/spec/support/active_record_setup.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 if testing_rails?
   # Remove the old sqlite database
+  puts "Removing _test_.db"
   `rm -f ./_test_.db`
 
   if ActiveRecord.respond_to?(:async_query_executor=) # Rails 7.1+


### PR DESCRIPTION
This allows us to `compare_by_identity` which is faster than hashing strings. And it simplifies the API (in advance of addressing #4919)