### PR TITLE
Use config.before_eager_load

### DIFF
--- a/lib/graphql/railtie.rb
+++ b/lib/graphql/railtie.rb
@@ -10,7 +10,9 @@ module GraphQL
   class Railtie < Rails::Railtie
     config.graphql = ActiveSupport::OrderedOptions.new
     config.graphql.parser_cache = false
-    config.eager_load_namespaces << GraphQL
+    config.before_eager_load do
+      GraphQL.eager_load!
+    end
 
     initializer("graphql.cache") do |app|
       if config.graphql.parser_cache


### PR DESCRIPTION
We want to make sure the gem is fully loaded in a production context before the application begins eagerly loading, otherwise we emit a warning. So, let's use `config.before_eager_load` to make sure gem eager loading happens before the app.

Before:
```
> RAILS_ENV=production bin/rails runner ""
GraphQL-Ruby thinks this is a production deployment but didn't eager-load its constants. Address this by:

  - Calling `GraphQL.eager_load!` in a production-only initializer or setup hook
  - Assign `GraphQL.env = "..."` to something _other_ than `"production"` (for example, `GraphQL.env = "development"`)

More details: https://graphql-ruby.org/schema/definition#production-considerations
```

After:
```
RAILS_ENV=production bin/rails runner ""
```