### PR TITLE
No longer pin yard to specific commit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,9 +9,6 @@ gem 'pry'
 gem 'pry-stack_explorer', platform: :ruby
 gem 'pry-byebug'
 
-# For Ruby 3.2 compat:
-gem "yard", github: "lsegal/yard", ref: "b51bf26"
-
 if RUBY_VERSION >= "3.0"
   gem "libev_scheduler"
   gem "evt"


### PR DESCRIPTION
`bundle install` gave me a warning because yard was specified twice in Gemfile: once from the gemspec and once explicitly in the file.

It seems we no longer need to pin yard to a specific commit as Ruby 3.2 is supported in recent releases.