### PR TITLE
Raise a ParseError on dangling close curly brace

### DIFF
--- a/lib/graphql/language/lexer.rb
+++ b/lib/graphql/language/lexer.rb
@@ -13,17 +13,21 @@ module GraphQL
         @pos = nil
         @max_tokens = max_tokens || Float::INFINITY
         @tokens_count = 0
+        @finished = false
       end
 
-      def eos?
-        @scanner.eos?
+      def finished?
+        @finished
       end
 
       attr_reader :pos, :tokens_count
 
       def advance
         @scanner.skip(IGNORE_REGEXP)
-        return false if @scanner.eos?
+        if @scanner.eos?
+          @finished = true
+          return false
+        end
         @tokens_count += 1
         if @tokens_count > @max_tokens
           raise_parse_error("This query is too large to execute.")

--- a/lib/graphql/language/parser.rb
+++ b/lib/graphql/language/parser.rb
@@ -110,7 +110,7 @@ module GraphQL
           # Only ignored characters is not a valid document
           raise GraphQL::ParseError.new("Unexpected end of document", nil, nil, @graphql_str)
         end
-        while !@lexer.eos?
+        while !@lexer.finished?
           defns << definition
         end
         Document.new(pos: 0, definitions: defns, filename: @filename, source: self)

--- a/spec/graphql/language/parser_spec.rb
+++ b/spec/graphql/language/parser_spec.rb
@@ -89,6 +89,12 @@ createRecord(data: {
     }
   end
 
+  it "raises a parse error when there's a dangling identifier" do
+    assert_raises(GraphQL::ParseError) {
+      GraphQL.parse('{ foo } fooagain')
+    }
+  end
+
   describe "when there are no selections" do
     it 'raises a ParseError' do
       assert_raises(GraphQL::ParseError) {

--- a/spec/graphql/language/parser_spec.rb
+++ b/spec/graphql/language/parser_spec.rb
@@ -83,6 +83,12 @@ createRecord(data: {
     assert GraphQL.parse("{ a(b: \"\\u0000\") }")
   end
 
+  it "raises a parse error when there's a dangling close curly brace" do
+    assert_raises(GraphQL::ParseError) {
+      GraphQL.parse('{ foo } }')
+    }
+  end
+
   describe "when there are no selections" do
     it 'raises a ParseError' do
       assert_raises(GraphQL::ParseError) {


### PR DESCRIPTION
Somehow between the lexer and parser, this last brace is being ignored. Something about `lexer.eos?` returning true even though there's an unhandled token still there. 