### PR TITLE
Fix two bugs (order dependency and false positive) in the `required` validation

### DIFF
--- a/lib/graphql/schema/validator/required_validator.rb
+++ b/lib/graphql/schema/validator/required_validator.rb
@@ -62,8 +62,18 @@ module GraphQL
                   fully_matched_conditions += 1
                 end
               when Array
-                full_match = one_of_condition.all? { |k| value.key?(k) }
-                partial_match = !full_match && one_of_condition.any? { |k| value.key?(k) }
+                any_match = false
+                full_match = true
+
+                one_of_condition.each do |k|
+                  if value.key?(k)
+                    any_match = true
+                  else
+                    full_match = false
+                  end
+                end
+
+                partial_match = !full_match && any_match
 
                 if full_match
                   fully_matched_conditions += 1

--- a/lib/graphql/schema/validator/required_validator.rb
+++ b/lib/graphql/schema/validator/required_validator.rb
@@ -63,7 +63,6 @@ module GraphQL
               when Array
                 if one_of_condition.all? { |k| value.key?(k) }
                   matched_conditions += 1
-                  break
                 end
               else
                 raise ArgumentError, "Unknown one_of condition: #{one_of_condition.inspect}"

--- a/spec/graphql/schema/validator/required_validator_spec.rb
+++ b/spec/graphql/schema/validator/required_validator_spec.rb
@@ -31,6 +31,18 @@ describe GraphQL::Schema::Validator::RequiredValidator do
       ]
     },
     {
+      name: "Definition order independence",
+      config: { one_of: [[:a, :b], :c] },
+      cases: [
+        { query: "{ validated: multiValidated(c: 1) }", result: 1, error_messages: [] },
+        { query: "{ validated: multiValidated(a: 2, b: 3) }", result: 5, error_messages: [] },
+        { query: "{ validated: multiValidated }", result: nil, error_messages: ["multiValidated must include exactly one of the following arguments: (a and b), c."] },
+        { query: "{ validated: multiValidated(a: 1, b: 2, c: 3) }", result: nil, error_messages: ["multiValidated must include exactly one of the following arguments: (a and b), c."] },
+        { query: "{ validated: multiValidated(a: 3) }", result: nil, error_messages: ["multiValidated must include exactly one of the following arguments: (a and b), c."] },
+        { query: "{ validated: multiValidated(b: 2) }", result: nil, error_messages: ["multiValidated must include exactly one of the following arguments: (a and b), c."] },
+      ]
+    },
+    {
       name: "Input object validation",
       config: { one_of: [:a, [:b, :c]] },
       cases: [

--- a/spec/graphql/schema/validator/required_validator_spec.rb
+++ b/spec/graphql/schema/validator/required_validator_spec.rb
@@ -26,6 +26,8 @@ describe GraphQL::Schema::Validator::RequiredValidator do
         { query: "{ validated: multiValidated(b: 2, c: 3) }", result: 5, error_messages: [] },
         { query: "{ validated: multiValidated }", result: nil, error_messages: ["multiValidated must include exactly one of the following arguments: a, (b and c)."] },
         { query: "{ validated: multiValidated(a: 1, b: 2, c: 3) }", result: nil, error_messages: ["multiValidated must include exactly one of the following arguments: a, (b and c)."] },
+        { query: "{ validated: multiValidated(a: 1, b: 2) }", result: nil, error_messages: ["multiValidated must include exactly one of the following arguments: a, (b and c)."] },
+        { query: "{ validated: multiValidated(a: 1, c: 3) }", result: nil, error_messages: ["multiValidated must include exactly one of the following arguments: a, (b and c)."] },
         { query: "{ validated: multiValidated(c: 3) }", result: nil, error_messages: ["multiValidated must include exactly one of the following arguments: a, (b and c)."] },
         { query: "{ validated: multiValidated(b: 2) }", result: nil, error_messages: ["multiValidated must include exactly one of the following arguments: a, (b and c)."] },
       ]
@@ -38,6 +40,8 @@ describe GraphQL::Schema::Validator::RequiredValidator do
         { query: "{ validated: multiValidated(a: 2, b: 3) }", result: 5, error_messages: [] },
         { query: "{ validated: multiValidated }", result: nil, error_messages: ["multiValidated must include exactly one of the following arguments: (a and b), c."] },
         { query: "{ validated: multiValidated(a: 1, b: 2, c: 3) }", result: nil, error_messages: ["multiValidated must include exactly one of the following arguments: (a and b), c."] },
+        { query: "{ validated: multiValidated(a: 1, c: 3) }", result: nil, error_messages: ["multiValidated must include exactly one of the following arguments: (a and b), c."] },
+        { query: "{ validated: multiValidated(b: 2, c: 3) }", result: nil, error_messages: ["multiValidated must include exactly one of the following arguments: (a and b), c."] },
         { query: "{ validated: multiValidated(a: 3) }", result: nil, error_messages: ["multiValidated must include exactly one of the following arguments: (a and b), c."] },
         { query: "{ validated: multiValidated(b: 2) }", result: nil, error_messages: ["multiValidated must include exactly one of the following arguments: (a and b), c."] },
       ]
@@ -49,6 +53,8 @@ describe GraphQL::Schema::Validator::RequiredValidator do
         { query: "{ validated: validatedInput(input: { a: 1 }) }", result: 1, error_messages: [] },
         { query: "{ validated: validatedInput(input: { b: 2, c: 3 }) }", result: 5, error_messages: [] },
         { query: "{ validated: validatedInput(input: { a: 1, b: 2, c: 3 }) }", result: nil, error_messages: ["ValidatedInput must include exactly one of the following arguments: a, (b and c)."] },
+        { query: "{ validated: validatedInput(input: { a: 1, b: 2 }) }", result: nil, error_messages: ["ValidatedInput must include exactly one of the following arguments: a, (b and c)."] },
+        { query: "{ validated: validatedInput(input: { a: 1, c: 3 }) }", result: nil, error_messages: ["ValidatedInput must include exactly one of the following arguments: a, (b and c)."] },
         { query: "{ validated: validatedInput(input: { c: 3 }) }", result: nil, error_messages: ["ValidatedInput must include exactly one of the following arguments: a, (b and c)."] },
         { query: "{ validated: validatedInput(input: { b: 2 }) }", result: nil, error_messages: ["ValidatedInput must include exactly one of the following arguments: a, (b and c)."] },
       ]
@@ -60,6 +66,8 @@ describe GraphQL::Schema::Validator::RequiredValidator do
         { query: "{ validated: validatedResolver(a: 1) }", result: 1, error_messages: [] },
         { query: "{ validated: validatedResolver(b: 2, c: 3) }", result: 5, error_messages: [] },
         { query: "{ validated: validatedResolver(a: 1, b: 2, c: 3) }", result: nil, error_messages: ["validatedResolver must include exactly one of the following arguments: a, (b and c)."] },
+        { query: "{ validated: validatedResolver(a: 1, b: 2) }", result: nil, error_messages: ["validatedResolver must include exactly one of the following arguments: a, (b and c)."] },
+        { query: "{ validated: validatedResolver(a: 1, c: 3) }", result: nil, error_messages: ["validatedResolver must include exactly one of the following arguments: a, (b and c)."] },
         { query: "{ validated: validatedResolver(c: 3) }", result: nil, error_messages: ["validatedResolver must include exactly one of the following arguments: a, (b and c)."] },
         { query: "{ validated: validatedResolver(b: 2) }", result: nil, error_messages: ["validatedResolver must include exactly one of the following arguments: a, (b and c)."] },
         { query: "{ validated: validatedResolver }", result: nil, error_messages: ["validatedResolver must include exactly one of the following arguments: a, (b and c)."] },


### PR DESCRIPTION
The goal of this PR is to fix two bugs identified in the `required` validation.

### Bug <span>#</span>1: Order dependency for matching sets

When defining a required validation, if the first option defined is a set and that option is matched, the validation will pass, even if other options in the mutually exclusive group would match.

Consider the following query.

```gql
{
  findObject(node_id: '1', object_type: 'Invoice', object_id: '1') {
    id
  }
}
```

The behaviour of the required validation is different depending on how the validation is defined.

```ruby
field :find_object, Node, null: true do
  argument :node_id, ID, required: false
  argument :object_type, String, required: false
  argument :object_id, Integer, required: false

  # This will return a validation error.
  validates required: { one_of: [:node_id, [:object_type, :object_id]] }

  # This will NOT return a validation error.
  validates required: { one_of: [[:object_type, :object_id], :node_id] }
end
```

This is addressed in https://github.com/rmosolgo/graphql-ruby/commit/f2e4c0d7d48c4289cab1fcb04ebcc0b813136cc2.

### Bug <span>#</span>2: False positive for partially matched sets

When defining a required validation, if any of the options is matched alongside a set that is partially matched, the validation will pass. This violates the mutual exclusion rule.

Consider the following query.

```gql
{
  findObject(node_id: '1', object_type: 'Invoice') {
    id
  }
}
```

I would expect this to fail, given the following field definition.

```ruby
field :find_object, Node, null: true do
  argument :node_id, ID, required: false
  argument :object_type, String, required: false
  argument :object_id, Integer, required: false

  # This will NOT return a validation error.
  validates required: { one_of: [:node_id, [:object_type, :object_id]] }
end
```

This is addressed in https://github.com/rmosolgo/graphql-ruby/commit/f2e4c0d7d48c4289cab1fcb04ebcc0b813136cc2.

_Note: I came across this behaviour during development, and was surprised and confused by it. I can anticipate a perspective that deems this behaviour as acceptable because it still technically satisfies the property that "exactly one" option is matched. While I can appreciate this perspective, in my opinion it leaves room for ambiguity in the behaviour of validation._

### Developer impact

The first bug requires a developer to be specific when defining the order of the mutually exclusive options. This leads to a brittle implementation, where a seemingly innocuous reordering of the options can causing a breaking change in the API.

The second bug does not uphold the contract of "exactly one" and "mutually exclusive" that the required validation is meant to provide, _in my opinion_. If I am checking for the presence of arguments in the resolver to determine which of the mutually exclusive option has been provided, depending on the order I check the presence of the keys, if one of those options is a set that has been partially matched, I could attempt to access the other keys in the set which have not matched and cause a runtime error.

### Breaking changes

I consider both of these bug fixes to be breaking changes. A client passing a certain collection of inputs which may be valid under the existing behaviour may now experience a validation error, if they are not providing strictly mutually exclusive arguments.