### PR TITLE
Remove duplicate when clause from parser

### DIFF
--- a/lib/graphql/language/parser.rb
+++ b/lib/graphql/language/parser.rb
@@ -615,9 +615,6 @@ module GraphQL
         when :ON
           advance_token
           "on"
-        when :DIRECTIVE
-          advance_token
-          "directive"
         when :EXTEND
           advance_token
           "extend"


### PR DESCRIPTION
This PR removes a duplicate `when` clause from `GraphQL::Language::Parser#parse_name` which currently causes a warning.

https://github.com/rmosolgo/graphql-ruby/blob/ec5208ae56d8f1b707263ea87c46263ba09b273c/lib/graphql/language/parser.rb#L585-L587

https://github.com/rmosolgo/graphql-ruby/blob/ec5208ae56d8f1b707263ea87c46263ba09b273c/lib/graphql/language/parser.rb#L618-L620

```
/Users/thomasmarshall/.gem/ruby/3.3.1/gems/graphql-2.3.4/lib/graphql/language/parser.rb:618: warning: duplicated `when' clause with line 585 is ignored
```