### PR TITLE
Silence Ruby warnings when redefining field accessors

### DIFF
--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -136,6 +136,7 @@ module GraphQL
             def #{method_name}
               self[#{method_name.inspect}]
             end
+            alias_method :#{method_name}, :#{method_name}
           RUBY
           argument_defn
         end


### PR DESCRIPTION
A relatively common pattern is to redefine a field accessor, e.g.:

```ruby
field :billing_address,
  -> { MailingAddressInput },
  required: true,
  description: "The customer's billing address."

def billing_address
  Address.new(self[:billing_address].to_h)
end
```

Unfortunately this emits a Ruby warning.

To avoid it, we can either define these methods in a module that is included in the class, or use the self alias trick.

I chose to do the later as it is simpler.