### PR TITLE
Add an alternative type visiblity/filtering system

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
           - gemfile: gemfiles/rails_7.0.gemfile
             ruby: 3.1
           - gemfile: gemfiles/rails_master.gemfile
-            ruby: 3.1
+            ruby: 3.2
           - gemfile: gemfiles/rails_7.0.gemfile
             ruby: 3.2
           - gemfile: gemfiles/rails_7.1.gemfile

--- a/lib/graphql/analysis/field_usage.rb
+++ b/lib/graphql/analysis/field_usage.rb
@@ -72,7 +72,7 @@ module GraphQL
       end
 
       def extract_deprecated_enum_value(enum_type, value)
-        enum_value = @query.warden.enum_values(enum_type).find { |ev| ev.value == value }
+        enum_value = @query.types.enum_values(enum_type).find { |ev| ev.value == value }
         if enum_value&.deprecation_reason
           @used_deprecated_enum_values << enum_value.path
         end

--- a/lib/graphql/analysis/query_complexity.rb
+++ b/lib/graphql/analysis/query_complexity.rb
@@ -98,7 +98,7 @@ module GraphQL
         possible_scope_types.keys.each do |possible_scope_type|
           next unless possible_scope_type.kind.abstract?
 
-          query.possible_types(possible_scope_type).each do |impl_type|
+          query.types.possible_types(possible_scope_type).each do |impl_type|
             possible_scope_types[impl_type] ||= true
           end
           possible_scope_types.delete(possible_scope_type)
@@ -123,8 +123,8 @@ module GraphQL
       def types_intersect?(query, a, b)
         return true if a == b
 
-        a_types = query.possible_types(a)
-        query.possible_types(b).any? { |t| a_types.include?(t) }
+        a_types = query.types.possible_types(a)
+        query.types.possible_types(b).any? { |t| a_types.include?(t) }
       end
 
       # A hook which is called whenever a field's max complexity is calculated.

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -160,7 +160,7 @@ module GraphQL
               case node
               when GraphQL::Language::Nodes::InlineFragment
                 if node.type
-                  type_defn = schema.get_type(node.type.name, context)
+                  type_defn = query.types.type(node.type.name)
 
                   if query.types.possible_types(type_defn).include?(owner_type)
                     result = gather_selections(owner_object, owner_type, node.selections, selections_to_run, next_selections)

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -162,7 +162,7 @@ module GraphQL
                 if node.type
                   type_defn = schema.get_type(node.type.name, context)
 
-                  if query.warden.possible_types(type_defn).include?(owner_type)
+                  if query.types.possible_types(type_defn).include?(owner_type)
                     result = gather_selections(owner_object, owner_type, node.selections, selections_to_run, next_selections)
                     if !result.equal?(next_selections)
                       selections_to_run = result
@@ -177,8 +177,8 @@ module GraphQL
                 end
               when GraphQL::Language::Nodes::FragmentSpread
                 fragment_def = query.fragments[node.name]
-                type_defn = query.get_type(fragment_def.type.name)
-                if query.warden.possible_types(type_defn).include?(owner_type)
+                type_defn = query.types.type(fragment_def.type.name)
+                if query.types.possible_types(type_defn).include?(owner_type)
                   result = gather_selections(owner_object, owner_type, fragment_def.selections, selections_to_run, next_selections)
                   if !result.equal?(next_selections)
                     selections_to_run = result
@@ -245,7 +245,7 @@ module GraphQL
           end
           field_name = ast_node.name
           owner_type = selections_result.graphql_result_type
-          field_defn = query.warden.get_field(owner_type, field_name)
+          field_defn = query.types.field(owner_type, field_name)
 
           # Set this before calling `run_with_directives`, so that the directive can have the latest path
           runtime_state = get_current_runtime_state
@@ -579,7 +579,7 @@ module GraphQL
                 resolved_value = value
               end
 
-              possible_types = query.possible_types(current_type)
+              possible_types = query.types.possible_types(current_type)
               if !possible_types.include?(resolved_type)
                 parent_type = field.owner_type
                 err_class = current_type::UnresolvedTypeError

--- a/lib/graphql/introspection/directive_type.rb
+++ b/lib/graphql/introspection/directive_type.rb
@@ -22,7 +22,7 @@ module GraphQL
       field :is_repeatable, Boolean, method: :repeatable?
 
       def args(include_deprecated:)
-        args = @context.warden.arguments(@object)
+        args = @context.types.arguments(@object)
         args = args.reject(&:deprecation_reason) unless include_deprecated
         args
       end

--- a/lib/graphql/introspection/entry_points.rb
+++ b/lib/graphql/introspection/entry_points.rb
@@ -15,8 +15,8 @@ module GraphQL
       end
 
       def __type(name:)
-        if context.warden.reachable_type?(name)
-          context.warden.get_type(name)
+        if context.types.reachable_type?(name)
+          context.types.type(name)
         elsif (type = context.schema.extra_types.find { |t| t.graphql_name == name })
           type
         else

--- a/lib/graphql/introspection/field_type.rb
+++ b/lib/graphql/introspection/field_type.rb
@@ -19,7 +19,7 @@ module GraphQL
       end
 
       def args(include_deprecated:)
-        args = @context.warden.arguments(@object)
+        args = @context.types.arguments(@object)
         args = args.reject(&:deprecation_reason) unless include_deprecated
         args
       end

--- a/lib/graphql/introspection/schema_type.rb
+++ b/lib/graphql/introspection/schema_type.rb
@@ -20,7 +20,8 @@ module GraphQL
       end
 
       def types
-        types = context.types.all_types.to_a + context.schema.extra_types
+        query_types = context.types.all_types.to_a
+        types = query_types + context.schema.extra_types
         types.sort_by!(&:graphql_name)
         types
       end

--- a/lib/graphql/introspection/schema_type.rb
+++ b/lib/graphql/introspection/schema_type.rb
@@ -20,7 +20,7 @@ module GraphQL
       end
 
       def types
-        query_types = context.types.all_types.to_a
+        query_types = context.types.all_types
         types = query_types + context.schema.extra_types
         types.sort_by!(&:graphql_name)
         types

--- a/lib/graphql/introspection/schema_type.rb
+++ b/lib/graphql/introspection/schema_type.rb
@@ -20,7 +20,7 @@ module GraphQL
       end
 
       def types
-        types = context.warden.reachable_types + context.schema.extra_types
+        types = context.types.all_types.to_a + context.schema.extra_types
         types.sort_by!(&:graphql_name)
         types
       end
@@ -38,13 +38,22 @@ module GraphQL
       end
 
       def directives
-        @context.warden.directives
+        @context.types.directives
       end
 
       private
 
       def permitted_root_type(op_type)
-        @context.warden.root_type_for_operation(op_type)
+        case op_type
+        when "query"
+          @context.types.query_root
+        when "mutation"
+          @context.types.mutation_root
+        when "subcription"
+          @context.types.subscription_root
+        else
+          nil
+        end
       end
     end
   end

--- a/lib/graphql/introspection/type_type.rb
+++ b/lib/graphql/introspection/type_type.rb
@@ -52,7 +52,7 @@ module GraphQL
         if !@object.kind.enum?
           nil
         else
-          enum_values = @context.warden.enum_values(@object)
+          enum_values = @context.types.enum_values(@object)
 
           if !include_deprecated
             enum_values = enum_values.select {|f| !f.deprecation_reason }
@@ -64,7 +64,7 @@ module GraphQL
 
       def interfaces
         if @object.kind.object? || @object.kind.interface?
-          @context.warden.interfaces(@object).sort_by(&:graphql_name)
+          @context.types.interfaces(@object).sort_by(&:graphql_name)
         else
           nil
         end
@@ -72,7 +72,7 @@ module GraphQL
 
       def input_fields(include_deprecated:)
         if @object.kind.input_object?
-          args = @context.warden.arguments(@object)
+          args = @context.types.arguments(@object)
           args = args.reject(&:deprecation_reason) unless include_deprecated
           args
         else
@@ -82,7 +82,7 @@ module GraphQL
 
       def possible_types
         if @object.kind.abstract?
-          @context.warden.possible_types(@object).sort_by(&:graphql_name)
+          @context.types.possible_types(@object).sort_by(&:graphql_name)
         else
           nil
         end
@@ -92,7 +92,7 @@ module GraphQL
         if !@object.kind.fields?
           nil
         else
-          fields = @context.warden.fields(@object)
+          fields = @context.types.fields(@object)
           if !include_deprecated
             fields = fields.select {|f| !f.deprecation_reason }
           end

--- a/lib/graphql/language/document_from_schema_definition.rb
+++ b/lib/graphql/language/document_from_schema_definition.rb
@@ -25,7 +25,7 @@ module GraphQL
         @include_one_of = false
 
         dummy_query = @schema.query_class.new(@schema, "{ __typename }", validate: false, context: context)
-        @types = dummy_query.types
+        @types = dummy_query.types # rubocop:disable Development/ContextIsPassedCop
       end
 
       def document

--- a/lib/graphql/language/sanitized_printer.rb
+++ b/lib/graphql/language/sanitized_printer.rb
@@ -113,7 +113,7 @@ module GraphQL
       end
 
       def print_field(field, indent: "")
-        @current_field = query.get_field(@current_type, field.name)
+        @current_field = query.types.field(@current_type, field.name)
         old_type = @current_type
         @current_type = @current_field.type.unwrap
         super

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -95,17 +95,17 @@ module GraphQL
     # @param root_value [Object] the object used to resolve fields on the root type
     # @param max_depth [Numeric] the maximum number of nested selections allowed for this query (falls back to schema-level value)
     # @param max_complexity [Numeric] the maximum field complexity for this query (falls back to schema-level value)
-    def initialize(schema, query_string = nil, query: nil, document: nil, context: nil, variables: nil, validate: true, static_validator: nil, subscription_topic: nil, operation_name: nil, root_value: nil, max_depth: schema.max_depth, max_complexity: schema.max_complexity, warden: nil, use_subset: nil)
+    def initialize(schema, query_string = nil, query: nil, document: nil, context: nil, variables: nil, validate: true, static_validator: nil, subscription_topic: nil, operation_name: nil, root_value: nil, max_depth: schema.max_depth, max_complexity: schema.max_complexity, warden: nil, use_schema_subset: nil)
       # Even if `variables: nil` is passed, use an empty hash for simpler logic
       variables ||= {}
       @schema = schema
       @context = schema.context_class.new(query: self, values: context)
 
-      if use_subset.nil?
-        use_subset = warden ? false : schema.use_schema_subset?
+      if use_schema_subset.nil?
+        use_schema_subset = warden ? false : schema.use_schema_subset?
       end
 
-      if use_subset
+      if use_schema_subset
         @schema_subset = @schema.subset_class.new(self)
         @warden = Schema::Warden::NullWarden.new(context: self, schema: @schema)
       else

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -103,7 +103,7 @@ module GraphQL
       @warden = warden
       if true # shape
         @shape = GraphQL::Schema::Shape.new(self)
-        @warden = :__using_shape_instead__
+        @warden = Schema::Warden::PassThruWarden
       end
       @subscription_topic = subscription_topic
       @root_value = root_value

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -100,9 +100,11 @@ module GraphQL
       variables ||= {}
       @schema = schema
       @context = schema.context_class.new(query: self, values: context)
-      @warden = warden
-      if true # shape
-        @shape = GraphQL::Schema::Shape.new(self)
+      if warden
+        @shape = nil
+        @warden = warden
+      else
+        @shape = @schema.shape_class.new(self)
         @warden = Schema::Warden::NullWarden.new(context: self, schema: @schema)
       end
       @subscription_topic = subscription_topic

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -101,7 +101,7 @@ module GraphQL
       @schema = schema
       @context = schema.context_class.new(query: self, values: context)
       @warden = warden
-      if shape
+      if true # shape
         @shape = GraphQL::Schema::Shape.new(self)
         @warden = :__using_shape_instead__
       end
@@ -199,7 +199,14 @@ module GraphQL
     def lookahead
       @lookahead ||= begin
         ast_node = selected_operation
-        root_type = warden.root_type_for_operation(ast_node.operation_type || "query")
+        root_type = case ast_node.operation_type
+        when nil, "query"
+          types.query_root
+        when "mutation"
+          types.mutation_root
+        when "subscription"
+          types.subscription_root
+        end
         GraphQL::Execution::Lookahead.new(query: self, root_type: root_type, ast_nodes: [ast_node])
       end
     end

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -104,15 +104,13 @@ module GraphQL
       if use_subset.nil?
         use_subset = schema.use_schema_subset?
       end
-      if warden
-        @schema_subset = nil
-        @warden = warden
-      elsif use_subset
+
+      if use_subset
         @schema_subset = @schema.subset_class.new(self)
         @warden = Schema::Warden::NullWarden.new(context: self, schema: @schema)
       else
         @schema_subset = nil
-        @warden = nil # initialized lazily later
+        @warden = warden
       end
 
       @subscription_topic = subscription_topic

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -103,7 +103,7 @@ module GraphQL
       @warden = warden
       if true # shape
         @shape = GraphQL::Schema::Shape.new(self)
-        @warden = Schema::Warden::PassThruWarden
+        @warden = Schema::Warden::NullWarden.new(context: self, schema: @schema)
       end
       @subscription_topic = subscription_topic
       @root_value = root_value

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -102,7 +102,7 @@ module GraphQL
       @context = schema.context_class.new(query: self, values: context)
 
       if use_subset.nil?
-        use_subset = schema.use_schema_subset?
+        use_subset = warden ? false : schema.use_schema_subset?
       end
 
       if use_subset

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -203,11 +203,11 @@ module GraphQL
         ast_node = selected_operation
         root_type = case ast_node.operation_type
         when nil, "query"
-          types.query_root
+          types.query_root # rubocop:disable Development/ContextIsPassedCop
         when "mutation"
-          types.mutation_root
+          types.mutation_root # rubocop:disable Development/ContextIsPassedCop
         when "subscription"
-          types.subscription_root
+          types.subscription_root # rubocop:disable Development/ContextIsPassedCop
         end
         GraphQL::Execution::Lookahead.new(query: self, root_type: root_type, ast_nodes: [ast_node])
       end

--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -201,7 +201,7 @@ module GraphQL
       end
 
       def to_h
-        if (current_scoped_context = @scoped_context&.merged_context)
+        if (current_scoped_context = @scoped_context.merged_context)
           @provided_values.merge(current_scoped_context)
         else
           @provided_values

--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -84,6 +84,10 @@ module GraphQL
 
       def_delegators :@query, :trace, :interpreter?
 
+      def types
+        @query.types
+      end
+
       RUNTIME_METADATA_KEYS = Set.new([:current_object, :current_arguments, :current_field, :current_path])
       # @!method []=(key, value)
       #   Reassign `key` to the hash passed to {Schema#execute} as `context:`

--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -201,7 +201,7 @@ module GraphQL
       end
 
       def to_h
-        if (current_scoped_context = @scoped_context.merged_context)
+        if (current_scoped_context = @scoped_context&.merged_context)
           @provided_values.merge(current_scoped_context)
         else
           @provided_values

--- a/lib/graphql/query/null_context.rb
+++ b/lib/graphql/query/null_context.rb
@@ -30,6 +30,10 @@ module GraphQL
       def interpreter?
         true
       end
+
+      def types
+        @types ||= GraphQL::Schema::Warden::Shapish.new(@warden)
+      end
     end
   end
 end

--- a/lib/graphql/query/null_context.rb
+++ b/lib/graphql/query/null_context.rb
@@ -32,7 +32,7 @@ module GraphQL
       end
 
       def types
-        @types ||= GraphQL::Schema::Warden::Shapish.new(@warden)
+        @types ||= GraphQL::Schema::Warden::SchemaSubset.new(@warden)
       end
     end
   end

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -502,6 +502,18 @@ module GraphQL
 
       attr_writer :warden_class
 
+      def shape_class
+        if defined?(@shape_class)
+          @shape_class
+        elsif superclass.respond_to?(:shape_class)
+          superclass.shape_class
+        else
+          GraphQL::Schema::Shape
+        end
+      end
+
+      attr_writer :shape_class
+
       # @param type [Module] The type definition whose possible types you want to see
       # @return [Hash<String, Module>] All possible types, if no `type` is given.
       # @return [Array<Module>] Possible types for `type`, if it's given.

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -46,7 +46,7 @@ require "graphql/schema/mutation"
 require "graphql/schema/has_single_input_argument"
 require "graphql/schema/relay_classic_mutation"
 require "graphql/schema/subscription"
-require "graphql/schema/shape"
+require "graphql/schema/subset"
 
 module GraphQL
   # A GraphQL schema which may be queried with {GraphQL::Query}.
@@ -371,7 +371,7 @@ module GraphQL
         when nil
           nil
         when Array
-          if context.respond_to?(:types) && context.types.is_a?(GraphQL::Schema::Shape)
+          if context.respond_to?(:types) && context.types.is_a?(GraphQL::Schema::Subset)
             local_entry
           else
             visible_t = nil
@@ -502,17 +502,27 @@ module GraphQL
 
       attr_writer :warden_class
 
-      def shape_class
-        if defined?(@shape_class)
-          @shape_class
-        elsif superclass.respond_to?(:shape_class)
-          superclass.shape_class
+      def subset_class
+        if defined?(@subset_class)
+          @subset_class
+        elsif superclass.respond_to?(:subset_class)
+          superclass.subset_class
         else
-          GraphQL::Schema::Shape
+          GraphQL::Schema::Subset
         end
       end
 
-      attr_writer :shape_class
+      attr_writer :subset_class, :use_schema_subset
+
+      def use_schema_subset?
+        if defined?(@use_schema_subset)
+          @use_schema_subset
+        elsif superclass.respond_to?(:use_schema_subset?)
+          superclass.use_schema_subset?
+        else
+          false
+        end
+      end
 
       # @param type [Module] The type definition whose possible types you want to see
       # @return [Hash<String, Module>] All possible types, if no `type` is given.

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -46,6 +46,7 @@ require "graphql/schema/mutation"
 require "graphql/schema/has_single_input_argument"
 require "graphql/schema/relay_classic_mutation"
 require "graphql/schema/subscription"
+require "graphql/schema/shape"
 
 module GraphQL
   # A GraphQL schema which may be queried with {GraphQL::Query}.
@@ -574,7 +575,7 @@ module GraphQL
       end
 
       def type_from_ast(ast_node, context: nil)
-        type_owner = context ? context.warden : self
+        type_owner = context ? context.query.types : self
         GraphQL::Schema::TypeExpression.build_type(type_owner, ast_node)
       end
 
@@ -1053,6 +1054,10 @@ module GraphQL
         Member::HasDirectives.get_directives(self, @own_schema_directives, :schema_directives)
       end
 
+      # Called when a type is needed by name at runtime
+      def load_type(type_name, ctx)
+        get_type(type_name, ctx)
+      end
       # This hook is called when an object fails an `authorized?` check.
       # You might report to your bug tracker here, so you can correct
       # the field resolvers not to return unauthorized objects.

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -365,13 +365,13 @@ module GraphQL
 
       # @param type_name [String]
       # @return [Module, nil] A type, or nil if there's no type called `type_name`
-      def get_type(type_name, context = GraphQL::Query::NullContext.instance, skip_visible: false)
+      def get_type(type_name, context = GraphQL::Query::NullContext.instance)
         local_entry = own_types[type_name]
         type_defn = case local_entry
         when nil
           nil
         when Array
-          if skip_visible
+          if context.respond_to?(:types) && context.types.is_a?(GraphQL::Schema::Shape)
             local_entry
           else
             visible_t = nil
@@ -1071,7 +1071,7 @@ module GraphQL
 
       # Called when a type is needed by name at runtime
       def load_type(type_name, ctx)
-        get_type(type_name, ctx, skip_visible: true)
+        get_type(type_name, ctx)
       end
       # This hook is called when an object fails an `authorized?` check.
       # You might report to your bug tracker here, so you can correct

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -578,9 +578,8 @@ module GraphQL
         end
       end
 
-      def type_from_ast(ast_node, context: nil)
-        type_owner = context ? context.query.types : self
-        GraphQL::Schema::TypeExpression.build_type(type_owner, ast_node)
+      def type_from_ast(ast_node, context: self.query_class.new(self, "{ __typename }").context)
+        GraphQL::Schema::TypeExpression.build_type(context.query.types, ast_node)
       end
 
       def get_field(type_or_name, field_name, context = GraphQL::Query::NullContext.instance)

--- a/lib/graphql/schema/always_visible.rb
+++ b/lib/graphql/schema/always_visible.rb
@@ -4,7 +4,7 @@ module GraphQL
     class AlwaysVisible
       def self.use(schema, **opts)
         schema.warden_class = GraphQL::Schema::Warden::NullWarden
-        schema.shape_class = GraphQL::Schema::Warden::NullWarden::NullShape
+        schema.subset_class = GraphQL::Schema::Warden::NullWarden::NullSubset
       end
     end
   end

--- a/lib/graphql/schema/always_visible.rb
+++ b/lib/graphql/schema/always_visible.rb
@@ -4,6 +4,7 @@ module GraphQL
     class AlwaysVisible
       def self.use(schema, **opts)
         schema.warden_class = GraphQL::Schema::Warden::NullWarden
+        schema.shape_class = GraphQL::Schema::Warden::NullWarden::NullShape
       end
     end
   end

--- a/lib/graphql/schema/enum.rb
+++ b/lib/graphql/schema/enum.rb
@@ -77,7 +77,7 @@ module GraphQL
               visible_values << v
             end
           end
-          visible_values.flatten!
+
           if inherited_values
             # Local values take precedence over inherited ones
             inherited_values.each do |i_val|

--- a/lib/graphql/schema/enum.rb
+++ b/lib/graphql/schema/enum.rb
@@ -130,7 +130,7 @@ module GraphQL
         end
 
         def validate_non_null_input(value_name, ctx, max_errors: nil)
-          allowed_values = ctx.warden.enum_values(self)
+          allowed_values = ctx.types.enum_values(self)
           matching_value = allowed_values.find { |v| v.graphql_name == value_name }
 
           if matching_value.nil?
@@ -152,7 +152,7 @@ module GraphQL
         end
 
         def coerce_input(value_name, ctx)
-          all_values = ctx.warden ? ctx.warden.enum_values(self) : values.each_value
+          all_values = ctx.types ? ctx.types.enum_values(self) : values.each_value
 
           if v = all_values.find { |val| val.graphql_name == value_name }
             v.value

--- a/lib/graphql/schema/enum.rb
+++ b/lib/graphql/schema/enum.rb
@@ -141,8 +141,8 @@ module GraphQL
         end
 
         def coerce_result(value, ctx)
-          warden = ctx.warden
-          all_values = warden ? warden.enum_values(self) : values.each_value
+          types = ctx.types
+          all_values = types ? types.enum_values(self) : values.each_value
           enum_value = all_values.find { |val| val.value == value }
           if enum_value
             enum_value.graphql_name

--- a/lib/graphql/schema/enum.rb
+++ b/lib/graphql/schema/enum.rb
@@ -77,7 +77,7 @@ module GraphQL
               visible_values << v
             end
           end
-
+          visible_values.flatten!
           if inherited_values
             # Local values take precedence over inherited ones
             inherited_values.each do |i_val|

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -614,7 +614,7 @@ module GraphQL
               using_arg_values = false
             end
 
-            args = context.warden.arguments(self)
+            args = context.types.arguments(self)
             args.each do |arg|
               arg_key = arg.keyword
               if arg_values.key?(arg_key)

--- a/lib/graphql/schema/has_single_input_argument.rb
+++ b/lib/graphql/schema/has_single_input_argument.rb
@@ -59,8 +59,8 @@ module GraphQL
           dummy.arguments(context)
         end
 
-        def get_field_argument(name, context = GraphQL::Query::NullContext.instance, skip_visible:)
-          dummy.get_argument(name, context, skip_visible: skip_visible)
+        def get_field_argument(name, context = GraphQL::Query::NullContext.instance)
+          dummy.get_argument(name, context)
         end
 
         def own_field_arguments

--- a/lib/graphql/schema/has_single_input_argument.rb
+++ b/lib/graphql/schema/has_single_input_argument.rb
@@ -59,8 +59,8 @@ module GraphQL
           dummy.arguments(context)
         end
 
-        def get_field_argument(name, context = GraphQL::Query::NullContext.instance)
-          dummy.get_argument(name, context)
+        def get_field_argument(name, context = GraphQL::Query::NullContext.instance, skip_visible:)
+          dummy.get_argument(name, context, skip_visible: skip_visible)
         end
 
         def own_field_arguments

--- a/lib/graphql/schema/has_single_input_argument.rb
+++ b/lib/graphql/schema/has_single_input_argument.rb
@@ -149,7 +149,8 @@ module GraphQL
 
       def authorize_arguments(args, values)
         # remove the `input` wrapper to match values
-        input_args = args["input"].type.unwrap.arguments(context)
+        input_type = args.find { |a| a.graphql_name == "input" }.type.unwrap
+        input_args = context.types.arguments(input_type)
         super(input_args, values)
       end
     end

--- a/lib/graphql/schema/introspection_system.rb
+++ b/lib/graphql/schema/introspection_system.rb
@@ -69,7 +69,7 @@ module GraphQL
       def resolve_late_bindings
         @types.each do |name, t|
           if t.kind.fields?
-            t.fields.each do |_name, field_defn|
+            t.all_field_definitions.each do |field_defn|
               field_defn.type = resolve_late_binding(field_defn.type)
             end
           end
@@ -113,19 +113,7 @@ module GraphQL
 
       def get_fields_from_class(class_sym:)
         object_type_defn = load_constant(class_sym)
-
-        if object_type_defn.is_a?(Module)
-          object_type_defn.fields
-        else
-          extracted_field_defns = {}
-          object_class = object_type_defn.metadata[:type_class]
-          object_type_defn.all_fields.each do |field_defn|
-            inner_resolve = field_defn.resolve_proc
-            resolve_with_instantiate = PerFieldProxyResolve.new(object_class: object_class, inner_resolve: inner_resolve)
-            extracted_field_defns[field_defn.name] = field_defn.redefine(resolve: resolve_with_instantiate)
-          end
-          extracted_field_defns
-        end
+        object_type_defn.fields
       end
 
       # This is probably not 100% robust -- but it has to be good enough to avoid modifying the built-in introspection types

--- a/lib/graphql/schema/member/base_dsl_methods.rb
+++ b/lib/graphql/schema/member/base_dsl_methods.rb
@@ -108,7 +108,7 @@ module GraphQL
         end
 
         def visible?(context)
-          true
+          @mutation ? @mutation.visible?(context) : true
         end
 
         def authorized?(object, context)

--- a/lib/graphql/schema/member/base_dsl_methods.rb
+++ b/lib/graphql/schema/member/base_dsl_methods.rb
@@ -108,7 +108,7 @@ module GraphQL
         end
 
         def visible?(context)
-          @mutation ? @mutation.visible?(context) : true
+          true
         end
 
         def authorized?(object, context)

--- a/lib/graphql/schema/member/has_arguments.rb
+++ b/lib/graphql/schema/member/has_arguments.rb
@@ -230,7 +230,7 @@ module GraphQL
         # @return [Interpreter::Arguments, Execution::Lazy<Interpreter::Arguments>]
         def coerce_arguments(parent_object, values, context, &block)
           # Cache this hash to avoid re-merging it
-          arg_defns = context.warden.arguments(self)
+          arg_defns = context.types.arguments(self)
           total_args_count = arg_defns.size
 
           finished_args = nil

--- a/lib/graphql/schema/member/has_arguments.rb
+++ b/lib/graphql/schema/member/has_arguments.rb
@@ -364,8 +364,8 @@ module GraphQL
                   end
 
                   if !(
-                      context.warden.possible_types(argument.loads).include?(application_object_type) ||
-                      context.warden.loadable?(argument.loads, context)
+                      context.types.possible_types(argument.loads).include?(application_object_type) ||
+                      context.types.loadable?(argument.loads, context)
                     )
                     err = GraphQL::LoadApplicationObjectFailedError.new(context: context, argument: argument, id: id, object: application_object)
                     application_object = load_application_object_failed(err)

--- a/lib/graphql/schema/member/has_arguments.rb
+++ b/lib/graphql/schema/member/has_arguments.rb
@@ -135,7 +135,7 @@ module GraphQL
 
             def get_argument(argument_name, context = GraphQL::Query::NullContext.instance)
               warden = Warden.from_context(context)
-              skip_visible = context.respond_to?(:types) && context.types.is_a?(GraphQL::Schema::Shape)
+              skip_visible = context.respond_to?(:types) && context.types.is_a?(GraphQL::Schema::Subset)
               for ancestor in ancestors
                 if ancestor.respond_to?(:own_arguments) &&
                   (a = ancestor.own_arguments[argument_name]) &&
@@ -206,7 +206,7 @@ module GraphQL
         # @return [GraphQL::Schema::Argument, nil] Argument defined on this thing, fetched by name.
         def get_argument(argument_name, context = GraphQL::Query::NullContext.instance)
           warden = Warden.from_context(context)
-          if (arg_config = own_arguments[argument_name]) && ((context.respond_to?(:types) && context.types.is_a?(GraphQL::Schema::Shape)) || (visible_arg = Warden.visible_entry?(:visible_argument?, arg_config, context, warden)))
+          if (arg_config = own_arguments[argument_name]) && ((context.respond_to?(:types) && context.types.is_a?(GraphQL::Schema::Subset)) || (visible_arg = Warden.visible_entry?(:visible_argument?, arg_config, context, warden)))
             visible_arg || arg_config
           elsif defined?(@resolver_class) && @resolver_class
             @resolver_class.get_field_argument(argument_name, context)

--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -97,13 +97,13 @@ module GraphQL
         end
 
         module InterfaceMethods
-          def get_field(field_name, context = GraphQL::Query::NullContext.instance)
+          def get_field(field_name, context = GraphQL::Query::NullContext.instance, skip_visible: false)
             warden = Warden.from_context(context)
             for ancestor in ancestors
               if ancestor.respond_to?(:own_fields) &&
                   (f_entry = ancestor.own_fields[field_name]) &&
-                  (f = Warden.visible_entry?(:visible_field?, f_entry, context, warden))
-                return f
+                  (skip_visible || (f_entry = Warden.visible_entry?(:visible_field?, f_entry, context, warden)))
+                return f_entry
               end
             end
             nil
@@ -130,7 +130,7 @@ module GraphQL
         end
 
         module ObjectMethods
-          def get_field(field_name, context = GraphQL::Query::NullContext.instance)
+          def get_field(field_name, context = GraphQL::Query::NullContext.instance, skip_visible: false)
             # Objects need to check that the interface implementation is visible, too
             warden = Warden.from_context(context)
             ancs = ancestors
@@ -139,8 +139,8 @@ module GraphQL
               if ancestor.respond_to?(:own_fields) &&
                   visible_interface_implementation?(ancestor, context, warden) &&
                   (f_entry = ancestor.own_fields[field_name]) &&
-                  (f = Warden.visible_entry?(:visible_field?, f_entry, context, warden))
-                return f
+                  (skip_visible || (f_entry = Warden.visible_entry?(:visible_field?, f_entry, context, warden)))
+                return f_entry
               end
               i += 1
             end

--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -97,8 +97,9 @@ module GraphQL
         end
 
         module InterfaceMethods
-          def get_field(field_name, context = GraphQL::Query::NullContext.instance, skip_visible: false)
+          def get_field(field_name, context = GraphQL::Query::NullContext.instance)
             warden = Warden.from_context(context)
+            skip_visible = context.respond_to?(:types) && context.types.is_a?(GraphQL::Schema::Shape)
             for ancestor in ancestors
               if ancestor.respond_to?(:own_fields) &&
                   (f_entry = ancestor.own_fields[field_name]) &&
@@ -130,10 +131,11 @@ module GraphQL
         end
 
         module ObjectMethods
-          def get_field(field_name, context = GraphQL::Query::NullContext.instance, skip_visible: false)
+          def get_field(field_name, context = GraphQL::Query::NullContext.instance)
             # Objects need to check that the interface implementation is visible, too
             warden = Warden.from_context(context)
             ancs = ancestors
+            skip_visible = context.respond_to?(:types) && context.types.is_a?(GraphQL::Schema::Shape)
             i = 0
             while (ancestor = ancs[i])
               if ancestor.respond_to?(:own_fields) &&

--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -99,7 +99,7 @@ module GraphQL
         module InterfaceMethods
           def get_field(field_name, context = GraphQL::Query::NullContext.instance)
             warden = Warden.from_context(context)
-            skip_visible = context.respond_to?(:types) && context.types.is_a?(GraphQL::Schema::Shape)
+            skip_visible = context.respond_to?(:types) && context.types.is_a?(GraphQL::Schema::Subset)
             for ancestor in ancestors
               if ancestor.respond_to?(:own_fields) &&
                   (f_entry = ancestor.own_fields[field_name]) &&
@@ -135,7 +135,7 @@ module GraphQL
             # Objects need to check that the interface implementation is visible, too
             warden = Warden.from_context(context)
             ancs = ancestors
-            skip_visible = context.respond_to?(:types) && context.types.is_a?(GraphQL::Schema::Shape)
+            skip_visible = context.respond_to?(:types) && context.types.is_a?(GraphQL::Schema::Subset)
             i = 0
             while (ancestor = ancs[i])
               if ancestor.respond_to?(:own_fields) &&

--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -227,8 +227,8 @@ module GraphQL
           any_arguments?
         end
 
-        def get_field_argument(name, context = GraphQL::Query::NullContext.instance)
-          get_argument(name, context)
+        def get_field_argument(name, context = GraphQL::Query::NullContext.instance, skip_visible:)
+          get_argument(name, context, skip_visible: skip_visible)
         end
 
         def all_field_argument_definitions

--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -36,7 +36,7 @@ module GraphQL
         @field = field
         # Since this hash is constantly rebuilt, cache it for this call
         @arguments_by_keyword = {}
-        self.class.arguments(context).each do |name, arg|
+        context.types.arguments(self.class).each do |arg|
           @arguments_by_keyword[arg.keyword] = arg
         end
         @prepared_arguments = nil
@@ -152,7 +152,7 @@ module GraphQL
       # @return [Boolean, early_return_data] If `false`, execution will stop (and `early_return_data` will be returned instead, if present.)
       def authorized?(**inputs)
         arg_owner = @field # || self.class
-        args = arg_owner.arguments(context)
+        args = context.types.arguments(arg_owner)
         authorize_arguments(args, inputs)
       end
 
@@ -169,7 +169,7 @@ module GraphQL
       private
 
       def authorize_arguments(args, inputs)
-        args.each_value do |argument|
+        args.each do |argument|
           arg_keyword = argument.keyword
           if inputs.key?(arg_keyword) && !(arg_value = inputs[arg_keyword]).nil? && (arg_value != argument.default_value)
             auth_result = argument.authorized?(self, arg_value, context)
@@ -182,10 +182,9 @@ module GraphQL
             elsif auth_result == false
               return auth_result
             end
-          else
-            true
           end
         end
+        true
       end
 
       def load_arguments(args)

--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -227,8 +227,8 @@ module GraphQL
           any_arguments?
         end
 
-        def get_field_argument(name, context = GraphQL::Query::NullContext.instance, skip_visible:)
-          get_argument(name, context, skip_visible: skip_visible)
+        def get_field_argument(name, context = GraphQL::Query::NullContext.instance)
+          get_argument(name, context)
         end
 
         def all_field_argument_definitions

--- a/lib/graphql/schema/shape.rb
+++ b/lib/graphql/schema/shape.rb
@@ -7,24 +7,62 @@ module GraphQL
         @query = query
         @context = query.context
         @schema = query.schema
-        @all_types = Set.new.compare_by_identity
+        @all_types = {}
         @all_types_loaded = false
+        @unvisited_types = []
+        @cached_visible = Hash.new { |h, k| h[k] = k.visible?(@context) }.compare_by_identity
+
+        @cached_reachable = Hash.new do |h, type|
+          h[type] = case type.kind.name
+          when "UNION"
+            possible_types(type).any?
+          else
+            true
+          end
+        end.compare_by_identity
+
+        @cached_visible_fields = Hash.new { |h, field|
+          h[field] = if @cached_visible[field] && (ret_type = field.type.unwrap) && @cached_visible[ret_type] && @cached_reachable[ret_type]
+            add_type(ret_type)
+            true
+          else
+            false
+          end
+        }.compare_by_identity
+        # TODO don't I also need @cached_visible_args?
       end
 
       def type(type_name)
-        # TODO filter
-        t = @all_types.find { |t| t.graphql_name == t } || @schema.load_type(type_name, @context)
-        if t&.visible?(@context)
-          # TODO add type?
-          t
+        if (loaded_t = @all_types[type_name])
+          loaded_t
         else
-          nil
+          t = @schema.load_type(type_name, @context)
+          if t.is_a?(Array)
+            vis_t = nil
+            t.each do |t_defn|
+              if @cached_visible[t_defn]
+                if vis_t.nil?
+                  add_type(t_defn)
+                  vis_t = t_defn
+                else
+                  raise_duplicate_definition(vis_t, t_defn)
+                end
+              end
+            end
+            vis_t
+          else
+            if t && @cached_visible[t]
+              add_type(t)
+              t
+            else
+              nil
+            end
+          end
         end
       end
 
       def field(owner, field_name)
-        # TODO filter
-        f = if owner.kind.fields? && (field = owner.get_field(field_name, @context)) # TODO pass context
+        f = if owner.kind.fields? && (field = owner.get_field(field_name, @context, skip_visible: true))
           field
         elsif owner == query_root && (entry_point_field = @schema.introspection_system.entry_point(name: field_name))
           entry_point_field
@@ -33,54 +71,84 @@ module GraphQL
         else
           nil
         end
-        if f&.visible?(@context) && (ret_type = f.type.unwrap).visible?(@context)
-          add_type(owner)
-          add_type(ret_type)
-          f
+        if f.is_a?(Array)
+          visible_f = nil
+          f.each do |f_defn|
+            if @cached_visible_fields[f_defn]
+
+              if visible_f.nil?
+                visible_f = f_defn
+              else
+                raise_duplicate_definition(visible_f, f_defn)
+              end
+            end
+          end
+          visible_f
         else
-          nil
+          if f && @cached_visible_fields[f]
+            f
+          else
+            nil
+          end
         end
       end
 
       def fields(owner)
-        # TODO filter
-        owner.fields.values.select { |f| f.visible?(@context) }
+        non_duplicate_items(owner.all_field_definitions, @cached_visible_fields)
       end
 
       def arguments(owner)
-        # TODO filter
-        owner.arguments.values.select { |a| a.visible?(@context) }
+        non_duplicate_items(owner.all_argument_definitions, @cached_visible)
       end
 
       def argument(owner, arg_name)
-        arg = owner.get_argument(arg_name) # TODO filter
-        if arg&.visible?(@context)
-          if arg&.loads
-            add_type(arg.loads)
+        # TODO this makes a Warden.visible_entry call down the stack
+        # I need a non-Warden implementation
+        arg = owner.get_argument(arg_name, @context, skip_visible: true)
+        if arg.is_a?(Array)
+          visible_arg = nil
+          arg.each do |arg_defn|
+            if @cached_visible[arg_defn]
+              if arg_defn&.loads
+                add_type(arg_defn.loads)
+              end
+              if visible_arg.nil?
+                visible_arg = arg_defn
+              else
+                raise_duplicate_definition(visible_arg, arg_defn)
+              end
+            end
           end
-          arg
+          visible_arg
         else
-          nil
+          if arg && @cached_visible[arg]
+            if arg&.loads
+              add_type(arg.loads)
+            end
+            arg
+          else
+            nil
+          end
         end
       end
 
       def possible_types(type)
-        # TODO filter
-        @all_types.add(type)
+        add_type(type)
         pt = case type.kind.name
         when "OBJECT"
           [type]
         when "INTERFACE"
           @schema.possible_types(type)
         when "UNION"
-          type.possible_types
+          type.type_memberships.select { |tm| @cached_visible[tm] && @cached_visible[tm.object_type] }.map!(&:object_type)
         end
-        pt.each { |t| add_type(t) }
+
+        pt = pt.select { |t|  @cached_visible[t] ? (add_type(t); true) : false  }
         pt
       end
 
       def interfaces(obj_type)
-        obj_type.interfaces # TODO filter
+        obj_type.interface_type_memberships.select { |itm| @cached_visible[itm] && @cached_visible[itm.abstract_type] }.map!(&:abstract_type)
       end
 
       def query_root
@@ -102,29 +170,26 @@ module GraphQL
       end
 
       def all_types
-        if !@all_types_loaded
-          @schema.types.each_value { |t| add_type(t) }
-          @all_types_loaded = true
-        end
-        @all_types
+        load_all_types
+        @all_types.values
       end
 
       def enum_values(owner)
         add_type(owner)
-        # TODO filter
-        owner.enum_values.select { |v| v.visible?(@context) }
+        non_duplicate_items(owner.all_enum_value_definitions, @cached_visible)
       end
 
       def directive_exists?(dir_name)
-        @schema.directives[dir_name]&.visible?(@context)
+        dir = @schema.directives[dir_name]
+        dir && @cached_visible[dir]
       end
 
       def directives
-        @schema.directives.each_value.select { |d| d.visible?(@context) }
+        @schema.directives.each_value.select { |d| @cached_visible[d] }
       end
 
       def loadable?(t, _ctx)
-        !@all_types.include?(t) # TODO make sure t is not reachable but t is visible
+        !@all_types[t.graphql_name] # TODO make sure t is not reachable but t is visible
       end
 
       def reachable_type?(t)
@@ -134,7 +199,94 @@ module GraphQL
       private
 
       def add_type(t)
-        t && @all_types.add(t)
+        if t && @cached_visible[t]
+          n = t.graphql_name
+          if prev_t = @all_types[n]
+            if !prev_t.equal?(t)
+              raise_duplicate_definition(prev_t, t)
+            end
+            false
+          else
+            if !t.respond_to?(:kind)
+              binding.pry
+            end
+            @all_types[n] = t
+            @unvisited_types << t
+            true
+          end
+        else
+          false
+        end
+      end
+
+      def non_duplicate_items(definitions, visibility_cache)
+        non_dups = []
+        definitions.each do |defn|
+          if visibility_cache[defn]
+            if (dup_defn = non_dups.find { |d| d.graphql_name == defn.graphql_name })
+              raise_duplicate_definition(dup_defn, defn)
+            end
+            non_dups << defn
+          end
+        end
+        non_dups
+      end
+
+      def raise_duplicate_definition(first_defn, second_defn)
+        raise DuplicateNamesError.new(duplicated_name: first_defn.path, duplicated_definition_1: first_defn.inspect, duplicated_definition_2: second_defn.inspect)
+      end
+
+      def load_all_types
+        return if @all_types_loaded
+        @all_types_loaded = true
+        schema_types = @schema.types.values
+        schema_types.compact! # TODO why is this necessary?!
+        schema_types.flatten! # handle multiple defns
+        schema_types.each { |t| add_type(t) }
+        while t = @unvisited_types.pop
+          # These have already been checked for `.visible?`
+          visit_type(t)
+        end
+      end
+
+      def visit_type(type, include_interface_possible_types: false)
+        if type.kind.input_object?
+          # recurse into visible arguments
+          arguments(type).each do |argument|
+            add_type(argument.type.unwrap)
+          end
+        elsif type.kind.union?
+          # recurse into visible possible types
+          possible_types(type).each do |possible_type|
+            add_type(possible_type)
+          end
+        elsif type.kind.fields?
+          if type.kind.object?
+            # recurse into visible implemented interfaces
+            interfaces(type).each do |interface|
+              add_type(interface)
+            end
+          elsif include_interface_possible_types
+            possible_types(type).each do |pt|
+              add_type(interface)
+            end
+          end
+          # Don't visit interface possible types -- it's not enough to justify visibility
+
+          # recurse into visible fields
+          t_f = fields(type)
+          t_f.each do |field|
+            field_type = field.type.unwrap
+            # In this case, if it's an interface, we want to include
+            # visit_type(unvisited_types, field_type, include_interface_possible_types: true)
+            # TODO ^^ reimplement that
+            add_type(field_type)
+            # recurse into visible arguments
+            arguments(field).each do |argument|
+              add_type(argument.type.unwrap)
+            end
+          end
+        end
       end
     end
   end

--- a/lib/graphql/schema/shape.rb
+++ b/lib/graphql/schema/shape.rb
@@ -152,12 +152,12 @@ module GraphQL
         @cached_possible_types ||= Hash.new do |h, type|
           add_type(type)
           pt = case type.kind.name
-          when "OBJECT"
-            [type]
           when "INTERFACE"
             @schema.possible_types(type)
           when "UNION"
             type.type_memberships.select { |tm| @cached_visible[tm] && @cached_visible[tm.object_type] }.map!(&:object_type)
+          else
+            [type]
           end
 
           h[type] = pt.select { |t|  @cached_visible[t] ? (add_type(t); true) : false  }
@@ -215,6 +215,10 @@ module GraphQL
       def reachable_type?(type_name)
         load_all_types
         !!@all_types[type_name]
+      end
+
+      def loaded_types
+        @all_types.values
       end
 
       private

--- a/lib/graphql/schema/shape.rb
+++ b/lib/graphql/schema/shape.rb
@@ -178,7 +178,11 @@ module GraphQL
 
       def enum_values(owner)
         add_type(owner)
-        non_duplicate_items(owner.all_enum_value_definitions, @cached_visible)
+        values = non_duplicate_items(owner.all_enum_value_definitions, @cached_visible)
+        if values.size == 0
+          raise GraphQL::Schema::Enum::MissingValuesError.new(owner)
+        end
+        values
       end
 
       def directive_exists?(dir_name)

--- a/lib/graphql/schema/shape.rb
+++ b/lib/graphql/schema/shape.rb
@@ -333,10 +333,6 @@ module GraphQL
             interfaces(type).each do |interface|
               add_type(interface)
             end
-          else
-            # possible_types(type).each do |pt|
-            #   add_type(pt)
-            # end
           end
 
           # recurse into visible fields
@@ -344,7 +340,20 @@ module GraphQL
           t_f.each do |field|
             if @cached_visible[field]
               field_type = field.type.unwrap
+              if field_type.kind.interface?
+
+                @schema.possible_types(field_type).each do |obj_type|
+                  if @cached_visible[obj_type] &&
+                      (tm = obj_type.interface_type_memberships.find { |tm| tm.abstract_type == field_type }) &&
+                      @cached_visible[tm]
+                    add_type(obj_type)
+                  end
+                end
+
+
+              end
               add_type(field_type)
+
               # recurse into visible arguments
               arguments(field).each do |argument|
                 add_type(argument.type.unwrap)

--- a/lib/graphql/schema/shape.rb
+++ b/lib/graphql/schema/shape.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module GraphQL
+  class Schema
+    class Shape
+      def initialize(query)
+        @query = query
+        @context = query.context
+        @schema = query.schema
+        @all_types = Set.new.compare_by_identity
+      end
+
+      def type(type_name)
+        # TODO filter
+        @all_types.find { |t| t.graphql_name == t } || @schema.load_type(type_name, @context)
+      end
+
+      def field(owner, field_name)
+        # TODO filter
+        @all_types.add(owner)
+        f = if owner.kind.fields? && (field = owner.get_field(field_name)) # TODO pass context
+          field
+        elsif owner == query_root && (entry_point_field = @schema.introspection_system.entry_point(name: field_name))
+          entry_point_field
+        elsif (dynamic_field = @schema.introspection_system.dynamic_field(name: field_name))
+          dynamic_field
+        else
+          nil
+        end
+        f && @all_types.add(f.type.unwrap)
+        f
+      end
+
+      def arguments(owner)
+        # TODO filter
+        owner.arguments.values
+      end
+
+      def argument(owner, arg_name)
+        owner.get_argument(arg_name) # TODO filter
+      end
+
+      def possible_types(type)
+        # TODO filter
+        @all_types.add(type)
+        pt = case type.kind.name
+        when "OBJECT"
+          [type]
+        when "INTERFACE"
+          @schema.possible_types(type)
+        when "UNION"
+          type.possible_types
+        end
+        @all_types.merge(pt)
+        pt
+      end
+
+      def query_root
+        t = @schema.query # TODO filter
+        @all_types.add(t)
+        t
+      end
+
+      def all_types
+        @all_types
+      end
+
+      def enum_values(owner)
+        @all_types.add(owner)
+        owner.enum_values # TODO filter
+      end
+    end
+  end
+end

--- a/lib/graphql/schema/shape.rb
+++ b/lib/graphql/schema/shape.rb
@@ -31,13 +31,22 @@ module GraphQL
         f
       end
 
+      def fields(owner)
+        # TODO filter
+        owner.fields.values
+      end
+
       def arguments(owner)
         # TODO filter
         owner.arguments.values
       end
 
       def argument(owner, arg_name)
-        owner.get_argument(arg_name) # TODO filter
+        arg = owner.get_argument(arg_name) # TODO filter
+        if arg.loads
+          @all_types.add(arg.loads)
+        end
+        arg
       end
 
       def possible_types(type)
@@ -55,8 +64,24 @@ module GraphQL
         pt
       end
 
+      def interfaces(obj_type)
+        obj_type.interfaces # TODO filter
+      end
+
       def query_root
         t = @schema.query # TODO filter
+        @all_types.add(t)
+        t
+      end
+
+      def mutation_root
+        t = @schema.mutation # TODO filter
+        @all_types.add(t)
+        t
+      end
+
+      def subscription_root
+        t = @schema.subscription # TODO filter
         @all_types.add(t)
         t
       end
@@ -68,6 +93,23 @@ module GraphQL
       def enum_values(owner)
         @all_types.add(owner)
         owner.enum_values # TODO filter
+      end
+
+      def directive_exists?(dir_name)
+        # TODO filter
+        @schema.directives.key?(dir_name)
+      end
+
+      def directives
+        @schema.directives.values
+      end
+
+      def loadable?(t, _ctx)
+        !@all_types.include?(t) # TODO make sure t is not reachable but t is visible
+      end
+
+      def reachable_type?(t)
+        true # TODO ...
       end
     end
   end

--- a/lib/graphql/schema/shape.rb
+++ b/lib/graphql/schema/shape.rb
@@ -329,9 +329,16 @@ module GraphQL
           query_root,
           mutation_root,
           subscription_root,
-          *@schema.orphan_types,
           *@schema.introspection_system.types.values,
         ]
+
+        # Don't include any orphan_types whose interfaces aren't visible.
+        @schema.orphan_types.each do |orphan_type|
+          if @cached_visible[orphan_type] &&
+            orphan_type.interface_type_memberships.any? { |tm| @cached_visible[tm] && @cached_visible[tm.abstract_type] }
+            schema_types << orphan_type
+          end
+        end
         schema_types.compact! # TODO why is this necessary?!
         schema_types.flatten! # handle multiple defns
         schema_types.each { |t| add_type(t) }

--- a/lib/graphql/schema/shape.rb
+++ b/lib/graphql/schema/shape.rb
@@ -64,7 +64,7 @@ module GraphQL
         any_interface_has_field = false
         any_interface_has_visible_field = false
         ints.each do |int_t|
-          if (_int_f_defn = int_t.get_field(field_name, @context, skip_visible: true))
+          if (_int_f_defn = int_t.get_field(field_name, @context))
             any_interface_has_field = true
 
             if filtered_ints.include?(int_t) # TODO cycles, or maybe not necessary since previously checked? && @cached_visible_fields[owner][field]
@@ -115,7 +115,7 @@ module GraphQL
       end
 
       def field(owner, field_name)
-        f = if owner.kind.fields? && (field = owner.get_field(field_name, @context, skip_visible: true))
+        f = if owner.kind.fields? && (field = owner.get_field(field_name, @context))
           field
         elsif owner == query_root && (entry_point_field = @schema.introspection_system.entry_point(name: field_name))
           entry_point_field
@@ -157,7 +157,7 @@ module GraphQL
       def argument(owner, arg_name)
         # TODO this makes a Warden.visible_entry call down the stack
         # I need a non-Warden implementation
-        arg = owner.get_argument(arg_name, @context, skip_visible: true)
+        arg = owner.get_argument(arg_name, @context)
         if arg.is_a?(Array)
           visible_arg = nil
           arg.each do |arg_defn|

--- a/lib/graphql/schema/subset.rb
+++ b/lib/graphql/schema/subset.rb
@@ -306,14 +306,13 @@ module GraphQL
 
       def referenced?(t)
         load_all_types
-        res = if (ref = @referenced_types[t].find{ |member| (member == true) || @cached_visible[member] } )
+        res = if @referenced_types[t].any? { |member| (member == true) || @cached_visible[member] }
           if t.kind.abstract?
             possible_types(t).any?
           else
             true
           end
         end
-        # p [:referenced?, t.graphql_name, res, ref, :Visible?, @cached_visible[t]]
         res
       end
 

--- a/lib/graphql/schema/subset.rb
+++ b/lib/graphql/schema/subset.rb
@@ -2,7 +2,7 @@
 
 module GraphQL
   class Schema
-    class Shape
+    class Subset
       def initialize(query)
         @query = query
         @context = query.context

--- a/lib/graphql/schema/type_expression.rb
+++ b/lib/graphql/schema/type_expression.rb
@@ -5,7 +5,7 @@ module GraphQL
     module TypeExpression
       # Fetch a type from a type map by its AST specification.
       # Return `nil` if not found.
-      # @param type_owner [#get_type] A thing for looking up types by name
+      # @param type_owner [#type] A thing for looking up types by name
       # @param ast_node [GraphQL::Language::Nodes::AbstractNode]
       # @return [Class, GraphQL::Schema::NonNull, GraphQL::Schema:List]
       def self.build_type(type_owner, ast_node)

--- a/lib/graphql/schema/type_expression.rb
+++ b/lib/graphql/schema/type_expression.rb
@@ -11,7 +11,7 @@ module GraphQL
       def self.build_type(type_owner, ast_node)
         case ast_node
         when GraphQL::Language::Nodes::TypeName
-          type_owner.get_type(ast_node.name) # rubocop:disable Development/ContextIsPassedCop -- this is a `context` or `warden`, it's already query-aware
+          type_owner.type(ast_node.name) # rubocop:disable Development/ContextIsPassedCop -- this is a `context` or `warden`, it's already query-aware
         when GraphQL::Language::Nodes::NonNullType
           ast_inner_type = ast_node.of_type
           inner_type = build_type(type_owner, ast_inner_type)

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -149,6 +149,10 @@ module GraphQL
         def loadable?(t, ctx) # TODO remove ctx here?
           @warden.loadable?(t, ctx)
         end
+
+        def reachable_type?(type_name)
+          @warden.reachable_type?(type_name)
+        end
       end
 
       # @param context [GraphQL::Query::Context]

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -73,6 +73,13 @@ module GraphQL
           @shapish = Warden::Shapish.new(self)
         end
 
+        # @api private
+        module NullShape
+          def self.new(query)
+            NullWarden.new(context: query.context, schema: query.schema).shapish
+          end
+        end
+
         attr_reader :shapish
 
         def visible_field?(field_defn, _ctx = nil, owner = nil); true; end

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -138,6 +138,18 @@ module GraphQL
         def enum_values(enum_type)
           @warden.enum_values(enum_type)
         end
+
+        def all_types
+          @warden.reachable_types
+        end
+
+        def interfaces(obj_type)
+          @warden.interfaces(obj_type)
+        end
+
+        def loadable?(t, ctx) # TODO remove ctx here?
+          @warden.loadable?(t, ctx)
+        end
       end
 
       # @param context [GraphQL::Query::Context]

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -133,8 +133,20 @@ module GraphQL
           @warden.root_type_for_operation("query")
         end
 
+        def mutation_root
+          @warden.root_type_for_operation("mutation")
+        end
+
+        def subscription_root
+          @warden.root_type_for_operation("subscription")
+        end
+
         def arguments(owner)
           @warden.arguments(owner)
+        end
+
+        def fields(owner)
+          @warden.fields(owner)
         end
 
         def possible_types(type)

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -65,7 +65,6 @@ module GraphQL
             @shapish ||= Warden::Shapish.new(self)
           end
         end
-
       end
 
       class NullWarden

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -61,8 +61,8 @@ module GraphQL
           def interface_type_memberships(obj_t, ctx); obj_t.interface_type_memberships; end
           def arguments(owner, ctx); owner.arguments(ctx); end
           def loadable?(type, ctx); type.visible?(ctx); end
-          def shapish
-            @shapish ||= Warden::Shapish.new(self)
+          def schema_subset
+            @schema_subset ||= Warden::SchemaSubset.new(self)
           end
         end
       end
@@ -70,17 +70,17 @@ module GraphQL
       class NullWarden
         def initialize(_filter = nil, context:, schema:)
           @schema = schema
-          @shapish = Warden::Shapish.new(self)
+          @schema_subset = Warden::SchemaSubset.new(self)
         end
 
         # @api private
-        module NullShape
+        module NullSubset
           def self.new(query)
-            NullWarden.new(context: query.context, schema: query.schema).shapish
+            NullWarden.new(context: query.context, schema: query.schema).schema_subset
           end
         end
 
-        attr_reader :shapish
+        attr_reader :schema_subset
 
         def visible_field?(field_defn, _ctx = nil, owner = nil); true; end
         def visible_argument?(arg_defn, _ctx = nil); true; end
@@ -104,13 +104,17 @@ module GraphQL
         def interfaces(obj_type); obj_type.interfaces; end
       end
 
-      def shapish
-        @shapish ||= Shapish.new(self)
+      def schema_subset
+        @schema_subset ||= SchemaSubset.new(self)
       end
 
-      class Shapish
+      class SchemaSubset
         def initialize(warden)
           @warden = warden
+        end
+
+        def directives
+          @warden.directives
         end
 
         def directive_exists?(dir_name)
@@ -190,7 +194,7 @@ module GraphQL
           @visible_possible_types = @visible_fields = @visible_arguments = @visible_enum_arrays =
           @visible_enum_values = @visible_interfaces = @type_visibility = @type_memberships =
           @visible_and_reachable_type = @unions = @unfiltered_interfaces =
-          @reachable_type_set = @shapish =
+          @reachable_type_set = @schema_subset =
             nil
       end
 

--- a/lib/graphql/static_validation/base_visitor.rb
+++ b/lib/graphql/static_validation/base_visitor.rb
@@ -10,6 +10,7 @@ module GraphQL
         @argument_definitions = []
         @directive_definitions = []
         @context = context
+        @types = context.query.types
         @schema = context.schema
         super(document)
       end
@@ -77,7 +78,7 @@ module GraphQL
 
         def on_field(node, parent)
           parent_type = @object_types.last
-          field_definition = @schema.get_field(parent_type, node.name, @context.query.context)
+          field_definition = @types.field(parent_type, node.name)
           @field_definitions.push(field_definition)
           if !field_definition.nil?
             next_object_type = field_definition.type.unwrap
@@ -103,14 +104,14 @@ module GraphQL
           argument_defn = if (arg = @argument_definitions.last)
             arg_type = arg.type.unwrap
             if arg_type.kind.input_object?
-              @context.warden.get_argument(arg_type, node.name)
+              @types.argument(arg_type, node.name)
             else
               nil
             end
           elsif (directive_defn = @directive_definitions.last)
-            @context.warden.get_argument(directive_defn, node.name)
+            @types.argument(directive_defn, node.name)
           elsif (field_defn = @field_definitions.last)
-            @context.warden.get_argument(field_defn, node.name)
+            @types.argument(field_defn, node.name)
           else
             nil
           end
@@ -170,7 +171,7 @@ module GraphQL
 
         def on_fragment_with_type(node)
           object_type = if node.type
-            @context.warden.get_type(node.type.name)
+            @types.type(node.type.name)
           else
             @object_types.last
           end

--- a/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb
+++ b/lib/graphql/static_validation/rules/argument_literals_are_compatible.rb
@@ -15,7 +15,7 @@ module GraphQL
         if @context.schema.error_bubbling || context.errors.none? { |err| err.path.take(@path.size) == @path }
           parent_defn = parent_definition(parent)
 
-          if parent_defn && (arg_defn = context.warden.get_argument(parent_defn, node.name))
+          if parent_defn && (arg_defn = @types.argument(parent_defn, node.name))
             validation_result = context.validate_literal(node.value, arg_defn.type)
             if !validation_result.valid?
               kind_of_node = node_type(parent)

--- a/lib/graphql/static_validation/rules/arguments_are_defined.rb
+++ b/lib/graphql/static_validation/rules/arguments_are_defined.rb
@@ -5,7 +5,7 @@ module GraphQL
       def on_argument(node, parent)
         parent_defn = parent_definition(parent)
 
-        if parent_defn && context.warden.get_argument(parent_defn, node.name)
+        if parent_defn && @types.argument(parent_defn, node.name)
           super
         elsif parent_defn
           kind_of_node = node_type(parent)

--- a/lib/graphql/static_validation/rules/directives_are_defined.rb
+++ b/lib/graphql/static_validation/rules/directives_are_defined.rb
@@ -4,11 +4,10 @@ module GraphQL
     module DirectivesAreDefined
       def initialize(*)
         super
-        @directive_names = context.warden.directives.map(&:graphql_name)
       end
 
       def on_directive(node, parent)
-        if !@directive_names.include?(node.name)
+        if !@types.directive_exists?(node.name)
           @directives_are_defined_errors_by_name ||= {}
           error = @directives_are_defined_errors_by_name[node.name] ||= begin
             err = GraphQL::StaticValidation::DirectivesAreDefinedError.new(

--- a/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb
+++ b/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb
@@ -4,7 +4,7 @@ module GraphQL
     module FieldsAreDefinedOnType
       def on_field(node, parent)
         parent_type = @object_types[-2]
-        field = context.warden.get_field(parent_type, node.name)
+        field = context.query.types.field(parent_type, node.name)
 
         if field.nil?
           if parent_type.kind.union?

--- a/lib/graphql/static_validation/rules/fields_will_merge.rb
+++ b/lib/graphql/static_validation/rules/fields_will_merge.rb
@@ -117,8 +117,8 @@ module GraphQL
 
         return if fragment1.nil? || fragment2.nil?
 
-        fragment_type1 = context.warden.get_type(fragment1.type.name)
-        fragment_type2 = context.warden.get_type(fragment2.type.name)
+        fragment_type1 = context.query.types.type(fragment1.type.name)
+        fragment_type2 = context.query.types.type(fragment2.type.name)
 
         return if fragment_type1.nil? || fragment_type2.nil?
 
@@ -411,8 +411,8 @@ module GraphQL
               false
             else
               # Check if these two scopes have _any_ types in common.
-              possible_right_types = context.query.possible_types(type1)
-              possible_left_types = context.query.possible_types(type2)
+              possible_right_types = context.types.possible_types(type1)
+              possible_left_types = context.types.possible_types(type2)
               (possible_right_types & possible_left_types).empty?
             end
           end

--- a/lib/graphql/static_validation/rules/fields_will_merge.rb
+++ b/lib/graphql/static_validation/rules/fields_will_merge.rb
@@ -170,7 +170,7 @@ module GraphQL
         fragment = context.fragments[fragment_name]
         return if fragment.nil?
 
-        fragment_type = context.warden.get_type(fragment.type.name)
+        fragment_type = @types.type(fragment.type.name)
         return if fragment_type.nil?
 
         fragment_fields, fragment_spreads = fields_and_fragments_from_selection(fragment, owner_type: fragment_type, parents: [*fragment_spread.parents, fragment_type])
@@ -340,10 +340,10 @@ module GraphQL
         selections.each do |node|
           case node
           when GraphQL::Language::Nodes::Field
-            definition = context.warden.get_field(owner_type, node.name)
+            definition = @types.field(owner_type, node.name)
             fields << Field.new(node, definition, owner_type, parents)
           when GraphQL::Language::Nodes::InlineFragment
-            fragment_type = node.type ? context.warden.get_type(node.type.name) : owner_type
+            fragment_type = node.type ? @types.type(node.type.name) : owner_type
             find_fields_and_fragments(node.selections, parents: [*parents, fragment_type], owner_type: owner_type, fields: fields, fragment_spreads: fragment_spreads) if fragment_type
           when GraphQL::Language::Nodes::FragmentSpread
             fragment_spreads << FragmentSpread.new(node.name, parents)

--- a/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb
+++ b/lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb
@@ -28,7 +28,7 @@ module GraphQL
           frag_node = context.fragments[frag_spread.node.name]
           if frag_node
             fragment_child_name = frag_node.type.name
-            fragment_child = context.warden.get_type(fragment_child_name)
+            fragment_child = @types.type(fragment_child_name)
             # Might be non-existent type name
             if fragment_child
               validate_fragment_in_scope(frag_spread.parent_type, fragment_child, frag_spread.node, context, frag_spread.path)
@@ -44,8 +44,8 @@ module GraphQL
           # It's not a valid fragment type, this error was handled someplace else
           return
         end
-        parent_types = context.warden.possible_types(parent_type.unwrap)
-        child_types = context.warden.possible_types(child_type.unwrap)
+        parent_types = @types.possible_types(parent_type.unwrap)
+        child_types = @types.possible_types(child_type.unwrap)
 
         if child_types.none? { |c| parent_types.include?(c) }
           name = node.respond_to?(:name) ? " #{node.name}" : ""

--- a/lib/graphql/static_validation/rules/fragment_types_exist.rb
+++ b/lib/graphql/static_validation/rules/fragment_types_exist.rb
@@ -21,7 +21,7 @@ module GraphQL
           true
         else
           type_name = fragment_node.type.name
-          type = context.warden.get_type(type_name)
+          type = @types.type(type_name)
           if type.nil?
             add_error(GraphQL::StaticValidation::FragmentTypesExistError.new(
               "No such type #{type_name}, so it can't be a fragment condition",

--- a/lib/graphql/static_validation/rules/fragments_are_on_composite_types.rb
+++ b/lib/graphql/static_validation/rules/fragments_are_on_composite_types.rb
@@ -19,7 +19,7 @@ module GraphQL
           true
         else
           type_name = node_type.to_query_string
-          type_def = context.warden.get_type(type_name)
+          type_def = @types.type(type_name)
           if type_def.nil? || !type_def.kind.composite?
             add_error(GraphQL::StaticValidation::FragmentsAreOnCompositeTypesError.new(
               "Invalid fragment on type #{type_name} (must be Union, Interface or Object)",

--- a/lib/graphql/static_validation/rules/mutation_root_exists.rb
+++ b/lib/graphql/static_validation/rules/mutation_root_exists.rb
@@ -3,7 +3,7 @@ module GraphQL
   module StaticValidation
     module MutationRootExists
       def on_operation_definition(node, _parent)
-        if node.operation_type == 'mutation' && context.warden.root_type_for_operation("mutation").nil?
+        if node.operation_type == 'mutation' && context.query.types.mutation_root.nil?
           add_error(GraphQL::StaticValidation::MutationRootExistsError.new(
             'Schema is not configured for mutations',
             nodes: node

--- a/lib/graphql/static_validation/rules/query_root_exists.rb
+++ b/lib/graphql/static_validation/rules/query_root_exists.rb
@@ -3,7 +3,7 @@ module GraphQL
   module StaticValidation
     module QueryRootExists
       def on_operation_definition(node, _parent)
-        if (node.operation_type == 'query' || node.operation_type.nil?) && context.warden.root_type_for_operation("query").nil?
+        if (node.operation_type == 'query' || node.operation_type.nil?) && context.query.types.query_root.nil?
           add_error(GraphQL::StaticValidation::QueryRootExistsError.new(
             'Schema is not configured for queries',
             nodes: node

--- a/lib/graphql/static_validation/rules/required_arguments_are_present.rb
+++ b/lib/graphql/static_validation/rules/required_arguments_are_present.rb
@@ -16,11 +16,11 @@ module GraphQL
       private
 
       def assert_required_args(ast_node, defn)
-        args = defn.arguments(context.query.context)
+        args = @context.query.types.arguments(defn)
         return if args.empty?
         present_argument_names = ast_node.arguments.map(&:name)
-        required_argument_names = context.warden.arguments(defn)
-          .select { |a| a.type.kind.non_null? && !a.default_value? && context.warden.get_argument(defn, a.name) }
+        required_argument_names = context.query.types.arguments(defn)
+          .select { |a| a.type.kind.non_null? && !a.default_value? && context.query.types.argument(defn, a.name) }
           .map!(&:name)
 
         missing_names = required_argument_names - present_argument_names

--- a/lib/graphql/static_validation/rules/required_input_object_attributes_are_present.rb
+++ b/lib/graphql/static_validation/rules/required_input_object_attributes_are_present.rb
@@ -26,7 +26,7 @@ module GraphQL
           context.directive_definition || context.field_definition
         end
 
-        parent_type = context.warden.get_argument(defn, parent_name(parent, defn))
+        parent_type = context.types.argument(defn, parent_name(parent, defn))
         parent_type ? parent_type.type.unwrap : nil
       end
 
@@ -34,7 +34,7 @@ module GraphQL
         parent_type = get_parent_type(context, parent)
         return unless parent_type && parent_type.kind.input_object?
 
-        required_fields = context.warden.arguments(parent_type)
+        required_fields = context.types.arguments(parent_type)
           .select{ |arg| arg.type.kind.non_null? && !arg.default_value? }
           .map!(&:graphql_name)
 
@@ -43,7 +43,7 @@ module GraphQL
 
         missing_fields.each do |missing_field|
           path = [*context.path, missing_field]
-          missing_field_type = context.warden.get_argument(parent_type, missing_field).type
+          missing_field_type = context.types.argument(parent_type, missing_field).type
           add_error(RequiredInputObjectAttributesArePresentError.new(
             "Argument '#{missing_field}' on InputObject '#{parent_type.to_type_signature}' is required. Expected type #{missing_field_type.to_type_signature}",
             argument_name: missing_field,

--- a/lib/graphql/static_validation/rules/subscription_root_exists.rb
+++ b/lib/graphql/static_validation/rules/subscription_root_exists.rb
@@ -3,7 +3,7 @@ module GraphQL
   module StaticValidation
     module SubscriptionRootExists
       def on_operation_definition(node, _parent)
-        if node.operation_type == "subscription" && context.warden.root_type_for_operation("subscription").nil?
+        if node.operation_type == "subscription" && context.types.subscription_root.nil?
           add_error(GraphQL::StaticValidation::SubscriptionRootExistsError.new(
             'Schema is not configured for subscriptions',
             nodes: node

--- a/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb
+++ b/lib/graphql/static_validation/rules/variable_usages_are_allowed.rb
@@ -65,7 +65,7 @@ module GraphQL
           end
         end
 
-        arg_defn = context.warden.get_argument(argument_owner, arg_node.name)
+        arg_defn = @types.argument(argument_owner, arg_node.name)
         arg_defn_type = arg_defn.type
 
         # If the argument is non-null, but it was given a default value,

--- a/lib/graphql/static_validation/rules/variables_are_input_types.rb
+++ b/lib/graphql/static_validation/rules/variables_are_input_types.rb
@@ -4,7 +4,7 @@ module GraphQL
     module VariablesAreInputTypes
       def on_variable_definition(node, parent)
         type_name = get_type_name(node.type)
-        type = context.warden.get_type(type_name)
+        type = context.query.types.type(type_name)
 
         if type.nil?
           add_error(GraphQL::StaticValidation::VariablesAreInputTypesError.new(

--- a/lib/graphql/static_validation/validation_context.rb
+++ b/lib/graphql/static_validation/validation_context.rb
@@ -13,14 +13,14 @@ module GraphQL
 
       attr_reader :query, :errors, :visitor,
         :on_dependency_resolve_handlers,
-        :max_errors, :warden, :schema
+        :max_errors, :types, :schema
 
 
       def_delegators :@query, :document, :fragments, :operations
 
       def initialize(query, visitor_class, max_errors)
         @query = query
-        @warden = query.warden
+        @types = query.types # TODO update migrated callers to use this accessor
         @schema = query.schema
         @literal_validator = LiteralValidator.new(context: query.context)
         @errors = []

--- a/lib/graphql/subscriptions.rb
+++ b/lib/graphql/subscriptions.rb
@@ -64,12 +64,12 @@ module GraphQL
       event_name = event_name.to_s
 
       # Try with the verbatim input first:
-      field = @schema.get_field(@schema.subscription, event_name, context)
+      field = dummy_query.types.field(@schema.subscription, event_name)
 
       if field.nil?
         # And if it wasn't found, normalize it:
         normalized_event_name = normalize_name(event_name)
-        field = @schema.get_field(@schema.subscription, normalized_event_name, context)
+        field = dummy_query.types.field(@schema.subscription, normalized_event_name)
         if field.nil?
           raise InvalidTriggerError, "No subscription matching trigger: #{event_name} (looked for #{@schema.subscription.graphql_name}.#{normalized_event_name})"
         end

--- a/lib/graphql/subscriptions.rb
+++ b/lib/graphql/subscriptions.rb
@@ -64,12 +64,12 @@ module GraphQL
       event_name = event_name.to_s
 
       # Try with the verbatim input first:
-      field = dummy_query.types.field(@schema.subscription, event_name)
+      field = dummy_query.types.field(@schema.subscription, event_name) # rubocop:disable Development/ContextIsPassedCop
 
       if field.nil?
         # And if it wasn't found, normalize it:
         normalized_event_name = normalize_name(event_name)
-        field = dummy_query.types.field(@schema.subscription, normalized_event_name)
+        field = dummy_query.types.field(@schema.subscription, normalized_event_name) # rubocop:disable Development/ContextIsPassedCop
         if field.nil?
           raise InvalidTriggerError, "No subscription matching trigger: #{event_name} (looked for #{@schema.subscription.graphql_name}.#{normalized_event_name})"
         end

--- a/lib/graphql/subscriptions/event.rb
+++ b/lib/graphql/subscriptions/event.rb
@@ -137,7 +137,7 @@ module GraphQL
         end
 
         def get_arg_definition(arg_owner, arg_name, context)
-          arg_owner.get_argument(arg_name, context) || arg_owner.arguments(context).each_value.find { |v| v.keyword.to_s == arg_name }
+          context.types.argument(arg_owner, arg_name) || context.types.arguments(arg_owner).find { |v| v.keyword.to_s == arg_name }
         end
       end
     end

--- a/lib/graphql/testing/helpers.rb
+++ b/lib/graphql/testing/helpers.rb
@@ -43,7 +43,7 @@ module GraphQL
         type_name, *field_names = field_path.split(".")
         dummy_query = GraphQL::Query.new(schema, "{ __typename }", context: context)
         query_context = dummy_query.context
-        object_type = dummy_query.get_type(type_name) # rubocop:disable Development/ContextIsPassedCop
+        object_type = dummy_query.types.type(type_name) # rubocop:disable Development/ContextIsPassedCop
         if object_type
           graphql_result = object
           field_names.each do |field_name|
@@ -52,7 +52,7 @@ module GraphQL
             if graphql_result.nil?
               return nil
             end
-            visible_field = dummy_query.get_field(object_type, field_name)
+            visible_field = dummy_query.types.field(object_type, field_name)
             if visible_field
               dummy_query.context.dataloader.run_isolated {
                 field_args = visible_field.coerce_arguments(graphql_result, arguments, query_context)

--- a/lib/graphql/testing/helpers.rb
+++ b/lib/graphql/testing/helpers.rb
@@ -52,7 +52,7 @@ module GraphQL
             if graphql_result.nil?
               return nil
             end
-            visible_field = dummy_query.types.field(object_type, field_name)
+            visible_field = dummy_query.types.field(object_type, field_name) # rubocop:disable Development/ContextIsPassedCop
             if visible_field
               dummy_query.context.dataloader.run_isolated {
                 field_args = visible_field.coerce_arguments(graphql_result, arguments, query_context)

--- a/spec/graphql/authorization_spec.rb
+++ b/spec/graphql/authorization_spec.rb
@@ -72,19 +72,17 @@ describe "GraphQL::Authorization" do
     module HiddenInterface
       include BaseInterface
 
-      definition_methods do
-        def visible?(ctx)
-          super && !ctx[:hide]
-        end
+      def self.visible?(ctx)
+        super && !ctx[:hide]
+      end
 
-        def resolve_type(obj, ctx)
-          HiddenObject
-        end
+      def self.resolve_type(obj, ctx)
+        HiddenObject
       end
     end
 
     module HiddenDefaultInterface
-      include HiddenInterface
+      include BaseInterface
       # visible? will call the super method
       def self.resolve_type(obj, ctx)
         HiddenObject

--- a/spec/graphql/authorization_spec.rb
+++ b/spec/graphql/authorization_spec.rb
@@ -72,17 +72,19 @@ describe "GraphQL::Authorization" do
     module HiddenInterface
       include BaseInterface
 
-      def self.visible?(ctx)
-        super && !ctx[:hide]
-      end
+      definition_methods do
+        def visible?(ctx)
+          super && !ctx[:hide]
+        end
 
-      def self.resolve_type(obj, ctx)
-        HiddenObject
+        def resolve_type(obj, ctx)
+          HiddenObject
+        end
       end
     end
 
     module HiddenDefaultInterface
-      include BaseInterface
+      include HiddenInterface
       # visible? will call the super method
       def self.resolve_type(obj, ctx)
         HiddenObject

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -359,7 +359,7 @@ describe GraphQL::Execution::Interpreter do
     GRAPHQL
 
     vars = {expansion: "RAV", id1: "Dark Confidant", id2: "RAV"}
-    result = InterpreterTest::Schema.execute(query_string, shape: true, variables: vars)
+    result = InterpreterTest::Schema.execute(query_string, variables: vars)
     assert_equal ["BLACK"], result["data"]["card"]["colors"]
     assert_equal "Ravnica, City of Guilds", result["data"]["card"]["expansion"]["name"]
     assert_equal [{"name" => "Dark Confidant"}], result["data"]["card"]["expansion"]["cards"]

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -359,7 +359,7 @@ describe GraphQL::Execution::Interpreter do
     GRAPHQL
 
     vars = {expansion: "RAV", id1: "Dark Confidant", id2: "RAV"}
-    result = InterpreterTest::Schema.execute(query_string, variables: vars)
+    result = InterpreterTest::Schema.execute(query_string, shape: true, variables: vars)
     assert_equal ["BLACK"], result["data"]["card"]["colors"]
     assert_equal "Ravnica, City of Guilds", result["data"]["card"]["expansion"]["name"]
     assert_equal [{"name" => "Dark Confidant"}], result["data"]["card"]["expansion"]["cards"]

--- a/spec/graphql/execution_error_spec.rb
+++ b/spec/graphql/execution_error_spec.rb
@@ -160,7 +160,6 @@ describe GraphQL::ExecutionError do
       }
     }
     |}
-
     it "the error is inserted into the errors key and the rest of the query is fulfilled" do
       expected_result = {
         "data"=>{

--- a/spec/graphql/execution_error_spec.rb
+++ b/spec/graphql/execution_error_spec.rb
@@ -160,6 +160,7 @@ describe GraphQL::ExecutionError do
       }
     }
     |}
+
     it "the error is inserted into the errors key and the rest of the query is fulfilled" do
       expected_result = {
         "data"=>{

--- a/spec/graphql/logger_spec.rb
+++ b/spec/graphql/logger_spec.rb
@@ -69,10 +69,6 @@ describe "Logger" do
         module Node
           include GraphQL::Schema::Interface
           field :id, ID
-
-          def self.visible?(ctx)
-            false
-          end
         end
 
         class Query < GraphQL::Schema::Object

--- a/spec/graphql/logger_spec.rb
+++ b/spec/graphql/logger_spec.rb
@@ -69,6 +69,10 @@ describe "Logger" do
         module Node
           include GraphQL::Schema::Interface
           field :id, ID
+
+          def self.visible?(ctx)
+            false
+          end
         end
 
         class Query < GraphQL::Schema::Object
@@ -98,7 +102,12 @@ describe "Logger" do
     it "logs about hidden interfaces with no implementations" do
       res = LoggerTest::CustomLoggerSchema.execute("{ node(id: \"5\") { id } }")
       assert_equal ["Field 'node' doesn't exist on type 'Query'"], res["errors"].map { |err| err["message"] }
-      assert_includes LoggerTest::CustomLoggerSchema::LOG_STRING.string, "Interface `Node` hidden because it has no visible implementers"
+      if res.query.types.is_a?(GraphQL::Schema::Shape)
+        # TODO make this actually test something?
+        assert_equal "", LoggerTest::CustomLoggerSchema::LOG_STRING.string
+      else
+        assert_includes LoggerTest::CustomLoggerSchema::LOG_STRING.string, "Interface `Node` hidden because it has no visible implementers"
+      end
     end
 
     it "doesn't print messages by default" do

--- a/spec/graphql/logger_spec.rb
+++ b/spec/graphql/logger_spec.rb
@@ -102,7 +102,7 @@ describe "Logger" do
     it "logs about hidden interfaces with no implementations" do
       res = LoggerTest::CustomLoggerSchema.execute("{ node(id: \"5\") { id } }")
       assert_equal ["Field 'node' doesn't exist on type 'Query'"], res["errors"].map { |err| err["message"] }
-      if res.query.types.is_a?(GraphQL::Schema::Shape)
+      if res.query.types.is_a?(GraphQL::Schema::Subset)
         # TODO make this actually test something?
         assert_equal "", LoggerTest::CustomLoggerSchema::LOG_STRING.string
       else

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -137,7 +137,14 @@ type Word {
       secret_type = parsed_schema.get_type("Secret")
       assert_equal 2, secret_type.directives.size
 
-      assert_schema_and_compare_output(schema)
+      if GraphQL::Schema.use_schema_subset?
+        # Subset hides this because it has no possible types of its own :S
+        schema_output = GraphQL::Schema.from_definition(schema).to_definition
+        expected_output = schema.sub(/interface Secret2[^}]+\}\n\n/m, "")
+        assert_equal expected_output, schema_output
+      else
+        assert_schema_and_compare_output(schema)
+      end
     end
 
     it 'supports descriptions and definition_line' do

--- a/spec/graphql/schema/dynamic_members_spec.rb
+++ b/spec/graphql/schema/dynamic_members_spec.rb
@@ -333,7 +333,6 @@ describe "Dynamic types, fields, arguments, and enum values" do
       # just to attach these to the schema:
       field :example_locale, Locale
       field :example_region, Region
-      field :example_country, Country
     end
 
     class BaseMutation < GraphQL::Schema::RelayClassicMutation
@@ -480,7 +479,6 @@ ERR
 type Query {
   actor: Actor
   add(left: Int!, right: Int!): String!
-  exampleCountry: Country
   f1: Int
   favoriteLanguage(lang: Language): Language!
   legacyThing(id: ID!): LegacyThing!
@@ -494,7 +492,6 @@ GRAPHQL
 type Query {
   actor: Actor
   add(left: Float!, right: Float!): String!
-  exampleCountry: Country
   exampleLocale: Locale
   exampleRegion: Region
   f1: String

--- a/spec/graphql/schema/dynamic_members_spec.rb
+++ b/spec/graphql/schema/dynamic_members_spec.rb
@@ -675,8 +675,7 @@ GRAPHQL
     expected_message = "Found two visible definitions for `Money`: MultifieldSchema::Money, MultifieldSchema::MoneyScalar"
     assert_equal expected_message, err.message
 
-    res = exec_query("{ thing( input: { id: 1 }) { price } }")
-    assert_equal "⚛︎100",res["data"]["thing"]["price"]
+    assert_equal "⚛︎100",exec_query("{ thing( input: { id: 1 }) { price } }")["data"]["thing"]["price"]
     res = exec_query("{ __type(name: \"Money\") { kind name } }")
     assert_equal "SCALAR", res["data"]["__type"]["kind"]
     assert_equal "Money", res["data"]["__type"]["name"]

--- a/spec/graphql/schema/dynamic_members_spec.rb
+++ b/spec/graphql/schema/dynamic_members_spec.rb
@@ -897,8 +897,6 @@ GRAPHQL
             raise ArgumentError, "Unhandled type kind: #{type_kind.inspect}"
           end
         end
-
-        field :other, OtherObject
       end
 
       query(Query)

--- a/spec/graphql/schema/dynamic_members_spec.rb
+++ b/spec/graphql/schema/dynamic_members_spec.rb
@@ -672,7 +672,8 @@ GRAPHQL
     expected_message = "Found two visible definitions for `Money`: MultifieldSchema::Money, MultifieldSchema::MoneyScalar"
     assert_equal expected_message, err.message
 
-    assert_equal "⚛︎100",exec_query("{ thing( input: { id: 1 }) { price } }")["data"]["thing"]["price"]
+    res = exec_query("{ thing( input: { id: 1 }) { price } }")
+    assert_equal "⚛︎100",res["data"]["thing"]["price"]
     res = exec_query("{ __type(name: \"Money\") { kind name } }")
     assert_equal "SCALAR", res["data"]["__type"]["kind"]
     assert_equal "Money", res["data"]["__type"]["name"]

--- a/spec/graphql/schema/dynamic_members_spec.rb
+++ b/spec/graphql/schema/dynamic_members_spec.rb
@@ -897,6 +897,8 @@ GRAPHQL
             raise ArgumentError, "Unhandled type kind: #{type_kind.inspect}"
           end
         end
+
+        field :other, OtherObject
       end
 
       query(Query)

--- a/spec/graphql/schema/dynamic_members_spec.rb
+++ b/spec/graphql/schema/dynamic_members_spec.rb
@@ -475,7 +475,8 @@ ERR
     assert_equal "String", exec_future_query(introspection_query_str)["data"]["__type"]["fields"].find { |f| f["name"] == "f1" }["type"]["name"]
 
     # Schema dump
-    assert_includes legacy_schema_sdl, <<-GRAPHQL
+    legacy_query_type_str = legacy_schema_sdl[/type Query \{[^}]*\}/m]
+    assert_equal legacy_query_type_str, <<-GRAPHQL.chomp
 type Query {
   actor: Actor
   add(left: Int!, right: Int!): String!

--- a/spec/graphql/schema/dynamic_members_spec.rb
+++ b/spec/graphql/schema/dynamic_members_spec.rb
@@ -333,6 +333,7 @@ describe "Dynamic types, fields, arguments, and enum values" do
       # just to attach these to the schema:
       field :example_locale, Locale
       field :example_region, Region
+      field :example_country, Country
     end
 
     class BaseMutation < GraphQL::Schema::RelayClassicMutation
@@ -478,6 +479,7 @@ ERR
 type Query {
   actor: Actor
   add(left: Int!, right: Int!): String!
+  exampleCountry: Country
   f1: Int
   favoriteLanguage(lang: Language): Language!
   legacyThing(id: ID!): LegacyThing!
@@ -491,6 +493,7 @@ GRAPHQL
 type Query {
   actor: Actor
   add(left: Float!, right: Float!): String!
+  exampleCountry: Country
   exampleLocale: Locale
   exampleRegion: Region
   f1: String

--- a/spec/graphql/schema/enum_spec.rb
+++ b/spec/graphql/schema/enum_spec.rb
@@ -206,7 +206,7 @@ describe GraphQL::Schema::Enum do
         assert_equal("YAK", enum.coerce_isolated_result("YAK"))
         # NOT OK
         assert_raises(GraphQL::Schema::Enum::UnresolvedValueError) {
-          enum.coerce_result("YAK", OpenStruct.new(warden: NothingWarden))
+          enum.coerce_result("YAK", OpenStruct.new(types: NothingWarden))
         }
       end
     end

--- a/spec/graphql/schema/resolver_spec.rb
+++ b/spec/graphql/schema/resolver_spec.rb
@@ -543,7 +543,7 @@ describe GraphQL::Schema::Resolver do
     end
 
     it "works on instances" do
-      r = ResolverTest::Resolver1.new(object: nil, context: nil, field: nil)
+      r = ResolverTest::Resolver1.new(object: nil, context: GraphQL::Query::NullContext.instance, field: nil)
       assert_equal "Resolver1", r.path
     end
   end

--- a/spec/graphql/schema/shape_spec.rb
+++ b/spec/graphql/schema/shape_spec.rb
@@ -20,6 +20,6 @@ describe GraphQL::Schema::Shape do
     res = query.result
 
     assert_equal "Something", res["data"]["thing"]["name"]
-    assert_equal ["Query", "Thing", "String"], query.types.all_types.to_a.map(&:graphql_name)
+    assert_equal ["Query", "Thing", "String"], query.types.all_types.map(&:graphql_name)
   end
 end

--- a/spec/graphql/schema/shape_spec.rb
+++ b/spec/graphql/schema/shape_spec.rb
@@ -16,10 +16,10 @@ describe GraphQL::Schema::Shape do
   end
   it "only loads the types it needs" do
     query = GraphQL::Query.new(ShapeSchema, "{ thing { name } }", shape: true)
-    assert_equal [], query.types.to_a
+    assert_equal [], query.types.loaded_types
     res = query.result
 
     assert_equal "Something", res["data"]["thing"]["name"]
-    assert_equal ["Query", "Thing", "String"], query.types.all_types.map(&:graphql_name)
+    assert_equal ["Query", "String", "Thing"], query.types.loaded_types.map(&:graphql_name).sort
   end
 end

--- a/spec/graphql/schema/shape_spec.rb
+++ b/spec/graphql/schema/shape_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::Schema::Shape do
+  class ShapeSchema < GraphQL::Schema
+    class Thing < GraphQL::Schema::Object
+      field :name, String
+    end
+
+    class Query < GraphQL::Schema::Object
+      field :thing, Thing, fallback_value: :Something
+      field :greeting, String
+    end
+
+    query(Query)
+  end
+  it "only loads the types it needs" do
+    query = GraphQL::Query.new(ShapeSchema, "{ thing { name } }", shape: true)
+    assert_equal [], query.types.to_a
+    res = query.result
+
+    assert_equal "Something", res["data"]["thing"]["name"]
+    assert_equal ["Query", "Thing", "String"], query.types.all_types.to_a.map(&:graphql_name)
+  end
+end

--- a/spec/graphql/schema/shape_spec.rb
+++ b/spec/graphql/schema/shape_spec.rb
@@ -15,6 +15,7 @@ describe GraphQL::Schema::Shape do
     query(Query)
   end
   it "only loads the types it needs" do
+    skip "TODO optimize how this thing works"
     query = GraphQL::Query.new(ShapeSchema, "{ thing { name } }", shape: true)
     assert_equal [], query.types.loaded_types
     res = query.result

--- a/spec/graphql/schema/subset_spec.rb
+++ b/spec/graphql/schema/subset_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe GraphQL::Schema::Shape do
-  class ShapeSchema < GraphQL::Schema
+describe GraphQL::Schema::Subset do
+  class SubsetSchema < GraphQL::Schema
     class Thing < GraphQL::Schema::Object
       field :name, String
     end
@@ -16,7 +16,7 @@ describe GraphQL::Schema::Shape do
   end
   it "only loads the types it needs" do
     skip "TODO optimize how this thing works"
-    query = GraphQL::Query.new(ShapeSchema, "{ thing { name } }", shape: true)
+    query = GraphQL::Query.new(SubsetSchema, "{ thing { name } }", use_subset: true)
     assert_equal [], query.types.loaded_types
     res = query.result
 

--- a/spec/graphql/schema/subset_spec.rb
+++ b/spec/graphql/schema/subset_spec.rb
@@ -16,7 +16,7 @@ describe GraphQL::Schema::Subset do
   end
   it "only loads the types it needs" do
     skip "TODO optimize how this thing works"
-    query = GraphQL::Query.new(SubsetSchema, "{ thing { name } }", use_subset: true)
+    query = GraphQL::Query.new(SubsetSchema, "{ thing { name } }", use_schema_subset: true)
     assert_equal [], query.types.loaded_types
     res = query.result
 

--- a/spec/graphql/schema/type_expression_spec.rb
+++ b/spec/graphql/schema/type_expression_spec.rb
@@ -2,12 +2,11 @@
 require "spec_helper"
 
 describe GraphQL::Schema::TypeExpression do
-  let(:type_owner) { Dummy::Schema }
   let(:ast_node) {
     document = GraphQL.parse("query dostuff($var: #{type_name}) { id } ")
     document.definitions.first.variables.first.type
   }
-  let(:type_expression_result) { GraphQL::Schema::TypeExpression.build_type(type_owner, ast_node) }
+  let(:type_expression_result) { Dummy::Schema.type_from_ast(ast_node) }
 
   describe "#type" do
     describe "simple types" do

--- a/spec/graphql/schema/warden_spec.rb
+++ b/spec/graphql/schema/warden_spec.rb
@@ -50,43 +50,64 @@ module MaskHelpers
     end
   end
 
+  module VisibleByFilters
+    def visible?(context)
+      result = super(context)
+      if result && context[:only] && !Array(context[:only]).all? { |func| func.call(self, context) }
+        return false
+      end
+      if result && context[:except] && Array(context[:except]).any? { |func| func.call(self, context) }
+        return false
+      end
+      result
+    end
+  end
+
 
   class BaseArgument < GraphQL::Schema::Argument
     include HasMetadata
+    include VisibleByFilters
   end
 
   class BaseField < GraphQL::Schema::Field
     include HasMetadata
+    include VisibleByFilters
     argument_class BaseArgument
   end
 
   class BaseObject < GraphQL::Schema::Object
     extend HasMetadata
+    extend VisibleByFilters
     field_class BaseField
   end
 
   class BaseEnumValue < GraphQL::Schema::EnumValue
     include HasMetadata
+    include VisibleByFilters
   end
 
   class BaseEnum < GraphQL::Schema::Enum
     extend HasMetadata
+    extend VisibleByFilters
     enum_value_class BaseEnumValue
   end
 
   class BaseInputObject < GraphQL::Schema::InputObject
     extend HasMetadata
+    extend VisibleByFilters
     argument_class BaseArgument
   end
 
   class BaseUnion < GraphQL::Schema::Union
     extend HasMetadata
+    extend VisibleByFilters
   end
 
   module BaseInterface
     include GraphQL::Schema::Interface
     module DefinitionMethods
       include HasMetadata
+      include VisibleByFilters
     end
     field_class BaseField
   end
@@ -249,16 +270,7 @@ module MaskHelpers
       PhonemeType
     end
 
-    def self.visible?(member, context)
-      result = super(member, context)
-      if result && context[:only] && !Array(context[:only]).all? { |func| func.call(member, context) }
-        return false
-      end
-      if result && context[:except] && Array(context[:except]).any? { |func| func.call(member, context) }
-        return false
-      end
-      result
-    end
+
   end
 
   module Data

--- a/spec/graphql/schema/warden_spec.rb
+++ b/spec/graphql/schema/warden_spec.rb
@@ -250,7 +250,7 @@ module MaskHelpers
     end
 
     def self.visible?(member, context)
-      result = super
+      result = super(member, context)
       if result && context[:only] && !Array(context[:only]).all? { |func| func.call(member, context) }
         return false
       end

--- a/spec/graphql/schema/warden_spec.rb
+++ b/spec/graphql/schema/warden_spec.rb
@@ -269,8 +269,6 @@ module MaskHelpers
     def self.resolve_type(type, obj, ctx)
       PhonemeType
     end
-
-
   end
 
   module Data

--- a/spec/graphql/schema/warden_spec.rb
+++ b/spec/graphql/schema/warden_spec.rb
@@ -223,9 +223,7 @@ module MaskHelpers
 
     field :manners, [MannerType], null: false
 
-    field :public_type, PublicType, null: false do
-      metadata :hidden_field, true
-    end
+    field :public_type, PublicType, null: false
   end
 
   class MutationType < BaseObject

--- a/spec/graphql/schema/warden_spec.rb
+++ b/spec/graphql/schema/warden_spec.rb
@@ -50,64 +50,43 @@ module MaskHelpers
     end
   end
 
-  module VisibleByFilters
-    def visible?(context)
-      result = super(context)
-      if result && context[:only] && !Array(context[:only]).all? { |func| func.call(self, context) }
-        return false
-      end
-      if result && context[:except] && Array(context[:except]).any? { |func| func.call(self, context) }
-        return false
-      end
-      result
-    end
-  end
-
 
   class BaseArgument < GraphQL::Schema::Argument
     include HasMetadata
-    include VisibleByFilters
   end
 
   class BaseField < GraphQL::Schema::Field
     include HasMetadata
-    include VisibleByFilters
     argument_class BaseArgument
   end
 
   class BaseObject < GraphQL::Schema::Object
     extend HasMetadata
-    extend VisibleByFilters
     field_class BaseField
   end
 
   class BaseEnumValue < GraphQL::Schema::EnumValue
     include HasMetadata
-    include VisibleByFilters
   end
 
   class BaseEnum < GraphQL::Schema::Enum
     extend HasMetadata
-    extend VisibleByFilters
     enum_value_class BaseEnumValue
   end
 
   class BaseInputObject < GraphQL::Schema::InputObject
     extend HasMetadata
-    extend VisibleByFilters
     argument_class BaseArgument
   end
 
   class BaseUnion < GraphQL::Schema::Union
     extend HasMetadata
-    extend VisibleByFilters
   end
 
   module BaseInterface
     include GraphQL::Schema::Interface
     module DefinitionMethods
       include HasMetadata
-      include VisibleByFilters
     end
     field_class BaseField
   end
@@ -268,6 +247,17 @@ module MaskHelpers
     orphan_types [Character]
     def self.resolve_type(type, obj, ctx)
       PhonemeType
+    end
+
+    def self.visible?(member, context)
+      result = super
+      if result && context[:only] && !Array(context[:only]).all? { |func| func.call(member, context) }
+        return false
+      end
+      if result && context[:except] && Array(context[:except]).any? { |func| func.call(member, context) }
+        return false
+      end
+      result
     end
   end
 

--- a/spec/graphql/schema/warden_spec.rb
+++ b/spec/graphql/schema/warden_spec.rb
@@ -188,7 +188,6 @@ module MaskHelpers
   end
 
   class CheremeWithInterface < BaseObject
-    # Commenting this would make the test pass
     implements PublicInterfaceType
 
     field :name, String, null: false
@@ -245,8 +244,9 @@ module MaskHelpers
 
     field :manners, [MannerType], null: false
 
-    # Commenting this would make the test pass
-    field :test, PublicType, null: false
+    field :public_type, PublicType, null: false do
+      metadata :hidden_field, true
+    end
   end
 
   class MutationType < BaseObject

--- a/spec/graphql/subscriptions/event_spec.rb
+++ b/spec/graphql/subscriptions/event_spec.rb
@@ -21,15 +21,20 @@ describe GraphQL::Subscriptions::Event do
     subscription(Subscription)
   end
 
+  def build_dummy_context(context = {})
+    GraphQL::Query.new(EventSchema, "{ __typename }", context: context).context
+  end
+
+
   it "should serialize a JSON argument into the topic name" do
     field = EventSchema.subscription.fields["jsonSubscription"]
-    event = GraphQL::Subscriptions::Event.new(name: "test", arguments: { "someJson" => { "b" => 1, "a" => 0 } }, field: field, context: nil, scope: nil)
+    event = GraphQL::Subscriptions::Event.new(name: "test", arguments: { "someJson" => { "b" => 1, "a" => 0 } }, field: field, context: build_dummy_context, scope: nil)
     assert_equal %Q{:jsonSubscription:someJson:{"a":0,"b":1}}, event.topic
   end
 
   it "should not serialize the context into the topic name" do
     field = EventSchema.subscription.fields["jsonSubscription"]
-    context = { my_id: "abc" }
+    context = build_dummy_context({ my_id: "abc" })
     event = GraphQL::Subscriptions::Event.new(name: "test", arguments: { "someJson" => { "b" => 1, "a" => 0 } }, field: field, context: context, scope: nil)
     assert_equal %Q{:jsonSubscription:someJson:{"a":0,"b":1}}, event.topic
     assert_equal event.context[:my_id], "abc"
@@ -37,8 +42,8 @@ describe GraphQL::Subscriptions::Event do
 
   it "should serialize two equivalent JSON hashes with different key orderings into equivalent topic names" do
     field = EventSchema.subscription.fields["jsonSubscription"]
-    event_a = GraphQL::Subscriptions::Event.new(name: "test", arguments: { "someJson" => { "b" => 1, "a" => 0 } }, field: field, context: nil, scope: nil)
-    event_b = GraphQL::Subscriptions::Event.new(name: "test", arguments: { "someJson" => { "a" => 0, "b" => 1 } }, field: field, context: nil, scope: nil)
+    event_a = GraphQL::Subscriptions::Event.new(name: "test", arguments: { "someJson" => { "b" => 1, "a" => 0 } }, field: field, context: build_dummy_context, scope: nil)
+    event_b = GraphQL::Subscriptions::Event.new(name: "test", arguments: { "someJson" => { "a" => 0, "b" => 1 } }, field: field, context: build_dummy_context, scope: nil)
     assert_equal event_a.topic, event_b.topic
   end
 
@@ -52,25 +57,25 @@ describe GraphQL::Subscriptions::Event do
       },
       "a" => 0
     }
-    event = GraphQL::Subscriptions::Event.new(name: "test", arguments: { "someJson" => nested_hash }, field: field, context: nil, scope: nil)
+    event = GraphQL::Subscriptions::Event.new(name: "test", arguments: { "someJson" => nested_hash }, field: field, context: build_dummy_context, scope: nil)
     assert_equal %Q{:jsonSubscription:someJson:{"a":0,"b":1,"c":{"y":99,"z":100}}}, event.topic
   end
 
   it "should serialize a hash inside an array as a sorted hash" do
     field = EventSchema.subscription.fields["jsonSubscription"]
-    event = GraphQL::Subscriptions::Event.new(name: "test", arguments: { "someJson" => [{ "b" => 1, "a" => 0 }] }, field: field, context: nil, scope: nil)
+    event = GraphQL::Subscriptions::Event.new(name: "test", arguments: { "someJson" => [{ "b" => 1, "a" => 0 }] }, field: field, context: build_dummy_context, scope: nil)
     assert_equal %Q{:jsonSubscription:someJson:[{"a":0,"b":1}]}, event.topic
   end
 
   it "should serialize a hash inside an array of an array as a sorted hash" do
     field = EventSchema.subscription.fields["jsonSubscription"]
-    event = GraphQL::Subscriptions::Event.new(name: "test", arguments: { "someJson" => [[{ "b" => 1, "a" => 0 }]] }, field: field, context: nil, scope: nil)
+    event = GraphQL::Subscriptions::Event.new(name: "test", arguments: { "someJson" => [[{ "b" => 1, "a" => 0 }]] }, field: field, context: build_dummy_context, scope: nil)
     assert_equal %Q{:jsonSubscription:someJson:[[{"a":0,"b":1}]]}, event.topic
   end
 
   it "should serialize a hash inside an array inside of a hash" do
     field = EventSchema.subscription.fields["jsonSubscription"]
-    event = GraphQL::Subscriptions::Event.new(name: "test", arguments: { "someJson" => { "key" => [{ "b" => 1, "a" => 0}]} }, field: field, context: nil, scope: nil)
+    event = GraphQL::Subscriptions::Event.new(name: "test", arguments: { "someJson" => { "key" => [{ "b" => 1, "a" => 0}]} }, field: field, context: build_dummy_context, scope: nil)
     assert_equal %Q{:jsonSubscription:someJson:{"key":[{"a":0,"b":1}]}}, event.topic
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,8 @@ end
 if ENV["GRAPHQL_REJECT_NUMBERS_FOLLOWED_BY_NAMES"]
   puts "Opting into GraphQL.reject_numbers_followed_by_names"
   GraphQL.reject_numbers_followed_by_names = true
+  puts "Opting into GraphQL::Schema::Subset"
+  GraphQL::Schema.use_schema_subset = true
 end
 
 require "rake"


### PR DESCRIPTION
`GraphQL::Schema::Warden` has been reliably applying type visibility filtering for many years. I'm interested in exploring a new approach for a few reasons: 

- `Warden` requires schema-wide caches of type information, which means that the whole schema must be loaded to run any query. A new approach could load only what's _necessary_. (Part of #4919) 
- A new approach could cache schemas between queries, for example, by name. This could speed up queries using the same subset of the schema. This could be coupled with a DSL for making certain types visible in named subsets.
- A new approach could simplify the expectations and behaviors of filtering, reducing edge case oddities (or at least making it clear how to address them).


This PR starts down that path by adding `GraphQL::Query#types` which uses _either_ `Schema::Subset` or `Schema::Warden`. The `types` object has the same API in either case, but behaves slightly differently. (I expect to widen the gap further in behavior, carefully, so that people can migrate.)

I don't expect any changes to application behavior after merging this PR because `Query#warden` is still available and the default implementation of `Query#types` (which is now used internally by GraphQL-Ruby) behaves the same as Warden (and uses Warden under the hood).

TODO: 

- [x] Re-implement `Schema::Warden` so that one implementation can be tinkered with while the other stays in place 
  - [x] Rename to something nice
  - [x] Update CI to run both implementations
- [x] Audit changes to test suite: revert them or document them 

In later PRs:

- Build out support for lazily-loading types as-needed 
  - Lazy-loading schema root types 
  - Lazily traversing field / argument types, possible types
  - Lazy-loading types by name -- convention-based? 
- Make forward-compatible APIs for plugins, etc, to run code when types are loaded
- Optimize performance
- Build a way to re-use schema subsets
  - Cache subsets between requests 
  - Make it easy to attach types and fields to subsets