### PR TITLE
Optimization - Skip processing non-existing fields in FieldsWillMerge

### DIFF
--- a/lib/graphql/static_validation/rules/fields_will_merge.rb
+++ b/lib/graphql/static_validation/rules/fields_will_merge.rb
@@ -212,6 +212,7 @@ module GraphQL
 
       def find_conflict(response_key, field1, field2, mutually_exclusive: false)
         return if @conflict_count >= context.max_errors
+        return if field1.definition.nil? || field2.definition.nil?
 
         node1 = field1.node
         node2 = field2.node


### PR DESCRIPTION
# Context
It was observed that if a query includes thousands of non-existing fields, it takes a lot of processing time within the [FieldsWillMerge#find_conflicts_within](https://github.com/rmosolgo/graphql-ruby/blob/c66362145bd120a22fdbc14aac612b486c32b3d8/lib/graphql/static_validation/rules/fields_will_merge.rb#L197-L211). 

# What
The iteration loop represents `n(n-1^2)/2`, where `n` is the number of duplicated fields being queried, and the underlying call to [#find_conflict](https://github.com/rmosolgo/graphql-ruby/blob/c66362145bd120a22fdbc14aac612b486c32b3d8/lib/graphql/static_validation/rules/fields_will_merge.rb#L205
) is using considerable time. For example, a query with `2000` times the same non-existing field i.e.`query { a a ... 2000 times }` takes ~6000 ms to process and skipping these fields reduces the response time to ~500ms.

# Optimization
As far as I can tell, skipping non-existing fields from the `FieldsWillMerge` rule doesn't alter the business logic. 

The only caveat of this optimization, is that if a service using this library was relying on the [Schema#validate_timeout](https://graphql-ruby.org/api-doc/2.3.18/GraphQL/Schema#validate_timeout-class_method) to safeguard from a potentially malicious query, it may no longer reach the configured timeout but rather instead return multiple `undefinedField` errors, which can be mitigated by the [Schema#validate_max_errors](https://graphql-ruby.org/api-doc/2.3.18/GraphQL/Schema#validate_max_errors-class_method).