### PR TITLE
Set default timeout for GraphQL schema validation

### DIFF
--- a/guides/queries/timeout.md
+++ b/guides/queries/timeout.md
@@ -67,14 +67,20 @@ end
 
 Queries can originate from a user, and may be crafted in a manner to take a long time to validate against the schema.
 
-It is possible to limit how many seconds the static validation rules and analysers are allowed to run before returning a validation timeout error. The default is no timeout.
+It is possible to limit how many seconds the static validation rules and analysers are allowed to run before returning a validation timeout error. By default, validation and query analysis have a 3-second timeout. You can customize this timeout or disable it completely:
 
 For example:
 
 ```ruby
+# Customize timeout (in seconds)
 class MySchema < GraphQL::Schema
   # Applies to static validation and query analysis
   validate_timeout 10
+end
+
+# OR disable timeout completely
+class MySchema < GraphQL::Schema
+  validate_timeout nil
 end
 ```
 

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -821,13 +821,13 @@ module GraphQL
 
       attr_writer :validate_timeout
 
-      def validate_timeout(new_validate_timeout = nil)
-        if new_validate_timeout
+      def validate_timeout(new_validate_timeout = :not_provided)
+        if new_validate_timeout != :not_provided
           @validate_timeout = new_validate_timeout
         elsif defined?(@validate_timeout)
           @validate_timeout
         else
-          find_inherited_value(:validate_timeout)
+          find_inherited_value(:validate_timeout) || 3
         end
       end
 

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -604,4 +604,24 @@ To add other types to your schema, you might want `extra_types`: https://graphql
       assert_equal expected_errors, schema.execute(query_str).to_h['errors']
     end
   end
+  describe ".validate_timeout" do
+    it "provides a default timeout when not explicitly set" do
+      schema = Class.new(GraphQL::Schema)
+      assert_equal 3, schema.validate_timeout
+    end
+
+    it "allows overriding the default timeout" do
+      schema = Class.new(GraphQL::Schema) do
+        validate_timeout 15
+      end
+      assert_equal 15, schema.validate_timeout
+    end
+
+    it "allows disabling the timeout" do
+      schema = Class.new(GraphQL::Schema) do
+        validate_timeout nil
+      end
+      assert_nil schema.validate_timeout
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Currently, `graphql-ruby` does not enforce a timeout for schema validation by default. When `validate_timeout` isn't explicitly set, maliciously crafted queries can consume substantial server resources and potentially cause denial of service (DoS) conditions.

Through Shopify's bug bounty program, we've received multiple reports demonstrating that a single host can leverage this behavior to impact an entire API.


## Solution

Add a reasonable default timeout (3 seconds) for schema validation that:
- protects all downstream consumers
- maintains backward compatibility and 
- preserves the ability to customize or disable the timeout

### Why 3 seconds?

- **Data-Driven Decision**: We analyzed performance metrics across many GraphQL services at Shopify, examining the 95th percentile of GraphQL execution time (not including data retrieval). Most queries execute in under 500ms, with even our most complex queries rarely exceeding 700ms.
- **Configurable Override**: Services with exceptional needs can still override the default value



