### PR TITLE
Migrate internal runtime state to Fiber storage

### DIFF
--- a/lib/graphql/current.rb
+++ b/lib/graphql/current.rb
@@ -41,7 +41,7 @@ module GraphQL
     # @see GraphQL::Field#path for a string identifying this field
     # @return [GraphQL::Field, nil] The currently-running field, if there is one.
     def self.field
-      Thread.current[:__graphql_runtime_info]&.values&.first&.current_field
+      Fiber[:__graphql_runtime_info]&.values&.first&.current_field
     end
 
     # @return [Class, nil] The currently-running {Dataloader::Source} class, if there is one.

--- a/lib/graphql/dataloader.rb
+++ b/lib/graphql/dataloader.rb
@@ -78,10 +78,7 @@ module GraphQL
     def get_fiber_variables
       fiber_vars = {}
       Thread.current.keys.each do |fiber_var_key|
-        # This variable should be fresh in each new fiber
-        if fiber_var_key != :__graphql_runtime_info
-          fiber_vars[fiber_var_key] = Thread.current[fiber_var_key]
-        end
+        fiber_vars[fiber_var_key] = Thread.current[fiber_var_key]
       end
       fiber_vars
     end

--- a/lib/graphql/dataloader/async_dataloader.rb
+++ b/lib/graphql/dataloader/async_dataloader.rb
@@ -3,7 +3,7 @@ module GraphQL
   class Dataloader
     class AsyncDataloader < Dataloader
       def yield
-        if (condition = Thread.current[:graphql_dataloader_next_tick])
+        if (condition = Fiber[:graphql_dataloader_next_tick])
           condition.wait
         else
           Fiber.yield
@@ -78,7 +78,7 @@ module GraphQL
           fiber_vars = get_fiber_variables
           parent_task.async do
             set_fiber_variables(fiber_vars)
-            Thread.current[:graphql_dataloader_next_tick] = condition
+            Fiber[:graphql_dataloader_next_tick] = condition
             pending_sources.each(&:run_pending_keys)
             cleanup_fiber
           end

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -736,7 +736,7 @@ module GraphQL
         end
 
         def get_current_runtime_state
-          current_state = Thread.current[:__graphql_runtime_info] ||= {}.compare_by_identity
+          current_state = Fiber[:__graphql_runtime_info] ||= {}.compare_by_identity
           current_state[@query] ||= CurrentState.new
         end
 
@@ -821,11 +821,11 @@ module GraphQL
         end
 
         def delete_all_interpreter_context
-          per_query_state = Thread.current[:__graphql_runtime_info]
+          per_query_state = Fiber[:__graphql_runtime_info]
           if per_query_state
             per_query_state.delete(@query)
             if per_query_state.size == 0
-              Thread.current[:__graphql_runtime_info] = nil
+              Fiber[:__graphql_runtime_info] = nil
             end
           end
           nil

--- a/lib/graphql/pagination/connection.rb
+++ b/lib/graphql/pagination/connection.rb
@@ -223,7 +223,7 @@ module GraphQL
 
       def detect_was_authorized_by_scope_items
         if @context &&
-            (current_runtime_state = Thread.current[:__graphql_runtime_info]) &&
+            (current_runtime_state = Fiber[:__graphql_runtime_info]) &&
             (query_runtime_state = current_runtime_state[@context.query])
           query_runtime_state.was_authorized_by_scope_items
         else

--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -104,7 +104,7 @@ module GraphQL
           if key == :current_path
             current_path
           else
-            (current_runtime_state = Thread.current[:__graphql_runtime_info]) &&
+            (current_runtime_state = Fiber[:__graphql_runtime_info]) &&
               (query_runtime_state = current_runtime_state[@query]) &&
               (query_runtime_state.public_send(key))
           end
@@ -144,7 +144,7 @@ module GraphQL
       end
 
       def current_path
-        current_runtime_state = Thread.current[:__graphql_runtime_info]
+        current_runtime_state = Fiber[:__graphql_runtime_info]
         query_runtime_state = current_runtime_state && current_runtime_state[@query]
 
         path = query_runtime_state &&
@@ -169,7 +169,7 @@ module GraphQL
 
       def fetch(key, default = UNSPECIFIED_FETCH_DEFAULT)
         if RUNTIME_METADATA_KEYS.include?(key)
-          (runtime = Thread.current[:__graphql_runtime_info]) &&
+          (runtime = Fiber[:__graphql_runtime_info]) &&
             (query_runtime_state = runtime[@query]) &&
             (query_runtime_state.public_send(key))
         elsif @scoped_context.key?(key)
@@ -187,7 +187,7 @@ module GraphQL
 
       def dig(key, *other_keys)
         if RUNTIME_METADATA_KEYS.include?(key)
-          (current_runtime_state = Thread.current[:__graphql_runtime_info]) &&
+          (current_runtime_state = Fiber[:__graphql_runtime_info]) &&
             (query_runtime_state = current_runtime_state[@query]) &&
             (obj = query_runtime_state.public_send(key)) &&
             if other_keys.empty?

--- a/lib/graphql/schema/field/scope_extension.rb
+++ b/lib/graphql/schema/field/scope_extension.rb
@@ -12,7 +12,7 @@ module GraphQL
             if ret_type.respond_to?(:scope_items)
               scoped_items = ret_type.scope_items(value, context)
               if !scoped_items.equal?(value) && !ret_type.reauthorize_scoped_objects
-                if (current_runtime_state = Thread.current[:__graphql_runtime_info]) &&
+                if (current_runtime_state = Fiber[:__graphql_runtime_info]) &&
                     (query_runtime_state = current_runtime_state[context.query])
                   query_runtime_state.was_authorized_by_scope_items = true
                 end

--- a/lib/graphql/types/relay/connection_behaviors.rb
+++ b/lib/graphql/types/relay/connection_behaviors.rb
@@ -196,7 +196,7 @@ module GraphQL
         def edges
           # Assume that whatever authorization needed to happen
           # already happened at the connection level.
-          current_runtime_state = Thread.current[:__graphql_runtime_info]
+          current_runtime_state = Fiber[:__graphql_runtime_info]
           query_runtime_state = current_runtime_state[context.query]
           query_runtime_state.was_authorized_by_scope_items = @object.was_authorized_by_scope_items?
           @object.edges
@@ -205,7 +205,7 @@ module GraphQL
         def nodes
           # Assume that whatever authorization needed to happen
           # already happened at the connection level.
-          current_runtime_state = Thread.current[:__graphql_runtime_info]
+          current_runtime_state = Fiber[:__graphql_runtime_info]
           query_runtime_state = current_runtime_state[context.query]
           query_runtime_state.was_authorized_by_scope_items = @object.was_authorized_by_scope_items?
           @object.nodes

--- a/lib/graphql/types/relay/edge_behaviors.rb
+++ b/lib/graphql/types/relay/edge_behaviors.rb
@@ -14,7 +14,7 @@ module GraphQL
         end
 
         def node
-          current_runtime_state = Thread.current[:__graphql_runtime_info]
+          current_runtime_state = Fiber[:__graphql_runtime_info]
           query_runtime_state = current_runtime_state[context.query]
           query_runtime_state.was_authorized_by_scope_items = @object.was_authorized_by_scope_items?
           @object.node

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -309,7 +309,7 @@ describe GraphQL::Execution::Interpreter do
       module EnsureThreadCleanedUp
         def execute_multiplex(multiplex:)
           res = super
-          runtime_info = Thread.current[:__graphql_runtime_info]
+          runtime_info = Fiber[:__graphql_runtime_info]
           if !runtime_info.nil? && runtime_info != {}
             if !multiplex.context[:allow_pending_thread_state]
               # `nestedQuery` can allow this
@@ -369,7 +369,7 @@ describe GraphQL::Execution::Interpreter do
       {"__typename" => "Expansion", "sym" => "RAV"},
     ]
     assert_equal expected_abstract_list, result["data"]["find"]
-    assert_nil Thread.current[:__graphql_runtime_info]
+    assert_nil Fiber[:__graphql_runtime_info]
   end
 
   it "runs a nested query and maintains proper state" do
@@ -377,7 +377,7 @@ describe GraphQL::Execution::Interpreter do
     result = InterpreterTest::Schema.execute(query_str, variables: { queryStr: "{ __typename }" })
     assert_equal '{"data":{"__typename":"Query"}}', result["data"]["nestedQuery"]["result"]
     assert_equal ["nestedQuery"], result["data"]["nestedQuery"]["currentPath"]
-    assert_nil Thread.current[:__graphql_runtime_info]
+    assert_nil Fiber[:__graphql_runtime_info]
   end
 
   it "runs mutation roots atomically and sequentially" do
@@ -428,7 +428,7 @@ describe GraphQL::Execution::Interpreter do
       "exp5" => {"name" => "Ravnica, City of Guilds"},
     }
     assert_equal expected_data, result["data"]
-    assert_nil Thread.current[:__graphql_runtime_info]
+    assert_nil Fiber[:__graphql_runtime_info]
   end
 
   describe "runtime info in context" do
@@ -469,7 +469,7 @@ describe GraphQL::Execution::Interpreter do
       # propagated to here
       assert_nil res["data"].fetch("expansion")
       assert_equal ["Cannot return null for non-nullable field Expansion.name"], res["errors"].map { |e| e["message"] }
-      assert_nil Thread.current[:__graphql_runtime_info]
+      assert_nil Fiber[:__graphql_runtime_info]
     end
 
     it "places errors ahead of data in the response" do

--- a/spec/graphql/pagination/connection_spec.rb
+++ b/spec/graphql/pagination/connection_spec.rb
@@ -11,11 +11,11 @@ describe GraphQL::Pagination::Connection do
       conn.context = context
       assert_nil conn.was_authorized_by_scope_items?
 
-      Thread.current[:__graphql_runtime_info] = { context.query => OpenStruct.new(was_authorized_by_scope_items: true) }
+      Fiber[:__graphql_runtime_info] = { context.query => OpenStruct.new(was_authorized_by_scope_items: true) }
       conn.context = context
       assert_equal true, conn.was_authorized_by_scope_items?
     ensure
-      Thread.current[:__graphql_runtime_info] = nil
+      Fiber[:__graphql_runtime_info] = nil
     end
   end
 end

--- a/spec/graphql/query/context_spec.rb
+++ b/spec/graphql/query/context_spec.rb
@@ -5,7 +5,7 @@ describe GraphQL::Query::Context do
   after do
     # Clean up test fixtures so they don't pollute later tests
     # (Usually this is cleaned up by execution code, but many tests here don't actually execute queries)
-    Thread.current[:__graphql_runtime_info] = nil
+    Fiber[:__graphql_runtime_info] = nil
   end
 
   class ContextTestSchema < GraphQL::Schema
@@ -100,7 +100,7 @@ describe GraphQL::Query::Context do
 
     it "allows you to read values of contexts using dig" do
       assert_equal(1, context.dig(:a, :b))
-      Thread.current[:__graphql_runtime_info] = { context.query => OpenStruct.new(current_arguments: {c: 1}) }
+      Fiber[:__graphql_runtime_info] = { context.query => OpenStruct.new(current_arguments: {c: 1}) }
       assert_equal 1, context.dig(:current_arguments, :c)
       assert_equal({c: 1}, context.dig(:current_arguments))
     end
@@ -118,7 +118,7 @@ describe GraphQL::Query::Context do
 
   it "can override values set by runtime" do
     context = GraphQL::Query::Context.new(query: OpenStruct.new(schema: schema), values: {a: {b: 1}})
-    Thread.current[:__graphql_runtime_info] = { context.query => OpenStruct.new({ current_object: :runtime_value }) }
+    Fiber[:__graphql_runtime_info] = { context.query => OpenStruct.new({ current_object: :runtime_value }) }
     assert_equal :runtime_value, context[:current_object]
     context[:current_object] = :override_value
     assert_equal :override_value, context[:current_object]
@@ -391,7 +391,7 @@ describe GraphQL::Query::Context do
     it "always retrieves a scoped context value if set" do
       context = GraphQL::Query::Context.new(query: OpenStruct.new(schema: schema), values: nil)
       dummy_runtime = OpenStruct.new(current_result: nil)
-      Thread.current[:__graphql_runtime_info] = { context.query => dummy_runtime }
+      Fiber[:__graphql_runtime_info] = { context.query => dummy_runtime }
       dummy_runtime.current_result = OpenStruct.new(path: ["somewhere"])
       expected_key = :a
       expected_value = :test
@@ -453,7 +453,7 @@ describe GraphQL::Query::Context do
     it "has a #current_path method" do
       context = GraphQL::Query::Context.new(query: OpenStruct.new(schema: schema), values: nil)
       current_result = OpenStruct.new(path: ["somewhere", "child", "grandchild"])
-      Thread.current[:__graphql_runtime_info] = { context.query => OpenStruct.new(current_result: current_result) }
+      Fiber[:__graphql_runtime_info] = { context.query => OpenStruct.new(current_result: current_result) }
       assert_equal ["somewhere", "child", "grandchild"], context.scoped_context.current_path
     end
   end


### PR DESCRIPTION
Trying out part of the suggestion from #5173 


TODO: 

- [x] See if tests pass. `:__graphql_runtime_info` was specially-handled before to _not_ be inherited into new fibers.
- [x] Consider compat issues? This should all be internal 
  - I searched google for `:__graphql_runtime_info` and didn't find anything outside of GraphQL-Ruby. I also checked GraphQL-Pro and GraphQL-Enterprise and didn't find any usages.
