### PR TITLE
Allow accessing enum value names via methods

### DIFF
--- a/gemfiles/mongoid_7.gemfile
+++ b/gemfiles/mongoid_7.gemfile
@@ -12,5 +12,6 @@ if RUBY_VERSION >= "3.0"
   gem "evt"
 end
 gem "fiber-storage"
+gem "concurrent-ruby", "1.3.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -11,5 +11,6 @@ gem "sqlite3", "~> 1.4", platform: :ruby
 gem "sequel"
 gem "evt"
 gem "async"
+gem "concurrent-ruby", "1.3.4"
 
 gemspec path: "../"

--- a/guides/type_definitions/enums.md
+++ b/guides/type_definitions/enums.md
@@ -76,5 +76,5 @@ Enum classes are never instantiated and their methods are never called.
 You can get the GraphQL name of the enum value using the method matching its downcased name:
 
 ```ruby
-Types::MediaCategory.audio # => "Audio"
+Types::MediaCategory.audio # => "AUDIO"
 ```

--- a/guides/type_definitions/enums.md
+++ b/guides/type_definitions/enums.md
@@ -78,3 +78,19 @@ You can get the GraphQL name of the enum value using the method matching its dow
 ```ruby
 Types::MediaCategory.audio # => "AUDIO"
 ```
+
+You can pass a `value_method:` to override the value of the generated method:
+
+```ruby
+value "AUDIO", value: :audio, value_method: :lo_fi_audio
+
+# ...
+
+Types::MediaCategory.lo_fi_audio # => "AUDIO"
+```
+
+Also, you can completely skip the method generation by setting `value_method` to `false`
+
+```ruby
+value "AUDIO", value: :audio, value_method: false
+```

--- a/guides/type_definitions/enums.md
+++ b/guides/type_definitions/enums.md
@@ -72,3 +72,9 @@ value "AUDIO", value: :audio
 Then, GraphQL inputs of `AUDIO` will be converted to `:audio` and Ruby values of `:audio` will be converted to `"AUDIO"` in GraphQL responses.
 
 Enum classes are never instantiated and their methods are never called.
+
+You can get the GraphQL name of the enum value using the method matching its downcased name:
+
+```ruby
+Types::MediaCategory.audio # => "Audio"
+```

--- a/lib/graphql/introspection/directive_location_enum.rb
+++ b/lib/graphql/introspection/directive_location_enum.rb
@@ -7,7 +7,7 @@ module GraphQL
                   "a __DirectiveLocation describes one such possible adjacencies."
 
       GraphQL::Schema::Directive::LOCATIONS.each do |location|
-        value(location.to_s, GraphQL::Schema::Directive::LOCATION_DESCRIPTIONS[location], value: location)
+        value(location.to_s, GraphQL::Schema::Directive::LOCATION_DESCRIPTIONS[location], value: location, value_method: false)
       end
       introspection true
     end

--- a/lib/graphql/schema/enum.rb
+++ b/lib/graphql/schema/enum.rb
@@ -67,6 +67,7 @@ module GraphQL
         def value(*args, **kwargs, &block)
           kwargs[:owner] = self
           value = enum_value_class.new(*args, **kwargs, &block)
+          singleton_class.define_method(value.graphql_name.downcase) { value.graphql_name }
           key = value.graphql_name
           prev_value = own_values[key]
           case prev_value

--- a/lib/graphql/schema/enum.rb
+++ b/lib/graphql/schema/enum.rb
@@ -234,7 +234,7 @@ module GraphQL
           value_method_name = configured_value_method || value.graphql_name.downcase
 
           if respond_to?(value_method_name.to_sym)
-            $stderr << "Failed to define value method for :#{value_method_name}, because " \
+            warn "Failed to define value method for :#{value_method_name}, because " \
               "#{value.owner.name} already responds to that method. Use `value_name:` to override the method name."
             return
           end

--- a/lib/graphql/schema/enum.rb
+++ b/lib/graphql/schema/enum.rb
@@ -67,7 +67,7 @@ module GraphQL
         def value(*args, **kwargs, &block)
           kwargs[:owner] = self
           value = enum_value_class.new(*args, **kwargs, &block)
-          singleton_class.define_method(value.graphql_name.downcase) { value.graphql_name }
+          instance_eval("def #{value.graphql_name.downcase}; #{value.graphql_name.inspect}; end;")
           key = value.graphql_name
           prev_value = own_values[key]
           case prev_value

--- a/spec/graphql/schema/enum_spec.rb
+++ b/spec/graphql/schema/enum_spec.rb
@@ -10,6 +10,18 @@ describe GraphQL::Schema::Enum do
     end
   end
 
+  describe "value methods" do
+    it "defines methods to fetch graphql names" do
+      assert_equal enum.string, "STRING"
+      assert_equal enum.woodwind, "WOODWIND"
+      assert_equal enum.brass, "BRASS"
+      assert_equal enum.percussion, "PERCUSSION"
+      assert_equal enum.didgeridoo, "DIDGERIDOO"
+      assert_equal enum.keys, "KEYS"
+      assert_equal enum.silence, "SILENCE"
+    end
+  end
+
   describe "type info" do
     it "tells about the definition" do
       assert_equal "Family", enum.graphql_name

--- a/spec/graphql/schema/enum_spec.rb
+++ b/spec/graphql/schema/enum_spec.rb
@@ -11,14 +11,41 @@ describe GraphQL::Schema::Enum do
   end
 
   describe "value methods" do
-    it "defines methods to fetch graphql names" do
+    it "defines default methods to fetch graphql names" do
       assert_equal enum.string, "STRING"
       assert_equal enum.woodwind, "WOODWIND"
       assert_equal enum.brass, "BRASS"
-      assert_equal enum.percussion, "PERCUSSION"
       assert_equal enum.didgeridoo, "DIDGERIDOO"
       assert_equal enum.keys, "KEYS"
-      assert_equal enum.silence, "SILENCE"
+    end
+
+    describe "when value_method is configured" do
+      it "use custom method" do
+        assert_equal enum.respond_to?(:percussion), false
+        assert_equal enum.precussion_custom_value_method, "PERCUSSION"
+      end
+    end
+
+    describe "when value_method conflicts with existing method" do
+      it "does not define method and emits warning" do
+        expected_message = "Failed to define value method for :value, because " \
+          "ConflictEnum already responds to that method. Use `value_name:` to override the method name."
+
+        assert_warns(expected_message) do
+          conflict_enum = Class.new(GraphQL::Schema::Enum)
+          Object.const_set("ConflictEnum", conflict_enum)
+          already_defined_method = conflict_enum.method(:value)
+          conflict_enum.value "VALUE", "Makes conflict"
+          assert_equal conflict_enum.method(:value), already_defined_method
+        end
+      end
+
+    end
+
+    describe "when value_method = false" do
+      it "does not define method" do
+        assert_equal enum.respond_to?(:silence), false
+      end
     end
   end
 

--- a/spec/graphql/schema/enum_spec.rb
+++ b/spec/graphql/schema/enum_spec.rb
@@ -29,7 +29,7 @@ describe GraphQL::Schema::Enum do
     describe "when value_method conflicts with existing method" do
       it "does not define method and emits warning" do
         expected_message = "Failed to define value method for :value, because " \
-          "ConflictEnum already responds to that method. Use `value_name:` to override the method name."
+          "ConflictEnum already responds to that method. Use `value_name:` to override the method name.\n"
 
         assert_warns(expected_message) do
           conflict_enum = Class.new(GraphQL::Schema::Enum)

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -240,12 +240,13 @@ module Jazz
     value "STRING", "Makes a sound by vibrating strings", value: :str, custom_setting: 1
     value :WOODWIND, "Makes a sound by vibrating air in a pipe"
     value :BRASS, "Makes a sound by amplifying the sound of buzzing lips"
-    value "PERCUSSION", "Makes a sound by hitting something that vibrates"
+    value "PERCUSSION", "Makes a sound by hitting something that vibrates",
+      value_method: :precussion_custom_value_method
     value "DIDGERIDOO", "Makes a sound by amplifying the sound of buzzing lips", deprecation_reason: "Merged into BRASS"
     value "KEYS" do
       description "Neither here nor there, really"
     end
-    value "SILENCE", "Makes no sound", value: false
+    value "SILENCE", "Makes no sound", value: false, value_method: false
   end
 
   class InstrumentType < BaseObject


### PR DESCRIPTION
This is a pretty minor change, but might be helpful: now you can grab GraphQL name of the enum value using the method instead of a complex spell.

Before: `Jazz::Family.values["STRING"].graphql_name`
Now: `Jazz::Family.string`