### PR TITLE
Handle no selected operation for `Query#lookahead`

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -209,15 +209,19 @@ module GraphQL
     def lookahead
       @lookahead ||= begin
         ast_node = selected_operation
-        root_type = case ast_node.operation_type
-        when nil, "query"
-          types.query_root # rubocop:disable Development/ContextIsPassedCop
-        when "mutation"
-          types.mutation_root # rubocop:disable Development/ContextIsPassedCop
-        when "subscription"
-          types.subscription_root # rubocop:disable Development/ContextIsPassedCop
+        if ast_node.nil?
+          GraphQL::Execution::Lookahead::NULL_LOOKAHEAD
+        else
+          root_type = case ast_node.operation_type
+          when nil, "query"
+            types.query_root # rubocop:disable Development/ContextIsPassedCop
+          when "mutation"
+            types.mutation_root # rubocop:disable Development/ContextIsPassedCop
+          when "subscription"
+            types.subscription_root # rubocop:disable Development/ContextIsPassedCop
+          end
+          GraphQL::Execution::Lookahead.new(query: self, root_type: root_type, ast_nodes: [ast_node])
         end
-        GraphQL::Execution::Lookahead.new(query: self, root_type: root_type, ast_nodes: [ast_node])
       end
     end
 

--- a/spec/graphql/execution/lookahead_spec.rb
+++ b/spec/graphql/execution/lookahead_spec.rb
@@ -142,6 +142,11 @@ describe GraphQL::Execution::Lookahead do
       assert_equal true, query.lookahead.selects?("__typename")
     end
 
+    it "uses null lookahead when no operation is selected" do
+      query = GraphQL::Query.new(schema, document: document, variables: { name: "Cardinal" }, operation_name: "Invalid")
+      assert_selection_is_null query.lookahead
+    end
+
     describe "with a NullWarden" do
       let(:schema) { LookaheadTest::AlwaysVisibleSchema }
 


### PR DESCRIPTION
Resolves https://github.com/rmosolgo/graphql-ruby/issues/5126