### PR TITLE
Don't wrap GraphQL::ExecutionError with a Backtrace error

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -1125,7 +1125,7 @@ module GraphQL
           end
           handler[:handler].call(err, obj, args, context, field)
         else
-          if context[:backtrace] || using_backtrace
+          if (context[:backtrace] || using_backtrace) && !err.is_a?(GraphQL::ExecutionError)
             err = GraphQL::Backtrace::TracedError.new(err, context)
           end
 


### PR DESCRIPTION
Fixes #5232

I cherry-picked this commit onto 2.4.8 to make sure that these tests also passed there (ie, this is _compatible_ with that version)