### PR TITLE
Allow InputObject instances to be pattern matched via #deconstruct_keys

### DIFF
--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -57,8 +57,9 @@ module GraphQL
         if keys.nil?
           @ruby_style_hash
         else
-          keys.select { @ruby_style_hash.key?(_1) }
-              .to_h { [_1, @ruby_style_hash[_1]] }
+          new_h = {}
+          keys.each { |k| @ruby_style_hash.key?(k) && new_h[k] = @ruby_style_hash[k] }
+          new_h 
         end
       end
 

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -53,6 +53,15 @@ module GraphQL
         to_h
       end
 
+      def deconstruct_keys(keys = nil)
+        if keys.nil?
+          @ruby_style_hash
+        else
+          keys.select { @ruby_style_hash.key?(_1) }
+              .to_h { [_1, @ruby_style_hash[_1]] }
+        end
+      end
+
       def prepare
         if @context
           object = @context[:current_object]


### PR DESCRIPTION
This allows Ruby's case/in syntax, like:

```ruby
case input
in { x:, y: }
  # do something with x and y
end
```

This is easy for individual projects to add in their own `InputObject` superclass, but it seems generally useful, so I figured I'd raise a PR with it. No hard feelings if you don't want it upstream. :slightly_smiling_face: 