### PR TITLE
Make Enum value_methods optional

### DIFF
--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -298,7 +298,6 @@ module GraphQL
                 description: enum_value_definition.description,
                 directives: builder.prepare_directives(enum_value_definition, type_resolver),
                 ast_node: enum_value_definition,
-                value_method: GraphQL::Schema::Enum.respond_to?(enum_value_definition.name.downcase) ? false : nil,
               )
             end
           end

--- a/lib/graphql/schema/enum.rb
+++ b/lib/graphql/schema/enum.rb
@@ -70,7 +70,9 @@ module GraphQL
           kwargs[:owner] = self
           value = enum_value_class.new(*args, **kwargs, &block)
 
-          generate_value_method(value, value_method)
+          if value_method || (value_methods && value_method != false)
+            generate_value_method(value, value_method)
+          end
 
           key = value.graphql_name
           prev_value = own_values[key]
@@ -159,6 +161,18 @@ module GraphQL
           end
         end
 
+        def value_methods(new_value = NOT_CONFIGURED)
+          if NOT_CONFIGURED.equal?(new_value)
+            if @value_methods != nil
+              @value_methods
+            else
+              find_inherited_value(:value_methods, false)
+            end
+          else
+            @value_methods = new_value
+          end
+        end
+
         def kind
           GraphQL::TypeKinds::ENUM
         end
@@ -220,6 +234,7 @@ module GraphQL
             # because they would end up with names like `#<Class0x1234>::UnresolvedValueError` which messes up bug trackers
             child_class.const_set(:UnresolvedValueError, Class.new(Schema::Enum::UnresolvedValueError))
           end
+          child_class.class_eval { @value_methods = nil }
           super
         end
 

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -156,7 +156,7 @@ module GraphQL
               def #{method_name}
                 self[#{method_name.inspect}]
               end
-              alias_method :#{method_name}, :#{method_name}
+              alias_method #{method_name.inspect}, #{method_name.inspect}
             RUBY
           end
           argument_defn

--- a/lib/graphql/schema/loader.rb
+++ b/lib/graphql/schema/loader.rb
@@ -108,7 +108,6 @@ module GraphQL
                   enum_value["name"],
                   description: enum_value["description"],
                   deprecation_reason: enum_value["deprecationReason"],
-                  value_method: respond_to?(enum_value["name"].downcase) ? false : nil
                 )
               end
             end

--- a/spec/graphql/schema/dynamic_members_spec.rb
+++ b/spec/graphql/schema/dynamic_members_spec.rb
@@ -175,7 +175,7 @@ describe "Dynamic types, fields, arguments, and enum values" do
 
     class Language < BaseEnum
       value "RUBY"
-      value "PERL6", deprecation_reason: "Use RAKU instead", future_schema: true, value_method: false
+      value "PERL6", deprecation_reason: "Use RAKU instead", future_schema: true
       value "PERL6", future_schema: false
       value "RAKU", future_schema: true
       value "COFFEE_SCRIPT", future_schema: false
@@ -1026,7 +1026,7 @@ GRAPHQL
       class DuplicateEnumValue < GraphQL::Schema::Enum
         enum_value_class(BaseEnumValue)
         value "ONE", description: "second definition", allow_for: [2, 3]
-        value "ONE", description: "first definition", allow_for: [1, 2], value_method: false
+        value "ONE", description: "first definition", allow_for: [1, 2]
       end
 
       class DuplicateFieldObject < GraphQL::Schema::Object

--- a/spec/graphql/schema/enum_spec.rb
+++ b/spec/graphql/schema/enum_spec.rb
@@ -160,7 +160,7 @@ describe GraphQL::Schema::Enum do
     class MultipleNameTestEnum < GraphQL::Schema::Enum
       value "A"
       value "B", value: :a
-      value "B", value: :b, value_method: false
+      value "B", value: :b
     end
 
     it "doesn't allow it from enum_values" do

--- a/spec/graphql/schema/loader_spec.rb
+++ b/spec/graphql/schema/loader_spec.rb
@@ -19,8 +19,7 @@ describe GraphQL::Schema::Loader do
 
       value "FOO", value: :foo
       value "BAR", deprecation_reason: "Don't use BAR"
-      value "NAME", value_method: false
-      value "foo", value_method: false
+      value "foo"
     end
 
     sub_input_type = Class.new(GraphQL::Schema::InputObject) do

--- a/spec/support/jazz.rb
+++ b/spec/support/jazz.rb
@@ -246,7 +246,7 @@ module Jazz
     value "KEYS" do
       description "Neither here nor there, really"
     end
-    value "SILENCE", "Makes no sound", value: false, value_method: false
+    value "SILENCE", "Makes no sound", value: false
   end
 
   class InstrumentType < BaseObject


### PR DESCRIPTION
To opt in, add 

```ruby 
  value_methods(true)
```

To your base enum class. Fixes #5254 