### PR TITLE
Use `attr_reader` where applicable

### DIFF
--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -409,9 +409,7 @@ module GraphQL
 
         private
 
-        def own_extensions
-          @own_extensions
-        end
+        attr_reader :own_extensions
       end
     end
   end

--- a/spec/graphql/analysis_spec.rb
+++ b/spec/graphql/analysis_spec.rb
@@ -523,9 +523,7 @@ describe GraphQL::Analysis do
           super
         end
 
-        def result
-          @result
-        end
+        attr_reader :result
       end
       class BaseField < GraphQL::Schema::Field
         def initialize(*args, visible: true, **kwargs, &block)

--- a/spec/graphql/tracing/statsd_trace_spec.rb
+++ b/spec/graphql/tracing/statsd_trace_spec.rb
@@ -9,9 +9,7 @@ describe GraphQL::Tracing::StatsdTracing do
         yield
       end
 
-      def timings
-        @timings
-      end
+      attr_reader :timings
 
       def clear
         @timings = []

--- a/spec/graphql/tracing/statsd_tracing_spec.rb
+++ b/spec/graphql/tracing/statsd_tracing_spec.rb
@@ -9,9 +9,7 @@ describe GraphQL::Tracing::StatsdTracing do
         yield
       end
 
-      def timings
-        @timings
-      end
+      attr_reader :timings
 
       def clear
         @timings = []


### PR DESCRIPTION
Just a small suggestion Rubocop found a while back.

Methods generated by `attr_reader` are technically ever-so-slightly faster than regular Ruby methods, though these aren't hot paths, so that doesn't matter much.