### PR TITLE
fix: avoid iterating on null array if all validator permits null value

### DIFF
--- a/lib/graphql/schema/validator/all_validator.rb
+++ b/lib/graphql/schema/validator/all_validator.rb
@@ -28,6 +28,8 @@ module GraphQL
         end
 
         def validate(object, context, value)
+          return EMPTY_ARRAY if permitted_empty_value?(value)
+
           all_errors = EMPTY_ARRAY
 
           value.each do |subvalue|

--- a/spec/graphql/schema/validator/all_validator_spec.rb
+++ b/spec/graphql/schema/validator/all_validator_spec.rb
@@ -48,4 +48,20 @@ describe GraphQL::Schema::Validator::AllValidator do
   ]
 
   build_tests(:all, [Integer], expectations)
+
+  expectations = [
+    {
+      config: { allow_null: true, inclusion: { in: 1..5 }, numericality: { odd: true } },
+      cases: [
+        { query: "{ validated(value: null) }", result: nil, error_messages: [] },
+        { query: "{ validated(value: []) }", result: [], error_messages: [] },
+        { query: "{ validated(value: [1]) }", result: [1], error_messages: [] },
+        { query: "{ validated(value: [1, 3]) }", result: [1, 3], error_messages: [] },
+        { query: "{ validated(value: [4]) }", result: nil, error_messages: ["value must be odd"] },
+        { query: "{ validated(value: [7]) }", result: nil, error_messages: ["value is not included in the list"] },
+      ],
+    },
+  ]
+
+  build_tests(:all, [Integer], expectations)
 end


### PR DESCRIPTION
When you want to validate an array only has values within a pre-defined set (`all: inclusion: []`), but also want to permit it to be `null`, right now it will crash on `undefined method `each' for nil:NilClass`

Example field and query that will crash before the patch, and won't after.
```ruby
field :pets, [Types::PetsType] do
  argument :filters, [String],
           description: 'Filters to apply -- nil for all',
           validates: {
             all: {
               allow_null: true,
               inclusion: { in: %w[cat dog turtle bird] },
             },
           }
end
```

```graphql
query MyFavoritePets {
  pets(filters: null) {
    name
  }
}
```
