### PR TITLE
Fix CI failures for latest version of `ActiveSupport` 7

### DIFF
--- a/gemfiles/mongoid_7.gemfile
+++ b/gemfiles/mongoid_7.gemfile
@@ -12,5 +12,6 @@ if RUBY_VERSION >= "3.0"
   gem "evt"
 end
 gem "fiber-storage"
+gem "concurrent-ruby", "< 1.3.5"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -11,5 +11,6 @@ gem "sqlite3", "~> 1.4", platform: :ruby
 gem "sequel"
 gem "evt"
 gem "async"
+gem "concurrent-ruby", "< 1.3.5"
 
 gemspec path: "../"

--- a/gemfiles/rails_master.gemfile
+++ b/gemfiles/rails_master.gemfile
@@ -15,5 +15,8 @@ if RUBY_ENGINE == "ruby" # This doesn't work on truffle-ruby because there's no 
   gem "libev_scheduler"
 end
 gem "async"
+if RUBY_VERSION >= "3.4.1"
+  gem "csv"
+end
 
 gemspec path: "../"

--- a/gemfiles/rails_master.gemfile
+++ b/gemfiles/rails_master.gemfile
@@ -17,6 +17,7 @@ end
 gem "async"
 if RUBY_VERSION >= "3.4.1"
   gem "csv"
+  gem "mutex_m"
 end
 
 gemspec path: "../"


### PR DESCRIPTION
This attempts to fix some CI failures related to a recent update to `concurrent-ruby`, which is causing issues in Rails/ActiveSupport, as seen in https://github.com/rails/rails/pull/54264.