### PR TITLE
Improve Visibility profile contexts

### DIFF
--- a/guides/authorization/visibility.md
+++ b/guides/authorization/visibility.md
@@ -52,7 +52,9 @@ use GraphQL::Schema::Visibility, profiles: {
 }
 ```
 
-Then, you can run queries with `context[:visibility_profile]` equal to one of the pre-defined profiles. When you do, GraphQL-Ruby will use a precomputed set of types and fields for that query.
+Then, you can run queries with `context[:visibility_profile]` equal to one of the pre-defined profiles. When you do, GraphQL-Ruby will create a cached set of types for named profile. `.visible?` will only be called with the context hash passed to `profiles: ...`.
+
+The profile contexts passed to `profiles` will have `visibility_profile: ...` added to them, then they're frozen by GraphQL-Ruby.
 
 ### Preloading profiles
 

--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -97,21 +97,22 @@ module GraphQL
     # @param root_value [Object] the object used to resolve fields on the root type
     # @param max_depth [Numeric] the maximum number of nested selections allowed for this query (falls back to schema-level value)
     # @param max_complexity [Numeric] the maximum field complexity for this query (falls back to schema-level value)
-    # @param visibility_profile [Symbol]
+    # @param visibility_profile [Symbol] Another way to assign `context[:visibility_profile]`
     def initialize(schema, query_string = nil, query: nil, document: nil, context: nil, variables: nil, validate: true, static_validator: nil, visibility_profile: nil, subscription_topic: nil, operation_name: nil, root_value: nil, max_depth: schema.max_depth, max_complexity: schema.max_complexity, warden: nil, use_visibility_profile: nil)
       # Even if `variables: nil` is passed, use an empty hash for simpler logic
       variables ||= {}
       @schema = schema
       @context = schema.context_class.new(query: self, values: context)
+      if visibility_profile
+        @context[:visibility_profile] ||= visibility_profile
+      end
 
       if use_visibility_profile.nil?
         use_visibility_profile = warden ? false : schema.use_visibility_profile?
       end
 
-      @visibility_profile = visibility_profile
-
       if use_visibility_profile
-        @visibility_profile = @schema.visibility.profile_for(@context, visibility_profile)
+        @visibility_profile = @schema.visibility.profile_for(@context)
         @warden = Schema::Warden::NullWarden.new(context: @context, schema: @schema)
       else
         @visibility_profile = nil

--- a/lib/graphql/schema/visibility.rb
+++ b/lib/graphql/schema/visibility.rb
@@ -13,6 +13,10 @@ module GraphQL
       # @param preload [Boolean] if `true`, load the default schema profile and all named profiles immediately (defaults to `true` for `Rails.env.production?`)
       # @param migration_errors [Boolean] if `true`, raise an error when `Visibility` and `Warden` return different results
       def self.use(schema, dynamic: false, profiles: EmptyObjects::EMPTY_HASH, preload: (defined?(Rails) ? Rails.env.production? : nil), migration_errors: false)
+        profiles&.each { |name, ctx|
+          ctx[:visibility_profile] = name
+          ctx.freeze
+        }
         schema.visibility = self.new(schema, dynamic: dynamic, preload: preload, profiles: profiles, migration_errors: migration_errors)
         if preload
           schema.visibility.preload
@@ -81,8 +85,7 @@ module GraphQL
         types_to_visit.compact!
         ensure_all_loaded(types_to_visit)
         @profiles.each do |profile_name, example_ctx|
-          example_ctx[:visibility_profile] = profile_name
-          prof = profile_for(example_ctx, profile_name)
+          prof = profile_for(example_ctx)
           prof.all_types # force loading
         end
       end
@@ -145,7 +148,7 @@ module GraphQL
 
       attr_reader :cached_profiles
 
-      def profile_for(context, visibility_profile)
+      def profile_for(context, visibility_profile = context[:visibility_profile])
         if !@profiles.empty?
           if visibility_profile.nil?
             if @dynamic
@@ -160,7 +163,19 @@ module GraphQL
           elsif !@profiles.include?(visibility_profile)
             raise ArgumentError, "`#{visibility_profile.inspect}` isn't allowed for `visibility_profile:` (must be one of #{@profiles.keys.map(&:inspect).join(", ")}). Or, add `#{visibility_profile.inspect}` to the list of profiles in the schema definition."
           else
-            @cached_profiles[visibility_profile] ||= @schema.visibility_profile_class.new(name: visibility_profile, context: context, schema: @schema)
+            profile_ctx = @profiles[visibility_profile]
+            if profile_ctx.nil?
+              raise ArgumentError, <<~ERR
+              Received visibility_profile `#{visibility_profile.inspect}` but this profile doesn't have a predefined context.
+              Add one in your `profiles:` configuration, for example:
+
+                  use GraphQL::Schema::Visibility, profiles: {
+                    # ...
+                    #{visibility_profile}: { some: :context, ... },
+                  }
+              ERR
+            end
+            @cached_profiles[visibility_profile] ||= @schema.visibility_profile_class.new(name: visibility_profile, context: profile_ctx, schema: @schema)
           end
         elsif context.is_a?(Query::NullContext)
           top_level_profile

--- a/lib/graphql/schema/visibility.rb
+++ b/lib/graphql/schema/visibility.rb
@@ -164,17 +164,6 @@ module GraphQL
             raise ArgumentError, "`#{visibility_profile.inspect}` isn't allowed for `visibility_profile:` (must be one of #{@profiles.keys.map(&:inspect).join(", ")}). Or, add `#{visibility_profile.inspect}` to the list of profiles in the schema definition."
           else
             profile_ctx = @profiles[visibility_profile]
-            if profile_ctx.nil?
-              raise ArgumentError, <<~ERR
-              Received visibility_profile `#{visibility_profile.inspect}` but this profile doesn't have a predefined context.
-              Add one in your `profiles:` configuration, for example:
-
-                  use GraphQL::Schema::Visibility, profiles: {
-                    # ...
-                    #{visibility_profile}: { some: :context, ... },
-                  }
-              ERR
-            end
             @cached_profiles[visibility_profile] ||= @schema.visibility_profile_class.new(name: visibility_profile, context: profile_ctx, schema: @schema)
           end
         elsif context.is_a?(Query::NullContext)

--- a/lib/graphql/schema/visibility/profile.rb
+++ b/lib/graphql/schema/visibility/profile.rb
@@ -18,7 +18,7 @@ module GraphQL
           if ctx.respond_to?(:types) && (types = ctx.types).is_a?(self)
             types
           else
-            schema.visibility.profile_for(ctx, nil)
+            schema.visibility.profile_for(ctx)
           end
         end
 

--- a/spec/graphql/schema/visibility/profile_spec.rb
+++ b/spec/graphql/schema/visibility/profile_spec.rb
@@ -57,4 +57,59 @@ describe GraphQL::Schema::Visibility::Profile do
       assert 1, result["errors"].size
     end
   end
+
+  describe "using configured contexts" do
+    class ProfileContextSchema < GraphQL::Schema
+      class << self
+        attr_accessor :modify_visibility_context
+        attr_accessor :last_visibility_context
+      end
+
+      class Query < GraphQL::Schema::Object
+        def self.visible?(ctx)
+          ProfileContextSchema.last_visibility_context = JSON.dump(ctx)
+          if ProfileContextSchema.modify_visibility_context
+            ctx[:this] = :breaks
+          end
+          !!ctx[:internal]
+        end
+
+        field :inspect_context, String
+
+        def inspect_context
+          JSON.dump(context.to_h)
+        end
+      end
+
+      query(Query)
+      use GraphQL::Schema::Visibility, profiles: {
+        internal: { internal: true },
+        public: { public: true },
+        public2: { public: true }, # This is for testing FrozenError below
+      }
+    end
+
+    before do
+      ProfileContextSchema.modify_visibility_context = false
+      ProfileContextSchema.last_visibility_context = nil
+    end
+
+    it "uses the configured context for `visible?` calls, not the query context" do
+      res = ProfileContextSchema.execute("{ inspectContext }", context: { visibility_profile: :internal })
+      assert_equal '{"visibility_profile":"internal"}', res["data"]["inspectContext"]
+      assert_equal '{"internal":true,"visibility_profile":"internal"}', ProfileContextSchema.last_visibility_context
+
+      res = ProfileContextSchema.execute("{ inspectContext }", context: { internal: true, visibility_profile: :public })
+      assert_equal ["Schema is not configured for queries"], res["errors"].map { |e| e["message"] }
+      assert_equal '{"public":true,"visibility_profile":"public"}', ProfileContextSchema.last_visibility_context
+    end
+
+    it "freezes profile contexts" do
+      ProfileContextSchema.modify_visibility_context = true
+      assert_raises FrozenError do
+        ProfileContextSchema.execute("{ inspectContext }", context: { visibility_profile: :public2 })
+      end
+      assert_equal '{"public":true,"visibility_profile":"public2"}', ProfileContextSchema.last_visibility_context
+    end
+  end
 end


### PR DESCRIPTION
As discussed in #5231: 


- Always use `context[:visibility_profile]`, route the query argument to that context key 
- When that key is present, used the configured context for `.visible?` calls (not the query context). The full query context is still used for dynamic queries (without `context[:visibility_profile]`) 
- For good measure, freeze passed-in profile hashes. 