### PR TITLE
Defer calling field do ... end blocks until needed

### DIFF
--- a/lib/graphql/rubocop.rb
+++ b/lib/graphql/rubocop.rb
@@ -2,3 +2,4 @@
 
 require "graphql/rubocop/graphql/default_null_true"
 require "graphql/rubocop/graphql/default_required_true"
+require "graphql/rubocop/graphql/field_type_in_block"

--- a/lib/graphql/rubocop/graphql/field_type_in_block.rb
+++ b/lib/graphql/rubocop/graphql/field_type_in_block.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+require_relative "./base_cop"
+
+module GraphQL
+  module Rubocop
+    module GraphQL
+      # Identify (and auto-correct) any field whose type configuration isn't given
+      # in the configuration block.
+      #
+      # @example
+      #   # bad, immediately causes Rails to load `app/graphql/types/thing.rb`
+      #   field :thing, Types::Thing
+      #
+      #   # good, defers loading until the file is needed
+      #   field :thing do
+      #     type(Types::Thing)
+      #   end
+      #
+      class FieldTypeInBlock < BaseCop
+        MSG = "type configuration can be moved to a block to defer loading the type's file"
+
+        BUILT_IN_SCALAR_NAMES = ["Float", "Int", "Integer", "String", "ID", "Boolean"]
+        def_node_matcher :field_config_with_inline_type, <<-Pattern
+        (
+          send {nil? _} :field sym ${const array} ...
+        )
+        Pattern
+
+        def_node_matcher :field_config_with_inline_type_and_block, <<-Pattern
+        (
+          block
+            (send {nil? _} :field sym ${const array}) ...
+            (args)
+            _
+
+        )
+        Pattern
+
+        def on_block(node)
+          field_config_with_inline_type_and_block(node) do |type_const|
+            ignore_node(type_const)
+            type_const_str = get_type_argument_str(node, type_const)
+            if ignore_inline_type_str?(type_const_str)
+              # Do nothing ...
+            else
+              add_offense(type_const) do |corrector|
+                cleaned_node_source = delete_type_argument(node, type_const)
+                field_indent = determine_field_indent(node)
+                cleaned_node_source.sub!(/(\{|do)/, "\\1\n#{field_indent}  type #{type_const_str}")
+                corrector.replace(node, cleaned_node_source)
+              end
+            end
+          end
+        end
+
+        def on_send(node)
+          field_config_with_inline_type(node) do |type_const|
+            return if ignored_node?(type_const)
+            type_const_str = get_type_argument_str(node, type_const)
+            if ignore_inline_type_str?(type_const_str)
+              # Do nothing -- not loading from another file
+            else
+              add_offense(type_const) do |corrector|
+                cleaned_node_source = delete_type_argument(node, type_const)
+                field_indent = determine_field_indent(node)
+                cleaned_node_source += " do\n#{field_indent}  type #{type_const_str}\n#{field_indent}end"
+                corrector.replace(node, cleaned_node_source)
+              end
+            end
+          end
+        end
+
+
+        private
+
+        def ignore_inline_type_str?(type_str)
+          BUILT_IN_SCALAR_NAMES.include?(type_str)
+        end
+
+        def get_type_argument_str(send_node, type_const)
+          first_pos = type_const.location.expression.begin_pos
+          end_pos = type_const.location.expression.end_pos
+          node_source = send_node.source_range.source
+          node_first_pos = send_node.location.expression.begin_pos
+
+          relative_first_pos = first_pos - node_first_pos
+          end_removal_pos = end_pos - node_first_pos
+
+          node_source[relative_first_pos...end_removal_pos]
+        end
+
+        def delete_type_argument(send_node, type_const)
+          first_pos = type_const.location.expression.begin_pos
+          end_pos = type_const.location.expression.end_pos
+          node_source = send_node.source_range.source
+          node_first_pos = send_node.location.expression.begin_pos
+
+          relative_first_pos = first_pos - node_first_pos
+          end_removal_pos = end_pos - node_first_pos
+
+          begin_removal_pos = relative_first_pos
+          while node_source[begin_removal_pos] != ","
+            begin_removal_pos -= 1
+            if begin_removal_pos < 1
+              raise "Invariant: somehow backtracked to beginning of node looking for a comma (node source: #{node_source.inspect})"
+            end
+          end
+
+          node_source[0...begin_removal_pos] + node_source[end_removal_pos..-1]
+        end
+
+        def determine_field_indent(send_node)
+          surrounding_node = send_node.parent.parent
+          surrounding_source = surrounding_node.source
+          indent_test_idx = send_node.location.expression.begin_pos - surrounding_node.source_range.begin_pos - 1
+          field_indent = "".dup
+          while surrounding_source[indent_test_idx] == " "
+            field_indent << " "
+            indent_test_idx -= 1
+            if indent_test_idx == 0
+              raise "Invariant: somehow backtracted to beginning of class when looking for field indent (source: #{node_source.inspect})"
+            end
+          end
+          field_indent
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/schema/addition.rb
+++ b/lib/graphql/schema/addition.rb
@@ -189,6 +189,7 @@ module GraphQL
           add_directives_from(type)
           if type.kind.fields?
             type.all_field_definitions.each do |field|
+              field.ensure_loaded
               name = field.graphql_name
               field_type = field.type.unwrap
               if !field_type.is_a?(GraphQL::Schema::LateBoundType)

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -353,7 +353,11 @@ module GraphQL
         end
       end
 
+      # Calls the definition block, if one was given.
+      # This is deferred so that references to the return type
+      # can be lazily evaluated, reducing Rails boot time.
       # @return [self]
+      # @api private
       def ensure_loaded
         if @definition_block
           if @definition_block.arity == 1
@@ -580,6 +584,11 @@ module GraphQL
       class MissingReturnTypeError < GraphQL::Error; end
       attr_writer :type
 
+      # Get or set the return type of this field.
+      #
+      # It may return nil if no type was configured or if the given definition block wasn't called yet.
+      # @param new_type [Module, GraphQL::Schema::NonNull, GraphQL::Schema::List] A GraphQL return type
+      # @return [Module, GraphQL::Schema::NonNull, GraphQL::Schema::List, nil] the configured type for this field
       def type(new_type = NOT_CONFIGURED)
         if NOT_CONFIGURED.equal?(new_type)
           if @resolver_class

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -600,7 +600,7 @@ module GraphQL
             end
             nullable = @return_type_null.nil? ? @resolver_class.null : @return_type_null
             Member::BuildType.parse_type(return_type, null: nullable)
-          elsif @return_type_expr
+          elsif !@return_type_expr.nil?
             @type ||= Member::BuildType.parse_type(@return_type_expr, null: @return_type_null)
           end
         else

--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -104,7 +104,7 @@ module GraphQL
               if ancestor.respond_to?(:own_fields) &&
                   (f_entry = ancestor.own_fields[field_name]) &&
                   (skip_visible || (f_entry = Warden.visible_entry?(:visible_field?, f_entry, context, warden)))
-                return f_entry
+                return f_entry.ensure_loaded
               end
             end
             nil
@@ -121,7 +121,7 @@ module GraphQL
                   # Choose the most local definition that passes `.visible?` --
                   # stop checking for fields by name once one has been found.
                   if !visible_fields.key?(field_name) && (f = Warden.visible_entry?(:visible_field?, fields_entry, context, warden))
-                    visible_fields[field_name] = f
+                    visible_fields[field_name] = f.ensure_loaded
                   end
                 end
               end
@@ -142,7 +142,7 @@ module GraphQL
                   visible_interface_implementation?(ancestor, context, warden) &&
                   (f_entry = ancestor.own_fields[field_name]) &&
                   (skip_visible || (f_entry = Warden.visible_entry?(:visible_field?, f_entry, context, warden)))
-                return f_entry
+                return f_entry.ensure_loaded
               end
               i += 1
             end
@@ -161,7 +161,7 @@ module GraphQL
                   # Choose the most local definition that passes `.visible?` --
                   # stop checking for fields by name once one has been found.
                   if !visible_fields.key?(field_name) && (f = Warden.visible_entry?(:visible_field?, fields_entry, context, warden))
-                    visible_fields[field_name] = f
+                    visible_fields[field_name] = f.ensure_loaded
                   end
                 end
               end

--- a/lib/graphql/schema/member/has_fields.rb
+++ b/lib/graphql/schema/member/has_fields.rb
@@ -104,7 +104,7 @@ module GraphQL
               if ancestor.respond_to?(:own_fields) &&
                   (f_entry = ancestor.own_fields[field_name]) &&
                   (skip_visible || (f_entry = Warden.visible_entry?(:visible_field?, f_entry, context, warden)))
-                return f_entry.ensure_loaded
+                return f_entry
               end
             end
             nil
@@ -142,7 +142,7 @@ module GraphQL
                   visible_interface_implementation?(ancestor, context, warden) &&
                   (f_entry = ancestor.own_fields[field_name]) &&
                   (skip_visible || (f_entry = Warden.visible_entry?(:visible_field?, f_entry, context, warden)))
-                return f_entry.ensure_loaded
+                return (skip_visible ? f_entry : f_entry.ensure_loaded)
               end
               i += 1
             end

--- a/lib/graphql/schema/subset.rb
+++ b/lib/graphql/schema/subset.rb
@@ -213,13 +213,11 @@ module GraphQL
               end
             end
           end
-          visible_f
+          visible_f.ensure_loaded
+        elsif f && @cached_visible_fields[owner][f]
+          f.ensure_loaded
         else
-          if f && @cached_visible_fields[owner][f]
-            f
-          else
-            nil
-          end
+          nil
         end
       end
 

--- a/lib/graphql/schema/subset.rb
+++ b/lib/graphql/schema/subset.rb
@@ -214,8 +214,8 @@ module GraphQL
             end
           end
           visible_f.ensure_loaded
-        elsif f && @cached_visible_fields[owner][f]
-          f.ensure_loaded
+        elsif f && @cached_visible_fields[owner][f.ensure_loaded]
+          f
         else
           nil
         end

--- a/lib/graphql/schema/subset.rb
+++ b/lib/graphql/schema/subset.rb
@@ -129,7 +129,7 @@ module GraphQL
         end.compare_by_identity
 
         @cached_fields = Hash.new do |h, owner|
-          h[owner] = non_duplicate_items(owner.all_field_definitions, @cached_visible_fields[owner])
+          h[owner] = non_duplicate_items(owner.all_field_definitions.each(&:ensure_loaded), @cached_visible_fields[owner])
         end.compare_by_identity
 
         @cached_arguments = Hash.new do |h, owner|
@@ -446,6 +446,7 @@ module GraphQL
           # recurse into visible fields
           t_f = type.all_field_definitions
           t_f.each do |field|
+            field.ensure_loaded
             if @cached_visible[field]
               visit_directives(field)
               field_type = field.type.unwrap

--- a/lib/graphql/schema/types_migration.rb
+++ b/lib/graphql/schema/types_migration.rb
@@ -165,6 +165,8 @@ module GraphQL
             equivalent_schema_members?(inner_member1, inner_member2)
           end
         when GraphQL::Schema::Field
+          member1.ensure_loaded
+          member2.ensure_loaded
           if member1.introspection? && member2.introspection?
             member1.inspect == member2.inspect
           else

--- a/spec/fixtures/cop/.rubocop.yml
+++ b/spec/fixtures/cop/.rubocop.yml
@@ -13,3 +13,6 @@ GraphQL/DefaultRequiredTrue:
 
 GraphQL/FieldTypeInBlock:
   Enabled: true
+  Include:
+    - field_type.rb
+    - field_type_autocorrect.rb

--- a/spec/fixtures/cop/.rubocop.yml
+++ b/spec/fixtures/cop/.rubocop.yml
@@ -10,3 +10,6 @@ GraphQL/DefaultNullTrue:
 
 GraphQL/DefaultRequiredTrue:
   Enabled: true
+
+GraphQL/FieldTypeInBlock:
+  Enabled: true

--- a/spec/fixtures/cop/field_type.rb
+++ b/spec/fixtures/cop/field_type.rb
@@ -1,0 +1,18 @@
+class Types::Query
+  field :current_account, Types::Account, null: false, description: "The account of the current viewer"
+
+  field :find_account, Types::Account do
+    argument :id, ID
+  end
+
+  # Don't modify these:
+  field :current_time, String, description: "The current time in the viewer's timezone"
+  field :current_time, Integer, description: "The current time in the viewer's timezone"
+  field :current_time, Int, description: "The current time in the viewer's timezone"
+  field :current_time, Float, description: "The current time in the viewer's timezone"
+  field :current_time, Boolean, description: "The current time in the viewer's timezone"
+
+  field(:all_accounts, [Types::Account, null: false]) {
+    argument :active, Boolean, default_value: false
+  }
+end

--- a/spec/fixtures/cop/field_type_corrected.rb
+++ b/spec/fixtures/cop/field_type_corrected.rb
@@ -1,0 +1,22 @@
+class Types::Query
+  field :current_account, null: false, description: "The account of the current viewer" do
+    type Types::Account
+  end
+
+  field :find_account do
+    type Types::Account
+    argument :id, ID
+  end
+
+  # Don't modify these:
+  field :current_time, String, description: "The current time in the viewer's timezone"
+  field :current_time, Integer, description: "The current time in the viewer's timezone"
+  field :current_time, Int, description: "The current time in the viewer's timezone"
+  field :current_time, Float, description: "The current time in the viewer's timezone"
+  field :current_time, Boolean, description: "The current time in the viewer's timezone"
+
+  field(:all_accounts) {
+    type [Types::Account, null: false]
+    argument :active, Boolean, default_value: false
+  }
+end

--- a/spec/graphql/cop/field_type_in_block_spec.rb
+++ b/spec/graphql/cop/field_type_in_block_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe "GraphQL::Cop::FieldTypeInBlock" do
+  include RubocopTestHelpers
+
+  it "finds and autocorrects `null: true` field configurations" do
+    result = run_rubocop_on("spec/fixtures/cop/field_type.rb")
+    assert_equal 3, rubocop_errors(result)
+
+    assert_includes result, <<-RUBY
+  field :current_account, Types::Account, null: false, description: "The account of the current viewer"
+                          ^^^^^^^^^^^^^^
+    RUBY
+
+    assert_includes result, <<-RUBY
+  field :find_account, Types::Account do
+                       ^^^^^^^^^^^^^^
+    RUBY
+
+    assert_includes result, <<-RUBY
+  field(:all_accounts, [Types::Account, null: false]) {
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    RUBY
+
+    assert_rubocop_autocorrects_all("spec/fixtures/cop/field_type.rb")
+  end
+end

--- a/spec/graphql/cop/field_type_in_block_spec.rb
+++ b/spec/graphql/cop/field_type_in_block_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 describe "GraphQL::Cop::FieldTypeInBlock" do
   include RubocopTestHelpers
 
-  it "finds and autocorrects `null: true` field configurations" do
+  it "finds and autocorrects field corrections with inline types" do
     result = run_rubocop_on("spec/fixtures/cop/field_type.rb")
     assert_equal 3, rubocop_errors(result)
 

--- a/spec/graphql/schema/directive/one_of_spec.rb
+++ b/spec/graphql/schema/directive/one_of_spec.rb
@@ -16,7 +16,7 @@ describe GraphQL::Schema::Directive::OneOf do
 
         field :one_of_field, output_type, null: false do
           argument :one_of_arg, this.one_of_input_object
-        end
+        end.ensure_loaded
 
         def one_of_field(one_of_arg:)
           one_of_arg

--- a/spec/graphql/schema/field_spec.rb
+++ b/spec/graphql/schema/field_spec.rb
@@ -32,7 +32,7 @@ describe GraphQL::Schema::Field do
 
       underscored_field = GraphQL::Schema::Field.from_options(:underscored_field, String, null: false, camelize: false, owner: nil) do
         argument :underscored_arg, String, camelize: false
-      end
+      end.ensure_loaded
 
       arg_name, arg_defn = underscored_field.arguments.first
       assert_equal 'underscored_arg', arg_name
@@ -345,7 +345,7 @@ describe GraphQL::Schema::Field do
 
             field :complexityTest, String do
               complexity 'One hundred and eighty'
-            end
+            end.ensure_loaded
           end
         end
 
@@ -359,7 +359,7 @@ describe GraphQL::Schema::Field do
 
             field :complexityTest, String do
               complexity ->(one, two) { 52 }
-            end
+            end.ensure_loaded
           end
         end
 
@@ -726,6 +726,7 @@ This is probably a bug in GraphQL-Ruby, please report this error on GitHub: http
     field = GraphQL::Schema::Field.new(name: "blah", owner: nil, resolver_class: resolver, extras: [:blah]) do
       argument :a, GraphQL::Types::Int
     end
+    field.ensure_loaded
 
     assert_equal "description 1", field.description
     assert_equal "[Float!]", field.type.to_type_signature

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -410,7 +410,10 @@ module Dummy
       result
     end
 
-    field :all_edible, [Edible, null: true]
+    field :all_edible do
+      type [Edible, null: true]
+    end
+
     def all_edible
       CHEESES.values + MILKS.values
     end
@@ -474,7 +477,10 @@ module Dummy
       )
     end
 
-    field :deep_non_null, DeepNonNull, null: false
+    field :deep_non_null, null: false do
+      type(DeepNonNull)
+    end
+
     def deep_non_null; :deep_non_null; end
 
     field :huge_integer, Integer


### PR DESCRIPTION
This way, in theory, loading `my_object.rb` doesn't _necessary_ load the field return types of these fields. (Rails won't try to load files until the constants are actually referenced, and in this case, it can be deferred until execution.)

cc @gmcgibbon  -- would this approach work in your type-checking setup? Like this:

```ruby 
field :thing do 
  type Types::Thing 
end 

# or 
field :thing { type(Types::Thing) } 

# or, we could add sugar, 
# where the block's return value is used as the field's return type 
# if no return type was already configured: 
# ~~field :thing { Types::Thing } ~~
# Nevermind, that's not valid ruby :'( You could do it with params: 
field(:thing) { Types::Thing } # <- not implemented yet
```

I think that would give you plain Ruby constants in the source. 

The downside is the need to call `ensure_loaded` everywhere. It's too bad and reminds me of how GraphQL-Ruby used to be full of `ensure_defined`, yuck 😩 . But, I think it's the right thing, and thanks to caching by the schema / Warden / Subset, calls to that method were surprisingly manageable. 

`ensure_loaded` could even be _helpful_. For example, lots of `field.rb` checks to see if `@resolver` has a return type, arguments, etc, and uses those if they're given. But those checks could be done eagerly in `ensure_loaded`, and maybe even a `freeze` call to avoid surprises if the field is modified after `ensure_loaded` has run.

Part of #5014


TODO: 

- [x] Write up an integration test or something to make sure that this actually _delivers_ the expected Rails behavior
- [x] Write a Rubocop rule to migrate these automatically (excluding built-in scalars)
- [x] Update `Field#type(t)` to updated `connection?` as needed
- ~~Document support for this~~ I'm going to wait and document the whole thing when it's ready