### PR TITLE
Suppress warning for objectId arguments

### DIFF
--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -133,12 +133,14 @@ module GraphQL
           end
           # Add a method access
           method_name = argument_defn.keyword
-          class_eval <<-RUBY, __FILE__, __LINE__
-            def #{method_name}
-              self[#{method_name.inspect}]
-            end
-            alias_method :#{method_name}, :#{method_name}
-          RUBY
+          suppress_redefinition_warning do
+            class_eval <<-RUBY, __FILE__, __LINE__
+              def #{method_name}
+                self[#{method_name.inspect}]
+              end
+              alias_method :#{method_name}, :#{method_name}
+            RUBY
+          end
           argument_defn
         end
 
@@ -242,6 +244,17 @@ module GraphQL
           end
 
           result
+        end
+
+        private
+
+        # Suppress redefinition warning for objectId arguments
+        def suppress_redefinition_warning
+          verbose = $VERBOSE
+          $VERBOSE = nil
+          yield
+        ensure
+          $VERBOSE = verbose
         end
       end
 

--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -1409,4 +1409,14 @@ describe GraphQL::Schema::InputObject do
       assert_equal "[a: 1, true], [b: nil, false], [c: nil, true]", result["data"]["values"]["result"]
     end
   end
+
+  describe "when argument is named objectId" do
+    it "doesn't emit a warning" do
+      assert_output "", "" do
+        Class.new(GraphQL::Schema::InputObject) do
+          argument :object_id, GraphQL::Types::ID, required: false
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Using an argument named `objectId` currently [emits a warning](https://github.com/ruby/ruby/blob/1001ea9606fd9bbbce70deaab0e6a31c5af1a20c/vm_method.c#L1066-L1070) because it redefines the `#object_id` method. This should technically be safe to do because Ruby doesn't use that method internally, but it still warns because third party code might.

`objectId` is a valid name for an argument, and a useful one too. This commit suppresses the warning by temporarily setting `$VERBOSE` to `nil` while defining the method. It's unlikely any code is relying on the `#object_id` method for GraphQL input argument objects, but if so it's already broken—this commit just silences the warning.

Host projects could of course suppress the warnings themselves, but it's tricky to do in a localized way when using `Schema.from_definition`. We'd have to suppress all warnings before calling that, potentially disguising other issues. Ideally GraphQL Ruby would handle this, but let me know if it's not suitable and we can try to work around locally instead.