### PR TITLE
Update to Mongoid 8 and 9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,6 +80,7 @@ jobs:
     - run: bundle exec rake compile
     - run: bundle exec rake test
     - run: git fetch --no-tags --prune --unshallow origin +refs/heads/*:refs/remotes/origin/*
+      if: ${{ !!matrix.coverage }}
     - run: bundle exec pronto run -f github_pr -c origin/${{ github.base_ref }}
       if: ${{ !!matrix.coverage }}
       env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,8 +139,8 @@ jobs:
       fail-fast: false
       matrix:
         gemfile:
-          - gemfiles/mongoid_6.gemfile
-          - gemfiles/mongoid_7.gemfile
+          - gemfiles/mongoid_9.gemfile
+          - gemfiles/mongoid_8.gemfile
     runs-on: ubuntu-latest
     services:
       mongodb:
@@ -152,6 +152,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 3.4
         bundler-cache: true
     - run: bundle exec rake compile test

--- a/gemfiles/mongoid_8.gemfile
+++ b/gemfiles/mongoid_8.gemfile
@@ -7,11 +7,10 @@ gem "bootsnap"
 gem "ruby-prof", platform: :ruby
 gem "pry"
 gem "pry-stack_explorer", platform: :ruby
-gem "mongoid", "~> 7.0"
-if RUBY_VERSION >= "3.0"
-  gem "libev_scheduler"
-  gem "evt"
-end
+gem "mongoid", "~> 8.0"
+gem "libev_scheduler"
+gem "evt"
+gem "async"
 gem "fiber-storage"
 gem "concurrent-ruby", "1.3.4"
 

--- a/gemfiles/mongoid_9.gemfile
+++ b/gemfiles/mongoid_9.gemfile
@@ -6,11 +6,10 @@ gem "bootsnap"
 gem "ruby-prof", platform: :ruby
 gem "pry"
 gem "pry-stack_explorer", platform: :ruby
-gem "mongoid", "~> 6.4.1"
-if RUBY_VERSION >= "3.0"
-  gem "libev_scheduler"
-  gem "evt"
-end
+gem "mongoid", "~> 9.0"
+gem "libev_scheduler"
+gem "evt"
+gem "async"
 gem "fiber-storage"
 
 gemspec path: "../"


### PR DESCRIPTION
Old mongoid versions depended on versions of ActiveSupport which didn't have `Notifications.monotonic_subscribe`. I'd rather just update these builds to use modern versions than support Rails 5 😩 