### PR TITLE
Avoid warnings during Schema.from_introspection

### DIFF
--- a/lib/graphql/schema/loader.rb
+++ b/lib/graphql/schema/loader.rb
@@ -108,6 +108,7 @@ module GraphQL
                   enum_value["name"],
                   description: enum_value["description"],
                   deprecation_reason: enum_value["deprecationReason"],
+                  value_method: GraphQL::Schema::Enum.respond_to?(enum_value["name"]) ? false : nil
                 )
               end
             end

--- a/lib/graphql/schema/loader.rb
+++ b/lib/graphql/schema/loader.rb
@@ -108,7 +108,7 @@ module GraphQL
                   enum_value["name"],
                   description: enum_value["description"],
                   deprecation_reason: enum_value["deprecationReason"],
-                  value_method: GraphQL::Schema::Enum.respond_to?(enum_value["name"]) ? false : nil
+                  value_method: GraphQL::Schema::Enum.respond_to?(enum_value["name"].downcase) ? false : nil
                 )
               end
             end

--- a/spec/graphql/schema/loader_spec.rb
+++ b/spec/graphql/schema/loader_spec.rb
@@ -19,6 +19,7 @@ describe GraphQL::Schema::Loader do
 
       value "FOO", value: :foo
       value "BAR", deprecation_reason: "Don't use BAR"
+      value "NAME", value_method: false
     end
 
     sub_input_type = Class.new(GraphQL::Schema::InputObject) do


### PR DESCRIPTION
Avoid stderr output when using `GraphQL::Schema.from_introspection` to load a Scheme containing Enums with values like e.g. `"NAME"`. 

Copied somewhat-naively from a [similar change](https://github.com/rmosolgo/graphql-ruby/commit/52153a243e265fb75b01d1a6a62766a3583ef2c9). Please ensure this solution is appropriate!

Not sure where/if I should add a test