### PR TITLE
Remove old interpreter?, using_ast_analysis?, and new_connections? flags

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -187,10 +187,6 @@ module GraphQL
       @query_string ||= (document ? document.to_query_string : nil)
     end
 
-    def interpreter?
-      true
-    end
-
     attr_accessor :multiplex
 
     # @return [GraphQL::Tracing::Trace]

--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -82,7 +82,7 @@ module GraphQL
         @provided_values[key] = value
       end
 
-      def_delegators :@query, :trace, :interpreter?
+      def_delegators :@query, :trace
 
       def types
         @types ||= @query.types

--- a/lib/graphql/query/null_context.rb
+++ b/lib/graphql/query/null_context.rb
@@ -27,10 +27,6 @@ module GraphQL
         @warden = Schema::Warden::NullWarden.new(context: self, schema: @schema)
       end
 
-      def interpreter?
-        true
-      end
-
       def types
         @types ||= GraphQL::Schema::Warden::SchemaSubset.new(@warden)
       end

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -424,10 +424,6 @@ module GraphQL
         end
       end
 
-      def new_connections?
-        !!connections
-      end
-
       def query(new_query_object = nil)
         if new_query_object
           if @query_object
@@ -794,16 +790,6 @@ module GraphQL
       def analysis_engine
         @analysis_engine || find_inherited_value(:analysis_engine, self.default_analysis_engine)
       end
-
-      def using_ast_analysis?
-        true
-      end
-
-      def interpreter?
-        true
-      end
-
-      attr_writer :interpreter
 
       def error_bubbling(new_error_bubbling = nil)
         if !new_error_bubbling.nil?

--- a/lib/graphql/schema/field/connection_extension.rb
+++ b/lib/graphql/schema/field/connection_extension.rb
@@ -50,7 +50,7 @@ module GraphQL
               if field.has_default_page_size? && !value.has_default_page_size_override?
                 value.default_page_size = field.default_page_size
               end
-              if context.schema.new_connections? && (custom_t = context.schema.connections.edge_class_for_field(@field))
+              if (custom_t = context.schema.connections.edge_class_for_field(@field))
                 value.edge_class = custom_t
               end
               value

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -431,14 +431,6 @@ describe GraphQL::Execution::Interpreter do
     assert_nil Thread.current[:__graphql_runtime_info]
   end
 
-  describe "temporary interpreter flag" do
-    it "is set" do
-      # This can be removed later, just a sanity check during migration
-      res = InterpreterTest::Schema.execute("{ __typename }")
-      assert_equal true, res.context.interpreter?
-    end
-  end
-
   describe "runtime info in context" do
     it "is available" do
       res = InterpreterTest::Schema.execute <<-GRAPHQL


### PR DESCRIPTION
These were used many years ago and have returned `true` since GraphQL-Ruby v2.0. If you find these in your code, remove usages because they're always `true`.