### PR TITLE
bug fix: respect options when using `trace_with` after `trace_class`.

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -162,6 +162,7 @@ module GraphQL
           # re-apply them here
           mods = trace_modules_for(:default)
           mods.each { |mod| new_class.include(mod) }
+          new_class.include(DefaultTraceClass)
           trace_mode(:default, new_class)
           backtrace_class = Class.new(new_class)
           backtrace_class.include(GraphQL::Backtrace::Trace)

--- a/spec/graphql/tracing/trace_modes_spec.rb
+++ b/spec/graphql/tracing/trace_modes_spec.rb
@@ -171,6 +171,22 @@ describe "Trace modes for schemas" do
       trace_with Module.new, mode: :special_with_base_class
     end
 
+    class TraceWithWithOptionsSchema < GraphQL::Schema
+      class CustomTrace < GraphQL::Tracing::Trace
+      end
+
+      module OptionsTrace
+        def initialize(configured_option:, **_rest)
+          @configured_option = configured_option
+          super
+        end
+      end
+
+      trace_class CustomTrace
+      trace_with OptionsTrace, configured_option: :foo
+    end
+
+
     it "uses the default trace class for default mode" do
       assert_equal CustomBaseTraceParentSchema::CustomTrace, CustomBaseTraceParentSchema.trace_class_for(:default)
       assert_equal CustomBaseTraceParentSchema::CustomTrace, CustomBaseTraceSubclassSchema.trace_class_for(:default).superclass
@@ -182,6 +198,10 @@ describe "Trace modes for schemas" do
     it "uses the default trace class for special modes" do
       assert_includes CustomBaseTraceSubclassSchema.trace_class_for(:special_with_base_class).ancestors, CustomBaseTraceParentSchema::CustomTrace
       assert_kind_of CustomBaseTraceParentSchema::CustomTrace, CustomBaseTraceSubclassSchema.new_trace(mode: :special_with_base_class)
+    end
+
+    it "custom options are retained when using `trace_with` when there is already default tracer configured with `trace_class`" do
+      assert_equal({configured_option: :foo}, TraceWithWithOptionsSchema.trace_options_for(:default))
     end
   end
 


### PR DESCRIPTION
https://github.com/rmosolgo/graphql-ruby/pull/5045 introduced a new behaviour to `add_trace_options_for` where it no longer merges options when trace class does not include `DefaultTraceClass`. While it did update `build_trace_mode` to include `DefaultTraceClass` in the trace classes, there is still `trace_class` method where it can register a new trace class in default mode without including `DefaultTraceClass`. So I fix the issue by ensuring `DefaultTraceClass` is included in the `new_class` in `trace_class`.