### PR TITLE
Handle GraphQL::ExecutionError from loading objects during analysis

### DIFF
--- a/lib/graphql/analysis.rb
+++ b/lib/graphql/analysis.rb
@@ -81,7 +81,7 @@ module GraphQL
       end
     rescue Timeout::Error
       [GraphQL::AnalysisError.new("Timeout on validation of query")]
-    rescue GraphQL::UnauthorizedError
+    rescue GraphQL::UnauthorizedError, GraphQL::ExecutionError
       # This error was raised during analysis and will be returned the client before execution
       []
     end

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -490,7 +490,7 @@ module GraphQL
             if arguments[:last] && (max_possible_page_size.nil? || arguments[:last] > max_possible_page_size)
               max_possible_page_size = arguments[:last]
             end
-          elsif arguments.is_a?(GraphQL::UnauthorizedError)
+          elsif arguments.is_a?(GraphQL::ExecutionError) || arguments.is_a?(GraphQL::UnauthorizedError)
             raise arguments
           end
 

--- a/spec/graphql/analysis/max_query_complexity_spec.rb
+++ b/spec/graphql/analysis/max_query_complexity_spec.rb
@@ -190,7 +190,11 @@ describe GraphQL::Analysis::MaxQueryComplexity do
       end
 
       def self.object_from_id(id, ctx)
-        { name: "Loaded thing #{id}" }
+        if id == "13"
+          raise GraphQL::ExecutionError, "No Thing ##{id}"
+        else
+          { name: "Loaded thing #{id}" }
+        end
       end
 
       def self.unauthorized_object(err)
@@ -208,6 +212,12 @@ describe GraphQL::Analysis::MaxQueryComplexity do
 
       res2 = AuthorizedTypeSchema.execute(query_str)
       assert_equal ["Unauthorized Object: \"Loaded thing 123\""], res2["errors"].map { |e| e["message"] }
+    end
+
+    it "returns the right error when the loaded object raises an error" do
+      query_str = "{ things(thingId: \"13\", first: 1) { nodes { name } } }"
+      res = AuthorizedTypeSchema.execute(query_str, context: { authorized: true })
+      assert_equal ["No Thing #13"], res["errors"].map { |e| e["message"] }
     end
   end
 end


### PR DESCRIPTION
Fixes #5036 