### PR TITLE
Docs: Mention SQIDs as an alternative to `to_pid_param`

### DIFF
--- a/guides/schema/object_identification.md
+++ b/guides/schema/object_identification.md
@@ -30,6 +30,8 @@ class MySchema < GraphQL::Schema
 end
 ```
 
+> [SQIDs](https://sqids.org/ruby) are an alternative to `to_gid_param` which generate shorter IDs. Here is a [detailed guide](https://blog.gripdev.xyz/2024/06/09/sqids-graphql-and-ruby/) of how they can be used.
+
 ## Node interface
 
 One requirement for Relay's object management is implementing the `"Node"` interface.


### PR DESCRIPTION
closes #5089 

Is this ok? I didn't want to pull too much content into the guide as it might confuse folks, went with little trail and a link to detailed guide.