### PR TITLE
Use a non-runtime error class for InvalidNameError

### DIFF
--- a/lib/graphql/invalid_name_error.rb
+++ b/lib/graphql/invalid_name_error.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module GraphQL
-  class InvalidNameError < GraphQL::ExecutionError
+  class InvalidNameError < GraphQL::Error
     attr_reader :name, :valid_regex
     def initialize(name, valid_regex)
       @name = name


### PR DESCRIPTION
Fixes #5245 