### PR TITLE
Fix GraphQL::Backtrace::TracedError handling

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -1114,9 +1114,6 @@ module GraphQL
 
       # @api private
       def handle_or_reraise(context, err)
-        if context[:backtrace] || using_backtrace
-          err = GraphQL::Backtrace::TracedError.new(err, context)
-        end
         handler = Execution::Errors.find_handler_for(self, err.class)
         if handler
           obj = context[:current_object]
@@ -1128,6 +1125,10 @@ module GraphQL
           end
           handler[:handler].call(err, obj, args, context, field)
         else
+          if context[:backtrace] || using_backtrace
+            err = GraphQL::Backtrace::TracedError.new(err, context)
+          end
+
           raise err
         end
       end

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -560,4 +560,48 @@ To add other types to your schema, you might want `extra_types`: https://graphql
     assert schema2.subscription
     assert schema2.instance_variable_get(:@subscription_extension_added)
   end
+
+  describe "backtrace error handling" do
+    class CustomError < RuntimeError; end
+    class Query < GraphQL::Schema::Object
+      field :test, Integer, null: false
+
+      def test
+        raise CustomError
+      end
+    end
+
+    it "raises a TracedError when backtrace is enabled" do
+      schema = Class.new(GraphQL::Schema) do
+        query(Query)
+        use GraphQL::Backtrace
+      end
+      query_str = '{ test }'
+
+      assert_raises(GraphQL::Backtrace::TracedError) do
+        schema.execute(query_str)
+      end
+    end
+
+    it "rescues them when using rescue_from with backtrace" do
+      schema = Class.new(GraphQL::Schema) do
+        query(Query)
+        use GraphQL::Backtrace
+
+        rescue_from(CustomError) do
+          raise GraphQL::ExecutionError.new('Handled CustomError')
+        end
+      end
+      query_str = '{ test }'
+      expected_errors = [
+        {
+          'message' => 'Handled CustomError',
+          'locations' => [{'line' => 1, 'column' => 3}],
+          'path' => ['test']
+        }
+      ]
+
+      assert_equal expected_errors, schema.execute(query_str).to_h['errors']
+    end
+  end
 end


### PR DESCRIPTION
Fix: https://github.com/rmosolgo/graphql-ruby/issues/5222

In GraphQL 2.4.9, there was a change in how exceptions are handled when using `GraphQL::Backtrace`. 
This PR restores the 2.4.8 behavior when using backtrace and rescue_from.
