### PR TITLE
Improve default InvalidNullError handling

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -473,7 +473,7 @@ module GraphQL
                 # When this comes from a list item, use the parent object:
                 parent_type = selection_result.is_a?(GraphQLResultArray) ? selection_result.graphql_parent.graphql_result_type : selection_result.graphql_result_type
                 # This block is called if `result_name` is not dead. (Maybe a previous invalid nil caused it be marked dead.)
-                err = parent_type::InvalidNullError.new(parent_type, field, value)
+                err = parent_type::InvalidNullError.new(parent_type, field, value, ast_node)
                 schema.type_error(err, context)
               end
             else

--- a/lib/graphql/invalid_null_error.rb
+++ b/lib/graphql/invalid_null_error.rb
@@ -2,7 +2,7 @@
 module GraphQL
   # Raised automatically when a field's resolve function returns `nil`
   # for a non-null field.
-  class InvalidNullError < GraphQL::RuntimeTypeError
+  class InvalidNullError < GraphQL::Error
     # @return [GraphQL::BaseType] The owner of {#field}
     attr_reader :parent_type
 
@@ -12,21 +12,15 @@ module GraphQL
     # @return [nil, GraphQL::ExecutionError] The invalid value for this field
     attr_reader :value
 
-    def initialize(parent_type, field, value)
+    # @return [GraphQL::Language::Nodes::Field] the field where the error occurred
+    attr_reader :ast_node
+
+    def initialize(parent_type, field, value, ast_node)
       @parent_type = parent_type
       @field = field
       @value = value
+      @ast_node = ast_node
       super("Cannot return null for non-nullable field #{@parent_type.graphql_name}.#{@field.graphql_name}")
-    end
-
-    # @return [Hash] An entry for the response's "errors" key
-    def to_h
-      { "message" => message }
-    end
-
-    # @deprecated always false
-    def parent_error?
-      false
     end
 
     class << self

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -1298,7 +1298,10 @@ module GraphQL
       def type_error(type_error, ctx)
         case type_error
         when GraphQL::InvalidNullError
-          ctx.errors << type_error
+          execution_error = GraphQL::ExecutionError.new(type_error.message, ast_node: type_error.ast_node)
+          execution_error.path = ctx[:current_path]
+
+          ctx.errors << execution_error
         when GraphQL::UnresolvedTypeError, GraphQL::StringEncodingError, GraphQL::IntegerEncodingError
           raise type_error
         when GraphQL::IntegerDecodingError

--- a/spec/graphql/execution/errors_spec.rb
+++ b/spec/graphql/execution/errors_spec.rb
@@ -307,7 +307,9 @@ describe "GraphQL::Execution::Errors" do
       it "outputs the appropriate error message when using non-interpreter schema" do
         res = ErrorsTestSchemaWithoutInterpreter.execute("{ nonNullableArray }")
         expected_error = {
-          "message" => "Cannot return null for non-nullable field Query.nonNullableArray"
+          "message" => "Cannot return null for non-nullable field Query.nonNullableArray",
+          "path" => ["nonNullableArray", 0],
+          "locations" => [{ "line" => 1, "column" => 3 }]
         }
         assert_equal({ "data" => nil, "errors" => [expected_error] }, res)
       end
@@ -315,7 +317,9 @@ describe "GraphQL::Execution::Errors" do
       it "outputs the appropriate error message when using interpreter schema" do
         res = ErrorsTestSchema.execute("{ nonNullableArray }")
         expected_error = {
-          "message" => "Cannot return null for non-nullable field Query.nonNullableArray"
+          "message" => "Cannot return null for non-nullable field Query.nonNullableArray",
+          "path" => ["nonNullableArray", 0],
+          "locations" => [{ "line" => 1, "column" => 3 }]
         }
         assert_equal({ "data" => nil, "errors" => [expected_error] }, res)
       end

--- a/spec/graphql/execution/multiplex_spec.rb
+++ b/spec/graphql/execution/multiplex_spec.rb
@@ -114,7 +114,11 @@ describe GraphQL::Execution::Multiplex do
         },
         {
           "data"=>{"invalidNestedNull"=>{"value" => 2,"nullableNestedSum" => nil}},
-          "errors"=>[{"message"=>"Cannot return null for non-nullable field LazySum.nestedSum"}],
+          "errors"=>[{
+            "message"=>"Cannot return null for non-nullable field LazySum.nestedSum",
+            "path"=>["invalidNestedNull", "nullableNestedSum", "nestedSum"],
+            "locations"=>[{"line"=>5, "column"=>11}],
+          }],
         },
         {
           "errors" => [{

--- a/spec/graphql/non_null_type_spec.rb
+++ b/spec/graphql/non_null_type_spec.rb
@@ -7,7 +7,11 @@ describe "GraphQL::NonNullType" do
       query_string = %|{ cow { name cantBeNullButIs } }|
       result = Dummy::Schema.execute(query_string)
       assert_equal({"cow" => nil }, result["data"])
-      assert_equal([{"message"=>"Cannot return null for non-nullable field Cow.cantBeNullButIs"}], result["errors"])
+      assert_equal([{
+        "message" => "Cannot return null for non-nullable field Cow.cantBeNullButIs",
+        "path" => ["cow", "cantBeNullButIs"],
+        "locations" => [{"line" => 1, "column" => 14}],
+      }], result["errors"])
     end
 
     it "propagates the null up to the next nullable field" do
@@ -26,7 +30,11 @@ describe "GraphQL::NonNullType" do
       |
       result = Dummy::Schema.execute(query_string)
       assert_nil(result["data"])
-      assert_equal([{"message"=>"Cannot return null for non-nullable field DeepNonNull.nonNullInt"}], result["errors"])
+      assert_equal([{
+        "message" => "Cannot return null for non-nullable field DeepNonNull.nonNullInt",
+        "path" => ["nn1", "nn2", "nn3", "nni3"],
+        "locations" => [{"line" => 8, "column" => 15}],
+      }], result["errors"])
     end
 
     describe "when type_error is configured to raise an error" do

--- a/spec/graphql/query/executor_spec.rb
+++ b/spec/graphql/query/executor_spec.rb
@@ -147,7 +147,9 @@ describe "GraphQL::Query::Executor" do
           "data" => { "cow" => nil },
           "errors" => [
             {
-              "message" => "Cannot return null for non-nullable field Cow.cantBeNullButIs"
+              "message" => "Cannot return null for non-nullable field Cow.cantBeNullButIs",
+              "path" => ["cow", "cantBeNullButIs"],
+              "locations" => [{ "line" => 1, "column" => 28 }]
             }
           ]
         }

--- a/spec/graphql/schema/mutation_spec.rb
+++ b/spec/graphql/schema/mutation_spec.rb
@@ -113,9 +113,6 @@ describe GraphQL::Schema::Mutation do
       query_str = "mutation { returnInvalidNull { int } }"
       response = Jazz::Schema.execute(query_str)
       assert_equal ["Cannot return null for non-nullable field ReturnInvalidNullPayload.int"], response["errors"].map { |e| e["message"] }
-      error = response.query.context.errors.first
-      assert_instance_of Jazz::ReturnInvalidNull.payload_type::InvalidNullError, error
-      assert_equal "Jazz::ReturnInvalidNull::ReturnInvalidNullPayload::InvalidNullError", error.class.inspect
     end
   end
 


### PR DESCRIPTION
Closes https://github.com/rmosolgo/graphql-ruby/issues/5239

`InvalidNullError` was modeled as a `RuntimeTypeError` but also implemented `to_h` to act like an `ExecutionError`. It was a strange hybrid which made it harder for applications to change how the errors were handled.

It also caused limitations such as not being easy to add `extensions` or `path` to the error in the response.

This changes `InvalidNullError` to inherit from the base `GraphQL::Error` instead of `RuntimeTypeError`. Instead of adding the instance of `InvalidNullError` directly to `context.errors`, the default implementation is changed to create a new `ExecutionError` instead.

This provides a simpler middle ground where applications can still choose to handle `InvalidNullError` exceptions differently (such as reporting them to their exception handler app) but keep the proper spec compliant field error response.

Note: assuming this solution is good, I'll rebase this after https://github.com/rmosolgo/graphql-ruby/pull/5256