### PR TITLE
Remove rule that prohibits non-null variables from having default values

### DIFF
--- a/lib/graphql/static_validation/rules/variable_default_values_are_correctly_typed.rb
+++ b/lib/graphql/static_validation/rules/variable_default_values_are_correctly_typed.rb
@@ -5,36 +5,27 @@ module GraphQL
       def on_variable_definition(node, parent)
         if !node.default_value.nil?
           value = node.default_value
-          if node.type.is_a?(GraphQL::Language::Nodes::NonNullType)
-            add_error(GraphQL::StaticValidation::VariableDefaultValuesAreCorrectlyTypedError.new(
-              "Non-null variable $#{node.name} can't have a default value",
-              nodes: node,
-              name: node.name,
-              error_type: VariableDefaultValuesAreCorrectlyTypedError::VIOLATIONS[:INVALID_ON_NON_NULL]
-            ))
+          type = context.schema.type_from_ast(node.type, context: context)
+          if type.nil?
+            # This is handled by another validator
           else
-            type = context.schema.type_from_ast(node.type, context: context)
-            if type.nil?
-              # This is handled by another validator
-            else
-              validation_result = context.validate_literal(value, type)
+            validation_result = context.validate_literal(value, type)
 
-              if !validation_result.valid?
-                problems = validation_result.problems
-                first_problem = problems && problems.first
-                if first_problem
-                  error_message = first_problem["explanation"]
-                end
-
-                error_message ||= "Default value for $#{node.name} doesn't match type #{type.to_type_signature}"
-                add_error(GraphQL::StaticValidation::VariableDefaultValuesAreCorrectlyTypedError.new(
-                  error_message,
-                  nodes: node,
-                  name: node.name,
-                  type: type.to_type_signature,
-                  error_type: VariableDefaultValuesAreCorrectlyTypedError::VIOLATIONS[:INVALID_TYPE],
-                ))
+            if !validation_result.valid?
+              problems = validation_result.problems
+              first_problem = problems && problems.first
+              if first_problem
+                error_message = first_problem["explanation"]
               end
+
+              error_message ||= "Default value for $#{node.name} doesn't match type #{type.to_type_signature}"
+              add_error(GraphQL::StaticValidation::VariableDefaultValuesAreCorrectlyTypedError.new(
+                error_message,
+                nodes: node,
+                name: node.name,
+                type: type.to_type_signature,
+                error_type: VariableDefaultValuesAreCorrectlyTypedError::VIOLATIONS[:INVALID_TYPE],
+              ))
             end
           end
         end

--- a/spec/graphql/static_validation/rules/variable_default_values_are_correctly_typed_spec.rb
+++ b/spec/graphql/static_validation/rules/variable_default_values_are_correctly_typed_spec.rb
@@ -36,12 +36,6 @@ describe GraphQL::StaticValidation::VariableDefaultValuesAreCorrectlyTyped do
         "path"=>["query getCheese"],
         "extensions"=>{"code"=>"defaultValueInvalidType", "variableName"=>"badInput", "typeName"=>"DairyProductInput"}
       },
-      {
-        "message"=>"Non-null variable $nonNull can't have a default value",
-        "locations"=>[{"line"=>8, "column"=>7}],
-        "path"=>["query getCheese"],
-        "extensions"=>{"code"=>"defaultValueInvalidOnNonNullVariable", "variableName"=>"nonNull"}
-      }
     ]
     assert_equal(expected, errors)
   end
@@ -115,16 +109,16 @@ describe GraphQL::StaticValidation::VariableDefaultValuesAreCorrectlyTyped do
       it "finds errors" do
         expected = [
           {
-            "message"=>"Non-null variable $a can't have a default value",
+            "message"=>"Default value for $a doesn't match type Int!",
             "locations"=>[{"line"=>3, "column"=>11}],
             "path"=>["query getCheese"],
-            "extensions"=>{"code"=>"defaultValueInvalidOnNonNullVariable", "variableName"=>"a"}
+            "extensions"=> {"code"=>"defaultValueInvalidType", "variableName"=>"a", "typeName"=>"Int!"}
           },
           {
-            "message"=>"Non-null variable $b can't have a default value",
+            "message"=>"Default value for $b doesn't match type String!",
             "locations"=>[{"line"=>4, "column"=>11}],
             "path"=>["query getCheese"],
-            "extensions"=>{"code"=>"defaultValueInvalidOnNonNullVariable", "variableName"=>"b"}
+            "extensions"=>{"code"=>"defaultValueInvalidType", "variableName"=>"b", "typeName"=>"String!"}
           },
           {
             "message"=>"Default value for $c doesn't match type ComplexInput",
@@ -133,7 +127,6 @@ describe GraphQL::StaticValidation::VariableDefaultValuesAreCorrectlyTyped do
             "extensions"=>{"code"=>"defaultValueInvalidType", "variableName"=>"c", "typeName"=>"ComplexInput"}
           }
         ]
-
         assert_equal expected, errors
       end
     end


### PR DESCRIPTION
This rule isn't actually part of the spec, and GraphQL-JS allows this construction. 

From a compatibility standpoint, I don't think this poses any risks: any queries that were previously returned as invalid (wrongly) will now be executed. But I think anyone who encountered this in the past probably removed the `!`.

Fixes #5029 