### PR TITLE
Schema::Subset: Don't build schema caches, sort directives in introspection

### DIFF
--- a/lib/graphql/introspection/schema_type.rb
+++ b/lib/graphql/introspection/schema_type.rb
@@ -39,7 +39,7 @@ module GraphQL
       end
 
       def directives
-        @context.types.directives
+        @context.types.directives.sort_by(&:graphql_name)
       end
     end
   end

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -493,7 +493,11 @@ module GraphQL
       end
 
       def root_types
-        @root_types
+        if use_schema_subset?
+          [query, mutation, subscription].compact
+        else
+          @root_types
+        end
       end
 
       def warden_class

--- a/lib/graphql/schema/introspection_system.rb
+++ b/lib/graphql/schema/introspection_system.rb
@@ -90,7 +90,8 @@ module GraphQL
       def resolve_late_binding(late_bound_type)
         case late_bound_type
         when GraphQL::Schema::LateBoundType
-          @schema.get_type(late_bound_type.name)
+          type_name = late_bound_type.name
+          @types[type_name] || @schema.get_type(type_name)
         when GraphQL::Schema::List
           resolve_late_binding(late_bound_type.of_type).to_list_type
         when GraphQL::Schema::NonNull

--- a/lib/graphql/schema/subset.rb
+++ b/lib/graphql/schema/subset.rb
@@ -288,7 +288,7 @@ module GraphQL
 
       def directive_exists?(dir_name)
         if (dir = @schema.directives[dir_name]) && @cached_visible[dir]
-          dir
+          !!dir
         else
           load_all_types
           !!@cached_directives[dir_name]

--- a/lib/graphql/schema/subset.rb
+++ b/lib/graphql/schema/subset.rb
@@ -15,6 +15,16 @@ module GraphQL
     #
     # @see Schema::TypesMigration for a helper class in adopting this filter
     class Subset
+      # @return [Schema::Subset]
+      def self.from_context(ctx, schema)
+        if ctx.respond_to?(:types) && (types = ctx.types).is_a?(self)
+          types
+        else
+          # TODO use a cached instance from the schema
+          self.new(context: ctx, schema: schema)
+        end
+      end
+
       def initialize(context:, schema:)
         @context = context
         @schema = schema
@@ -258,6 +268,11 @@ module GraphQL
       def all_types
         load_all_types
         @all_types.values
+      end
+
+      def all_types_h
+        load_all_types
+        @all_types
       end
 
       def enum_values(owner)

--- a/lib/graphql/schema/subset.rb
+++ b/lib/graphql/schema/subset.rb
@@ -25,6 +25,12 @@ module GraphQL
         end
       end
 
+      def self.pass_thru(context:, schema:)
+        subset = self.new(context: context, schema: schema)
+        subset.instance_variable_set(:@cached_visible, Hash.new { |h,k| h[k] = true })
+        subset
+      end
+
       def initialize(context:, schema:)
         @context = context
         @schema = schema

--- a/lib/graphql/testing/helpers.rb
+++ b/lib/graphql/testing/helpers.rb
@@ -90,10 +90,13 @@ module GraphQL
             end
           end
           graphql_result
-        elsif schema.has_defined_type?(type_name)
-          raise TypeNotVisibleError.new(type_name: type_name)
         else
-          raise TypeNotDefinedError.new(type_name: type_name)
+          unfiltered_type = Schema::Subset.pass_thru(schema: schema, context: context).type(type_name)
+          if unfiltered_type
+            raise TypeNotVisibleError.new(type_name: type_name)
+          else
+            raise TypeNotDefinedError.new(type_name: type_name)
+          end
         end
       end
 

--- a/spec/graphql/introspection/directive_type_spec.rb
+++ b/spec/graphql/introspection/directive_type_spec.rb
@@ -39,6 +39,26 @@ describe GraphQL::Introspection::DirectiveType do
       "__schema" => {
         "directives" => [
           {
+            "name" => "deprecated",
+            "args" => [
+              {"name"=>"reason", "type"=>{"kind"=>"SCALAR", "name"=>"String", "ofType"=>nil}}
+            ],
+            "locations"=>["FIELD_DEFINITION", "ENUM_VALUE", "ARGUMENT_DEFINITION", "INPUT_FIELD_DEFINITION"],
+            "isRepeatable" => false,
+            "onField" => false,
+            "onFragment" => false,
+            "onOperation" => false,
+          },
+          {
+            "name"=>"doStuff",
+            "args"=>[],
+            "locations"=>[],
+            "isRepeatable"=>true,
+            "onField"=>false,
+            "onFragment"=>false,
+            "onOperation"=>false,
+          },
+          {
             "name" => "include",
             "args" => [
               {"name"=>"if", "type"=>{"kind"=>"NON_NULL", "name"=>nil, "ofType"=>{"name"=>"Boolean"}}}
@@ -47,6 +67,15 @@ describe GraphQL::Introspection::DirectiveType do
             "isRepeatable" => false,
             "onField" => true,
             "onFragment" => true,
+            "onOperation" => false,
+          },
+          {
+            "name" => "oneOf",
+            "args" => [],
+            "locations"=>["INPUT_OBJECT"],
+            "isRepeatable" => false,
+            "onField" => false,
+            "onFragment" => false,
             "onOperation" => false,
           },
           {
@@ -61,26 +90,6 @@ describe GraphQL::Introspection::DirectiveType do
             "onOperation" => false,
           },
           {
-            "name" => "deprecated",
-            "args" => [
-              {"name"=>"reason", "type"=>{"kind"=>"SCALAR", "name"=>"String", "ofType"=>nil}}
-            ],
-            "locations"=>["FIELD_DEFINITION", "ENUM_VALUE", "ARGUMENT_DEFINITION", "INPUT_FIELD_DEFINITION"],
-            "isRepeatable" => false,
-            "onField" => false,
-            "onFragment" => false,
-            "onOperation" => false,
-          },
-          {
-            "name" => "oneOf",
-            "args" => [],
-            "locations"=>["INPUT_OBJECT"],
-            "isRepeatable" => false,
-            "onField" => false,
-            "onFragment" => false,
-            "onOperation" => false,
-          },
-          {
             "name" => "specifiedBy",
             "args" => [
               {"name"=>"url", "type"=>{"kind"=>"NON_NULL", "name"=>nil, "ofType"=>{"name"=>"String"}}}
@@ -91,19 +100,10 @@ describe GraphQL::Introspection::DirectiveType do
             "onFragment" => false,
             "onOperation" => false,
           },
-          {
-            "name"=>"doStuff",
-            "args"=>[],
-            "locations"=>[],
-            "isRepeatable"=>true,
-            "onField"=>false,
-            "onFragment"=>false,
-            "onOperation"=>false,
-          }
         ]
       }
     }}
-    assert_equal(expected, result)
+    assert_equal(expected, result.to_h)
   end
 
   it "hides deprecated arguments by default" do

--- a/spec/graphql/language/document_from_schema_definition_spec.rb
+++ b/spec/graphql/language/document_from_schema_definition_spec.rb
@@ -899,10 +899,22 @@ type Query {
       end
 
       directive CustomThing
+
+      class Query < GraphQL::Schema::Object
+        field :f, Int, directives: { CustomThing => { stuff: "ok" } }
+      end
+      query(Query)
     end
 
     it "prints them out" do
-      assert_equal "directive @customThing(stuff: String!) on FIELD_DEFINITION\n", CustomSDLDirectiveSchema.to_definition
+      expected_str = <<~GRAPHQL
+        directive @customThing(stuff: String!) on FIELD_DEFINITION
+
+        type Query {
+          f: Int @customThing(stuff: "ok")
+        }
+      GRAPHQL
+      assert_equal expected_str, CustomSDLDirectiveSchema.to_definition
     end
   end
 end

--- a/spec/graphql/schema/addition_spec.rb
+++ b/spec/graphql/schema/addition_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 describe GraphQL::Schema::Addition do
   it "handles duplicate types with cycles" do
     duplicate_types_schema = Class.new(GraphQL::Schema)
+    duplicate_types_schema.use_schema_subset = false
     duplicate_types = 2.times.map {
       Class.new(GraphQL::Schema::Object) do
         graphql_name "Thing"

--- a/spec/graphql/schema/argument_spec.rb
+++ b/spec/graphql/schema/argument_spec.rb
@@ -398,7 +398,7 @@ describe GraphQL::Schema::Argument do
       err = assert_raises ArgumentError do
         Class.new(GraphQL::Schema) do
           query(query_type)
-        end
+        end.to_definition
       end
 
       assert_equal "Required arguments cannot be deprecated: MyInput2.foo.", err.message
@@ -427,7 +427,7 @@ describe GraphQL::Schema::Argument do
       err = assert_raises ArgumentError do
         Class.new(InvalidArgumentTypeSchema) do
           query(InvalidArgumentTypeSchema::InvalidArgumentObject)
-        end
+        end.to_definition
       end
 
       expected_message = "Invalid input type for InvalidArgumentObject.invalid.objectRef: InvalidArgument. Must be scalar, enum, or input object, not OBJECT."
@@ -436,7 +436,7 @@ describe GraphQL::Schema::Argument do
       err = assert_raises ArgumentError do
         Class.new(InvalidArgumentTypeSchema) do
           query(InvalidArgumentTypeSchema::InvalidLazyArgumentObject)
-        end
+        end.to_definition
       end
 
       expected_message = "Invalid input type for InvalidLazyArgumentObject.invalid.lazyObjectRef: InvalidArgument. Must be scalar, enum, or input object, not OBJECT."
@@ -456,7 +456,7 @@ describe GraphQL::Schema::Argument do
       err = assert_raises GraphQL::Schema::Argument::InvalidDefaultValueError do
         Class.new(GraphQL::Schema) do
           query(query_type)
-        end
+        end.to_definition
       end
       expected_message = "`Query.f1.arg1` has an invalid default value: `nil` isn't accepted by `Int!`; update the default value or the argument type."
       assert_equal expected_message, err.message
@@ -478,7 +478,7 @@ describe GraphQL::Schema::Argument do
       err = assert_raises GraphQL::Schema::Argument::InvalidDefaultValueError do
         Class.new(GraphQL::Schema) do
           query(query_type)
-        end
+        end.to_definition
       end
 
       expected_message = "`InputObj.arg1` has an invalid default value: `[nil]` isn't accepted by `[String!]`; update the default value or the argument type."
@@ -501,7 +501,7 @@ describe GraphQL::Schema::Argument do
       err = assert_raises GraphQL::Schema::Argument::InvalidDefaultValueError do
         Class.new(GraphQL::Schema) do
           directive(localize)
-        end
+        end.to_definition
       end
 
       expected_message = "`@localize.lang` has an invalid default value: `\"ZH\"` isn't accepted by `Language`; update the default value or the argument type."
@@ -535,7 +535,7 @@ describe GraphQL::Schema::Argument do
 
 
       err2 = assert_raises GraphQL::Schema::Argument::InvalidDefaultValueError do
-        GraphQL::Schema.from_definition(directive_schema_str)
+        GraphQL::Schema.from_definition(directive_schema_str).to_definition
       end
       expected_message = "`@localize.lang` has an invalid default value: `\"ZH\"` isn't accepted by `Language`; update the default value or the argument type."
       assert_equal expected_message, err2.message

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -904,8 +904,8 @@ enum Enum {
 }
 
 type Query {
-  field(argument: String): String
-  deprecatedField(argument: String): String @deprecated(reason: "Test")
+  field(argument: Enum): Interface
+  deprecatedField(argument: Input): Union @deprecated(reason: "Test")
 }
 
 interface Interface {
@@ -928,7 +928,7 @@ directive @Directive (
 directive @custom(thing: Boolean) on SCHEMA
 
 type Type implements Interface {
-  field(argument: String): String
+  field(argument: Scalar): Type
 }
       GRAPHQL
 
@@ -941,8 +941,8 @@ type Type implements Interface {
       assert_equal [9, 1], schema.types["Query"].ast_node.position
       assert_equal [10, 3], schema.types["Query"].fields["field"].ast_node.position
       assert_equal [10, 9], schema.types["Query"].fields["field"].arguments["argument"].ast_node.position
-      assert_equal [11, 45], schema.types["Query"].fields["deprecatedField"].ast_node.directives[0].position
-      assert_equal [11, 57], schema.types["Query"].fields["deprecatedField"].ast_node.directives[0].arguments[0].position
+      assert_equal [11, 43], schema.types["Query"].fields["deprecatedField"].ast_node.directives[0].position
+      assert_equal [11, 55], schema.types["Query"].fields["deprecatedField"].ast_node.directives[0].arguments[0].position
       assert_equal [14, 1], schema.types["Interface"].ast_node.position
       assert_equal [15, 3], schema.types["Interface"].fields["field"].ast_node.position
       assert_equal [15, 9], schema.types["Interface"].fields["field"].arguments["argument"].ast_node.position
@@ -1485,7 +1485,7 @@ type ThingEdge {
     GRAPHQL
 
     schema = GraphQL::Schema.from_definition(schema_str)
-    assert_equal schema.directives["myDirective"].get_argument("id").type, schema.find("ID")
+    assert_equal schema.directives["myDirective"].get_argument("id").type, schema.get_type("ID")
   end
 
   describe "orphan types" do

--- a/spec/graphql/schema/directive_spec.rb
+++ b/spec/graphql/schema/directive_spec.rb
@@ -382,7 +382,7 @@ Use `locations(OBJECT)` to update this directive's definition, or remove it from
       type Query @tag(name: "t1") @tag(name: "t2") {
         something(
           arg: Boolean @tag(name: "t3") @tag(name: "t4")
-        ): Int @tag(name: "t5") @tag(name: "t6")
+        ): Stuff @tag(name: "t5") @tag(name: "t6")
       }
 
       enum Stuff {

--- a/spec/graphql/schema/dynamic_members_spec.rb
+++ b/spec/graphql/schema/dynamic_members_spec.rb
@@ -591,16 +591,16 @@ GRAPHQL
 
     # and the interface relationship is sometimes hidden:
     refute_includes MultifieldSchema::Country.interfaces({ future_schema: false }), MultifieldSchema::HasCapital
-    if GraphQL::Schema.use_schema_subset?
-      # TODO I think this is wrong -- it should be hidden.
-      assert_equal [MultifieldSchema::Country], MultifieldSchema.possible_types(MultifieldSchema::HasCapital, { future_schema: false })
-    else
-      refute_includes MultifieldSchema.possible_types(MultifieldSchema::HasCapital, { future_schema: false }), MultifieldSchema::Country
-    end
+    refute_includes MultifieldSchema.possible_types(MultifieldSchema::HasCapital, { future_schema: false }), MultifieldSchema::Country
     assert_includes MultifieldSchema::Country.interfaces({ future_schema: true }), MultifieldSchema::HasCapital
     assert_includes MultifieldSchema.possible_types(MultifieldSchema::HasCapital, { future_schema: true }), MultifieldSchema::Country
     assert_includes MultifieldSchema::Country.interfaces, MultifieldSchema::HasCapital
-    assert_includes MultifieldSchema.possible_types(MultifieldSchema::HasCapital), MultifieldSchema::Country
+    if GraphQL::Schema.use_schema_subset?
+      # filtered with `future_schema: nil`
+      refute_includes MultifieldSchema.possible_types(MultifieldSchema::HasCapital), MultifieldSchema::Country
+    else
+      assert_includes MultifieldSchema.possible_types(MultifieldSchema::HasCapital), MultifieldSchema::Country
+    end
   end
 
   it "hides hidden union memberships" do

--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -915,7 +915,7 @@ describe GraphQL::Schema::InputObject do
       describe "validate_input with null" do
         let(:schema) { GraphQL::Schema.from_definition(%|
           type Query {
-            a: Int
+            a(input: ExampleInputObject): Int
           }
 
           input ExampleInputObject {
@@ -1095,7 +1095,8 @@ describe GraphQL::Schema::InputObject do
     describe "coercion of null inputs" do
       let(:schema) { GraphQL::Schema.from_definition(%|
         type Query {
-          a: Int
+          a(input: ExampleInputObject): Int
+          b(input: SecondLevelInputObject): Int
         }
 
         input ExampleInputObject {

--- a/spec/graphql/schema/interface_spec.rb
+++ b/spec/graphql/schema/interface_spec.rb
@@ -482,8 +482,8 @@ interface Timestamped implements Node {
     let(:interface) { Dummy::Edible }
 
     it "has possible types" do
-      expected_defns = [Dummy::Cheese, Dummy::Milk, Dummy::Honey, Dummy::Aspartame]
-      assert_equal(expected_defns, Dummy::Schema.possible_types(interface))
+      expected_defns = [Dummy::Aspartame, Dummy::Cheese, Dummy::Honey, Dummy::Milk]
+      assert_equal(expected_defns, Dummy::Schema.possible_types(interface).sort_by(&:graphql_name))
     end
 
     describe "query evaluation" do

--- a/spec/graphql/schema/union_spec.rb
+++ b/spec/graphql/schema/union_spec.rb
@@ -288,7 +288,7 @@ describe GraphQL::Schema::Union do
     err2 = assert_raises ArgumentError do
       Class.new(GraphQL::Schema) do
         query(object_type)
-      end
+      end.to_definition
     end
 
     assert_match expected_message, err2.message

--- a/spec/integration/rails/graphql/schema_spec.rb
+++ b/spec/integration/rails/graphql/schema_spec.rb
@@ -16,6 +16,7 @@ describe GraphQL::Schema do
 
   describe "#union_memberships" do
     it "returns a list of unions that include the type" do
+      skip("Not implemented for Subset") if GraphQL::Schema.use_schema_subset?
       assert_equal [schema.types["Animal"], schema.types["AnimalAsCow"]], schema.union_memberships(schema.types["Cow"])
     end
   end
@@ -42,6 +43,7 @@ describe GraphQL::Schema do
 
   describe "#references_to" do
     it "returns a list of Field and Arguments of that type" do
+      skip "Not implemented when using Subset" if GraphQL::Schema.use_schema_subset?
       cow_field = schema.get_field("Query", "cow")
       cow_t = schema.get_type("Cow")
       assert_equal [cow_field], schema.references_to(cow_t)


### PR DESCRIPTION
To support lazy-loading types, this turns off eager-loading when `Schema::Subset` is enabled. 

Part of #5014  and #4919 

TODO: 

- [x] Document: `Schema.from_definition` used to retain unreferenced types, but it doesn't anymore.
- [x] Run benchmarks vs master to make sure this doesn't introduce problematic latency. (I don't expect so -- the calls to `Schema.` methods are only called once per type per query.)
    - Memory usage was identical, runtime was within margin of error