### PR TITLE
Return ordered result hashes

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -207,7 +207,7 @@ module GraphQL
             finished_jobs = 0
             enqueued_jobs = gathered_selections.size
             gathered_selections.each do |result_name, field_ast_nodes_or_ast_node|
-
+              selections_result.set_placeholder(result_name)
               # Field resolution may pause the fiber,
               # so it wouldn't get to the `Resolve` call that happens below.
               # So instead trigger a run from this outer context.

--- a/lib/graphql/execution/interpreter/runtime/graphql_result.rb
+++ b/lib/graphql/execution/interpreter/runtime/graphql_result.rb
@@ -78,6 +78,19 @@ module GraphQL
             value
           end
 
+
+          # @api private
+          PLACEHOLDER = Object.new
+
+          def set_placeholder(key)
+            @graphql_result_data[key] = PLACEHOLDER
+            @graphql_metadata && @graphql_metadata[key] = PLACEHOLDER
+            if (t = @graphql_merged_into)
+              t.set_placeholder(key)
+            end
+            nil
+          end
+
           def delete(key)
             @graphql_metadata && @graphql_metadata.delete(key)
             @graphql_result_data.delete(key)

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -537,7 +537,7 @@ describe GraphQL::Dataloader do
               ]
             }
           }
-          assert_equal expected_data, res
+          assert_graphql_equal expected_data, res
           assert_equal [[:mget, ["5", "6"]], [:mget, ["2", "3"]]], database_log
         end
 
@@ -549,7 +549,7 @@ describe GraphQL::Dataloader do
             }
           GRAPHQL
 
-          assert_equal({ "first" => "first", "second" => "second" }, res["data"])
+          assert_graphql_equal({ "first" => "first", "second" => "second" }, res["data"])
           assert_equal ["begin first", "end first", "begin second", "end second"], res.context[:mutation_log]
         end
 
@@ -561,7 +561,7 @@ describe GraphQL::Dataloader do
             }
           GRAPHQL
 
-          assert_equal({"setCache" => "Salad", "getCache" => "1"}, res["data"])
+          assert_graphql_equal({"setCache" => "Salad", "getCache" => "1"}, res["data"])
         end
 
         it "batch-loads" do
@@ -577,6 +577,7 @@ describe GraphQL::Dataloader do
             ri1: recipeIngredient(recipe: { id: 6, ingredientNumber: 3 }) {
               name
             }
+            __typename
           }
           GRAPHQL
 
@@ -594,8 +595,10 @@ describe GraphQL::Dataloader do
             "ri1" => {
               "name" => "Cheese",
             },
+            "__typename" => "Query",
           }
-          assert_equal(expected_data, res["data"])
+
+          assert_graphql_equal(expected_data, res["data"])
 
           expected_log = [
             [:mget, [
@@ -626,7 +629,7 @@ describe GraphQL::Dataloader do
             {"data"=>{"i2"=>{"name"=>"Corn"}, "r1"=>{"ingredients"=>[{"name"=>"Wheat"}, {"name"=>"Corn"}, {"name"=>"Butter"}, {"name"=>"Baking Soda"}]}}},
             {"data"=>{"i1"=>{"name"=>"Wheat"}, "ri1"=>{"name"=>"Corn"}}},
           ]
-          assert_equal expected_result, result
+          assert_graphql_equal expected_result, result
           expected_log = [
             [:mget, ["1", "2", "5"]],
             [:mget, ["3", "4"]],
@@ -643,7 +646,7 @@ describe GraphQL::Dataloader do
           GRAPHQL
 
           expected_data = { "i1" => { "name" => "Wheat" }, "i2" => { "name" => "Corn" } }
-          assert_equal expected_data, res["data"]
+          assert_graphql_equal expected_data, res["data"]
           assert_equal [[:mget, ["1", "2"]]], database_log
         end
 
@@ -709,7 +712,7 @@ describe GraphQL::Dataloader do
               "name" => "Wheat",
             }
           }
-          assert_equal expected_data, res["data"]
+          assert_graphql_equal expected_data, res["data"]
         end
 
         it "Works when the parent field didn't yield" do
@@ -739,7 +742,7 @@ describe GraphQL::Dataloader do
               ]},
             ]
           }
-          assert_equal expected_data, res["data"]
+          assert_graphql_equal expected_data, res["data"]
 
           expected_log = [
             [:mget, ["5", "6"]],
@@ -764,7 +767,7 @@ describe GraphQL::Dataloader do
               {"name"=>"Butter"},
             ]
           }
-          assert_equal expected_data, res["data"]
+          assert_graphql_equal expected_data, res["data"]
 
           expected_log = [
             [:mget, ["5", "6"]],
@@ -790,7 +793,7 @@ describe GraphQL::Dataloader do
               "name" => "Wheat",
             }
           }
-          assert_equal expected_data, res["data"]
+          assert_graphql_equal expected_data, res["data"]
         end
 
         it "Works with analyzing arguments with `loads:`, even with .request" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,24 @@ require "minitest/focus"
 require "minitest/reporters"
 require "graphql/batch"
 
+module Minitest
+  module Assertions
+    def assert_graphql_equal(data1, data2, message = "GraphQL Result was equal")
+      case data1
+      when Hash
+        assert_equal(data1, data2, message)
+        assert_equal(data1.keys, data2.keys, "Order of keys matched (#{message})")
+      when Array
+        data1.each_with_index do |item1, idx|
+          assert_graphql_equal(item1, data2[idx], message + "[Item #{idx + 1}] ")
+        end
+      else
+        raise ArgumentError, "assert_graphql_equal doesn't support #{data1.class} yet"
+      end
+    end
+  end
+end
+
 running_in_rubymine = ENV["RM_INFO"]
 unless running_in_rubymine
   Minitest::Reporters.use! Minitest::Reporters::DefaultReporter.new(color: true)


### PR DESCRIPTION
Fixes #5011 

The spec says that JSON key-value pairs should come back in the same order that they were requested in the query. I need an implementation that complies with the spec and adds as little overhead as possible (memory and runtime). Possibly, if it adds noticeable overhead, make it opt-in, since this is critical performance code

I need to somehow maintain the sequence of this result even when Dataloader or GraphQL-Batch write to it out of order (see #4252). 

I think the `selections_by_name` hash(es) have the correct order of keys here: https://github.com/rmosolgo/graphql-ruby/blob/d9bd9cf9ac6f01a9aa36c30a025bfa922eda4f46/lib/graphql/execution/interpreter/runtime.rb#L120-L192

I can't find any way to _re-order_ a Ruby Hash. So if I'm going to use a Hash, need to write the keys in the right order the _first_ time. (Technically, you can move a key to the back by doing `h[k] = h.delete(k)`, but I don't think that's a promising approach.) 

Another approach might be to use an Array to hold values and then build a Hash from there. For example, an array of `[k1, v1, k2, v2, ...]` could be used. One problem here is that it will require a second pass through the whole data structure. GraphQL-Ruby used to do this, but it was slow. I'd like to not make it do that again. 

Maybe I could mitigate the downside of the second iteration by implementing `Result#to_json` to return a properly-ordered string. This would work out-of-the-box with Rails... but I know a lot of JSON serializers are really optimized. Could GraphQL-Ruby deliver good performance in that case? (And if I take that approach, I should implement `.to_ordered_h` and test it against `.to_ordered_h.to_json` with an optimized JSON serializer.) 

`graphql-js` handles this by writing promises into the result hash. This is also how GraphQL-Ruby happens to handle `GraphQL::Execution::Lazy` instances (eg, GraphQL-Batch). Perhaps a similar approach can be made to work with Dataloader. But the challenge is cleaning up those placeholders. A `Promise` has its own `catch` block to do that, but Dataloader doesn't have that... (yet?) 