### PR TITLE
Make resolvers inherit description from superclass

### DIFF
--- a/lib/graphql/schema/resolver.rb
+++ b/lib/graphql/schema/resolver.rb
@@ -22,6 +22,7 @@ module GraphQL
       include Schema::Member::GraphQLTypeNames
       # Really we only need description & comment from here, but:
       extend Schema::Member::BaseDSLMethods
+      extend Member::BaseDSLMethods::ConfigurationExtension
       extend GraphQL::Schema::Member::HasArguments
       extend GraphQL::Schema::Member::HasValidators
       include Schema::Member::HasPath

--- a/spec/graphql/schema/resolver_spec.rb
+++ b/spec/graphql/schema/resolver_spec.rb
@@ -54,6 +54,8 @@ describe GraphQL::Schema::Resolver do
     class Resolver4 < BaseResolver
       type Integer, null: false
 
+      description "Adds object.value to ast_node.name.size"
+
       extras [:ast_node]
       def resolve(ast_node:)
         object.value + ast_node.name.size
@@ -721,6 +723,14 @@ describe GraphQL::Schema::Resolver do
       res = exec_query " { resolver7 resolver8 } ", root_value: OpenStruct.new(value: 0)
       assert_equal 2, res["data"]["resolver7"]
       assert_equal 2, res["data"]["resolver8"]
+    end
+  end
+
+  describe "description" do
+    it "is inherited" do
+      expected_desc = "Adds object.value to ast_node.name.size"
+      assert_equal expected_desc, ResolverTest::Resolver4.description
+      assert_equal expected_desc, ResolverTest::Resolver5.description
     end
   end
 


### PR DESCRIPTION
Oops -- I think this was just an oversight that `description` wasn't passed down to children.