### PR TITLE
Immediately return empty array in multiplex if queries list is empty

### DIFF
--- a/lib/graphql/execution/interpreter.rb
+++ b/lib/graphql/execution/interpreter.rb
@@ -33,6 +33,7 @@ module GraphQL
             end
           end
 
+          return GraphQL::EmptyObjects::EMPTY_ARRAY if queries.empty?
 
           multiplex = Execution::Multiplex.new(schema: schema, queries: queries, context: context, max_complexity: max_complexity)
           Fiber[:__graphql_current_multiplex] = multiplex

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -949,4 +949,25 @@ describe GraphQL::Execution::Interpreter do
       assert_equal(expected_result, res["data"])
     end
   end
+
+  describe "multiplex queries" do
+    it "runs multiplex queries" do
+      result = InterpreterTest::Schema.multiplex([
+        {
+          query: "query Card($name: String!) { card(name: $name) { colors } }",
+          variables: { name: "Dark Confidant" },
+          operation_name: "Card"
+        },
+        {
+          query: "query Expansion($expansion: String!) { expansion(sym: $expansion) { cards { name } } }",
+          variables: { expansion: "RAV" },
+          operation_name: "Expansion"
+        }
+      ])
+
+      assert_equal ["BLACK"], result[0]["data"]["card"]["colors"]
+      assert_equal [{"name" => "Dark Confidant"}], result[1]["data"]["expansion"]["cards"]
+      assert_nil Fiber[:__graphql_runtime_info]
+    end
+  end
 end

--- a/spec/graphql/tracing/new_relic_trace_spec.rb
+++ b/spec/graphql/tracing/new_relic_trace_spec.rb
@@ -237,4 +237,29 @@ describe GraphQL::Tracing::NewRelicTrace do
     ]
     assert_equal expected_steps, NewRelic::EXECUTION_SCOPES
   end
+
+  describe "multiplex queries" do
+    it "handles multiplex" do
+      NewRelicTraceTest::SchemaWithTransactionName.multiplex([
+        {
+          query: "query Q1 { int }",
+          variables: {},
+          operation_name: "Q1"
+        },
+        {
+          query: "query Q2 { int }",
+          variables: {},
+          operation_name: "Q2"
+        }
+      ])
+
+      assert_equal ["GraphQL/query.Q1"], NewRelic::TRANSACTION_NAMES
+    end
+
+    it "handles empty multiplex" do
+      NewRelicTraceTest::SchemaWithTransactionName.multiplex([])
+
+      assert_equal [], NewRelic::TRANSACTION_NAMES
+    end
+  end
 end


### PR DESCRIPTION
Version `2.4.10` changed the NewRelicTrace class to support fiber stops/starts.

Now `GraphQL::Execution::Interpreter` calls `begin_execute_multiplex`, which relies on the [first multiplex query](https://github.com/rmosolgo/graphql-ruby/blob/v2.4.10/lib/graphql/tracing/new_relic_trace.rb#L68) in the list:

```ruby
def begin_execute_multiplex(multiplex)
  query = multiplex.queries.first
  set_this_txn_name = query.context[:set_new_relic_transaction_name]
  ...
end
```

Theoretically, it is possible to call multiplex with an empty array (I know, this is an edge case, but it is possible). In this case, we don't have any query to run and can return an empty result.

If the Schema uses the NewRelic tracer, `GraphQL::Tracing::NewRelicTrace#begin_execute_multiplex` fails with error because `multiplex.queries.first` returns `nil`.

Easy steps to reproduce (fails with NewRelicTrace and works correctly without NewRelicTrace):

```ruby
class QueryType < GraphQL::Schema::Object
  field :name, GraphQL::Types::String, null: false
end

class Schema < GraphQL::Schema
  trace_with GraphQL::Tracing::NewRelicTrace

  query QueryType
end

Schema.multiplex([])
```

We can fix all trace classes to handle this case correctly, but it seems like we don't even need to analyze/execute an empty list of queries.