### PR TITLE
Fix(NewRelic) reimplement trace_scalars

### DIFF
--- a/cop/development/trace_methods_cop.rb
+++ b/cop/development/trace_methods_cop.rb
@@ -73,6 +73,7 @@ module Cop
             # Not really necessary for making a good trace:
             :lex, :analyze_query, :execute_query, :execute_query_lazy,
             # Only useful for isolated event tracking:
+            :begin_dataloader, :end_dataloader,
             :dataloader_fiber_exit, :dataloader_spawn_execution_fiber, :dataloader_spawn_source_fiber
           ]
           missing_defs.each do |missing_def|

--- a/spec/graphql/tracing/new_relic_trace_spec.rb
+++ b/spec/graphql/tracing/new_relic_trace_spec.rb
@@ -82,7 +82,7 @@ describe GraphQL::Tracing::NewRelicTrace do
 
     class SchemaWithoutAuthorizedOrResolveType < GraphQL::Schema
       query(Query)
-      trace_with(GraphQL::Tracing::NewRelicTrace, set_transaction_name: true, trace_authorized: false, trace_resolve_type: false)
+      trace_with(GraphQL::Tracing::NewRelicTrace, set_transaction_name: true, trace_authorized: false, trace_resolve_type: false, trace_scalars: true)
     end
   end
 
@@ -166,14 +166,12 @@ describe GraphQL::Tracing::NewRelicTrace do
         "FINISH GraphQL/Query/other",
         "GraphQL/Authorized/Other",
         "FINISH GraphQL/Authorized/Other",
-        "GraphQL/Other/name",
-        "FINISH GraphQL/Other/name",
       "FINISH GraphQL/execute"
     ]
     assert_equal expected_steps, NewRelic::EXECUTION_SCOPES
   end
 
-  it "can skip authorized and resolve type" do
+  it "can skip authorized and resolve type and instrument scalars" do
     NewRelicTraceTest::SchemaWithoutAuthorizedOrResolveType.execute("{ nameable { name } }")
     expected_steps = [
       "GraphQL/parse",
@@ -235,8 +233,6 @@ describe GraphQL::Tracing::NewRelicTrace do
       "GraphQL/Authorized/Other",
       "FINISH GraphQL/Authorized/Other",
 
-      "GraphQL/Other/name",
-      "FINISH GraphQL/Other/name",
       "FINISH GraphQL/execute",
     ]
     assert_equal expected_steps, NewRelic::EXECUTION_SCOPES


### PR DESCRIPTION
Oops, this option was accidentally removed in #5240 

Also, I learned while working on #5270  that a stack isn't really necessary here. Since a single fiber can only do one thing, just a `Fiber[...]` assignment will do. 