### PR TITLE
fix logic that checks whether a request has a subscription header

### DIFF
--- a/javascript_client/src/subscriptions/AblyLink.ts
+++ b/javascript_client/src/subscriptions/AblyLink.ts
@@ -56,7 +56,7 @@ class AblyLink extends ApolloLink {
       forward(operation).subscribe({ next: (data) => {
         // If the operation has the subscription header, it's a subscription
         const subscriptionChannelConfig = this._getSubscriptionChannel(operation)
-        if (subscriptionChannelConfig) {
+        if (subscriptionChannelConfig.channel) {
           // This will keep pushing to `.next`
           this._createSubscription(subscriptionChannelConfig, observer)
         }


### PR DESCRIPTION
Hey, I'm a new Pro subscriber integrating Ably subscriptions.  It went well aside from this issue.

If you look further down in the code, `_getSubscriptionChannel` ALWAYS returns an object, regardless of whether the headers were passed:

```
  _getSubscriptionChannel(operation: Operation) {
    const response = operation.getContext().response
    // Check to see if the response has the header
    const subscriptionChannel = response.headers.get("X-Subscription-ID")
    // The server returns this header when encryption is enabled.
    const cipherKey = response.headers.get("X-Subscription-Key")
    return { channel: subscriptionChannel, key: cipherKey }
  }
```

So this logic check:

```
if (subscriptionChannelConfig) {
```

was always returning true.