### PR TITLE
Fix double unsubscribe calls for Urql and Relay subscriptions

### DIFF
--- a/javascript_client/src/subscriptions/createActionCableHandler.ts
+++ b/javascript_client/src/subscriptions/createActionCableHandler.ts
@@ -57,7 +57,7 @@ function createActionCableHandler(options: ActionCableHandlerOptions) {
         } else if (result) {
           observer.onNext({data: result.data})
         }
-        if (!payload.more) {
+        if (!payload.more && subscribed) {
           // Subscription is finished
           observer.onCompleted()
         }


### PR DESCRIPTION
Fixes #5149

- prevent double unsubscribe calls in createUrqlActionCableSubscription
- call onCompleted only when we subscribed to AC for Relay & Urql handlers