### PR TITLE
Rewrite NewRelicTrace to support fiber stops/starts

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
   - ./lib/graphql/rubocop/graphql/default_null_true
   - ./lib/graphql/rubocop/graphql/default_required_true
   - ./cop/development/context_is_passed_cop
-  - ./cop/development/trace_calls_super_cop.rb
+  - ./cop/development/trace_methods_cop.rb
 
 AllCops:
   DisabledByDefault: true
@@ -45,9 +45,10 @@ Development/NoFocusCop:
   Include:
     - "spec/**/*"
 
-Development/TraceCallsSuperCop:
+Development/TraceMethodsCop:
   Include:
-    - "lib/graphql/tracing/*_trace.rb"
+    - "lib/graphql/tracing/perfetto_trace.rb"
+    - "lib/graphql/tracing/new_relic_trace.rb"
 
 # def ...
 # end

--- a/cop/development/trace_methods_cop.rb
+++ b/cop/development/trace_methods_cop.rb
@@ -69,7 +69,12 @@ module Cop
           end
 
           missing_defs = TRACE_HOOKS - all_defs
-          redundant_defs = [:lex, :analyze_query, :execute_query, :execute_query_lazy]
+          redundant_defs = [
+            # Not really necessary for making a good trace:
+            :lex, :analyze_query, :execute_query, :execute_query_lazy,
+            # Only useful for isolated event tracking:
+            :dataloader_fiber_exit, :dataloader_spawn_execution_fiber, :dataloader_spawn_source_fiber
+          ]
           missing_defs.each do |missing_def|
             if all_defs.include?(:"begin_#{missing_def}") && all_defs.include?(:"end_#{missing_def}")
               redundant_defs << missing_def

--- a/lib/graphql/execution/interpreter.rb
+++ b/lib/graphql/execution/interpreter.rb
@@ -37,7 +37,7 @@ module GraphQL
           multiplex = Execution::Multiplex.new(schema: schema, queries: queries, context: context, max_complexity: max_complexity)
           Fiber[:__graphql_current_multiplex] = multiplex
           trace = multiplex.current_trace
-          trace.begin_multiplex(multiplex)
+          trace.begin_execute_multiplex(multiplex)
           trace.execute_multiplex(multiplex: multiplex) do
             schema = multiplex.schema
             queries = multiplex.queries
@@ -155,7 +155,7 @@ module GraphQL
             end
           end
         ensure
-          trace&.end_multiplex(multiplex)
+          trace&.end_execute_multiplex(multiplex)
         end
       end
 

--- a/lib/graphql/static_validation/validator.rb
+++ b/lib/graphql/static_validation/validator.rb
@@ -27,8 +27,8 @@ module GraphQL
       # @param max_errors [Integer] Maximum number of errors before aborting validation. Any positive number will limit the number of errors. Defaults to nil for no limit.
       # @return [Array<Hash>]
       def validate(query, validate: true, timeout: nil, max_errors: nil)
+        errors = nil
         query.current_trace.begin_validate(query, validate)
-        is_valid = false
         query.current_trace.validate(validate: validate, query: query) do
           begin_t = Time.now
           errors = if validate == false
@@ -53,7 +53,6 @@ module GraphQL
 
             context.errors
           end
-          is_valid = errors.size == 0
 
           {
             remaining_timeout: timeout ? (timeout - (Time.now - begin_t)) : nil,

--- a/lib/graphql/static_validation/validator.rb
+++ b/lib/graphql/static_validation/validator.rb
@@ -61,13 +61,13 @@ module GraphQL
           }
         end
       rescue GraphQL::ExecutionError => e
-        is_valid = false
+        errors = [e]
         {
           remaining_timeout: nil,
-          errors: [e],
+          errors: errors,
         }
       ensure
-        query.current_trace.end_validate(query, validate, is_valid)
+        query.current_trace.end_validate(query, validate, errors)
       end
 
       # Invoked when static validation times out.

--- a/lib/graphql/tracing/new_relic_trace.rb
+++ b/lib/graphql/tracing/new_relic_trace.rb
@@ -5,72 +5,159 @@ require "graphql/tracing/platform_trace"
 module GraphQL
   module Tracing
     module NewRelicTrace
-      include PlatformTrace
-
       # @param set_transaction_name [Boolean] If true, the GraphQL operation name will be used as the transaction name.
       #   This is not advised if you run more than one query per HTTP request, for example, with `graphql-client` or multiplexing.
       #   It can also be specified per-query with `context[:set_new_relic_transaction_name]`.
       def initialize(set_transaction_name: false, **_rest)
         @set_transaction_name = set_transaction_name
+        @nr_field_names = Hash.new do |h, field|
+          h[field] = "GraphQL/#{field.owner.graphql_name}/#{field.graphql_name}"
+        end.compare_by_identity
+
+        @nr_authorized_names = Hash.new do |h, type|
+          h[type] = "GraphQL/Authorized/#{type.graphql_name}"
+        end.compare_by_identity
+
+        @nr_resolve_type_names = Hash.new do |h, type|
+          h[type] = "GraphQL/ResolveType/#{type.graphql_name}"
+        end.compare_by_identity
+
+        @nr_source_names = Hash.new do |h, source_inst|
+          h[source_inst] = "GraphQL/Source/#{source_inst.class.name}"
+        end.compare_by_identity
+
+        @nr_parse = @nr_validate = @nr_analyze = @nr_execute = nil
         super
       end
 
-      def execute_query(query:)
-        set_this_txn_name =  query.context[:set_new_relic_transaction_name]
-        if set_this_txn_name == true || (set_this_txn_name.nil? && @set_transaction_name)
+      def begin_parse(query_str)
+        @nr_parse = NewRelic::Agent::Tracer.start_transaction_or_segment(partial_name: "GraphQL/parse", category: :web)
+        super
+      end
+
+      def end_parse(query_str)
+        @nr_parse.finish
+        super
+      end
+
+      def begin_validate(query, validate)
+        @nr_validate = NewRelic::Agent::Tracer.start_transaction_or_segment(partial_name: "GraphQL/validate", category: :web)
+        super
+      end
+
+      def end_validate(query, validate, validation_errors)
+        @nr_validate.finish
+        super
+      end
+
+      def begin_analyze_multiplex(multiplex, analyzers)
+        @nr_analyze = NewRelic::Agent::Tracer.start_transaction_or_segment(partial_name: "GraphQL/analyze", category: :web)
+        super
+      end
+
+      def end_analyze_multiplex(multiplex, analyzers)
+        @nr_analyze.finish
+        super
+      end
+
+      def begin_execute_multiplex(multiplex)
+        query = multiplex.queries.first
+        set_this_txn_name = query.context[:set_new_relic_transaction_name]
+        if set_this_txn_name || (set_this_txn_name.nil? && @set_transaction_name)
           NewRelic::Agent.set_transaction_name(transaction_name(query))
         end
-        NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped("GraphQL/execute") do
-          super
+        @nr_execute = NewRelic::Agent::Tracer.start_transaction_or_segment(partial_name: "GraphQL/execute", category: :web)
+        super
+      end
+
+      def end_execute_multiplex(multiplex)
+        @nr_execute.finish
+        super
+      end
+
+      def begin_execute_field(field, object, arguments, query)
+        nr_segment_stack << NewRelic::Agent::Tracer.start_transaction_or_segment(partial_name: @nr_field_names[field], category: :web)
+        super
+      end
+
+      def end_execute_field(field, objects, arguments, query, result)
+        nr_segment_stack.pop.finish
+        super
+      end
+
+      def begin_authorized(type, obj, ctx)
+        nr_segment_stack << NewRelic::Agent::Tracer.start_transaction_or_segment(partial_name: @nr_authorized_names[type], category: :web)
+        super
+      end
+
+      def end_authorized(type, obj, ctx, is_authed)
+        nr_segment_stack.pop.finish
+        super
+      end
+
+      def begin_resolve_type(type, value, context)
+        nr_segment_stack << NewRelic::Agent::Tracer.start_transaction_or_segment(partial_name: @nr_resolve_type_names[type], category: :web)
+        super
+      end
+
+      def end_resolve_type(type, value, context, resolved_type)
+        nr_segment_stack.pop.finish
+        super
+      end
+
+      def begin_dataloader(dl)
+        # nr_segment_stack << NewRelic::Agent::Tracer.start_transaction_or_segment(partial_name: "GraphQL/dataloader", category: :web)
+        super
+      end
+
+      def end_dataloader(dl)
+        # nr_segment_stack.pop.finish
+        super
+      end
+
+      def begin_dataloader_source(source)
+        nr_segment_stack << NewRelic::Agent::Tracer.start_transaction_or_segment(partial_name: @nr_source_names[source], category: :web)
+        super
+      end
+
+      def end_dataloader_source(source)
+        nr_segment_stack.pop.finish
+        super
+      end
+
+      def dataloader_fiber_yield(source)
+        current_segment = nr_segment_stack.last
+        current_segment.finish
+        super
+      end
+
+      def dataloader_fiber_resume(source)
+        prev_segment = nr_segment_stack.pop
+        seg_partial_name = prev_segment.name.sub(/^.*(GraphQL.*)$/, '\1')
+        nr_segment_stack << NewRelic::Agent::Tracer.start_transaction_or_segment(partial_name: seg_partial_name, category: :web)
+        super
+      end
+
+      private
+
+      def nr_segment_stack
+        Fiber[:graphql_nr_segment_stack] ||= []
+      end
+
+      def transaction_name(query)
+        selected_op = query.selected_operation
+        txn_name = if selected_op
+          op_type = selected_op.operation_type
+          op_name = selected_op.name || fallback_transaction_name(query.context) || "anonymous"
+          "#{op_type}.#{op_name}"
+        else
+          "query.anonymous"
         end
+        "GraphQL/#{txn_name}"
       end
 
-      {
-        "lex" => "GraphQL/lex",
-        "parse" => "GraphQL/parse",
-        "validate" => "GraphQL/validate",
-        "analyze_query" => "GraphQL/analyze",
-        "analyze_multiplex" => "GraphQL/analyze",
-        "execute_multiplex" => "GraphQL/execute",
-        "execute_query_lazy" => "GraphQL/execute",
-      }.each do |trace_method, platform_key|
-        module_eval <<-RUBY, __FILE__, __LINE__
-          def #{trace_method}(**_keys)
-            NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped("#{platform_key}") do
-              super
-            end
-          end
-        RUBY
-      end
-
-      def platform_execute_field(platform_key)
-        NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped(platform_key) do
-          yield
-        end
-      end
-
-      def platform_authorized(platform_key)
-        NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped(platform_key) do
-          yield
-        end
-      end
-
-      def platform_resolve_type(platform_key)
-        NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped(platform_key) do
-          yield
-        end
-      end
-
-      def platform_field_key(field)
-        "GraphQL/#{field.owner.graphql_name}/#{field.graphql_name}"
-      end
-
-      def platform_authorized_key(type)
-        "GraphQL/Authorize/#{type.graphql_name}"
-      end
-
-      def platform_resolve_type_key(type)
-        "GraphQL/ResolveType/#{type.graphql_name}"
+      def fallback_transaction_name(context)
+        context[:tracing_fallback_transaction_name]
       end
     end
   end

--- a/lib/graphql/tracing/perfetto_trace.rb
+++ b/lib/graphql/tracing/perfetto_trace.rb
@@ -66,7 +66,6 @@ module GraphQL
         @sequence_id = object_id
         @pid = Process.pid
         @flow_ids = Hash.new { |h, source_inst| h[source_inst] = [] }.compare_by_identity
-        # TODO intern these too:
         @new_interned_event_names = {}
         @interned_event_name_iids = Hash.new { |h, k|
           new_id = 100 + h.size
@@ -172,7 +171,7 @@ module GraphQL
         end
       end
 
-      def begin_multiplex(m)
+      def begin_execute_multiplex(m)
         @packets << trace_packet(
           type: TrackEvent::Type::TYPE_SLICE_BEGIN,
           track_uuid: fid,
@@ -184,7 +183,7 @@ module GraphQL
         super
       end
 
-      def end_multiplex(m)
+      def end_execute_multiplex(m)
         @packets << trace_packet(
           type: TrackEvent::Type::TYPE_SLICE_END,
           track_uuid: fid,
@@ -286,7 +285,7 @@ module GraphQL
         super
       end
 
-      def end_validate(query, validate, is_valid)
+      def end_validate(query, validate, validation_errors)
         @packets << trace_packet(
           type: TrackEvent::Type::TYPE_SLICE_END,
           track_uuid: fid,
@@ -298,7 +297,7 @@ module GraphQL
           {
             debug_annotations: [
               @begin_validate.track_event.debug_annotations.first,
-              payload_to_debug("valid?", is_valid)
+              payload_to_debug("valid?", !validation_errors.empty?)
             ]
           }
         )

--- a/lib/graphql/tracing/trace.rb
+++ b/lib/graphql/tracing/trace.rb
@@ -42,7 +42,7 @@ module GraphQL
       def begin_validate(query, validate)
       end
 
-      def end_validate(query, validate, is_valid)
+      def end_validate(query, validate, errors)
       end
 
       # @param multiplex [GraphQL::Execution::Multiplex]
@@ -67,12 +67,12 @@ module GraphQL
       # Every Query is technically run _inside_ a {GraphQL::Multiplex}.
       # @param multiplex [GraphQL::Execution::Multiplex]
       # @return [void]
-      def begin_multiplex(multiplex); end;
+      def begin_execute_multiplex(multiplex); end;
 
       # This is the last event of the tracing lifecycle.
       # @param multiplex [GraphQL::Execution::Multiplex]
       # @return [void]
-      def end_multiplex(multiplex); end;
+      def end_execute_multiplex(multiplex); end;
 
       # This wraps an entire `.execute` call.
       # @param multiplex [GraphQL::Execution::Multiplex]

--- a/spec/graphql/tracing/new_relic_trace_spec.rb
+++ b/spec/graphql/tracing/new_relic_trace_spec.rb
@@ -191,4 +191,10 @@ describe GraphQL::Tracing::NewRelicTrace do
     ]
     assert_equal expected_steps, NewRelic::EXECUTION_SCOPES
   end
+
+  it "can generate a transaction name without a selected operation" do
+    res = NewRelicTraceTest::SchemaWithTransactionName.execute("query Q1 { other { name } } query Q2 { other { name } }")
+    assert_equal ["An operation name is required"], res["errors"].map { |e| e["message"] }
+    assert_equal ["GraphQL/query.anonymous"], NewRelic::TRANSACTION_NAMES
+  end
 end

--- a/spec/graphql/tracing/new_relic_trace_spec.rb
+++ b/spec/graphql/tracing/new_relic_trace_spec.rb
@@ -3,9 +3,15 @@ require "spec_helper"
 
 describe GraphQL::Tracing::NewRelicTrace do
   module NewRelicTraceTest
-    class OtherSource < GraphQL::Dataloader::Source
+    class NestedSource < GraphQL::Dataloader::Source
       def fetch(keys)
         keys
+      end
+    end
+
+    class OtherSource < GraphQL::Dataloader::Source
+      def fetch(keys)
+        dataloader.with(NestedSource).load_all(keys)
       end
     end
     class Thing < GraphQL::Schema::Object
@@ -125,6 +131,11 @@ describe GraphQL::Tracing::NewRelicTrace do
         "GraphQL/Query/other",
         "FINISH GraphQL/Query/other",
         # Here's the source run:
+        "GraphQL/Source/NewRelicTraceTest::OtherSource",
+        "FINISH GraphQL/Source/NewRelicTraceTest::OtherSource",
+          # Nested source:
+          "GraphQL/Source/NewRelicTraceTest::NestedSource",
+          "FINISH GraphQL/Source/NewRelicTraceTest::NestedSource",
         "GraphQL/Source/NewRelicTraceTest::OtherSource",
         "FINISH GraphQL/Source/NewRelicTraceTest::OtherSource",
         # And back to the field:

--- a/spec/graphql/tracing/trace_spec.rb
+++ b/spec/graphql/tracing/trace_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 
 describe GraphQL::Tracing::Trace do
   it "has all its methods in the development cop" do
-    trace_source = File.read("cop/development/trace_calls_super_cop.rb")
+    trace_source = File.read("cop/development/trace_methods_cop.rb")
     superable_methods = GraphQL::Tracing::Trace.instance_methods(false).sort
     superable_methods_source = superable_methods.map { |m| "        #{m.inspect},\n" }.join
     assert_includes trace_source, superable_methods_source

--- a/spec/support/new_relic.rb
+++ b/spec/support/new_relic.rb
@@ -26,11 +26,15 @@ module NewRelic
 
       class Finisher
         def initialize(name)
-          @name = name
+          @partial_name = name
+        end
+
+        def name
+          "Controller/#{@partial_name}"
         end
 
         def finish
-          EXECUTION_SCOPES << "FINISH #{@name}"
+          EXECUTION_SCOPES << "FINISH #{@partial_name}"
           nil
         end
       end

--- a/spec/support/new_relic.rb
+++ b/spec/support/new_relic.rb
@@ -18,6 +18,24 @@ module NewRelic
       TRANSACTION_NAMES << name
     end
 
+    module Tracer
+      def self.start_transaction_or_segment(partial_name:, category:)
+        EXECUTION_SCOPES << partial_name
+        Finisher.new(partial_name)
+      end
+
+      class Finisher
+        def initialize(name)
+          @name = name
+        end
+
+        def finish
+          EXECUTION_SCOPES << "FINISH #{@name}"
+          nil
+        end
+      end
+    end
+
     module MethodTracerHelpers
       def self.trace_execution_scoped(trace_name)
         EXECUTION_SCOPES << trace_name


### PR DESCRIPTION
Basically, using `do ... end`-type instrumentation can get confused when there's a `Fiber.yield` inside the block. (Dataloader does this when a field calls `.load`.) You can end up with situations where the sum of segments adds up to more than the total request time, because Fiber _wait_ time is being added to the time when another Fiber is running. This makes sense-ish from New Relic's standpoint; they can't really know when the application handed over control in a way that "shouldn't count." See discussion at https://github.com/newrelic/newrelic-ruby-agent/issues/3026. 

So, what we can do is _stop_ spans when there's a `.yield` called, then create a new span after the Fiber resumes control. I developed this in PerfettoTrace and I intend to roll it out to the other tracers, too. 


-----

I ran a little test app locally to confirm that this addresses the problem. Here's a before-after where the time tracking starts to line up: 

![image](https://github.com/user-attachments/assets/fd67f262-524b-4ea8-a1e7-245a75b6dfcc)


TODO: 

- [x] Confirm on test NewRelic account
- [x] Add tests demonstrating proper starts/stops
- ~~Also do #5078~~ Still not clear on this