### PR TITLE
Add top-level caches for Schema::Visibility

### DIFF
--- a/spec/graphql/schema/visibility_spec.rb
+++ b/spec/graphql/schema/visibility_spec.rb
@@ -40,9 +40,21 @@ describe GraphQL::Schema::Visibility do
     use GraphQL::Schema::Visibility, profiles: { public: {}, admin: {} }, dynamic: true, preload: false
   end
 
+  class PreloadDynVisSchema < VisSchema
+    use GraphQL::Schema::Visibility, profiles: { public: {}, admin: {} }, dynamic: true, preload: true
+  end
+
   def exec_query(...)
     VisSchema.execute(...)
   end
+
+  describe "top-level schema caches" do
+    it "re-uses results" do
+      assert_equal DynVisSchema.types.object_id, DynVisSchema.types.object_id
+      assert_equal PreloadDynVisSchema.types.object_id, PreloadDynVisSchema.types.object_id
+    end
+  end
+
   describe "running queries" do
     it "requires context[:visibility]" do
       err = assert_raises ArgumentError do


### PR DESCRIPTION
Fixes #5154 

This adds a top-level cache, like `Schema` makes when using `Warden`, but it supports lazy-loading. Currently, the cache rebuilds whenever something is lazy-loaded, but it could probably be made to grow in-place instead if it becomes a problem. 

Running the same benchmark from the original issue shows good results: 

```
$ N=1000 ruby types_bench.rb
GraphQL gem 2.4.2--accessing `GraphQL::Schema#types` 1000 times
                           user     system      total        real
Not using Visibility   0.291171   0.012367   0.303538 (  0.303684)
Using Visibility       0.156794   0.005118   0.161912 (  0.162134)
```