### PR TITLE
Return a parse error when a variable type is missing

### DIFF
--- a/lib/graphql/language/parser.rb
+++ b/lib/graphql/language/parser.rb
@@ -161,7 +161,7 @@ module GraphQL
               expect_token(:VAR_SIGN)
               var_name = parse_name
               expect_token(:COLON)
-              var_type = self.type
+              var_type = self.type || raise_parse_error("Missing type definition for variable: $#{var_name}")
               default_value = if at?(:EQUALS)
                 advance_token
                 value

--- a/spec/graphql/language/parser_spec.rb
+++ b/spec/graphql/language/parser_spec.rb
@@ -185,6 +185,19 @@ createRecord(data: {
     assert_equal "subscription", doc.definitions.first.name
   end
 
+  it "raises an error for bad variables definition" do
+    err = assert_raises(GraphQL::ParseError) do
+      GraphQL.parse("query someQuery($someVariable: ,) { account { id } }")
+    end
+    expected_msg = if USING_C_PARSER
+      "syntax error, unexpected RPAREN (\")\") at [1, 33]"
+    else
+      "Missing type definition for variable: $someVariable at [1, 33]"
+    end
+
+    assert_equal expected_msg, err.message
+  end
+
   it "raises an error when unicode is used as names" do
     err = assert_raises(GraphQL::ParseError) {
       GraphQL.parse('query 😘 { a b }')


### PR DESCRIPTION
Fixes #5224 