### PR TITLE
Fix autoloading of GraphQL::Types

### DIFF
--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -15,6 +15,7 @@ module GraphQL
     super
     Query.eager_load!
     Types.eager_load!
+    Schema.eager_load!
   end
 
   class Error < StandardError

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -75,6 +75,9 @@ module GraphQL
   class Schema
     extend GraphQL::Schema::Member::HasAstNode
     extend GraphQL::Schema::FindInheritedValue
+    extend Autoload
+
+    autoload :BUILT_IN_TYPES, "graphql/schema/built_in_types"
 
     class DuplicateNamesError < GraphQL::Error
       attr_reader :duplicated_name
@@ -1805,6 +1808,5 @@ module GraphQL
   end
 end
 
-require "graphql/schema/built_in_types"
 require "graphql/schema/loader"
 require "graphql/schema/printer"


### PR DESCRIPTION
Followup to #5178 

Types reference schema, which reference types, so we need to take the part of schema that reference types, and autoload it.

Currently, if you reference `GraphQL::Types::String`, you'll get:
```
graphql-ruby/lib/graphql/schema/built_in_types.rb:6:in `<class:Schema>': unin
itialized constant GraphQL::Types::String (NameError)

      "String" => GraphQL::Types::String,
                                ^^^^^^^^
Did you mean?  StringIO
               STDIN
        from graphql-ruby/lib/graphql/schema/built_in_types.rb:3:in `<module:
GraphQL>'
        from graphql-ruby/lib/graphql/schema/built_in_types.rb:2:in `<top (required)>'
        from /opt/rubies/3.3.6/lib/ruby/3.3.0/bundled_gems.rb:69:in `require'
        from /opt/rubies/3.3.6/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
        from graphql-ruby/lib/graphql/schema.rb:1813:in `<top (required)>'
        from /opt/rubies/3.3.6/lib/ruby/3.3.0/bundled_gems.rb:69:in `require'
        from /opt/rubies/3.3.6/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
        from graphql-ruby/lib/graphql/types/string.rb:5:in `<module:Types>'
        from graphql-ruby/lib/graphql/types/string.rb:4:in `<module:GraphQL>'
        from graphql-ruby/lib/graphql/types/string.rb:3:in `<top (required)>'
        from /opt/rubies/3.3.6/lib/ruby/3.3.0/bundled_gems.rb:69:in `require'
        from /opt/rubies/3.3.6/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
        from (irb):1:in `<main>'
        from <internal:kernel>:187:in `loop'
        from bin/console:8:in `<main>'
```

This fixes the problem. Sorry for not catching this earlier!