### PR TITLE
Allow `validate_max_errors` to be cleared/reset after being set

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -787,13 +787,11 @@ module GraphQL
 
       attr_writer :validate_max_errors
 
-      def validate_max_errors(new_validate_max_errors = nil)
-        if new_validate_max_errors
-          @validate_max_errors = new_validate_max_errors
-        elsif defined?(@validate_max_errors)
-          @validate_max_errors
+      def validate_max_errors(new_validate_max_errors = NOT_CONFIGURED)
+        if NOT_CONFIGURED.equal?(new_validate_max_errors)
+          defined?(@validate_max_errors) ? @validate_max_errors : find_inherited_value(:validate_max_errors)
         else
-          find_inherited_value(:validate_max_errors)
+          @validate_max_errors = new_validate_max_errors
         end
       end
 


### PR DESCRIPTION
## Objective

Allow for `validate_max_errors` to be cleared such that the bounding behaviour is removed by setting a `nil` value.

## Problem

`nil` is the default value so we cannot distinguish between a get and set.

## Proposal

Use existing `NOT_CONFIGURED` sentinel value as the default argument value. 

## Outcome

A schema can have a default `validate_max_errors` but can be overridden to be removed.