### PR TITLE
Optimize escape_single_quoted_newlines

### DIFF
--- a/lib/graphql/language.rb
+++ b/lib/graphql/language.rb
@@ -49,19 +49,19 @@ module GraphQL
       inside_single_quoted_string = false
       new_query_str = nil
       while !scanner.eos?
-        if (match = scanner.scan(/(?:\\"|[^"\n\r]|""")+/m)) && new_query_str
-          new_query_str << match
-        elsif scanner.scan('"')
+        if scanner.skip(/(?:\\"|[^"\n\r]|""")+/m)
+          new_query_str && (new_query_str << scanner.matched)
+        elsif scanner.skip('"')
           new_query_str && (new_query_str << '"')
           inside_single_quoted_string = !inside_single_quoted_string
-        elsif scanner.scan("\n")
+        elsif scanner.skip("\n")
           if inside_single_quoted_string
             new_query_str ||= query_str[0, scanner.pos - 1]
             new_query_str << '\\n'
           else
             new_query_str && (new_query_str << "\n")
           end
-        elsif scanner.scan("\r")
+        elsif scanner.skip("\r")
           if inside_single_quoted_string
             new_query_str ||= query_str[0, scanner.pos - 1]
             new_query_str << '\\r'


### PR DESCRIPTION
Inspired by #5094 

This makes the function ~20% faster in my little benchmark and reduces memory usage by ~40% (and down to _one_ object in the no-op case) 🎉  

<details>
<summary>Benchmark</summary>

<p>

```ruby
require "bundler/inline"

gemfile do
  gem "graphql", path: "./"
  gem "benchmark-ips"
  gem "memory_profiler"
end

no_strings = %|
mutation($arg1: String, $arg2: String) {
  doStuff(with: $arg1) { some result { fields } }
  doOtherStuff(with: { something: $arg2 }) {
    some {
      result {
        fields
      }
    }
  }
}
|

strings_with_nl = %|
mutation($arg1: String = "something
invalid") {
  doStuff(with: $arg1) { some result { fields } }
  doOtherStuff(with: { something: "in
val
id" }) {
    some {
      result {
        fields
      }
    }
  }
}
|

strings_without_nl = %|
mutation($arg1: String = "something valid") {
  doStuff(with: $arg1) { some result { fields } }
  doOtherStuff(with: { something: "valid" }) {
    some {
      result {
        fields
      }
    }
  }
}
|

Benchmark.ips do |x|
  x.report("escaping with newline") { GraphQL::Language.escape_single_quoted_newlines(strings_with_nl) }
  x.report("escaping without newline") { GraphQL::Language.escape_single_quoted_newlines(strings_without_nl) }
  x.report("escaping without strings") { GraphQL::Language.escape_single_quoted_newlines(no_strings) }
end

puts "\n\n\n\n\n\n\n"

report = MemoryProfiler.report do
  GraphQL::Language.escape_single_quoted_newlines(strings_with_nl)
end

report.pretty_print

puts "\n\n\n\n\n\n\n"

report = MemoryProfiler.report do
  GraphQL::Language.escape_single_quoted_newlines(no_strings)
end

report.pretty_print

```

</p>
</details>

```diff 
  Calculating -------------------------------------
  escaping with newline
-                          63.700k (±10.2%) i/s -    314.545k in   5.011696s
+                          75.654k (± 2.4%) i/s -    381.576k in   5.046543s
  escaping without newline
-                         108.140k (± 6.1%) i/s -    547.800k in   5.087078s
+                         119.067k (± 3.6%) i/s -    603.228k in   5.073817s
  escaping without strings
-                         127.028k (± 3.8%) i/s -    645.650k in   5.090279s
+                         141.213k (± 2.7%) i/s -    707.100k in   5.011146s

  # Escaping newlines 
- Total allocated: 2023 bytes (37 objects)
+ Total allocated: 1197 bytes (17 objects)

  # No-op
- Total allocated: 1152 bytes (22 objects)
+ Total allocated: 176 bytes (1 objects)
```