### PR TITLE
Fix: Incorrect/incomplete error message

### DIFF
--- a/lib/graphql/language/lexer.rb
+++ b/lib/graphql/language/lexer.rb
@@ -72,6 +72,9 @@ module GraphQL
             # Check for a matched decimal:
             @scanner[1] ? :FLOAT : :INT
           else
+            # Attempt to find the part after the `-`
+            value = @scanner.scan(/-\s?[a-z0-9]*/i)
+            invalid_byte_for_number_error_message = "Expected type 'number', but it was malformed#{value.nil? ? "" : ": #{value.inspect}"}."
             raise_parse_error(invalid_byte_for_number_error_message)
           end
         when ByteFor::ELLIPSIS
@@ -114,15 +117,6 @@ module GraphQL
         else
           token_value
         end
-      end
-
-      def invalid_byte_for_number_error_message
-        match_data = @string.match(/\{\s*(\w+)\((\w+):\s*([^\)]+)\)\s*\}/)
-        field = match_data[1]
-        argument = match_data[2]
-        value = match_data[3]
-
-        "Argument '#{argument}' on Field '#{field}' has an invalid value (#{value}). Expected type 'number'."
       end
 
       ESCAPES = /\\["\\\/bfnrt]/

--- a/lib/graphql/language/lexer.rb
+++ b/lib/graphql/language/lexer.rb
@@ -72,7 +72,7 @@ module GraphQL
             # Check for a matched decimal:
             @scanner[1] ? :FLOAT : :INT
           else
-            raise_parse_error("Expected a number, but it was malformed (#{@string[@pos].inspect})")
+            raise_parse_error(invalid_byte_for_number_error_message)
           end
         when ByteFor::ELLIPSIS
           if @string.getbyte(@pos + 1) != 46 || @string.getbyte(@pos + 2) != 46
@@ -114,6 +114,15 @@ module GraphQL
         else
           token_value
         end
+      end
+
+      def invalid_byte_for_number_error_message
+        match_data = @string.match(/\{\s*(\w+)\((\w+):\s*([^\)]+)\)\s*\}/)
+        field = match_data[1]
+        argument = match_data[2]
+        value = match_data[3]
+
+        "Argument '#{argument}' on Field '#{field}' has an invalid value (#{value}). Expected type 'number'."
       end
 
       ESCAPES = /\\["\\\/bfnrt]/

--- a/spec/graphql/language/parser_spec.rb
+++ b/spec/graphql/language/parser_spec.rb
@@ -121,6 +121,58 @@ createRecord(data: {
     assert_equal expected_message, err.message
   end
 
+  it "handles invalid minus signs in variable default values" do
+    err = assert_raises GraphQL::ParseError do
+      GraphQL.parse("query($something: Int = -foo) { }")
+    end
+    # TODO: this currently raises a NoMethodError:
+    #   graphql-ruby/lib/graphql/language/lexer.rb:121:in `invalid_byte_for_number_error_message'
+    #   graphql-ruby/lib/graphql/language/lexer.rb:75:in `advance'
+    #   graphql-ruby/lib/graphql/language/parser.rb:97:in `advance_token'
+    #   graphql-ruby/lib/graphql/language/parser.rb:166:in `definition'
+    #   graphql-ruby/lib/graphql/language/parser.rb:108:in `document'
+    #   graphql-ruby/lib/graphql/language/parser.rb:45:in `block in parse'
+    #   graphql-ruby/lib/graphql/tracing/trace.rb:24:in `parse'
+    #   graphql-ruby/lib/graphql/language/parser.rb:44:in `parse'
+    #   graphql-ruby/lib/graphql/language/parser.rb:16:in `parse'
+    #   graphql-ruby/lib/graphql.rb:39:in `parse'
+    #   graphql-ruby/spec/graphql/language/parser_spec.rb:126:in `block (3 levels) in <top (required)>'
+    assert_equal "TODO: add expected error messages here", err.message
+  end
+
+  it "handles invalid minus signs in deeply nested input objects" do
+    err = assert_raises GraphQL::ParseError do
+      GraphQL.parse("{ doSomething(a: { b: { c: { d: -foo } } }) }")
+    end
+    # TODO: this currently removes `a:` from the error message:
+    # "Argument 'a' on Field 'doSomething' has an invalid value ({ b: { c: { d: -foo } } }). Expected type 'number'."
+    assert_equal "TODO: add expected error messages here", err.message
+  end
+
+  it "handles invalid minus signs in schema definitions" do
+    err = assert_raises GraphQL::ParseError do
+      GraphQL.parse("
+      type Query {
+        someField(a: Int = -foo): Int
+      }
+      ")
+    end
+
+    # TODO: this currently raises the same NoMethodError as the other test
+    assert_equal "TODO: add expected error messages here", err.message
+  end
+
+  it "handles invalid minus signs in list literals" do
+    err = assert_raises GraphQL::ParseError do
+      GraphQL.parse("{
+        a1: a(b: [1,2,3])
+        a2: a(b: [1, 2, -foo])
+      }")
+    end
+    # TODO: this currently raises the same NoMethodError as the other test
+    assert_equal "TODO: add expected error messages here", err.message
+  end
+
   it "allows operation names to match operation types" do
     doc = GraphQL.parse("query subscription { foo }")
     assert_equal "subscription", doc.definitions.first.name

--- a/spec/graphql/language/parser_spec.rb
+++ b/spec/graphql/language/parser_spec.rb
@@ -116,7 +116,7 @@ createRecord(data: {
     expected_message = if USING_C_PARSER
       "syntax error, unexpected invalid token (\"-\") at [1, 8]"
     else
-      "Argument 'b' on Field 'a' has an invalid value (-c). Expected type 'number'."
+      "Expected type 'number', but it was malformed: \"-c\"."
     end
     assert_equal expected_message, err.message
   end
@@ -125,28 +125,24 @@ createRecord(data: {
     err = assert_raises GraphQL::ParseError do
       GraphQL.parse("query($something: Int = -foo) { }")
     end
-    # TODO: this currently raises a NoMethodError:
-    #   graphql-ruby/lib/graphql/language/lexer.rb:121:in `invalid_byte_for_number_error_message'
-    #   graphql-ruby/lib/graphql/language/lexer.rb:75:in `advance'
-    #   graphql-ruby/lib/graphql/language/parser.rb:97:in `advance_token'
-    #   graphql-ruby/lib/graphql/language/parser.rb:166:in `definition'
-    #   graphql-ruby/lib/graphql/language/parser.rb:108:in `document'
-    #   graphql-ruby/lib/graphql/language/parser.rb:45:in `block in parse'
-    #   graphql-ruby/lib/graphql/tracing/trace.rb:24:in `parse'
-    #   graphql-ruby/lib/graphql/language/parser.rb:44:in `parse'
-    #   graphql-ruby/lib/graphql/language/parser.rb:16:in `parse'
-    #   graphql-ruby/lib/graphql.rb:39:in `parse'
-    #   graphql-ruby/spec/graphql/language/parser_spec.rb:126:in `block (3 levels) in <top (required)>'
-    assert_equal "TODO: add expected error messages here", err.message
+    expected_message = if USING_C_PARSER
+      "syntax error, unexpected invalid token (\"-\") at [1, 25]"
+    else
+      "Expected type 'number', but it was malformed: \"-foo\"."
+    end
+    assert_equal expected_message, err.message
   end
 
   it "handles invalid minus signs in deeply nested input objects" do
     err = assert_raises GraphQL::ParseError do
       GraphQL.parse("{ doSomething(a: { b: { c: { d: -foo } } }) }")
     end
-    # TODO: this currently removes `a:` from the error message:
-    # "Argument 'a' on Field 'doSomething' has an invalid value ({ b: { c: { d: -foo } } }). Expected type 'number'."
-    assert_equal "TODO: add expected error messages here", err.message
+    expected_message = if USING_C_PARSER
+      "syntax error, unexpected invalid token (\"-\") at [1, 33]"
+    else
+      "Expected type 'number', but it was malformed: \"-foo\"."
+    end
+    assert_equal expected_message, err.message
   end
 
   it "handles invalid minus signs in schema definitions" do
@@ -157,9 +153,12 @@ createRecord(data: {
       }
       ")
     end
-
-    # TODO: this currently raises the same NoMethodError as the other test
-    assert_equal "TODO: add expected error messages here", err.message
+    expected_message = if USING_C_PARSER
+      "syntax error, unexpected invalid token (\"-\") at [3, 28]"
+    else
+      "Expected type 'number', but it was malformed: \"-foo\"."
+    end
+    assert_equal expected_message, err.message
   end
 
   it "handles invalid minus signs in list literals" do
@@ -169,8 +168,12 @@ createRecord(data: {
         a2: a(b: [1, 2, -foo])
       }")
     end
-    # TODO: this currently raises the same NoMethodError as the other test
-    assert_equal "TODO: add expected error messages here", err.message
+    expected_message = if USING_C_PARSER
+      "syntax error, unexpected invalid token (\"-\") at [3, 25]"
+    else
+      "Expected type 'number', but it was malformed: \"-foo\"."
+    end
+    assert_equal expected_message, err.message
   end
 
   it "allows operation names to match operation types" do
@@ -244,7 +247,7 @@ createRecord(data: {
     expected_msg = if USING_C_PARSER
       "syntax error, unexpected invalid token (\"-\") at [1, 19]"
     else
-      "Argument 'argument' on Field 'field' has an invalid value (a-b). Expected type 'number'."
+      "Expected type 'number', but it was malformed: \"-b\"."
     end
 
     assert_equal expected_msg, err.message

--- a/spec/graphql/language/parser_spec.rb
+++ b/spec/graphql/language/parser_spec.rb
@@ -116,7 +116,7 @@ createRecord(data: {
     expected_message = if USING_C_PARSER
       "syntax error, unexpected invalid token (\"-\") at [1, 8]"
     else
-      "Expected a number, but it was malformed (\"-\")"
+      "Argument 'b' on Field 'a' has an invalid value (-c). Expected type 'number'."
     end
     assert_equal expected_message, err.message
   end
@@ -192,7 +192,7 @@ createRecord(data: {
     expected_msg = if USING_C_PARSER
       "syntax error, unexpected invalid token (\"-\") at [1, 19]"
     else
-      "Expected a number, but it was malformed (\"-\")"
+      "Argument 'argument' on Field 'field' has an invalid value (a-b). Expected type 'number'."
     end
 
     assert_equal expected_msg, err.message


### PR DESCRIPTION
**Fix issue #5101**

Actual error message:
> _Expected a number, but it was malformed ("-")_

Expected error message:
> _Argument 'arg' on Field 'hello' has an invalid value (-foo). Expected type 'MyEnum!'._