### PR TITLE
Warn when Warden isn't explicitly enabled

### DIFF
--- a/lib/graphql/schema/printer.rb
+++ b/lib/graphql/schema/printer.rb
@@ -58,6 +58,7 @@ module GraphQL
           end
         end
         schema = Class.new(GraphQL::Schema) {
+          use GraphQL::Schema::Visibility
           query(query_root)
           def self.visible?(member, _ctx)
             member.graphql_name != "Root"

--- a/lib/graphql/schema/visibility/migration.rb
+++ b/lib/graphql/schema/visibility/migration.rb
@@ -96,6 +96,7 @@ module GraphQL
             end
             warden_ctx = GraphQL::Query::Context.new(query: context.query, values: warden_ctx_vals)
             warden_ctx.warden = GraphQL::Schema::Warden.new(schema: warden_schema, context: warden_ctx)
+            warden_ctx.warden.skip_warning = true
             warden_ctx.types = @warden_types = warden_ctx.warden.visibility_profile
           end
         end

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -73,6 +73,9 @@ module GraphQL
           @visibility_profile = Warden::VisibilityProfile.new(self)
         end
 
+        # No-op, but for compatibility:
+        attr_writer :skip_warning
+
         # @api private
         module NullVisibilityProfile
           def self.new(context:, schema:)
@@ -493,22 +496,27 @@ module GraphQL
           end
 
           schema_s = schema.name ? "#{schema.name}'s" : ""
-          warn(ADD_WARDEN_WARNING % { schema: schema_s, member: member_s, member_type: member_type })
+          schema_name = schema.name ? "#{schema.name}" : "your schema"
+          warn(ADD_WARDEN_WARNING % { schema_s: schema_s, schema_name: schema_name, member: member_s, member_type: member_type })
           @skip_warning = true # only warn once per query
           false
         end
       end
 
       ADD_WARDEN_WARNING = <<~WARNING
-%{schema} "%{member}" %{member_type} returned `false` for `.visible?` but no Visibility system was added. Address this warning by adding:
+DEPRECATION: %{schema} "%{member}" %{member_type} returned `false` for `.visible?` but `GraphQL::Schema::Visibility` isn't configured yet.
 
-  use GraphQL::Schema::Visibility
+  Address this warning by adding:
 
-Alternatively, for legacy behavior, add:
+      use GraphQL::Schema::Visibility
 
-  use GraphQL::Schema::Warden # legacy visibility behavior
+  to the definition for %{schema_name}. (Future GraphQL-Ruby versions won't check `.visible?` methods by default.)
 
-For more information see: https://graphql-ruby.org/authorization/visibility.html
+  Alternatively, for legacy behavior, add:
+
+      use GraphQL::Schema::Warden # legacy visibility behavior
+
+  For more information see: https://graphql-ruby.org/authorization/visibility.html
       WARNING
 
       def reachable_type_set

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -504,7 +504,7 @@ module GraphQL
       end
 
       ADD_WARDEN_WARNING = <<~WARNING
-DEPRECATION: %{schema} "%{member}" %{member_type} returned `false` for `.visible?` but `GraphQL::Schema::Visibility` isn't configured yet.
+DEPRECATION: %{schema_s} "%{member}" %{member_type} returned `false` for `.visible?` but `GraphQL::Schema::Visibility` isn't configured yet.
 
   Address this warning by adding:
 

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -19,6 +19,10 @@ module GraphQL
         PassThruWarden
       end
 
+      def self.use(schema)
+        # no-op
+      end
+
       # @param visibility_method [Symbol] a Warden method to call for this entry
       # @param entry [Object, Array<Object>] One or more definitions for a given name in a GraphQL Schema
       # @param context [GraphQL::Query::Context]
@@ -198,7 +202,7 @@ module GraphQL
           @visible_and_reachable_type = @unions = @unfiltered_interfaces =
           @reachable_type_set = @visibility_profile =
             nil
-        @skip_warning = false # TODO make this true when `use`'d
+        @skip_warning = schema.plugins.any? { |(plugin, _opts)| plugin == GraphQL::Schema::Warden }
       end
 
       attr_writer :skip_warning
@@ -499,6 +503,10 @@ module GraphQL
           schema_name = schema.name ? "#{schema.name}" : "your schema"
           warn(ADD_WARDEN_WARNING % { schema_s: schema_s, schema_name: schema_name, member: member_s, member_type: member_type })
           @skip_warning = true # only warn once per query
+          # If there's no schema name, add the backtrace for additional context:
+          if schema_s == ""
+            puts caller.map { |l| "    #{l}"}
+          end
           false
         end
       end

--- a/spec/graphql/analysis_spec.rb
+++ b/spec/graphql/analysis_spec.rb
@@ -516,6 +516,7 @@ describe GraphQL::Analysis do
 
   describe "when there's a hidden field" do
     class HiddenAnalyzedFieldSchema < GraphQL::Schema
+      use GraphQL::Schema::Warden if ADD_WARDEN
       class DoNothingAnalyzer < GraphQL::Analysis::Analyzer
         def on_enter_field(node, parent, visitor)
           @result ||= []

--- a/spec/graphql/authorization_spec.rb
+++ b/spec/graphql/authorization_spec.rb
@@ -370,7 +370,7 @@ describe "GraphQL::Authorization" do
 
     class SchemaWithFieldHook < GraphQL::Schema
       query(Query)
-
+      use GraphQL::Schema::Warden if ADD_WARDEN
       lazy_resolve(Box, :value)
 
       def self.unauthorized_field(err)

--- a/spec/graphql/authorization_spec.rb
+++ b/spec/graphql/authorization_spec.rb
@@ -350,7 +350,7 @@ describe "GraphQL::Authorization" do
       query(Query)
       mutation(Mutation)
       directive(Nothing)
-
+      use GraphQL::Schema::Warden if ADD_WARDEN
       lazy_resolve(Box, :value)
 
       def self.unauthorized_object(err)

--- a/spec/graphql/introspection/entry_points_spec.rb
+++ b/spec/graphql/introspection/entry_points_spec.rb
@@ -33,6 +33,7 @@ describe GraphQL::Introspection::EntryPoints do
 
       Class.new(GraphQL::Schema) do
         query query_type
+        use GraphQL::Schema::Warden if ADD_WARDEN
       end
     end
 

--- a/spec/graphql/introspection/schema_type_spec.rb
+++ b/spec/graphql/introspection/schema_type_spec.rb
@@ -180,6 +180,7 @@ describe GraphQL::Introspection::SchemaType do
       end
 
       Class.new(GraphQL::Schema) do
+        use GraphQL::Schema::Visibility
         query query_type
         directives invisible_directive, visible_directive
       end

--- a/spec/graphql/introspection/schema_type_spec.rb
+++ b/spec/graphql/introspection/schema_type_spec.rb
@@ -119,6 +119,7 @@ describe GraphQL::Introspection::SchemaType do
       Class.new(GraphQL::Schema) do
         query query_type
         orphan_types invisible_orphan_type
+        use GraphQL::Schema::Warden if ADD_WARDEN
       end
     end
 

--- a/spec/graphql/language/document_from_schema_definition_spec.rb
+++ b/spec/graphql/language/document_from_schema_definition_spec.rb
@@ -374,6 +374,7 @@ type Query {
 
       let(:document) {
         doc_schema = Class.new(schema) do
+          use GraphQL::Schema::Visibility
           def self.visible?(m, _ctx)
             m.respond_to?(:graphql_name) && m.graphql_name != "Type"
           end

--- a/spec/graphql/schema/always_visible_spec.rb
+++ b/spec/graphql/schema/always_visible_spec.rb
@@ -18,6 +18,7 @@ describe GraphQL::Schema::AlwaysVisible do
 
   class NotAlwaysVisibleSchema < GraphQL::Schema
     query(AlwaysVisibleSchema::Query)
+    use GraphQL::Schema::Warden if ADD_WARDEN
   end
 
   it "Doesn't call visibility methods" do

--- a/spec/graphql/schema/argument_spec.rb
+++ b/spec/graphql/schema/argument_spec.rb
@@ -680,6 +680,7 @@ describe GraphQL::Schema::Argument do
 
   describe "multiple argument definitions with default values" do
     class MultipleArgumentDefaultValuesSchema < GraphQL::Schema
+      use GraphQL::Schema::Warden if ADD_WARDEN
       class BaseArgument < GraphQL::Schema::Argument
         def initialize(*args, use_if:, **kwargs, &block)
           @use_if = use_if

--- a/spec/graphql/schema/directive/flagged_spec.rb
+++ b/spec/graphql/schema/directive/flagged_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 
 describe GraphQL::Schema::Directive::Flagged do
   class FlaggedSchema < GraphQL::Schema
+    use GraphQL::Schema::Warden if ADD_WARDEN
     module Animal
       include GraphQL::Schema::Interface
       if GraphQL::Schema.use_visibility_profile?

--- a/spec/graphql/schema/dynamic_members_spec.rb
+++ b/spec/graphql/schema/dynamic_members_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 
 describe "Dynamic types, fields, arguments, and enum values" do
   class MultifieldSchema < GraphQL::Schema
+    use GraphQL::Schema::Warden if ADD_WARDEN
     module AppliesToFutureSchema
       def initialize(*args, future_schema: nil, **kwargs, &block)
         @future_schema = future_schema
@@ -829,6 +830,7 @@ GRAPHQL
 
   describe "A schema with every possible type having the same name" do
     class NameConflictSchema < GraphQL::Schema
+      use GraphQL::Schema::Warden if ADD_WARDEN
       module ConflictingThing
         def visible?(context)
           super && kind.name == context[:thing_kind]
@@ -1071,7 +1073,10 @@ GRAPHQL
         field(:f1, DuplicateNames::DuplicateNameObject1, null: false)
         field(:f2, DuplicateNames::DuplicateNameObject2, null: false)
       }
-      schema = Class.new(GraphQL::Schema) { query(query_type) }
+      schema = Class.new(GraphQL::Schema) {
+        query(query_type)
+        use GraphQL::Schema::Warden if ADD_WARDEN
+      }
       assert_equal "first definition", schema.types({ allowed_for: 1 })["DuplicateNameObject"].description
       assert_equal "second definition", schema.get_type("DuplicateNameObject", { allowed_for: 3 }).description
       assert_includes schema.to_definition(context: { allowed_for: 1 }), "first definition"
@@ -1115,7 +1120,10 @@ GRAPHQL
     it "raises when a given context would permit multiple enum values with the same name" do
       enum_type = DuplicateNames::DuplicateEnumValue
       query_type = Class.new(GraphQL::Schema::Object) { graphql_name("Query"); field(:f, enum_type, null: false) }
-      schema = Class.new(GraphQL::Schema) { query(query_type) }
+      schema = Class.new(GraphQL::Schema) {
+        query(query_type)
+        use GraphQL::Schema::Warden if ADD_WARDEN
+       }
 
       assert_equal "first definition", enum_type.values({ allowed_for: 1 })["ONE"].description
       assert_equal "second definition", enum_type.values({ allowed_for: 3 })["ONE"].description
@@ -1151,7 +1159,10 @@ GRAPHQL
     end
 
     it "raises when a given context would permit multiple argument definitions" do
-      schema = Class.new(GraphQL::Schema) { query(DuplicateNames::DuplicateArgumentObject) }
+      schema = Class.new(GraphQL::Schema) {
+        query(DuplicateNames::DuplicateArgumentObject)
+        use GraphQL::Schema::Warden if ADD_WARDEN
+      }
       field = DuplicateNames::DuplicateArgumentObject.get_field("multiArg")
 
       assert_equal "first definition", field.get_argument("a", { allowed_for: 1 }).description
@@ -1193,7 +1204,10 @@ GRAPHQL
     end
 
     it "raises when a given context would permit multiple field definitions" do
-      schema = Class.new(GraphQL::Schema) { query(DuplicateNames::DuplicateFieldObject) }
+      schema = Class.new(GraphQL::Schema) {
+        query(DuplicateNames::DuplicateFieldObject)
+        use GraphQL::Schema::Warden if ADD_WARDEN
+      }
       assert_equal "first definition", DuplicateNames::DuplicateFieldObject.get_field("f", { allowed_for: 1 }).description
       assert_equal "second definition", DuplicateNames::DuplicateFieldObject.fields({ allowed_for: 3 })["f"].description
       assert_includes schema.to_definition(context: { allowed_for: 1 }), "first definition"

--- a/spec/graphql/schema/dynamic_members_spec.rb
+++ b/spec/graphql/schema/dynamic_members_spec.rb
@@ -1123,7 +1123,7 @@ GRAPHQL
       schema = Class.new(GraphQL::Schema) {
         query(query_type)
         use GraphQL::Schema::Warden if ADD_WARDEN
-       }
+      }
 
       assert_equal "first definition", enum_type.values({ allowed_for: 1 })["ONE"].description
       assert_equal "second definition", enum_type.values({ allowed_for: 3 })["ONE"].description

--- a/spec/graphql/schema/introspection_system_spec.rb
+++ b/spec/graphql/schema/introspection_system_spec.rb
@@ -252,6 +252,8 @@ describe GraphQL::Schema::IntrospectionSystem do
 
   describe "Dynamically hiding them" do
     class HidingIntrospectionSchema < GraphQL::Schema
+      use GraphQL::Schema::Warden if ADD_WARDEN
+
       module HideIntrospectionByContext
         def visible?(ctx)
           super &&

--- a/spec/graphql/schema/printer_spec.rb
+++ b/spec/graphql/schema/printer_spec.rb
@@ -681,6 +681,7 @@ type Query {
 SCHEMA
 
     custom_filter_schema = Class.new(schema) do
+      use GraphQL::Schema::Warden if ADD_WARDEN
       def self.visible?(member, ctx)
         case member
         when Module
@@ -810,6 +811,7 @@ type Subscription {
 SCHEMA
 
     custom_filter_schema = Class.new(schema) do
+      use GraphQL::Schema::Warden if ADD_WARDEN
       def self.visible?(member, ctx)
         !(ctx[:names].include?(member.graphql_name) || (member.respond_to?(:deprecation_reason) && member.deprecation_reason))
       end

--- a/spec/graphql/schema/subscription_spec.rb
+++ b/spec/graphql/schema/subscription_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 
 describe GraphQL::Schema::Subscription do
   class SubscriptionFieldSchema < GraphQL::Schema
+    use GraphQL::Schema::Warden if ADD_WARDEN
     TOOTS = []
     ALL_USERS = {
       "dhh" => {handle: "dhh", private: false},

--- a/spec/graphql/schema/warden_spec.rb
+++ b/spec/graphql/schema/warden_spec.rb
@@ -508,6 +508,7 @@ describe GraphQL::Schema::Warden do
       |
 
       schema = GraphQL::Schema.from_definition(sdl)
+      schema.use(GraphQL::Schema::Warden)
       schema.define_singleton_method(:visible?) do |member, ctx|
         super(member, ctx) && (ctx[:hiding] ? member.graphql_name != "Repository" : true)
       end
@@ -616,6 +617,7 @@ describe GraphQL::Schema::Warden do
       "
 
       schema = GraphQL::Schema.from_definition(sdl)
+      schema.use(GraphQL::Schema::Warden) if ADD_WARDEN
       schema.define_singleton_method(:visible?) do |member, context|
         res = super(member, context)
         if res && context[:except]

--- a/spec/graphql/schema/warden_spec.rb
+++ b/spec/graphql/schema/warden_spec.rb
@@ -245,6 +245,7 @@ module MaskHelpers
   end
 
   class Schema < GraphQL::Schema
+    use GraphQL::Schema::Warden if ADD_WARDEN
     query QueryType
     mutation MutationType
     subscription MutationType
@@ -525,6 +526,7 @@ describe GraphQL::Schema::Warden do
 
     it "hides unions if all possible types are hidden or its references are hidden" do
       class PossibleTypesSchema < GraphQL::Schema
+        use GraphQL::Schema::Warden if ADD_WARDEN
         class A < GraphQL::Schema::Object
           field :id, ID, null: false
         end
@@ -1067,6 +1069,7 @@ describe GraphQL::Schema::Warden do
 
     schema = Class.new(GraphQL::Schema) do
       query(query_type)
+      use GraphQL::Schema::Warden if ADD_WARDEN
     end
 
     query_str = <<-GRAPHQL

--- a/spec/graphql/static_validation/rules/required_arguments_are_present_spec.rb
+++ b/spec/graphql/static_validation/rules/required_arguments_are_present_spec.rb
@@ -87,6 +87,7 @@ describe GraphQL::StaticValidation::RequiredArgumentsArePresent do
     end
 
     class HiddenArgSchema < GraphQL::Schema
+      use GraphQL::Schema::Warden if ADD_WARDEN
       query(Query)
     end
 

--- a/spec/graphql/subscriptions_spec.rb
+++ b/spec/graphql/subscriptions_spec.rb
@@ -226,6 +226,7 @@ class ClassBasedInMemoryBackend < InMemoryBackend
     subscription { Subscription }
     use InMemoryBackend::Subscriptions, extra: 123
     max_complexity(InMemoryBackend::MAX_COMPLEXITY)
+    use GraphQL::Schema::Warden if ADD_WARDEN
   end
 end
 

--- a/spec/graphql/testing/helpers_spec.rb
+++ b/spec/graphql/testing/helpers_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 
 describe GraphQL::Testing::Helpers do
   class AssertionsSchema < GraphQL::Schema
+    use GraphQL::Schema::Warden if ADD_WARDEN
     class BillSource < GraphQL::Dataloader::Source
       def fetch(students)
         students.map { |s| { amount: 1_000_001 } }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,9 @@ if ENV["GRAPHQL_REJECT_NUMBERS_FOLLOWED_BY_NAMES"]
   GraphQL.reject_numbers_followed_by_names = true
   puts "Opting into GraphQL::Schema::Visibility::Profile"
   GraphQL::Schema.use(GraphQL::Schema::Visibility, migration_errors: true)
+  ADD_WARDEN = false
+else
+  ADD_WARDEN = true
 end
 
 require "rake"

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -914,6 +914,7 @@ module Jazz
     BlogPost = Class.new(GraphQL::Schema::Object)
     extra_types BlogPost
     use GraphQL::Dataloader
+    use GraphQL::Schema::Warden if ADD_WARDEN
   end
 
   class SchemaWithoutIntrospection < GraphQL::Schema
@@ -922,18 +923,21 @@ module Jazz
     disable_introspection_entry_points
 
     use GraphQL::Dataloader
+    use GraphQL::Schema::Warden if ADD_WARDEN
   end
 
   class SchemaWithoutSchemaIntrospection < GraphQL::Schema
     query(Query)
 
     disable_schema_introspection_entry_point
+    use GraphQL::Schema::Warden if ADD_WARDEN
   end
 
   class SchemaWithoutTypeIntrospection < GraphQL::Schema
     query(Query)
 
     disable_type_introspection_entry_point
+    use GraphQL::Schema::Warden if ADD_WARDEN
   end
 
   class SchemaWithoutSchemaOrTypeIntrospection < GraphQL::Schema
@@ -941,5 +945,6 @@ module Jazz
 
     disable_schema_introspection_entry_point
     disable_type_introspection_entry_point
+    use GraphQL::Schema::Warden if ADD_WARDEN
   end
 end


### PR DESCRIPTION
In a future version, visibility filtering will be disabled by default Eventually `Warden` will go away. (`Schema::Visibility` is the future implementation.) But for now, warn so that people using the current default won't be surprised when the default changes. 

TODO: 

- [x] Update the test suite to not warn 