### PR TITLE
Call super in NotificationsTrace

### DIFF
--- a/lib/graphql/tracing/notifications_trace.rb
+++ b/lib/graphql/tracing/notifications_trace.rb
@@ -33,8 +33,8 @@ module GraphQL
         "resolve_type_lazy" => "resolve_type.graphql",
       }.each do |trace_method, platform_key|
         module_eval <<-RUBY, __FILE__, __LINE__
-          def #{trace_method}(**metadata, &blk)
-            @notifications_engine.instrument("#{platform_key}", metadata, &blk)
+          def #{trace_method}(**metadata, &block)
+            @notifications_engine.instrument("#{platform_key}", metadata) { super(**metadata, &block) }
           end
         RUBY
       end

--- a/spec/graphql/tracing/notifications_trace_spec.rb
+++ b/spec/graphql/tracing/notifications_trace_spec.rb
@@ -12,17 +12,40 @@ describe GraphQL::Tracing::NotificationsTrace do
       end
     end
 
+    class DummyEngine
+      def self.dispatched_events
+        @dispatched_events ||= []
+      end
+
+      def self.instrument(event, payload)
+        dispatched_events << [event, payload]
+        yield if block_given?
+      end
+    end
+
+    module OtherTrace
+      def execute_query(query:)
+        query.context[:other_trace_ran] = true
+        super
+      end
+    end
+
     class Schema < GraphQL::Schema
       query Query
+      trace_with OtherTrace
+      trace_with GraphQL::Tracing::NotificationsTrace, engine: DummyEngine
     end
   end
 
+  before do
+    NotificationsTraceTest::DummyEngine.dispatched_events.clear
+  end
+
+
   describe "Observing" do
     it "dispatches the event to the notifications engine with suffixed key" do
-      dispatched_events = trigger_fake_notifications_tracer(NotificationsTraceTest::Schema).to_h
-
-      assert dispatched_events.length > 0
-
+      NotificationsTraceTest::Schema.execute "query X { int }"
+      dispatched_events = NotificationsTraceTest::DummyEngine.dispatched_events.to_h
       expected_event_keys = [
         'execute_multiplex.graphql',
         'analyze_multiplex.graphql',
@@ -43,20 +66,10 @@ describe GraphQL::Tracing::NotificationsTrace do
         assert payload.is_a?(Hash)
       end
     end
-  end
 
-  def trigger_fake_notifications_tracer(schema)
-    dispatched_events = []
-    engine = Object.new
-
-    engine.define_singleton_method(:instrument) do |event, payload, &blk|
-      dispatched_events << [event, payload]
-      blk.call if blk
+    it "works with other tracers" do
+      res = NotificationsTraceTest::Schema.execute "query X { int }"
+      assert res.context[:other_trace_ran]
     end
-
-    schema.trace_with GraphQL::Tracing::NotificationsTrace, engine: engine
-    schema.execute "query X { int }"
-
-    dispatched_events
   end
 end


### PR DESCRIPTION
Fixes #5044 

Oops, this was not migrated to correctly call `super`. It still called GraphQL code without any problem (from `blk.call`), but it didn't interact properly with other trace modules.