### PR TITLE
Base type classes for `Schema.from_definition`

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -111,7 +111,7 @@ module GraphQL
       # @param parser [Object] An object for handling definition string parsing (must respond to `parse`)
       # @param using [Hash] Plugins to attach to the created schema with `use(key, value)`
       # @return [Class] the schema described by `document`
-      def from_definition(definition_or_path, default_resolve: nil, parser: GraphQL.default_parser, using: {})
+      def from_definition(definition_or_path, default_resolve: nil, parser: GraphQL.default_parser, using: {}, base_types: {})
         # If the file ends in `.graphql` or `.graphqls`, treat it like a filepath
         if definition_or_path.end_with?(".graphql") || definition_or_path.end_with?(".graphqls")
           GraphQL::Schema::BuildFromDefinition.from_definition_path(
@@ -120,6 +120,7 @@ module GraphQL
             default_resolve: default_resolve,
             parser: parser,
             using: using,
+            base_types: base_types,
           )
         else
           GraphQL::Schema::BuildFromDefinition.from_definition(
@@ -128,6 +129,7 @@ module GraphQL
             default_resolve: default_resolve,
             parser: parser,
             using: using,
+            base_types: base_types,
           )
         end
       end


### PR DESCRIPTION
Something I've been considering for a while now... it'd be useful to be able to build a schema from SDL while also providing base type classes. This would allow the base type classes to setup features like visibility hooks in the constructed schema.

```ruby
sdl = %|
  type A { a:Int } 
  type B @private { a:Int } 
  type Query { 
    a:A
    b:B
  }
|

class BaseObject < GraphQL::Schema::Object
  def visible?(ctx)
    ctx[:visibility_profile] == "private" || !directives.find { _1.name == "private" }
  end
end

GraphQL::Schema.from_definition(sdl, base_types: { object: BaseObject })
```

At present you'd need to either modify the base library classes, or else build the schema with generic base types and then [step through all elements adding behavior mixins](https://github.com/gmac/graphql-stitching-ruby/pull/124/files#diff-e43aabaf38087b6a861051ddf533969d869d2052ad9af7fdc1311c7b9ad658d7R14-R29).