### PR TITLE
Fix dataloader with argument loading and auth

### DIFF
--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -126,7 +126,7 @@ describe GraphQL::Dataloader do
       end
 
       def fetch(recipes)
-        @counter && @counter.increment
+        @counter&.increment
         recipes.map { true }
       end
     end
@@ -229,6 +229,14 @@ describe GraphQL::Dataloader do
 
       def recipe(recipe:)
         recipe
+      end
+
+      field :recipes_by_id, [Recipe] do
+        argument :ids, [ID], loads: Recipe, as: :recipes
+      end
+
+      def recipes_by_id(recipes:)
+        recipes
       end
 
       field :key_ingredient, Ingredient do
@@ -837,6 +845,11 @@ describe GraphQL::Dataloader do
           assert_equal 1, context[:batched_calls_counter].count
 
           query_str = "{ recipes { name } }"
+          context = { batched_calls_counter: BatchedCallsCounter.new }
+          schema.execute(query_str, context: context)
+          assert_equal 1, context[:batched_calls_counter].count
+
+          query_str = "{ recipesById(ids: [5, 6]) { name } }"
           context = { batched_calls_counter: BatchedCallsCounter.new }
           schema.execute(query_str, context: context)
           assert_equal 1, context[:batched_calls_counter].count


### PR DESCRIPTION
Fixes #4979 

`.run_isolated` is not ideal because it may break some batching that previously existed, but I think it's more important to handle this use case. (And it didn't break any of the many dataloader tests, which cover so many happy paths...)