### PR TITLE
Expose parser `tokens_count`

### DIFF
--- a/graphql-c_parser/lib/graphql/c_parser.rb
+++ b/graphql-c_parser/lib/graphql/c_parser.rb
@@ -123,6 +123,11 @@ module GraphQL
         @result
       end
 
+      def tokens_count
+        result
+        @tokens.length
+      end
+
       attr_reader :tokens, :next_token_index, :query_string, :filename
     end
 

--- a/lib/graphql/language/lexer.rb
+++ b/lib/graphql/language/lexer.rb
@@ -19,7 +19,7 @@ module GraphQL
         @scanner.eos?
       end
 
-      attr_reader :pos
+      attr_reader :pos, :tokens_count
 
       def advance
         @scanner.skip(IGNORE_REGEXP)

--- a/lib/graphql/language/parser.rb
+++ b/lib/graphql/language/parser.rb
@@ -49,6 +49,11 @@ module GraphQL
         end
       end
 
+      def tokens_count
+        parse
+        @lexer.tokens_count
+      end
+
       def line_at(pos)
         line = lines_at.bsearch_index { |l| l >= pos }
         if line.nil?

--- a/spec/graphql/language/clexer_spec.rb
+++ b/spec/graphql/language/clexer_spec.rb
@@ -54,6 +54,13 @@ if defined?(GraphQL::CParser::Lexer)
       refute default_ast.definitions.first.name.frozen?
     end
 
+    it "exposes tokens_count" do
+      str = "type Query { f1: Int }"
+      parser = GraphQL::CParser::Parser.new(str, nil, GraphQL::Tracing::NullTrace, nil)
+
+      assert_equal 7, parser.tokens_count
+    end
+
     include LexerExamples
   end
 end

--- a/spec/graphql/language/parser_spec.rb
+++ b/spec/graphql/language/parser_spec.rb
@@ -506,6 +506,15 @@ GRAPHQL
     end
   end
 
+  describe "#tokens_count" do
+    it "counts parsed token" do
+      str = "type Query { f1: Int }"
+      parser = GraphQL::Language::Parser.new(str)
+
+      assert_equal 7, parser.tokens_count
+    end
+  end
+
   module ParserTrace
     TRACES = []
     def parse(query_string:)


### PR DESCRIPTION
## Objective

Ability to apply [`max_query_string_tokens`](https://graphql-ruby.org/api-doc/2.3.14/GraphQL/Schema#max_query_string_tokens-class_method) setting without breaking any existing operations.

## Problem

We don't know the current distribution of the size of the tokens in existing operations.

## Proposal

Expose `tokens_count` on `Parser#tokens_count`. Trigger parsing if not already done.

## Outcome

To gather data, temporarily swap from the convenient `GraphQL.parse` to `GraphQL::Language::Parser.new` (or similar)