### PR TITLE
Remove ensure_eager_load, use eager_load_namespaces

### DIFF
--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -82,35 +82,6 @@ This is probably a bug in GraphQL-Ruby, please report this error on GitHub: http
   class << self
     # If true, the parser should raise when an integer or float is followed immediately by an identifier (instead of a space or punctuation)
     attr_accessor :reject_numbers_followed_by_names
-
-    # If `production?` is detected but `eager_load!` wasn't called, emit a warning.
-    # @return [void]
-    def ensure_eager_load!
-      if production? && !eager_loading?
-        warn <<~WARNING
-          GraphQL-Ruby thinks this is a production deployment but didn't eager-load its constants. Address this by:
-
-            - Calling `GraphQL.eager_load!` in a production-only initializer or setup hook
-            - Assign `GraphQL.env = "..."` to something _other_ than `"production"` (for example, `GraphQL.env = "development"`)
-
-          More details: https://graphql-ruby.org/schema/definition#production-considerations
-        WARNING
-      end
-    end
-
-    attr_accessor :env
-
-    private
-
-    # Detect whether this is a production deployment or not
-    def production?
-      if env
-        # Manually assigned to production?
-        env == "production"
-      else
-        (detected_env = ENV["RACK_ENV"] || ENV["RAILS_ENV"] || ENV["HANAMI_ENV"] || ENV["APP_ENV"]) && detected_env.to_s.downcase == "production"
-      end
-    end
   end
 
   self.reject_numbers_followed_by_names = false

--- a/lib/graphql/autoload.rb
+++ b/lib/graphql/autoload.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module GraphQL
+  # @see GraphQL::Railtie for automatic Rails integration
   module Autoload
     # Register a constant named `const_name` to be loaded from `path`.
     # This is like `Kernel#autoload` but it tracks the constants so they can be eager-loaded with {#eager_load!}

--- a/lib/graphql/railtie.rb
+++ b/lib/graphql/railtie.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module GraphQL
-  # Support {GraphQL::Parser::Cache}
+  # Support {GraphQL::Parser::Cache} and {GraphQL.eager_load!}
   #
   # @example Enable the parser cache with default directory
   #
@@ -10,9 +10,7 @@ module GraphQL
   class Railtie < Rails::Railtie
     config.graphql = ActiveSupport::OrderedOptions.new
     config.graphql.parser_cache = false
-    config.before_eager_load do
-      GraphQL.eager_load!
-    end
+    config.eager_load_namespaces << GraphQL
 
     initializer("graphql.cache") do |app|
       if config.graphql.parser_cache

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -47,8 +47,6 @@ require "graphql/schema/relay_classic_mutation"
 require "graphql/schema/subscription"
 require "graphql/schema/visibility"
 
-GraphQL.ensure_eager_load!
-
 module GraphQL
   # A GraphQL schema which may be queried with {GraphQL::Query}.
   #

--- a/spec/graphql/autoload_spec.rb
+++ b/spec/graphql/autoload_spec.rb
@@ -45,44 +45,4 @@ describe GraphQL::Autoload do
       assert EagerModule::NestedEagerModule::NestedEagerClass
     end
   end
-
-
-  describe "warning in production" do
-    before do
-      @prev_env = ENV.to_hash
-      ENV.update("HANAMI_ENV" => "production")
-    end
-
-    after do
-      ENV.update(@prev_env)
-    end
-
-    it "emits a warning when not eager-loading" do
-      stdout, stderr = capture_io do
-        GraphQL.ensure_eager_load!
-      end
-
-      assert_equal "", stdout
-      expected_warning = "GraphQL-Ruby thinks this is a production deployment but didn't eager-load its constants. Address this by:
-
-  - Calling `GraphQL.eager_load!` in a production-only initializer or setup hook
-  - Assign `GraphQL.env = \"...\"` to something _other_ than `\"production\"` (for example, `GraphQL.env = \"development\"`)
-
-More details: https://graphql-ruby.org/schema/definition#production-considerations
-"
-      assert_equal expected_warning, stderr
-    end
-
-    it "silences the warning when GraphQL.env is assigned" do
-      prev_env = GraphQL.env
-      GraphQL.env = "staging"
-      stdout, stderr = capture_io do
-        GraphQL.ensure_eager_load!
-      end
-      assert_equal "", stdout
-      assert_equal "", stderr
-    ensure
-      GraphQL.env = prev_env
-    end
-  end
 end


### PR DESCRIPTION
I wish there was a reliable way to detect this condition, but it seems like ... there isn't. So: 

- remove this warning 
- use Rails's `eager_load_namespaces` instead, since it seems like the intended integration point