### PR TITLE
Update validation message for one_of

### DIFF
--- a/lib/graphql/schema/validator/required_validator.rb
+++ b/lib/graphql/schema/validator/required_validator.rb
@@ -35,7 +35,8 @@ module GraphQL
       #   end
       #
       class RequiredValidator < Validator
-        # @param one_of [Symbol, Array<Symbol>] An argument, or a list of arguments, that represents a valid set of inputs for this field
+        # @param one_of [Array<Symbol>] A list of arguments, exactly one of which is required for this field
+        # @param argument [Symbol] An argument that is required for this field
         # @param message [String]
         def initialize(one_of: nil, argument: nil, message: nil, **default_options)
           @one_of = if one_of

--- a/spec/graphql/schema/argument_spec.rb
+++ b/spec/graphql/schema/argument_spec.rb
@@ -604,7 +604,7 @@ describe GraphQL::Schema::Argument do
       res = RequiredNullableSchema.execute('{ echo(str: null) }')
       assert_nil res["data"].fetch("echo")
       res = RequiredNullableSchema.execute('{ echo }')
-      assert_equal ["echo has the wrong arguments"], res["errors"].map { |e| e["message"] }
+      assert_equal ["echo must include the following argument: str."], res["errors"].map { |e| e["message"] }
     end
   end
 

--- a/spec/graphql/schema/validator/required_validator_spec.rb
+++ b/spec/graphql/schema/validator/required_validator_spec.rb
@@ -9,10 +9,10 @@ describe GraphQL::Schema::Validator::RequiredValidator do
     {
       config: { one_of: [:a, :b] },
       cases: [
-        { query: "{ validated: multiValidated(a: 1, b: 2) }", result: nil, error_messages: ["multiValidated has the wrong arguments"] },
-        { query: "{ validated: multiValidated(a: 1, b: 2, c: 3) }", result: nil, error_messages: ["multiValidated has the wrong arguments"] },
-        { query: "{ validated: multiValidated }", result: nil, error_messages: ["multiValidated has the wrong arguments"] },
-        { query: "{ validated: multiValidated(c: 3) }", result: nil, error_messages: ["multiValidated has the wrong arguments"] },
+        { query: "{ validated: multiValidated(a: 1, b: 2) }", result: nil, error_messages: ["multiValidated must include exactly one of the following arguments: a, b."] },
+        { query: "{ validated: multiValidated(a: 1, b: 2, c: 3) }", result: nil, error_messages: ["multiValidated must include exactly one of the following arguments: a, b."] },
+        { query: "{ validated: multiValidated }", result: nil, error_messages: ["multiValidated must include exactly one of the following arguments: a, b."] },
+        { query: "{ validated: multiValidated(c: 3) }", result: nil, error_messages: ["multiValidated must include exactly one of the following arguments: a, b."] },
         { query: "{ validated: multiValidated(a: 1) }", result: 1, error_messages: [] },
         { query: "{ validated: multiValidated(a: 1, c: 3) }", result: 4, error_messages: [] },
         { query: "{ validated: multiValidated(b: 2) }", result: 2, error_messages: [] },
@@ -24,10 +24,10 @@ describe GraphQL::Schema::Validator::RequiredValidator do
       cases: [
         { query: "{ validated: multiValidated(a: 1) }", result: 1, error_messages: [] },
         { query: "{ validated: multiValidated(b: 2, c: 3) }", result: 5, error_messages: [] },
-        { query: "{ validated: multiValidated }", result: nil, error_messages: ["multiValidated has the wrong arguments"] },
-        { query: "{ validated: multiValidated(a: 1, b: 2, c: 3) }", result: nil, error_messages: ["multiValidated has the wrong arguments"] },
-        { query: "{ validated: multiValidated(c: 3) }", result: nil, error_messages: ["multiValidated has the wrong arguments"] },
-        { query: "{ validated: multiValidated(b: 2) }", result: nil, error_messages: ["multiValidated has the wrong arguments"] },
+        { query: "{ validated: multiValidated }", result: nil, error_messages: ["multiValidated must include exactly one of the following arguments: a, (b and c)."] },
+        { query: "{ validated: multiValidated(a: 1, b: 2, c: 3) }", result: nil, error_messages: ["multiValidated must include exactly one of the following arguments: a, (b and c)."] },
+        { query: "{ validated: multiValidated(c: 3) }", result: nil, error_messages: ["multiValidated must include exactly one of the following arguments: a, (b and c)."] },
+        { query: "{ validated: multiValidated(b: 2) }", result: nil, error_messages: ["multiValidated must include exactly one of the following arguments: a, (b and c)."] },
       ]
     },
     {
@@ -36,9 +36,9 @@ describe GraphQL::Schema::Validator::RequiredValidator do
       cases: [
         { query: "{ validated: validatedInput(input: { a: 1 }) }", result: 1, error_messages: [] },
         { query: "{ validated: validatedInput(input: { b: 2, c: 3 }) }", result: 5, error_messages: [] },
-        { query: "{ validated: validatedInput(input: { a: 1, b: 2, c: 3 }) }", result: nil, error_messages: ["ValidatedInput has the wrong arguments"] },
-        { query: "{ validated: validatedInput(input: { c: 3 }) }", result: nil, error_messages: ["ValidatedInput has the wrong arguments"] },
-        { query: "{ validated: validatedInput(input: { b: 2 }) }", result: nil, error_messages: ["ValidatedInput has the wrong arguments"] },
+        { query: "{ validated: validatedInput(input: { a: 1, b: 2, c: 3 }) }", result: nil, error_messages: ["ValidatedInput must include exactly one of the following arguments: a, (b and c)."] },
+        { query: "{ validated: validatedInput(input: { c: 3 }) }", result: nil, error_messages: ["ValidatedInput must include exactly one of the following arguments: a, (b and c)."] },
+        { query: "{ validated: validatedInput(input: { b: 2 }) }", result: nil, error_messages: ["ValidatedInput must include exactly one of the following arguments: a, (b and c)."] },
       ]
     },
     {
@@ -47,10 +47,10 @@ describe GraphQL::Schema::Validator::RequiredValidator do
       cases: [
         { query: "{ validated: validatedResolver(a: 1) }", result: 1, error_messages: [] },
         { query: "{ validated: validatedResolver(b: 2, c: 3) }", result: 5, error_messages: [] },
-        { query: "{ validated: validatedResolver(a: 1, b: 2, c: 3) }", result: nil, error_messages: ["validatedResolver has the wrong arguments"] },
-        { query: "{ validated: validatedResolver(c: 3) }", result: nil, error_messages: ["validatedResolver has the wrong arguments"] },
-        { query: "{ validated: validatedResolver(b: 2) }", result: nil, error_messages: ["validatedResolver has the wrong arguments"] },
-        { query: "{ validated: validatedResolver }", result: nil, error_messages: ["validatedResolver has the wrong arguments"] },
+        { query: "{ validated: validatedResolver(a: 1, b: 2, c: 3) }", result: nil, error_messages: ["validatedResolver must include exactly one of the following arguments: a, (b and c)."] },
+        { query: "{ validated: validatedResolver(c: 3) }", result: nil, error_messages: ["validatedResolver must include exactly one of the following arguments: a, (b and c)."] },
+        { query: "{ validated: validatedResolver(b: 2) }", result: nil, error_messages: ["validatedResolver must include exactly one of the following arguments: a, (b and c)."] },
+        { query: "{ validated: validatedResolver }", result: nil, error_messages: ["validatedResolver must include exactly one of the following arguments: a, (b and c)."] },
       ]
     },
     {

--- a/spec/graphql/schema/validator_spec.rb
+++ b/spec/graphql/schema/validator_spec.rb
@@ -195,7 +195,7 @@ describe GraphQL::Schema::Validator do
 
       res = ValidationInheritanceSchema.execute("{ intInput(input: { int: 1, otherInt: 2 }) }")
       assert_nil res["data"]["intInput"]
-      assert_equal ["IntInput has the wrong arguments"], res["errors"].map { |e| e["message"] }
+      assert_equal ["IntInput must include exactly one of the following arguments: int, otherInt."], res["errors"].map { |e| e["message"] }
     end
 
     it "works with resolvers" do
@@ -204,7 +204,7 @@ describe GraphQL::Schema::Validator do
 
       res = ValidationInheritanceSchema.execute("{ int(int: 1, otherInt: 2) }")
       assert_nil res["data"]["int"]
-      assert_equal ["int has the wrong arguments"], res["errors"].map { |e| e["message"] }
+      assert_equal ["int must include exactly one of the following arguments: int, otherInt."], res["errors"].map { |e| e["message"] }
     end
   end
 end


### PR DESCRIPTION
This PR updates the error message when a `one_of` validation is not satisfied to be more explicit about what the issue is.

Before: "{field_name} has the wrong arguments"
After: "{field_name} must include exactly one of the following arguments: a, b."

Note: PR seems to be failing due to unreliable tests. [Example 1](https://github.com/rmosolgo/graphql-ruby/actions/runs/11447293332/job/31848303250?pr=5130), [Example 2](https://github.com/rmosolgo/graphql-ruby/actions/runs/11447896670/job/31850249461?pr=5130)