### PR TITLE
Add top-level schema caches to Schema::Visibility for better performance

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -446,7 +446,12 @@ module GraphQL
             raise GraphQL::Error, "Second definition of `query(...)` (#{dup_defn.inspect}) is invalid, already configured with #{@query_object.inspect}"
           elsif use_visibility_profile?
             if block_given?
-              @query_object = lazy_load_block
+              if visibility.preload?
+                @query_object = lazy_load_block.call
+                self.visibility.query_configured(@query_object)
+              else
+                @query_object = lazy_load_block
+              end
             else
               @query_object = new_query_object
               self.visibility.query_configured(@query_object)
@@ -480,7 +485,12 @@ module GraphQL
             raise GraphQL::Error, "Second definition of `mutation(...)` (#{dup_defn.inspect}) is invalid, already configured with #{@mutation_object.inspect}"
           elsif use_visibility_profile?
             if block_given?
-              @mutation_object = lazy_load_block
+              if visibility.preload?
+                @mutation_object = lazy_load_block.call
+                self.visibility.mutation_configured(@mutation_object)
+              else
+                @mutation_object = lazy_load_block
+              end
             else
               @mutation_object = new_mutation_object
               self.visibility.mutation_configured(@mutation_object)
@@ -514,7 +524,12 @@ module GraphQL
             raise GraphQL::Error, "Second definition of `subscription(...)` (#{dup_defn.inspect}) is invalid, already configured with #{@subscription_object.inspect}"
           elsif use_visibility_profile?
             if block_given?
-              @subscription_object = lazy_load_block
+              if visibility.preload?
+                @subscription_object = lazy_load_block.call
+                visibility.subscription_configured(@subscription_object)
+              else
+                @subscription_object = lazy_load_block
+              end
             else
               @subscription_object = new_subscription_object
               self.visibility.subscription_configured(@subscription_object)

--- a/lib/graphql/schema/visibility.rb
+++ b/lib/graphql/schema/visibility.rb
@@ -13,6 +13,9 @@ module GraphQL
       # @param migration_errors [Boolean] if `true`, raise an error when `Visibility` and `Warden` return different results
       def self.use(schema, dynamic: false, profiles: EmptyObjects::EMPTY_HASH, preload: (defined?(Rails) ? Rails.env.production? : nil), migration_errors: false)
         schema.visibility = self.new(schema, dynamic: dynamic, preload: preload, profiles: profiles, migration_errors: migration_errors)
+        if preload
+          schema.visibility.preload
+        end
       end
 
       def initialize(schema, dynamic:, preload:, profiles:, migration_errors:)
@@ -26,11 +29,63 @@ module GraphQL
         @cached_profiles = {}
         @dynamic = dynamic
         @migration_errors = migration_errors
-        if preload
-          # Traverse the schema now (and in the *_configured hooks below)
-          # To make sure things are loaded during boot
-          @preloaded_types = Set.new
-          types_to_visit = [
+        @top_level = TopLevel.new(@schema)
+      end
+
+      class TopLevel
+        def initialize(schema)
+          @schema = schema
+          @loaded_all = false
+          @interface_type_memberships = Hash.new { |h, interface_type| h[interface_type] = [] }.compare_by_identity
+          @directives = []
+        end
+
+        def directives
+          load_all
+          @directives
+        end
+
+        def interface_type_memberships
+          load_all
+          @interface_type_memberships
+        end
+
+        private
+
+        def load_all
+          # TODO thread-safe
+          @loaded_all ||= begin
+            Visit.each(@schema) do |member|
+              if member.is_a?(Class)
+                if member < GraphQL::Schema::Directive
+                  @directives << member
+                elsif member.respond_to?(:interface_type_memberships)
+                  member.interface_type_memberships.each do |itm|
+                    @interface_type_memberships[itm.abstract_type] << itm
+                  end
+                end
+              end
+              true
+            end
+            true
+          end
+        end
+      end
+
+      class Visit
+        def self.each(schema, &block)
+          self.new(schema).visit_each(&block)
+        end
+
+        def initialize(schema)
+          @schema = schema
+        end
+
+        def visit_each
+          visited_types = Set.new.compare_by_identity
+          late_union_type_memberships = []
+          visited_directives = Set.new.compare_by_identity
+          unvisited_types = [
             @schema.query,
             @schema.mutation,
             @schema.subscription,
@@ -38,15 +93,119 @@ module GraphQL
             *@schema.introspection_system.entry_points.map { |ep| ep.type.unwrap },
             *@schema.orphan_types,
           ]
-          # Root types may have been nil:
-          types_to_visit.compact!
-          ensure_all_loaded(types_to_visit)
 
-          profiles.each do |profile_name, example_ctx|
-            example_ctx[:visibility_profile] = profile_name
-            prof = profile_for(example_ctx, profile_name)
-            prof.all_types # force loading
+          possible_types_to_add = []
+          directives_to_visit = []
+
+          unvisited_types.compact!
+
+          @schema.directives.each_value { |dir_class| yield(dir_class) }
+
+          while unvisited_types.any? || late_union_type_memberships.any?
+            while (type = unvisited_types.pop)
+              if visited_types.add?(type) && yield(type)
+                directives_to_visit.concat(type.directives)
+                append_next_visits(type, unvisited_types, possible_types_to_add, late_union_type_memberships, directives_to_visit)
+              end
+            end
+
+            directives_to_visit.each do |dir|
+              dir_class = dir.class
+              if visited_directives.add?(dir_class)
+                yield(dir_class)
+              end
+            end
+
+            # possible_types_to_add.each do |int_t|
+            #   int_t_mems = @interface_type_memberships[int_t]
+            #   int_t_mems.each do |int_t_mem|
+            #     unvisited_types << int_t_mem.object_type
+            #   end
+            # end
+            # possible_types_to_add.clear
+
+            while (union_tm = late_union_type_memberships.shift)
+              late_obj_t = union_tm.object_type
+              obj_t = all_types[late_obj_t.graphql_name] || raise("Failed to resolve union type membership: #{late_obj_t.graphql_name.inspect} on #{union_tm.inspect}")
+              union_tm.abstract_type.assign_type_membership_object_type(obj_t)
+            end
           end
+          nil
+        end
+
+        def append_next_visits(type, unvisited_types, possible_types_to_add, late_union_type_memberships, directives)
+          case type.kind.name
+          when "OBJECT", "INTERFACE"
+            type.interface_type_memberships.each do |itm|
+              unvisited_types << itm.abstract_type
+            end
+            if type.kind.interface?
+              unvisited_types.concat(type.orphan_types)
+            end
+
+            type.all_field_definitions.each do |field|
+              field.ensure_loaded
+              directives.concat(field.directives)
+              field_type = field.type.unwrap
+              if field_type.kind.interface?
+                possible_types_to_add << field_type
+              end
+              unvisited_types << field_type
+              field.all_argument_definitions.each do |argument|
+                directives.concat(argument.directives)
+                unvisited_types << argument.type.unwrap
+              end
+            end
+          when "INPUT_OBJECT"
+            type.all_argument_definitions.each do |argument|
+              directives.concat(argument.directives)
+              unvisited_types << argument.type.unwrap
+            end
+          when "UNION"
+            type.type_memberships.each do |tm|
+              obj_t = tm.object_type
+              if obj_t.is_a?(GraphQL::Schema::LateBoundType)
+                late_union_type_memberships << tm
+              else
+                if obj_t.is_a?(String)
+                  obj_t = Member::BuildType.constantize(obj_t)
+                  tm.object_type = obj_t
+                end
+                unvisited_types << obj_t
+              end
+            end
+          when "ENUM"
+            type.all_enum_value_definitions.each do |val|
+              directives.concat(val.directives)
+            end
+          when "SCALAR"
+            # pass
+          else
+            raise "Invariant: unhandled type kind: #{type.kind.inspect}"
+          end
+        end
+      end
+
+      def preload
+        # Traverse the schema now (and in the *_configured hooks below)
+        # To make sure things are loaded during boot
+        @preloaded_types = Set.new
+        types_to_visit = [
+          @schema.query,
+          @schema.mutation,
+          @schema.subscription,
+          *@schema.introspection_system.types.values,
+          *@schema.introspection_system.entry_points.map { |ep| ep.type.unwrap },
+          *@schema.orphan_types,
+        ]
+        # Root types may have been nil:
+        types_to_visit.compact!
+        ensure_all_loaded(types_to_visit)
+
+        @profiles.each do |profile_name, example_ctx|
+          example_ctx[:visibility_profile] = profile_name
+          prof = profile_for(example_ctx, profile_name)
+          prof.all_types # force loading
         end
       end
 
@@ -132,7 +291,10 @@ module GraphQL
         end
       end
 
-      private
+      attr_reader :top_level
+
+      # @api private
+      attr_reader :unfiltered_interface_type_memberships
 
       def top_level_profile(refresh: false)
         if refresh
@@ -140,6 +302,8 @@ module GraphQL
         end
         @top_level_profile ||= @schema.visibility_profile_class.new(context: Query::NullContext.instance, schema: @schema)
       end
+
+      private
 
       def ensure_all_loaded(types_to_visit)
         while (type = types_to_visit.shift)

--- a/lib/graphql/schema/visibility.rb
+++ b/lib/graphql/schema/visibility.rb
@@ -177,7 +177,7 @@ module GraphQL
 
       private
 
-      def ensure_all_fields_loaded(types_to_visit)
+      def ensure_all_loaded(types_to_visit)
         while (type = types_to_visit.shift)
           if type.kind.fields? && @preloaded_types.add?(type)
             type.all_field_definitions.each do |field_defn|

--- a/lib/graphql/schema/visibility.rb
+++ b/lib/graphql/schema/visibility.rb
@@ -133,7 +133,11 @@ module GraphQL
           directives_to_visit = []
 
 
-          @schema.directives.each_value { |dir_class| yield(dir_class) }
+          @schema.directives.each_value { |dir_class|
+            if visited_directives.add?(dir_class)
+              yield(dir_class)
+            end
+          }
 
           while unvisited_types.any? || late_union_type_memberships.any?
             while (type = unvisited_types.pop)

--- a/lib/graphql/schema/visibility/profile.rb
+++ b/lib/graphql/schema/visibility/profile.rb
@@ -209,15 +209,15 @@ module GraphQL
         end
 
         def query_root
-          (t = @schema.query) && @cached_visible[t] && t
+          ((t = @schema.query) && @cached_visible[t]) ? t : nil
         end
 
         def mutation_root
-          (t = @schema.mutation) && @cached_visible[t] && t
+          ((t = @schema.mutation) && @cached_visible[t]) ? t : nil
         end
 
         def subscription_root
-          (t = @schema.subscription) && @cached_visible[t] && t
+          ((t = @schema.subscription) && @cached_visible[t]) ? t : nil
         end
 
         def all_types
@@ -302,8 +302,6 @@ module GraphQL
           @all_types.delete_if { |type_name, type_defn| !referenced?(type_defn) }
           nil
         end
-
-        private
 
         def referenced?(type_defn)
           @schema.visibility.top_level.references[type_defn].any? { |ref_member| ref_member == true || @cached_visible[ref_member] }

--- a/lib/graphql/schema/visibility/profile.rb
+++ b/lib/graphql/schema/visibility/profile.rb
@@ -282,8 +282,7 @@ module GraphQL
         def load_all_types
           return if @all_types_loaded
           @all_types_loaded = true
-          visit = Visibility::Visit.new(@schema)
-          visit.visit_each do |member|
+          visit = Visibility::Visit.new(@schema) do |member|
             if member.is_a?(Module) && member.respond_to?(:kind)
               if @cached_visible[member]
                 type_name = member.graphql_name
@@ -299,7 +298,7 @@ module GraphQL
               @cached_visible[member]
             end
           end
-
+          visit.visit_each
           @all_types.delete_if { |type_name, type_defn| !referenced?(type_defn) }
           nil
         end

--- a/lib/graphql/schema/visibility/profile.rb
+++ b/lib/graphql/schema/visibility/profile.rb
@@ -243,6 +243,7 @@ module GraphQL
         end
 
         def loadable?(t, _ctx)
+          load_all_types
           !@all_types[t.graphql_name] && @cached_visible[t]
         end
 
@@ -304,7 +305,7 @@ module GraphQL
         end
 
         def referenced?(type_defn)
-          @schema.visibility.top_level.references[type_defn].any? { |ref_member| ref_member == true || @cached_visible[ref_member] }
+          @schema.visibility.top_level.references[type_defn].any? { |r| r == true ||  @cached_visible[r] }
         end
 
         def possible_types_for(type)

--- a/lib/graphql/schema/visibility/profile.rb
+++ b/lib/graphql/schema/visibility/profile.rb
@@ -38,7 +38,6 @@ module GraphQL
           @all_types = {}
           @all_types_loaded = false
           @unvisited_types = []
-          @referenced_types = Hash.new { |h, type_defn| h[type_defn] = [] }.compare_by_identity
           @all_directives = nil
           @cached_visible = Hash.new { |h, member|
             h[member] = @schema.visible?(member, @context)
@@ -284,7 +283,6 @@ module GraphQL
               end
               false
             else
-              @referenced_types[t] << by_member
               @all_types[n] = t
               @unvisited_types << t
               true
@@ -309,11 +307,6 @@ module GraphQL
 
         def raise_duplicate_definition(first_defn, second_defn)
           raise DuplicateNamesError.new(duplicated_name: first_defn.path, duplicated_definition_1: first_defn.inspect, duplicated_definition_2: second_defn.inspect)
-        end
-
-        def referenced?(t)
-          load_all_types
-          @referenced_types[t].any? { |reference| (reference == true) || @cached_visible[reference] }
         end
 
         protected

--- a/lib/graphql/schema/visibility/profile.rb
+++ b/lib/graphql/schema/visibility/profile.rb
@@ -111,7 +111,7 @@ module GraphQL
         end
 
         def type(type_name)
-          t = @schema.visibility.top_level.get_type(type_name) # rubocop:disable ContextIsPassedCop
+          t = @schema.visibility.get_type(type_name) # rubocop:disable ContextIsPassedCop
           if t
             if t.is_a?(Array)
               vis_t = nil
@@ -239,7 +239,7 @@ module GraphQL
         end
 
         def directives
-          @all_directives ||= @schema.visibility.top_level.directives.select { |dir| @cached_visible[dir] }
+          @all_directives ||= @schema.visibility.all_directives.select { |dir| @cached_visible[dir] }
         end
 
         def loadable?(t, _ctx)
@@ -288,7 +288,7 @@ module GraphQL
               if @cached_visible[member]
                 type_name = member.graphql_name
                 if (prev_t = @all_types[type_name]) && !prev_t.equal?(member)
-                  raise_duplicate_definition(prev_t, member)
+                  raise_duplicate_definition(member, prev_t)
                 end
                 @all_types[type_name] = member
                 true
@@ -305,14 +305,14 @@ module GraphQL
         end
 
         def referenced?(type_defn)
-          @schema.visibility.top_level.references[type_defn].any? { |r| r == true ||  @cached_visible[r] }
+          @schema.visibility.all_references[type_defn].any? { |r| r == true ||  @cached_visible[r] }
         end
 
         def possible_types_for(type)
           case type.kind.name
           when "INTERFACE"
             pts = []
-            @schema.visibility.top_level.interface_type_memberships[type].each do |itm|
+            @schema.visibility.all_interface_type_memberships[type].each do |itm|
               if @cached_visible[itm] && (ot = itm.object_type) && @cached_visible[ot] && referenced?(ot)
                 pts << ot
               end

--- a/lib/graphql/schema/visibility/visit.rb
+++ b/lib/graphql/schema/visibility/visit.rb
@@ -156,7 +156,7 @@ module GraphQL
                   pt << owner
                 end
                 int.interfaces.each do |indirect_int|
-                  if indirect_int.is_a?(LateBoundType) && (indirect_int_type = get_type(indirect_int.graphql_name))
+                  if indirect_int.is_a?(LateBoundType) && (indirect_int_type = get_type(indirect_int.graphql_name)) # rubocop:disable ContextIsPassedCop
                     update_type_owner(owner, indirect_int_type)
                   end
                 end

--- a/lib/graphql/schema/visibility/visit.rb
+++ b/lib/graphql/schema/visibility/visit.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+module GraphQL
+  class Schema
+    class Visibility
+      class Visit
+        def initialize(schema)
+          @schema = schema
+          @late_bound_types = nil
+          @unvisited_types = nil
+        end
+
+        def entry_point_types
+          ept = [
+            @schema.query,
+            @schema.mutation,
+            @schema.subscription,
+            *@schema.introspection_system.types.values,
+            *@schema.orphan_types,
+          ]
+          ept.compact!
+          ept
+        end
+
+        def visit_each
+          @unvisited_types && raise("Can't call #visit_each twice on this Visit object")
+          @unvisited_types = entry_point_types
+          @late_bound_types = []
+          visited_types = Set.new.compare_by_identity
+          visited_directives = Set.new.compare_by_identity
+
+          directives_to_visit = []
+
+          @schema.directives.each_value { |dir_class|
+            if visited_directives.add?(dir_class)
+              yield(dir_class)
+              dir_class.all_argument_definitions.each do |arg_defn|
+                if yield(arg_defn)
+                  directives_to_visit.concat(arg_defn.directives)
+                  append_unvisited_type(dir_class, arg_defn.type.unwrap)
+                end
+              end
+            end
+          }
+
+          while @unvisited_types.any? || @late_bound_types.any?
+            while (type = @unvisited_types.pop)
+              if visited_types.add?(type) && yield(type)
+                directives_to_visit.concat(type.directives)
+                case type.kind.name
+                when "OBJECT", "INTERFACE"
+                  type.interface_type_memberships.each do |itm|
+                    append_unvisited_type(type, itm.abstract_type)
+                  end
+                  if type.kind.interface?
+                    type.orphan_types.each do |orphan_type|
+                      append_unvisited_type(type, orphan_type)
+                    end
+                  end
+
+                  type.all_field_definitions.each do |field|
+                    field.ensure_loaded
+                    if yield(field)
+                      directives_to_visit.concat(field.directives)
+                      append_unvisited_type(type, field.type.unwrap)
+                      field.all_argument_definitions.each do |argument|
+                        if yield(argument)
+                          directives_to_visit.concat(argument.directives)
+                          append_unvisited_type(field, argument.type.unwrap)
+                        end
+                      end
+                    end
+                  end
+                when "INPUT_OBJECT"
+                  type.all_argument_definitions.each do |argument|
+                    if yield(argument)
+                      directives_to_visit.concat(argument.directives)
+                      append_unvisited_type(type, argument.type.unwrap)
+                    end
+                  end
+                when "UNION"
+                  type.type_memberships.each do |tm|
+                    append_unvisited_type(type, tm.object_type)
+                  end
+                when "ENUM"
+                  type.all_enum_value_definitions.each do |val|
+                    if yield(val)
+                      directives_to_visit.concat(val.directives)
+                    end
+                  end
+                when "SCALAR"
+                  # pass -- nothing else to visit
+                else
+                  raise "Invariant: unhandled type kind: #{type.kind.inspect}"
+                end
+              end
+            end
+
+            directives_to_visit.each do |dir|
+              dir_class = dir.class
+              if visited_directives.add?(dir_class)
+                yield(dir_class)
+              end
+            end
+
+            missed_late_types_streak = 0
+            while (owner, late_type = @late_bound_types.shift)
+              if (late_type.is_a?(String) && (type = Member::BuildType.constantize(type))) ||
+                  (late_type.is_a?(LateBoundType) && (type = visited_types.find { |t| t.graphql_name == late_type.graphql_name }))
+                missed_late_types_streak = 0 # might succeed next round
+                update_type_owner(owner, type)
+                append_unvisited_type(owner, type)
+              else
+                # Didn't find it -- keep trying
+                missed_late_types_streak += 1
+                @late_bound_types << [owner, late_type]
+                if missed_late_types_streak == @late_bound_types.size
+                  raise UnresolvedLateBoundTypeError.new(type: late_type)
+                end
+              end
+            end
+          end
+          nil
+        end
+
+        private
+
+        def append_unvisited_type(owner, type)
+          if type.is_a?(LateBoundType) || type.is_a?(String)
+            @late_bound_types << [owner, type]
+          else
+            @unvisited_types << type
+          end
+        end
+
+        def update_type_owner(owner, type)
+          case owner
+          when Module
+            if owner.kind.union?
+              owner.assign_type_membership_object_type(type)
+            elsif type.kind.interface?
+              new_interfaces = []
+              owner.interfaces.each do |int_t|
+                if int_t.is_a?(String) && int_t == type.graphql_name
+                  new_interfaces << type
+                elsif int_t.is_a?(LateBoundType) && int_t.graphql_name == type.graphql_name
+                  new_interfaces << type
+                else
+                  # Don't re-add proper interface definitions,
+                  # they were probably already added, maybe with options.
+                end
+              end
+              owner.implements(*new_interfaces)
+              new_interfaces.each do |int|
+                pt = @possible_types[int] ||= []
+                if !pt.include?(owner) && owner.is_a?(Class)
+                  pt << owner
+                end
+                int.interfaces.each do |indirect_int|
+                  if indirect_int.is_a?(LateBoundType) && (indirect_int_type = get_type(indirect_int.graphql_name))
+                    update_type_owner(owner, indirect_int_type)
+                  end
+                end
+              end
+            end
+          when GraphQL::Schema::Argument, GraphQL::Schema::Field
+            orig_type = owner.type
+            # Apply list/non-null wrapper as needed
+            if orig_type.respond_to?(:of_type)
+              transforms = []
+              while (orig_type.respond_to?(:of_type))
+                if orig_type.kind.non_null?
+                  transforms << :to_non_null_type
+                elsif orig_type.kind.list?
+                  transforms << :to_list_type
+                else
+                  raise "Invariant: :of_type isn't non-null or list"
+                end
+                orig_type = orig_type.of_type
+              end
+              transforms.reverse_each { |t| type = type.public_send(t) }
+            end
+            owner.type = type
+          else
+            raise "Unexpected update: #{owner.inspect} #{type.inspect}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/static_validation/validation_context.rb
+++ b/lib/graphql/static_validation/validation_context.rb
@@ -29,6 +29,7 @@ module GraphQL
         @visitor = visitor_class.new(document, self)
       end
 
+      # TODO stop using def_delegators because of Array allocations
       def_delegators :@visitor,
         :path, :type_definition, :field_definition, :argument_definition,
         :parent_type_definition, :directive_definition, :object_types, :dependencies

--- a/lib/graphql/testing/helpers.rb
+++ b/lib/graphql/testing/helpers.rb
@@ -92,7 +92,7 @@ module GraphQL
           end
           graphql_result
         else
-          unfiltered_type = schema.get_type(type_name, Query::NullContext.instance)
+          unfiltered_type = schema.use_visibility_profile? ? schema.visibility.top_level.get_type(type_name) : schema.get_type(type_name) # rubocop:disable ContextIsPassedCop
           if unfiltered_type
             raise TypeNotVisibleError.new(type_name: type_name)
           else

--- a/lib/graphql/testing/helpers.rb
+++ b/lib/graphql/testing/helpers.rb
@@ -92,7 +92,7 @@ module GraphQL
           end
           graphql_result
         else
-          unfiltered_type = schema.use_visibility_profile? ? schema.visibility.top_level.get_type(type_name) : schema.get_type(type_name) # rubocop:disable ContextIsPassedCop
+          unfiltered_type = schema.use_visibility_profile? ? schema.visibility.get_type(type_name) : schema.get_type(type_name) # rubocop:disable ContextIsPassedCop
           if unfiltered_type
             raise TypeNotVisibleError.new(type_name: type_name)
           else

--- a/lib/graphql/testing/helpers.rb
+++ b/lib/graphql/testing/helpers.rb
@@ -92,7 +92,7 @@ module GraphQL
           end
           graphql_result
         else
-          unfiltered_type = Schema::Visibility::Profile.null_profile(schema: schema, context: context).type(type_name)
+          unfiltered_type = schema.get_type(type_name, Query::NullContext.instance)
           if unfiltered_type
             raise TypeNotVisibleError.new(type_name: type_name)
           else

--- a/spec/graphql/schema/visibility/profile_spec.rb
+++ b/spec/graphql/schema/visibility/profile_spec.rb
@@ -19,9 +19,17 @@ describe GraphQL::Schema::Visibility::Profile do
   it "only loads the types it needs" do
     query = GraphQL::Query.new(ProfileSchema, "{ thing { name } }", use_visibility_profile: true)
     assert_equal [], query.types.loaded_types
-    res = query.result
 
+    res = query.result
     assert_equal "Something", res["data"]["thing"]["name"]
-    assert_equal ["Query", "String", "Thing"], query.types.loaded_types.map(&:graphql_name).sort
+    assert_equal [], query.types.loaded_types.map(&:graphql_name).sort
+
+    query = GraphQL::Query.new(ProfileSchema, "{ __schema { types { name }} }", use_visibility_profile: true)
+    assert_equal [], query.types.loaded_types
+
+    res = query.result
+    assert_equal 12, res["data"]["__schema"]["types"].size
+    loaded_type_names = query.types.loaded_types.map(&:graphql_name).reject { |n| n.start_with?("__") }.sort
+    assert_equal ["Boolean", "Query", "String", "Thing"], loaded_type_names
   end
 end


### PR DESCRIPTION
In order to support lazy-loading in development, I had bypassed the existing top-level caches for types, possible types, and schema references. But, that turned out to be noticeably slow when validating lots of queries all at once. So in this PR, I'm trying to have it all: 

- Continue supporting lazy-loading 
- Support thread-safe preloading in production 
- Be as fast as Warden when validating lots of queries 

I wrote a benchmark based on #5151: 

<details>
<summary>Validation benchmark, Warden vs Schema::Visibility</summary>

<p>

```ruby 
require "bundler/inline"

gemfile do
  gem "graphql", path: "~/code/graphql-ruby" 
  # gem "graphql", "2.4.3"
  gem "graphql-pro", path: "./"
  # gem "graphql-pro", "1.29.2"
  gem "benchmark-ips"
  gem "stackprof"
  gem "memory_profiler"
end

puts "GraphQL-Ruby: #{GraphQL::VERSION} / GraphQL-Pro: #{GraphQL::Pro::VERSION}"

WardenSchema = GraphQL::Schema.from_definition <<-GRAPHQL
schema {
  query: Query
  mutation: Mutation
}
# The query type, represents all of the entry points into our object graph
type Query {
  hero(episode: Episode): Character
  reviews(episode: Episode!): [Review]
  search(text: String): [SearchResult]
  character(id: ID!): Character
  droid(id: ID!): Droid
  human(id: ID!): Human
  starship(id: ID!): Starship
}
# The mutation type, represents all updates we can make to our data
type Mutation {
  createReview(episode: Episode, review: ReviewInput!): Review
}
# The episodes in the Star Wars trilogy
enum Episode {
  # Star Wars Episode IV: A New Hope, released in 1977.
  NEWHOPE
  # Star Wars Episode V: The Empire Strikes Back, released in 1980.
  EMPIRE
  # Star Wars Episode VI: Return of the Jedi, released in 1983.
  JEDI
}
# A character from the Star Wars universe
interface Character {
  # The ID of the character
  id: ID!
  # The name of the character
  name: String!
  # The friends of the character, or an empty list if they have none
  friends: [Character]
  # The friends of the character exposed as a connection with edges
  friendsConnection(first: Int, after: ID): FriendsConnection!
  # The movies this character appears in
  appearsIn: [Episode]!
}
# Units of height
enum LengthUnit {
  # The standard unit around the world
  METER
  # Primarily used in the United States
  FOOT
  # Ancient unit used during the Middle Ages
  CUBIT @deprecated(reason: "Test deprecated enum case")
}
# A humanoid creature from the Star Wars universe
type Human implements Character {
  # The ID of the human
  id: ID!
  # What this human calls themselves
  name: String!
  # The home planet of the human, or null if unknown
  homePlanet: String
  # Height in the preferred unit, default is meters
  height(unit: LengthUnit = METER): Float
  # Mass in kilograms, or null if unknown
  mass: Float
  # This human's friends, or an empty list if they have none
  friends: [Character]
  # The friends of the human exposed as a connection with edges
  friendsConnection(first: Int, after: ID): FriendsConnection!
  # The movies this human appears in
  appearsIn: [Episode]!
  # A list of starships this person has piloted, or an empty list if none
  starships: [Starship]
}
# An autonomous mechanical character in the Star Wars universe
type Droid implements Character {
  # The ID of the droid
  id: ID!
  # What others call this droid
  name: String!
  # This droid's friends, or an empty list if they have none
  friends: [Character]
  # The friends of the droid exposed as a connection with edges
  friendsConnection(first: Int, after: ID): FriendsConnection!
  # The movies this droid appears in
  appearsIn: [Episode]!
  # This droid's primary function
  primaryFunction: String
}
# A connection object for a character's friends
type FriendsConnection {
  # The total number of friends
  totalCount: Int
  # The edges for each of the character's friends.
  edges: [FriendsEdge]
  # A list of the friends, as a convenience when edges are not needed.
  friends: [Character]
  # Information for paginating this connection
  pageInfo: PageInfo!
}
# An edge object for a character's friends
type FriendsEdge {
  # A cursor used for pagination
  cursor: ID!
  # The character represented by this friendship edge
  node: Character
}
# Information for paginating this connection
type PageInfo {
  startCursor: ID
  endCursor: ID
  hasNextPage: Boolean!
}
# Represents a review for a movie
type Review {
  # The number of stars this review gave, 1-5
  stars: Int!
  # Comment about the movie
  commentary: String
}
# The input object sent when someone is creating a new review
input ReviewInput {
  # 0-5 stars
  stars: Int!
  # Comment about the movie, optional
  commentary: String
  # Favorite color, optional
  favorite_color: ColorInput
}
# The input object sent when passing in a color
input ColorInput {
  red: Int!
  green: Int!
  blue: Int!
}
type Starship {
  # The ID of the starship
  id: ID!
  # The name of the starship
  name: String!
  # Length of the starship, along the longest axis
  length(unit: LengthUnit = METER): Float
  coordinates: [[Float!]!]
}
union SearchResult = Human | Droid | Starship
GRAPHQL


doc1 = GraphQL.parse <<~GRAPHQL
query HeroAndFriendsNames($episode: Episode) {
  hero(episode: $episode) {
    name
    appearsIn
    friends {
      name
    }
  }
}
GRAPHQL

VisibilitySchema = Class.new(WardenSchema)
VisibilitySchema.use(GraphQL::Schema::Visibility)
doc2 = GraphQL.parse(GraphQL::Introspection::INTROSPECTION_QUERY)

# Warm-up:
GraphQL::Pro::OperationStore::Validate.validate(VisibilitySchema, doc1, client_name: "foo")
GraphQL::Pro::OperationStore::Validate.validate(WardenSchema, doc1, client_name: "foo")
GraphQL::Pro::OperationStore::Validate.validate(VisibilitySchema, doc2, client_name: "foo")
GraphQL::Pro::OperationStore::Validate.validate(WardenSchema, doc2, client_name: "foo")

if ENV["IPS"]
  Benchmark.ips do |x|
    x.report("Visibility 1") { GraphQL::Pro::OperationStore::Validate.validate(VisibilitySchema, doc1, client_name: "foo") }
    x.report("Warden 1") { GraphQL::Pro::OperationStore::Validate.validate(WardenSchema, doc1, client_name: "foo") }
    x.report("Visibility 2") { GraphQL::Pro::OperationStore::Validate.validate(VisibilitySchema, doc2, client_name: "foo") }
    x.report("Warden 2") { GraphQL::Pro::OperationStore::Validate.validate(WardenSchema, doc2, client_name: "foo") }
    x.compare!
  end
end

if ENV["PROF"]
  GC.start

  prof_doc = doc1

  StackProf.run(mode: :wall, interval: 1, out: 'tmp/warden-validate.dump', raw: true) do
    GraphQL::Pro::OperationStore::Validate.validate(WardenSchema, prof_doc, client_name: "foo")
  end


  StackProf.run(mode: :wall, interval: 1, out: 'tmp/validate.dump', raw: true) do
    GraphQL::Pro::OperationStore::Validate.validate(VisibilitySchema, prof_doc, client_name: "foo")
  end
end

if ENV["MEM"]
  GC.start
  report = MemoryProfiler.report do
    GraphQL::Pro::OperationStore::Validate.validate(VisibilitySchema, doc2, client_name: "foo")
  end
  puts report.pretty_print
end

```
</p>
</details>


And I got big (10x +)  performance gains so far: 

```diff 
  Calculating -------------------------------------
-        Visibility 1    205.565 (± 3.4%) i/s    (4.86 ms/i) -      1.040k in   5.065163s
+        Visibility 1      2.590k (± 6.3%) i/s  (386.13 μs/i) -     13.000k in   5.041105s
            Warden 1      2.554k (± 3.9%) i/s  (391.50 μs/i) -     12.852k in   5.039105s
-        Visibility 2     25.223 (± 4.0%) i/s   (39.65 ms/i) -    126.000 in   5.002731s
+        Visibility 2    827.604 (± 3.9%) i/s    (1.21 ms/i) -      4.212k in   5.097079s
            Warden 2    754.498 (± 3.3%) i/s    (1.33 ms/i) -      3.800k in   5.042172s
```

So, there are still some wrinkles to smooth out, but it's heading the right direction!


### TODO 

- [x] Add schema-level cache for `type => possible_types` and use it `Visibility::Profile` 
- [x] Add schema-level cache for `type => references` and use it 
- [x]  〃 `interface => interface_implementors` 〃
- [x] What caches can be removed from `Profile`? remove `def references?`
- [x] Reuse `Schema::Visibility::Visit` in `Profile` instead of hand-rolled visit code 
- [x] Consider how `TopLevel` interacts with `preload: true` and `preload: false` 
- [x] Unit-test `TopLevel` (and rename?) to make sure lazy-loading works as expected
- [x] Make top-level caches incrementally addable instead of `refresh: true`
- [ ] Does this remove the need for `top_level_profile`?

Fixes #5151 