### PR TITLE
Use symbols for namespaced_types generator option

### DIFF
--- a/lib/generators/graphql/orm_mutations_base.rb
+++ b/lib/generators/graphql/orm_mutations_base.rb
@@ -18,7 +18,7 @@ module Graphql
       class_option :orm, banner: "NAME", type: :string, required: true,
                          desc: "ORM to generate the controller for"
 
-      class_option 'namespaced_types',
+      class_option :namespaced_types,
         type: :boolean,
         required: false,
         default: false,

--- a/lib/generators/graphql/type_generator.rb
+++ b/lib/generators/graphql/type_generator.rb
@@ -11,7 +11,7 @@ module Graphql
     class TypeGeneratorBase < Rails::Generators::NamedBase
       include Core
 
-      class_option 'namespaced_types',
+      class_option :namespaced_types,
         type: :boolean,
         required: false,
         default: false,


### PR DESCRIPTION
this will allow the following to work:

    Rails.application.config.generators do |g|
      g.graphql namespaced_types: true

right now, the config needed is a bit quirky:

    Rails.application.config.generators do |g|
      g.graphql "namespaced_types" => true
