### PR TITLE
Don't raise NoMethodError on InvalidNullError.inspect

### DIFF
--- a/lib/graphql/invalid_null_error.rb
+++ b/lib/graphql/invalid_null_error.rb
@@ -39,7 +39,7 @@ module GraphQL
       end
 
       def inspect
-        if (name.nil? || parent_class.name.nil?) && parent_class.respond_to?(:mutation) && (mutation = parent_class.mutation)
+        if (name.nil? || parent_class&.name.nil?) && parent_class.respond_to?(:mutation) && (mutation = parent_class.mutation)
           "#{mutation.inspect}::#{parent_class.graphql_name}::InvalidNullError"
         else
           super

--- a/spec/graphql/invalid_null_error_spec.rb
+++ b/spec/graphql/invalid_null_error_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe "GraphQL::InvalidNullError" do
+  it "can be inspected" do
+    assert_equal "GraphQL::InvalidNullError", GraphQL::InvalidNullError.inspect
+  end
+end


### PR DESCRIPTION
I was listing the modules in my app with `ObjectSpace.each_object(Module)` and it failed while inspecting this class.

I also wanted to test the behavior of using the parent class's mutation but I couldn't find a way.