### PR TITLE
Add ostruct to gemspec for Ruby 3.5 compatibility

### DIFF
--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "base64"
   s.add_runtime_dependency "fiber-storage"
   s.add_runtime_dependency "logger"
+  s.add_runtime_dependency "ostruct"
 
   s.add_development_dependency "benchmark-ips"
   s.add_development_dependency "concurrent-ruby", "~>1.0"


### PR DESCRIPTION
### Context
Starting from Ruby 3.5, `ostruct` is no longer included in the standard library and must be explicitly added as a dependency. Without this change, the following warning appears in production environments:

```
root@43c58a12ab7e:/app# bundle exec rails c
/bundle/ruby/3.4.0/gems/graphql-2.4.8/lib/graphql/subscriptions/serialize.rb:3: warning: /usr/local/lib/ruby/3.4.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
Also please contact the author of graphql-2.4.8 to request adding ostruct into its gemspec.
Loading development environment (Rails 8.0.1)
```


### Changes
- Added `ostruct` to the gemspec to ensure compatibility with Ruby 3.5 and prevent the warning from being raised.

### Reproduction environment
- **Ruby**: `ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [aarch64-linux]`
- **Rails**: `8.0.1`

### Notes
This change ensures smooth operation for users upgrading to Ruby 3.5. Thank you for reviewing this PR!
