### PR TITLE
Remove `InvalidNullError#value` as it is always `nil`

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -473,7 +473,7 @@ module GraphQL
                 # When this comes from a list item, use the parent object:
                 parent_type = selection_result.is_a?(GraphQLResultArray) ? selection_result.graphql_parent.graphql_result_type : selection_result.graphql_result_type
                 # This block is called if `result_name` is not dead. (Maybe a previous invalid nil caused it be marked dead.)
-                err = parent_type::InvalidNullError.new(parent_type, field, value, ast_node)
+                err = parent_type::InvalidNullError.new(parent_type, field, ast_node)
                 schema.type_error(err, context)
               end
             else

--- a/lib/graphql/invalid_null_error.rb
+++ b/lib/graphql/invalid_null_error.rb
@@ -9,16 +9,12 @@ module GraphQL
     # @return [GraphQL::Field] The field which failed to return a value
     attr_reader :field
 
-    # @return [nil, GraphQL::ExecutionError] The invalid value for this field
-    attr_reader :value
-
     # @return [GraphQL::Language::Nodes::Field] the field where the error occurred
     attr_reader :ast_node
 
-    def initialize(parent_type, field, value, ast_node)
+    def initialize(parent_type, field, ast_node)
       @parent_type = parent_type
       @field = field
-      @value = value
       @ast_node = ast_node
       super("Cannot return null for non-nullable field #{@parent_type.graphql_name}.#{@field.graphql_name}")
     end

--- a/spec/graphql/non_null_type_spec.rb
+++ b/spec/graphql/non_null_type_spec.rb
@@ -49,7 +49,6 @@ describe "GraphQL::NonNullType" do
         assert_equal("Cannot return null for non-nullable field Cow.cantBeNullButIs", err.message)
         assert_equal("Cow", err.parent_type.graphql_name)
         assert_equal("cantBeNullButIs", err.field.name)
-        assert_nil(err.value)
       end
     end
   end


### PR DESCRIPTION
Resolves https://github.com/rmosolgo/graphql-ruby/issues/5243

`InvalidNullError#value` is always set to `nil`, it won't be a `GraphQL::ExecutionError` as the docs suggests.

https://github.com/rmosolgo/graphql-ruby/blob/c2dedb0dacb3c52f0531e5d035bc566961a30c93/lib/graphql/execution/interpreter/runtime.rb#L469-L476