### PR TITLE
Reduce object allocation in resolve_each_at_depth

### DIFF
--- a/lib/graphql/execution/interpreter/resolve.rb
+++ b/lib/graphql/execution/interpreter/resolve.rb
@@ -12,12 +12,16 @@ module GraphQL
         end
 
         def self.resolve_each_depth(lazies_at_depth, dataloader)
-          depths = lazies_at_depth.keys
-          depths.sort!
-          next_depth = depths.first
-          if next_depth
-            lazies = lazies_at_depth[next_depth]
-            lazies_at_depth.delete(next_depth)
+          smallest_depth = nil
+          lazies_at_depth.each_key do |depth_key|
+            smallest_depth ||= depth_key
+            if depth_key < smallest_depth
+              smallest_depth = depth_key
+            end
+          end
+
+          if smallest_depth
+            lazies = lazies_at_depth.delete(smallest_depth)
             if lazies.any?
               dataloader.append_job {
                 lazies.each(&:value) # resolve these Lazy instances


### PR DESCRIPTION
I noticed this while working on something else 

__TODO__: 

- [ ] Run a benchmark to see if this actually makes a difference