### PR TITLE
Add support for dynamic enum_values in Visibility::Profile

### DIFF
--- a/lib/graphql/query/null_context.rb
+++ b/lib/graphql/query/null_context.rb
@@ -24,6 +24,7 @@ module GraphQL
         @query = NullQuery.new
         @dataloader = GraphQL::Dataloader::NullDataloader.new
         @schema = NullSchema
+        @types = Schema::Visibility::Profile.pass_thru(context: self, schema: @schema)
         @warden = Schema::Warden::NullWarden.new(context: self, schema: @schema)
       end
 

--- a/lib/graphql/query/null_context.rb
+++ b/lib/graphql/query/null_context.rb
@@ -24,12 +24,8 @@ module GraphQL
         @query = NullQuery.new
         @dataloader = GraphQL::Dataloader::NullDataloader.new
         @schema = NullSchema
-        @types = Schema::Visibility::Profile.pass_thru(context: self, schema: @schema)
         @warden = Schema::Warden::NullWarden.new(context: self, schema: @schema)
-      end
-
-      def types
-        @types ||= Schema::Warden::VisibilityProfile.new(@warden)
+        @types = @warden.visibility_profile
       end
     end
   end

--- a/lib/graphql/query/null_context.rb
+++ b/lib/graphql/query/null_context.rb
@@ -18,7 +18,7 @@ module GraphQL
       extend Forwardable
 
       attr_reader :schema, :query, :warden, :dataloader
-      def_delegators GraphQL::EmptyObjects::EMPTY_HASH, :[], :fetch, :dig, :key?
+      def_delegators GraphQL::EmptyObjects::EMPTY_HASH, :[], :fetch, :dig, :key?, :to_h
 
       def initialize
         @query = NullQuery.new
@@ -26,6 +26,7 @@ module GraphQL
         @schema = NullSchema
         @warden = Schema::Warden::NullWarden.new(context: self, schema: @schema)
         @types = @warden.visibility_profile
+        freeze
       end
     end
   end

--- a/lib/graphql/schema/enum_value.rb
+++ b/lib/graphql/schema/enum_value.rb
@@ -74,7 +74,7 @@ module GraphQL
       end
 
       def inspect
-        "#<#{self.class} #{path} @value=#{@value.inspect}#{description ? " @description=#{description.inspect}" : ""}>"
+        "#<#{self.class} #{path} @value=#{@value.inspect}#{description ? " @description=#{description.inspect}" : ""}#{deprecation_reason ? " @deprecation_reason=#{deprecation_reason.inspect}" : ""}>"
       end
 
       def visible?(_ctx); true; end

--- a/lib/graphql/schema/visibility/migration.rb
+++ b/lib/graphql/schema/visibility/migration.rb
@@ -122,7 +122,8 @@ module GraphQL
           :mutation_root,
           :possible_types,
           :subscription_root,
-          :reachable_type?
+          :reachable_type?,
+          :visible_enum_value?,
         ]
 
         PUBLIC_PROFILE_METHODS.each do |profile_method|

--- a/lib/graphql/schema/visibility/profile.rb
+++ b/lib/graphql/schema/visibility/profile.rb
@@ -22,8 +22,10 @@ module GraphQL
           end
         end
 
-        def self.pass_thru(context:, schema:)
-          self.new(name: "PassThru", context: context, schema: schema)
+        def self.null_profile(context:, schema:)
+          profile = self.new(name: "NullProfile", context: context, schema: schema)
+          profile.instance_variable_set(:@cached_visible, Hash.new { |k, v| k[v] = true }.compare_by_identity)
+          profile
         end
 
         # @return [Symbol, nil]

--- a/lib/graphql/schema/visibility/profile.rb
+++ b/lib/graphql/schema/visibility/profile.rb
@@ -23,9 +23,7 @@ module GraphQL
         end
 
         def self.pass_thru(context:, schema:)
-          profile = self.new(context: context, schema: schema)
-          profile.instance_variable_set(:@cached_visible, Hash.new { |h,k| h[k] = true })
-          profile
+          self.new(name: "PassThru", context: context, schema: schema)
         end
 
         # @return [Symbol, nil]
@@ -123,7 +121,7 @@ module GraphQL
           end.compare_by_identity
 
           @cached_enum_values = Hash.new do |h, enum_t|
-            values = non_duplicate_items(enum_t.all_enum_value_definitions, @cached_visible)
+            values = non_duplicate_items(enum_t.enum_values(@context), @cached_visible)
             if values.size == 0
               raise GraphQL::Schema::Enum::MissingValuesError.new(enum_t)
             end
@@ -325,6 +323,10 @@ module GraphQL
         def reachable_type?(name)
           load_all_types
           !!@all_types[name]
+        end
+
+        def visible_enum_value?(enum_value, _ctx = nil)
+          @cached_visible[enum_value]
         end
 
         private

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -19,6 +19,13 @@ module GraphQL
         PassThruWarden
       end
 
+      def self.types_from_context(context)
+        context.types || PassThruWarden
+      rescue NoMethodError
+        # this might be a hash which won't respond to #warden
+        PassThruWarden
+      end
+
       def self.use(schema)
         # no-op
       end
@@ -182,6 +189,10 @@ module GraphQL
 
         def reachable_type?(type_name)
           !!@warden.reachable_type?(type_name)
+        end
+
+        def visible_enum_value?(enum_value, ctx = nil)
+          @warden.visible_enum_value?(enum_value, ctx)
         end
       end
 

--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -87,24 +87,17 @@ module GraphQL
         # No-op, but for compatibility:
         attr_writer :skip_warning
 
-        # @api private
-        module NullVisibilityProfile
-          def self.new(context:, schema:)
-            NullWarden.new(context: context, schema: schema).visibility_profile
-          end
-        end
-
         attr_reader :visibility_profile
 
         def visible_field?(field_defn, _ctx = nil, owner = nil); true; end
         def visible_argument?(arg_defn, _ctx = nil); true; end
         def visible_type?(type_defn, _ctx = nil); true; end
-        def visible_enum_value?(enum_value, _ctx = nil); true; end
+        def visible_enum_value?(enum_value, _ctx = nil); enum_value.visible?(Query::NullContext.instance); end
         def visible_type_membership?(type_membership, _ctx = nil); true; end
         def interface_type_memberships(obj_type, _ctx = nil); obj_type.interface_type_memberships; end
         def get_type(type_name); @schema.get_type(type_name, Query::NullContext.instance, false); end # rubocop:disable Development/ContextIsPassedCop
         def arguments(argument_owner, ctx = nil); argument_owner.all_argument_definitions; end
-        def enum_values(enum_defn); enum_defn.enum_values; end # rubocop:disable Development/ContextIsPassedCop
+        def enum_values(enum_defn); enum_defn.enum_values(Query::NullContext.instance); end # rubocop:disable Development/ContextIsPassedCop
         def get_argument(parent_type, argument_name); parent_type.get_argument(argument_name); end # rubocop:disable Development/ContextIsPassedCop
         def types; @schema.types; end # rubocop:disable Development/ContextIsPassedCop
         def root_type_for_operation(op_name); @schema.root_type_for_operation(op_name); end

--- a/lib/graphql/testing/helpers.rb
+++ b/lib/graphql/testing/helpers.rb
@@ -92,7 +92,7 @@ module GraphQL
           end
           graphql_result
         else
-          unfiltered_type = Schema::Visibility::Profile.pass_thru(schema: schema, context: context).type(type_name)
+          unfiltered_type = Schema::Visibility::Profile.null_profile(schema: schema, context: context).type(type_name)
           if unfiltered_type
             raise TypeNotVisibleError.new(type_name: type_name)
           else


### PR DESCRIPTION
Fixes #5140 


This has uncovered a bit of confusion in the codebase. There are two different kind of "dummy" visibility checks which are used when a real Query context isn't available: 

- One implementation skips any kind of `.visible?` check at all 
- Another implementation calls visible with `NullContext.instance` 

The only reason this worked with warden is because somewhere in the call stack, it shifted from using one of those approaches to the other. I think it'd be good work to follow the threads here an clearly delineate where one is used vs. where the other is used.