### PR TITLE
Allow `validate_timeout` to be cleared/reset after being set

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -750,13 +750,11 @@ module GraphQL
 
       attr_writer :validate_timeout
 
-      def validate_timeout(new_validate_timeout = nil)
-        if new_validate_timeout
-          @validate_timeout = new_validate_timeout
-        elsif defined?(@validate_timeout)
-          @validate_timeout
+      def validate_timeout(new_validate_timeout = NOT_CONFIGURED)
+        if NOT_CONFIGURED.equal?(new_validate_timeout)
+          defined?(@validate_timeout) ? @validate_timeout : find_inherited_value(:validate_timeout)
         else
-          find_inherited_value(:validate_timeout)
+          @validate_timeout = new_validate_timeout
         end
       end
 


### PR DESCRIPTION
## Objective

Allow for `validate_timeout` to be cleared such that the timeout behaviour is removed by setting a `nil` value. Technically `0` does work already.

## Problem

`nil` is the default value so we cannot distinguish between a get and set.

## Proposal

Use existing `NOT_CONFIGURED` sentinel value as the default argument value. 

## Outcome

A schema can have a default `validate_timeout` but can be overridden to be removed.