### PR TITLE
Fix Relay subscription handler sending an empty string

### DIFF
--- a/javascript_client/src/subscriptions/__tests__/createRelaySubscriptionHandlerTest.ts
+++ b/javascript_client/src/subscriptions/__tests__/createRelaySubscriptionHandlerTest.ts
@@ -1,7 +1,7 @@
 import createRelaySubscriptionHandler from "../createRelaySubscriptionHandler"
 import { createLegacyRelaySubscriptionHandler } from "../createRelaySubscriptionHandler"
 import type { Consumer } from "@rails/actioncable"
-import { Network} from 'relay-runtime'
+import { Network } from 'relay-runtime'
 
 describe("createRelaySubscriptionHandler", () => {
   it("returns a function producing a observable subscription", () => {
@@ -19,6 +19,48 @@ describe("createRelaySubscriptionHandler", () => {
     var fetchQuery: any
     // basically, make sure this doesn't blow up during type-checking or runtime
     expect(Network.create(fetchQuery, handler)).toBeTruthy()
+  })
+
+  it("doesn't send an empty string when no string is given", () => {
+    var channel: any;
+    var performLog: any[] = [];
+    var dummyActionCableConsumer = {
+      subscriptions: {
+        create: (opts1: any, opts2: any) => {
+          channel = Object.assign(
+            opts1,
+            opts2,
+            {
+              unsubscribe: () => true,
+              perform: (event: string, payload: object) => performLog.push([event, payload]),
+
+            }
+          )
+          return channel
+        }
+      },
+    }
+
+    var options = {
+      cable: (dummyActionCableConsumer as unknown) as Consumer
+    }
+
+    var handler = createRelaySubscriptionHandler(options)
+    var observable = handler({id: "abc", text: null, name: "def", operationKind: "subscription", metadata: {}}, { abc: true});
+    observable.subscribe({})
+    channel.connected()
+    var expectedLog = [
+      [
+        'execute',
+        {
+          variables: { abc: true },
+          operationName: 'def',
+          query: null,
+          operationId: null
+        }
+      ]
+    ]
+    expect(performLog).toEqual(expectedLog)
   })
 })
 

--- a/javascript_client/src/subscriptions/createRelaySubscriptionHandler.ts
+++ b/javascript_client/src/subscriptions/createRelaySubscriptionHandler.ts
@@ -45,7 +45,7 @@ function createRelaySubscriptionHandler(options: ActionCableHandlerOptions | Pus
       }) => {
         const client = handler(
           {
-            text: request.text || "",
+            text: request.text,
             name: request.name,
             id: request.id,
           },


### PR DESCRIPTION
Oops -- this was falling back to `""` when no query string was given, which breaks when using the OperationStore.