### PR TITLE
Hide directives when their uses are hidden

### DIFF
--- a/lib/graphql/schema/visibility/profile.rb
+++ b/lib/graphql/schema/visibility/profile.rb
@@ -239,7 +239,9 @@ module GraphQL
         end
 
         def directives
-          @all_directives ||= @schema.visibility.all_directives.select { |dir| @cached_visible[dir] }
+          @all_directives ||= @schema.visibility.all_directives.select { |dir|
+            @cached_visible[dir] && @schema.visibility.all_references[dir].any? { |ref| ref == true || (@cached_visible[ref] && referenced?(ref)) }
+          }
         end
 
         def loadable?(t, _ctx)

--- a/spec/graphql/schema/warden_spec.rb
+++ b/spec/graphql/schema/warden_spec.rb
@@ -167,7 +167,6 @@ module MaskHelpers
   end
 
   class CheremeDirective < GraphQL::Schema::Directive
-    graphql_name("cheremeDirectives")
     locations(GraphQL::Schema::Directive::OBJECT)
   end
 
@@ -415,15 +414,12 @@ describe GraphQL::Schema::Warden do
       |
 
       res = MaskHelpers.query_with_mask(query_string, mask)
-      expected_directives = ["include", "skip", "deprecated", "oneOf", "specifiedBy"]
+      expected_directives = ["deprecated", "include", "oneOf", "skip", "specifiedBy"]
+      if !GraphQL::Schema.use_visibility_profile?
+        # Not supported by Warden
+        expected_directives.unshift("cheremeDirective")
+      end
 
-      # Failure:
-      # GraphQL::Schema::Warden::hiding fields#test_0003_hides directives if no other fields are using it
-      # Minitest::Assertion: --- expected
-      # +++ actual
-      # @@ -1 +1 @@
-      # -["include", "skip", "deprecated", "oneOf", "specifiedBy"]
-      # +["include", "skip", "deprecated", "oneOf", "specifiedBy", "cheremeDirectives"]
       assert_equal(expected_directives, res["data"]["__schema"]["directives"].map { |d| d["name"] })
     end
 


### PR DESCRIPTION
Fixes #4882 

This adds _some_ hiding of directives when their uses are hidden. It only checks "one level" deep. Directives are hidden if: 

- They aren't registered to the schema with `directive(...)` configurations
- AND no types with `field(...)` configurations using the directive are visible 
- AND no resolvers and fields with `argument(...)` configurations using the directive are visible
- AND no enums with `value(...)` configurations using the directive are visible 

It doesn't do recursive checking, so if a type is hidden because fields using it are hidden, then the directive will still be visible. Maybe that's possible but I'm guessing that adding `visible?` implementations to the app is a less complicated solution in that case.