### PR TITLE
handle non-existing field selection on enum type correctly

### DIFF
--- a/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb
+++ b/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb
@@ -14,7 +14,9 @@ module GraphQL
               node_name: parent_type.graphql_name
             ))
           else
-            message = "Field '#{node.name}' doesn't exist on type '#{parent_type.graphql_name}'#{context.did_you_mean_suggestion(node.name, context.types.fields(parent_type).map(&:graphql_name))}"
+            possible_types = possible_types(context, parent_type)
+            suggestion = context.did_you_mean_suggestion(node.name, possible_types)
+            message = "Field '#{node.name}' doesn't exist on type '#{parent_type.graphql_name}'#{suggestion}"
             add_error(GraphQL::StaticValidation::FieldsAreDefinedOnTypeError.new(
               message,
               nodes: node,
@@ -25,6 +27,13 @@ module GraphQL
         else
           super
         end
+      end
+
+      private
+
+      def possible_types(context, parent_type)
+        return [] if parent_type.kind.enum?
+        context.types.fields(parent_type).map(&:graphql_name)
       end
     end
   end

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -479,11 +479,17 @@ To add other types to your schema, you might want `extra_types`: https://graphql
 
   describe "DidYouMean support" do
     class DidYouMeanSchema < GraphQL::Schema
+      class ExampleEnum < GraphQL::Schema::Enum
+        value "VALUE_ONE", "The first value"
+        value "VALUE_TWO", "The second value"
+      end
+
       class Query < GraphQL::Schema::Object
         field :first_field, String
         field :second_field, String
         field :second_fiel, String
         field :scond_field, String
+        field :third_field, ExampleEnum
       end
 
       query(Query)
@@ -507,8 +513,13 @@ To add other types to your schema, you might want `extra_types`: https://graphql
       res = no_dym_schema.execute("{ seconField }")
       assert_equal ["Field 'seconField' doesn't exist on type 'Query'"], res["errors"].map { |err| err["message"] }
     end
-  end 
-  
+
+    it "returns helpful message when non existing field is queried on enum" do
+      res = DidYouMeanSchema.execute("{ thirdField { foo } }")
+      assert_equal ["Field 'foo' doesn't exist on type 'ExampleEnum'"], res["errors"].map { |err| err["message"] }
+    end
+  end
+
   it "defers root type blocks until those types are used" do
     calls = []
     schema = Class.new(GraphQL::Schema) do


### PR DESCRIPTION
Since https://github.com/rmosolgo/graphql-ruby/pull/4966/files#diff-2252722dfaf6594778838471788047281b9c06a3f2419c5342a84221d75f086cR17, a query that select a (non existing) field on an enum type results in an exception: `"NoMethodError: undefined method 'fields' for class <an enum type>"`.