### PR TITLE
Don't print production eager loading warning if already eager loaded

### DIFF
--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -16,6 +16,7 @@ module GraphQL
     Query.eager_load!
     Types.eager_load!
     Schema.eager_load!
+    @_eager_loaded = true
   end
 
   class Error < StandardError
@@ -86,7 +87,7 @@ This is probably a bug in GraphQL-Ruby, please report this error on GitHub: http
     # If `production?` is detected but `eager_load!` wasn't called, emit a warning.
     # @return [void]
     def ensure_eager_load!
-      if production? && !eager_loading?
+      if production? && !eager_loaded?
         warn <<~WARNING
           GraphQL-Ruby thinks this is a production deployment but didn't eager-load its constants. Address this by:
 
@@ -110,6 +111,10 @@ This is probably a bug in GraphQL-Ruby, please report this error on GitHub: http
       else
         (detected_env = ENV["RACK_ENV"] || ENV["RAILS_ENV"] || ENV["HANAMI_ENV"] || ENV["APP_ENV"]) && detected_env.to_s.downcase == "production"
       end
+    end
+
+    def eager_loaded?
+      @_eager_loaded ||= false
     end
   end
 

--- a/spec/graphql/autoload_spec.rb
+++ b/spec/graphql/autoload_spec.rb
@@ -49,6 +49,7 @@ describe GraphQL::Autoload do
 
   describe "warning in production" do
     before do
+      GraphQL.remove_instance_variable(:@_eager_loaded) if GraphQL.instance_variable_defined?(:@_eager_loaded)
       @prev_env = ENV.to_hash
       ENV.update("HANAMI_ENV" => "production")
     end
@@ -83,6 +84,15 @@ More details: https://graphql-ruby.org/schema/definition#production-consideratio
       assert_equal "", stderr
     ensure
       GraphQL.env = prev_env
+    end
+
+    it "silences the warning when already eager-loaded" do
+      GraphQL.eager_load!
+      stdout, stderr = capture_io do
+        GraphQL.ensure_eager_load!
+      end
+      assert_equal "", stdout
+      assert_equal "", stderr
     end
   end
 end


### PR DESCRIPTION
This is my attempt to get the warning to not print if we've already eager loaded. Before, it was only checking if we were in the middle of eager loading, which always goes back to `false` when the eager load is complete.