### PR TITLE
Allow variable definition directives in validation

### DIFF
--- a/lib/graphql/static_validation/rules/directives_are_in_valid_locations.rb
+++ b/lib/graphql/static_validation/rules/directives_are_in_valid_locations.rb
@@ -19,6 +19,7 @@ module GraphQL
         GraphQL::Schema::Directive::FRAGMENT_DEFINITION => "fragment definitions",
         GraphQL::Schema::Directive::FRAGMENT_SPREAD =>     "fragment spreads",
         GraphQL::Schema::Directive::INLINE_FRAGMENT =>     "inline fragments",
+        GraphQL::Schema::Directive::VARIABLE_DEFINITION => "variable definitions",
       }
 
       SIMPLE_LOCATIONS = {
@@ -26,6 +27,7 @@ module GraphQL
         Nodes::InlineFragment =>      GraphQL::Schema::Directive::INLINE_FRAGMENT,
         Nodes::FragmentSpread =>      GraphQL::Schema::Directive::FRAGMENT_SPREAD,
         Nodes::FragmentDefinition =>  GraphQL::Schema::Directive::FRAGMENT_DEFINITION,
+        Nodes::VariableDefinition =>  GraphQL::Schema::Directive::VARIABLE_DEFINITION,
       }
 
       SIMPLE_LOCATION_NODES = SIMPLE_LOCATIONS.keys

--- a/spec/graphql/introspection/directive_type_spec.rb
+++ b/spec/graphql/introspection/directive_type_spec.rb
@@ -50,6 +50,15 @@ describe GraphQL::Introspection::DirectiveType do
             "onOperation" => false,
           },
           {
+            "name"=>"directiveForVariableDefinition",
+            "args"=>[],
+            "locations"=>["VARIABLE_DEFINITION"],
+            "isRepeatable"=>false,
+            "onField"=>false,
+            "onFragment"=>false,
+            "onOperation"=>false,
+          },
+          {
             "name"=>"doStuff",
             "args"=>[],
             "locations"=>[],

--- a/spec/graphql/static_validation/rules/directives_are_in_valid_locations_spec.rb
+++ b/spec/graphql/static_validation/rules/directives_are_in_valid_locations_spec.rb
@@ -3,39 +3,55 @@ require "spec_helper"
 
 describe GraphQL::StaticValidation::DirectivesAreInValidLocations do
   include StaticValidationHelpers
-  let(:query_string) {"
-    query getCheese @skip(if: true) {
-      okCheese: cheese(id: 1) {
-        id @skip(if: true),
-        source
-        ... on Cheese @skip(if: true) {
-          flavor
-          ... whatever
-        }
-      }
-    }
-
-    fragment whatever on Cheese @skip(if: true) {
-      id
-    }
-  "}
 
   describe "invalid directive locations" do
+    let(:query_string) {"
+      query getCheese @skip(if: true) {
+        okCheese: cheese(id: 1) {
+          id @skip(if: true),
+          source
+          ... on Cheese @skip(if: true) {
+            flavor
+            ... whatever
+          }
+        }
+      }
+  
+      fragment whatever on Cheese @skip(if: true) {
+        id
+      }
+    "}
+
     it "makes errors for them" do
       expected = [
         {
           "message"=> "'@skip' can't be applied to queries (allowed: fields, fragment spreads, inline fragments)",
-          "locations"=>[{"line"=>2, "column"=>21}],
+          "locations"=>[{"line"=>2, "column"=>23}],
           "path"=>["query getCheese"],
           "extensions"=>{"code"=>"directiveCannotBeApplied", "targetName"=>"queries", "name"=>"skip"}
         },
         {
           "message"=>"'@skip' can't be applied to fragment definitions (allowed: fields, fragment spreads, inline fragments)",
-          "locations"=>[{"line"=>13, "column"=>33}],
+          "locations"=>[{"line"=>13, "column"=>35}],
            "path"=>["fragment whatever"],
            "extensions"=>{"code"=>"directiveCannotBeApplied", "targetName"=>"fragment definitions", "name"=>"skip"}
         },
       ]
+      assert_equal(expected, errors)
+    end
+  end
+
+  describe "valid directive locations" do
+    let(:query_string) {"
+      query getCheese($id: Int! @directiveForVariableDefinition) {
+        cheese(id: $id) {
+          id
+        }
+      }
+    "}
+
+    it "does not make errors for them" do
+      expected = []
       assert_equal(expected, errors)
     end
   end

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -33,6 +33,9 @@ module Dummy
   class BaseScalar < GraphQL::Schema::Scalar
   end
 
+  class BaseDirective < GraphQL::Schema::Directive
+  end
+
   module LocalProduct
     include BaseInterface
     description "Something that comes from somewhere"
@@ -530,6 +533,10 @@ module Dummy
     end
   end
 
+  class DirectiveForVariableDefinition < BaseDirective
+    locations(VARIABLE_DEFINITION)
+  end
+
   class Subscription < BaseObject
     field :test, String
     def test; "Test"; end
@@ -542,6 +549,7 @@ module Dummy
     max_depth 5
     orphan_types Honey
     trace_with GraphQL::Tracing::CallLegacyTracers
+    directives(DirectiveForVariableDefinition)
 
     rescue_from(NoSuchDairyError) { |err| raise GraphQL::ExecutionError, err.message  }
 


### PR DESCRIPTION
Allow variable definition directives in the `DirectivesAreInValidLocations` static validation rule.

This also adds a test, but it feels a bit odd that it only tests the variable definition case and no others. I could remove the test, or add cases to cover more of the possible valid locations.