### PR TITLE
bug fix: extensions can register more extensions via apply method

### DIFF
--- a/spec/graphql/schema/field_extension_spec.rb
+++ b/spec/graphql/schema/field_extension_spec.rb
@@ -94,6 +94,18 @@ describe GraphQL::Schema::FieldExtension do
       end
     end
 
+    class AddNestedExtensionExtension < GraphQL::Schema::FieldExtension
+      def apply
+        field.extension(NestedExtension)
+      end
+
+      class NestedExtension < GraphQL::Schema::FieldExtension
+        def resolve(**_args)
+          1
+        end
+      end
+    end
+
     class BaseObject < GraphQL::Schema::Object
     end
 
@@ -154,6 +166,8 @@ describe GraphQL::Schema::FieldExtension do
       end
 
       field :object_class_test, [String], null: false, extensions: [ObjectClassExtension]
+
+      field :nested_extension, Integer, null: false, extensions: [AddNestedExtensionExtension]
     end
 
     class Schema < GraphQL::Schema
@@ -233,6 +247,13 @@ describe GraphQL::Schema::FieldExtension do
       # doubled then multiplied by 3 specified via option
       res = exec_query("{ multipleExtensions(input: 3) }")
       assert_equal 18, res["data"]["multipleExtensions"]
+    end
+  end
+
+  describe "nested extension in apply method" do
+    it "applies the nested extension" do
+      res = exec_query("{ nestedExtension }")
+      assert_equal 1, res["data"]["nestedExtension"]
     end
   end
 


### PR DESCRIPTION
https://github.com/rmosolgo/graphql-ruby/pull/5054 introduced a regression where an extension registered eagerly (using the kwarg) can no longer register another extension in its `apply` method. I fix the bug here by restoring the previous `@call_after_define` logic.