### PR TITLE
Fix bug in DataLoader::Source#load_all when sending only falsy values

### DIFF
--- a/lib/graphql/dataloader/source.rb
+++ b/lib/graphql/dataloader/source.rb
@@ -73,7 +73,7 @@ module GraphQL
           end
         }
 
-        if pending_keys.any?
+        if pending_keys.size.positive?
           sync(pending_keys)
         end
 


### PR DESCRIPTION
In ruby:
```rb
[nil].any? #=> false
[false].any? #=> false
```

When sending [nil] to load_all, it was making the source think that there are no pending keys, and raised GraphQL::InvariantError.