### PR TITLE
[1.11.x] Re-merge changes from 1.11.9, 1.11.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@
 
 - Security: Fix CVE-2025-27407
 
+# 1.11.10 (5 Nov 2021)
+
+### Bug fixes
+
+- Properly hook up `Schema.max_validation_errors` at query runtime #3690
+
+# 1.11.9
+
+### New Features
+
+- `Schema.max_validation_errors(val)` limits the number of errors that can be added during static validation #3675
+
+# 1.11.8 (12 Feb 2021)
+
+### Bug fixes
+
+- Improve performance of `Schema.possible_types(t)` for object types #3172
+
 # 1.11.7 (18 January 2021)
 
 ### Breaking changes

--- a/lib/graphql/query/validation_pipeline.rb
+++ b/lib/graphql/query/validation_pipeline.rb
@@ -72,7 +72,7 @@ module GraphQL
         elsif @operation_name_error
           @validation_errors << @operation_name_error
         else
-          validation_result = @schema.static_validator.validate(@query, validate: @validate, timeout: @schema.validate_timeout)
+          validation_result = @schema.static_validator.validate(@query, validate: @validate, timeout: @schema.validate_timeout, max_errors: @schema.validate_max_errors)
           @validation_errors.concat(validation_result[:errors])
           @internal_representation = validation_result[:irep]
 

--- a/lib/graphql/static_validation/base_visitor.rb
+++ b/lib/graphql/static_validation/base_visitor.rb
@@ -205,6 +205,9 @@ module GraphQL
       private
 
       def add_error(error, path: nil)
+        if @context.too_many_errors?
+          throw :too_many_validation_errors
+        end
         error.path ||= (path || @path.dup)
         context.errors << error
       end

--- a/lib/graphql/static_validation/rules/fields_will_merge.rb
+++ b/lib/graphql/static_validation/rules/fields_will_merge.rb
@@ -193,26 +193,26 @@ module GraphQL
           if node1.name != node2.name
             errored_nodes = [node1.name, node2.name].sort.join(" or ")
             msg = "Field '#{response_key}' has a field conflict: #{errored_nodes}?"
-            context.errors << GraphQL::StaticValidation::FieldsWillMergeError.new(
+            add_error(GraphQL::StaticValidation::FieldsWillMergeError.new(
               msg,
               nodes: [node1, node2],
               path: [],
               field_name: response_key,
               conflicts: errored_nodes
-            )
+            ))
           end
 
           if !same_arguments?(node1, node2)
             args = [serialize_field_args(node1), serialize_field_args(node2)]
             conflicts = args.map { |arg| GraphQL::Language.serialize(arg) }.join(" or ")
             msg = "Field '#{response_key}' has an argument conflict: #{conflicts}?"
-            context.errors << GraphQL::StaticValidation::FieldsWillMergeError.new(
+            add_error(GraphQL::StaticValidation::FieldsWillMergeError.new(
               msg,
               nodes: [node1, node2],
               path: [],
               field_name: response_key,
               conflicts: conflicts
-            )
+            ))
           end
         end
 

--- a/lib/graphql/static_validation/rules/fragments_are_finite.rb
+++ b/lib/graphql/static_validation/rules/fragments_are_finite.rb
@@ -7,12 +7,12 @@ module GraphQL
         dependency_map = context.dependencies
         dependency_map.cyclical_definitions.each do |defn|
           if defn.node.is_a?(GraphQL::Language::Nodes::FragmentDefinition)
-            context.errors << GraphQL::StaticValidation::FragmentsAreFiniteError.new(
+            add_error(GraphQL::StaticValidation::FragmentsAreFiniteError.new(
               "Fragment #{defn.name} contains an infinite loop",
               nodes: defn.node,
               path: defn.path,
               name: defn.name
-            )
+            ))
           end
         end
       end

--- a/lib/graphql/static_validation/validation_context.rb
+++ b/lib/graphql/static_validation/validation_context.rb
@@ -19,10 +19,11 @@ module GraphQL
 
       def_delegators :@query, :schema, :document, :fragments, :operations, :warden
 
-      def initialize(query, visitor_class)
+      def initialize(query, visitor_class, max_errors)
         @query = query
         @literal_validator = LiteralValidator.new(context: query.context)
         @errors = []
+        @max_errors = max_errors || Float::INFINITY
         @on_dependency_resolve_handlers = []
         @visitor = visitor_class.new(document, self)
       end
@@ -37,6 +38,10 @@ module GraphQL
 
       def validate_literal(ast_value, type)
         @literal_validator.validate(ast_value, type)
+      end
+
+      def too_many_errors?
+        @errors.length >= @max_errors
       end
     end
   end

--- a/lib/graphql/static_validation/validator.rb
+++ b/lib/graphql/static_validation/validator.rb
@@ -22,8 +22,9 @@ module GraphQL
       # @param query [GraphQL::Query]
       # @param validate [Boolean]
       # @param timeout [Float] Number of seconds to wait before aborting validation. Any positive number may be used, including Floats to specify fractional seconds.
+      # @param max_errors [Integer] Maximum number of errors before aborting validation. Any positive number will limit the number of errors. Defaults to nil for no limit.
       # @return [Array<Hash>]
-      def validate(query, validate: true, timeout: nil)
+      def validate(query, validate: true, timeout: nil, max_errors: nil)
         query.trace("validate", { validate: validate, query: query }) do
           can_skip_rewrite = query.context.interpreter? && query.schema.using_ast_analysis? && query.schema.is_a?(Class)
           errors = if validate == false && can_skip_rewrite
@@ -32,23 +33,26 @@ module GraphQL
             rules_to_use = validate ? @rules : []
             visitor_class = BaseVisitor.including_rules(rules_to_use, rewrite: !can_skip_rewrite)
 
-            context = GraphQL::StaticValidation::ValidationContext.new(query, visitor_class)
+            context = GraphQL::StaticValidation::ValidationContext.new(query, visitor_class, max_errors)
 
             begin
               # CAUTION: Usage of the timeout module makes the assumption that validation rules are stateless Ruby code that requires no cleanup if process was interrupted. This means no blocking IO calls, native gems, locks, or `rescue` clauses that must be reached.
               # A timeout value of 0 or nil will execute the block without any timeout.
               Timeout::timeout(timeout) do
-                # Attach legacy-style rules.
-                # Only loop through rules if it has legacy-style rules
-                unless (legacy_rules = rules_to_use - GraphQL::StaticValidation::ALL_RULES).empty?
-                  legacy_rules.each do |rule_class_or_module|
-                    if rule_class_or_module.method_defined?(:validate)
-                      rule_class_or_module.new.validate(context)
+
+                catch(:too_many_validation_errors) do
+                  # Attach legacy-style rules.
+                  # Only loop through rules if it has legacy-style rules
+                  unless (legacy_rules = rules_to_use - GraphQL::StaticValidation::ALL_RULES).empty?
+                    legacy_rules.each do |rule_class_or_module|
+                      if rule_class_or_module.method_defined?(:validate)
+                        rule_class_or_module.new.validate(context)
+                      end
                     end
                   end
-                end
 
-                context.visitor.visit
+                  context.visitor.visit
+                end
               end
             rescue Timeout::Error
               handle_timeout(query, context)

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -42,6 +42,13 @@ describe GraphQL::Query do
   )}
   let(:result) { query.result }
 
+  it "applies the max validation errors config" do
+    limited_schema = Class.new(schema) { validate_max_errors(2) }
+    res = limited_schema.execute("{ a b c d }")
+    assert_equal 2, res["errors"].size
+    refute res.key?("data")
+  end
+
   describe "when passed both a query string and a document" do
     it "returns an error to the client when query kwarg is used" do
       assert_raises ArgumentError do

--- a/spec/graphql/static_validation/rules/argument_names_are_unique_spec.rb
+++ b/spec/graphql/static_validation/rules/argument_names_are_unique_spec.rb
@@ -41,4 +41,38 @@ describe GraphQL::StaticValidation::ArgumentNamesAreUnique do
       assert_equal ["query GetStuff", "c1"], error["path"]
     end
   end
+
+  describe "with error limiting" do
+    let(:query_string) { <<-GRAPHQL
+    query GetStuff {
+      c1: cheese(id: 1, id: 2) @include(if: true, if: true) { flavor }
+      c2: cheese(id: 3, id: 3) @include(if: true) { flavor }
+    }
+    GRAPHQL
+    }
+
+    describe("disabled") do
+      let(:args) {
+        { max_errors: nil }
+      }
+
+      it "does not limit the number of errors" do
+        assert_equal(error_messages, [
+          "There can be only one argument named \"id\"",
+          "There can be only one argument named \"if\"",
+          "There can be only one argument named \"id\""
+        ])
+      end
+    end
+
+    describe("enabled") do
+      let(:args) {
+        { max_errors: 1 }
+      }
+
+      it "does limit the number of errors" do
+        assert_equal(error_messages, [ "There can be only one argument named \"id\"" ])
+      end
+    end
+  end
 end

--- a/spec/graphql/static_validation/rules/fields_will_merge_spec.rb
+++ b/spec/graphql/static_validation/rules/fields_will_merge_spec.rb
@@ -357,6 +357,33 @@ describe GraphQL::StaticValidation::FieldsWillMerge do
         "Field 'name' has a field conflict: name or nickname?"
       ], error_messages
     end
+
+    describe "with error limiting" do
+      describe("disabled") do
+        let(:args) {
+          { max_errors: nil }
+        }
+
+        it "does not limit the number of errors" do
+          assert_equal(error_messages, [
+            "Field 'x' has a field conflict: name or nickname?",
+            "Field 'name' has a field conflict: name or nickname?"
+          ])
+        end
+      end
+
+      describe("enabled") do
+        let(:args) {
+          { max_errors: 1 }
+        }
+
+        it "does limit the number of errors" do
+          assert_equal(error_messages, [
+            "Field 'x' has a field conflict: name or nickname?",
+          ])
+        end
+      end
+    end
   end
 
 
@@ -409,6 +436,33 @@ describe GraphQL::StaticValidation::FieldsWillMerge do
         "Field 'x' has a field conflict: name or nickname?",
         "Field 'y' has a field conflict: barkVolume or doesKnowCommand?",
       ], error_messages
+    end
+
+    describe "with error limiting" do
+      describe("disabled") do
+        let(:args) {
+          { max_errors: nil }
+        }
+
+        it "does not limit the number of errors" do
+          assert_equal(error_messages, [
+            "Field 'x' has a field conflict: name or nickname?",
+            "Field 'y' has a field conflict: barkVolume or doesKnowCommand?",
+          ])
+        end
+      end
+
+      describe("enabled") do
+        let(:args) {
+          { max_errors: 1 }
+        }
+
+        it "does limit the number of errors" do
+          assert_equal(error_messages, [
+            "Field 'x' has a field conflict: name or nickname?",
+          ])
+        end
+      end
     end
   end
 
@@ -800,4 +854,5 @@ describe GraphQL::StaticValidation::FieldsWillMerge do
       end
     end
   end
+
 end

--- a/spec/graphql/static_validation/rules/fragments_are_finite_spec.rb
+++ b/spec/graphql/static_validation/rules/fragments_are_finite_spec.rb
@@ -118,5 +118,32 @@ describe GraphQL::StaticValidation::FragmentsAreFinite do
       assert_equal("Fragment frag1 contains an infinite loop", errors[0]["message"])
       assert_equal("Operation name \"frag1\" must be unique", errors[1]["message"])
     end
+
+    describe "with error limiting" do
+      describe("disabled") do
+        let(:args) {
+          { max_errors: nil }
+        }
+
+        it "does not limit the number of errors" do
+          assert_equal(error_messages, [
+            "Fragment frag1 contains an infinite loop",
+            "Operation name \"frag1\" must be unique"
+          ])
+        end
+      end
+
+      describe("enabled") do
+        let(:args) {
+          { max_errors: 1 }
+        }
+
+        it "does limit the number of errors" do
+          assert_equal(error_messages, [
+            "Fragment frag1 contains an infinite loop",
+          ])
+        end
+      end
+    end
   end
 end

--- a/spec/graphql/static_validation/rules/fragments_are_used_spec.rb
+++ b/spec/graphql/static_validation/rules/fragments_are_used_spec.rb
@@ -48,4 +48,51 @@ describe GraphQL::StaticValidation::FragmentsAreUsed do
       })
     end
   end
+
+  describe "with error limiting" do
+    let(:query_string) {"
+      query getCheese {
+        ...cheeseFields
+        ...undefinedFields
+      }
+      fragment cheeseFields on Cheese { fatContent }
+      fragment unusedFields on Cheese { not_used }
+      fragment yetMoreUnusedFields on Cheese { must_be_vegan }
+    "}
+
+    describe("disabled") do
+      let(:args) {
+        { max_errors: nil }
+      }
+
+      it "does not limit the number of errors" do
+        assert_equal(error_messages.length, 6)
+        assert_equal(error_messages,[
+          "Field 'not_used' doesn't exist on type 'Cheese'",
+          "Field 'must_be_vegan' doesn't exist on type 'Cheese'",
+          "Fragment cheeseFields on Cheese can't be spread inside Query",
+          "Fragment undefinedFields was used, but not defined",
+          "Fragment yetMoreUnusedFields was defined, but not used",
+          "Fragment unusedFields was defined, but not used"
+        ])
+      end
+    end
+
+    describe("enabled") do
+      let(:args) {
+        { max_errors: 5 }
+      }
+
+      it "does limit the number of errors" do
+        assert_equal(error_messages.length, 5)
+        assert_equal(error_messages, [
+          "Field 'not_used' doesn't exist on type 'Cheese'",
+          "Field 'must_be_vegan' doesn't exist on type 'Cheese'",
+          "Fragment cheeseFields on Cheese can't be spread inside Query",
+          "Fragment undefinedFields was used, but not defined",
+          "Fragment yetMoreUnusedFields was defined, but not used",
+        ])
+      end
+    end
+  end
 end

--- a/spec/graphql/static_validation/rules/input_object_names_are_unique_spec.rb
+++ b/spec/graphql/static_validation/rules/input_object_names_are_unique_spec.rb
@@ -23,4 +23,42 @@ describe GraphQL::StaticValidation::InputObjectNamesAreUnique do
       assert_includes(errors, duplicate_input_field_error)
     end
   end
+
+  describe "with error limiting" do
+    let(:query_string) {%|
+      query getCheese {
+        validInputObjectName: searchDairy(product: [{source: YAK}]) { __typename }
+        duplicateInputObjectNames: searchDairy(product: [{source: YAK, source: YAK}]) { __typename }
+        moreDuplicateInputObjectNames: searchDairy(product: [{fatContent: YAK, fatContent: YAK, source: COW}]) { __typename }
+      }
+    |}
+
+    describe("disabled") do
+      let(:args) {
+        { max_errors: nil }
+      }
+
+      it "does not limit the number of errors" do
+        assert_equal(error_messages.length, 3)
+        assert_equal(error_messages, [
+          "There can be only one input field named \"source\"",
+          "There can be only one input field named \"fatContent\"",
+          "Argument 'fatContent' on InputObject 'DairyProductInput' has an invalid value (YAK). Expected type 'Float'."
+        ])
+      end
+    end
+
+    describe("enabled") do
+      let(:args) {
+        { max_errors: 1 }
+      }
+
+      it "does limit the number of errors" do
+        assert_equal(error_messages.length, 1)
+        assert_equal(error_messages, [
+          "There can be only one input field named \"source\"",
+        ])
+      end
+    end
+  end
 end

--- a/spec/graphql/static_validation/rules/operation_names_are_valid_spec.rb
+++ b/spec/graphql/static_validation/rules/operation_names_are_valid_spec.rb
@@ -79,4 +79,52 @@ describe GraphQL::StaticValidation::OperationNamesAreValid do
       assert_includes(errors, name_uniqueness_error)
     end
   end
+
+  describe "with error limiting" do
+    let(:query_string) { <<-GRAPHQL
+    query getCheese {
+      cheese(id: 1) { flavor }
+    }
+    query getCheese {
+      cheese(id: 2) { flavor }
+    }
+    query getCheeses{
+      searchDairy(product: [{ source: COW }]) {
+        __typename
+      }
+    }
+    query getCheeses{
+      searchDairy(product: [{ source: COW }]) {
+        __typename
+      }
+    }
+    GRAPHQL
+    }
+    describe("disabled") do
+      let(:args) {
+        { max_errors: nil }
+      }
+
+      it "does not limit the number of errors" do
+        assert_equal(error_messages.length, 2)
+        assert_equal(error_messages, [
+          "Operation name \"getCheese\" must be unique",
+          "Operation name \"getCheeses\" must be unique"
+        ])
+      end
+    end
+
+    describe("enabled") do
+      let(:args) {
+        { max_errors: 1 }
+      }
+
+      it "does limit the number of errors" do
+        assert_equal(error_messages.length, 1)
+        assert_equal(error_messages, [
+          "Operation name \"getCheese\" must be unique",
+        ])
+      end
+    end
+  end
 end

--- a/spec/graphql/static_validation/rules/required_input_object_attributes_are_present_spec.rb
+++ b/spec/graphql/static_validation/rules/required_input_object_attributes_are_present_spec.rb
@@ -83,4 +83,44 @@ describe GraphQL::StaticValidation::RequiredInputObjectAttributesArePresent do
       end
     end
   end
+
+  describe "with error limiting" do
+    describe("disabled") do
+      let(:args) {
+        { max_errors: nil }
+      }
+
+      it "does not limit the number of errors" do
+        assert_equal(error_messages.length, 10)
+        assert_equal(error_messages, [
+          "Argument 'id' on Field 'stringCheese' has an invalid value (\"aasdlkfj\"). Expected type 'Int!'.",
+          "Argument 'if' on Directive 'skip' has an invalid value (\"whatever\"). Expected type 'Boolean!'.",
+          "Argument 'source' on InputObject 'DairyProductInput' has an invalid value (1.1). Expected type 'DairyAnimal!'.",
+          "Argument 'source' on InputObject 'DairyProductInput' is required. Expected type DairyAnimal!",
+          "Argument 'source' on InputObject 'DairyProductInput' is required. Expected type DairyAnimal!",
+          "Argument 'direction' on InputObject 'ResourceOrderType' is required. Expected type String!",
+          "Argument 'source' on InputObject 'DairyProductInput' is required. Expected type DairyAnimal!",
+          "Argument 'direction' on InputObject 'ResourceOrderType' is required. Expected type String!",
+          "InputObject 'DairyProductInput' doesn't accept argument 'wacky'",
+          "Argument 'source' on Field 'similarCheese' has an invalid value (4.5). Expected type '[DairyAnimal!]!'."
+        ])
+      end
+    end
+
+    describe("enabled") do
+      let(:args) {
+        { max_errors: 4 }
+      }
+
+      it "does limit the number of errors" do
+        assert_equal(error_messages.length, 4)
+        assert_equal(error_messages, [
+          "Argument 'id' on Field 'stringCheese' has an invalid value (\"aasdlkfj\"). Expected type 'Int!'.",
+          "Argument 'if' on Directive 'skip' has an invalid value (\"whatever\"). Expected type 'Boolean!'.",
+          "Argument 'source' on InputObject 'DairyProductInput' has an invalid value (1.1). Expected type 'DairyAnimal!'.",
+          "Argument 'source' on InputObject 'DairyProductInput' is required. Expected type DairyAnimal!",
+        ])
+      end
+    end
+  end
 end

--- a/spec/graphql/static_validation/rules/unique_directives_per_location_spec.rb
+++ b/spec/graphql/static_validation/rules/unique_directives_per_location_spec.rb
@@ -185,4 +185,41 @@ describe GraphQL::StaticValidation::UniqueDirectivesPerLocation do
       }
     end
   end
+
+  describe "with error limiting" do
+    let(:query_string) {"
+      {
+        type @A @A {
+          field @A @A
+        }
+      }
+    "}
+
+    describe("disabled") do
+      let(:args) {
+        { max_errors: nil }
+      }
+
+      it "does not limit the number of errors" do
+        assert_equal(error_messages.length, 2)
+        assert_equal(error_messages, [
+          "The directive \"A\" can only be used once at this location.",
+          "The directive \"A\" can only be used once at this location."
+        ])
+      end
+    end
+
+    describe("enabled") do
+      let(:args) {
+        { max_errors: 1 }
+      }
+
+      it "does limit the number of errors" do
+        assert_equal(error_messages.length, 1)
+        assert_equal(error_messages, [
+          "The directive \"A\" can only be used once at this location."
+        ])
+      end
+    end
+  end
 end

--- a/spec/graphql/static_validation/rules/variable_names_are_unique_spec.rb
+++ b/spec/graphql/static_validation/rules/variable_names_are_unique_spec.rb
@@ -20,4 +20,33 @@ describe GraphQL::StaticValidation::VariableNamesAreUnique do
     assert_equal 'There can only be one variable named "var2"', last_err["message"]
     assert_equal 2, last_err["locations"].size
   end
+
+  describe "with error limiting" do
+    describe("disabled") do
+      let(:args) {
+        { max_errors: nil }
+      }
+
+      it "does not limit the number of errors" do
+        assert_equal(error_messages.length, 2)
+        assert_equal(error_messages, [
+          "There can only be one variable named \"var1\"",
+          "There can only be one variable named \"var2\""
+        ])
+      end
+    end
+
+    describe("enabled") do
+      let(:args) {
+        { max_errors: 1 }
+      }
+
+      it "does limit the number of errors" do
+        assert_equal(error_messages.length, 1)
+        assert_equal(error_messages, [
+          "There can only be one variable named \"var1\"",
+        ])
+      end
+    end
+  end
 end

--- a/spec/graphql/static_validation/rules/variable_usages_are_allowed_spec.rb
+++ b/spec/graphql/static_validation/rules/variable_usages_are_allowed_spec.rb
@@ -248,4 +248,35 @@ describe GraphQL::StaticValidation::VariableUsagesAreAllowed do
       end
     end
   end
+
+  describe "with error limiting" do
+    describe("disabled") do
+      let(:args) {
+        { max_errors: nil }
+      }
+
+      it "does not limit the number of errors" do
+        assert_equal(error_messages.length, 4)
+        assert_equal(error_messages, [
+          "Nullability mismatch on variable $badInt and argument id (Int / Int!)",
+          "Type mismatch on variable $badStr and argument id (String! / Int!)",
+          "Nullability mismatch on variable $badAnimals and argument source ([DairyAnimal]! / [DairyAnimal!]!)",
+          "List dimension mismatch on variable $deepAnimals and argument source ([[DairyAnimal!]!]! / [DairyAnimal!]!)"
+        ])
+      end
+    end
+
+    describe("enabled") do
+      let(:args) {
+        { max_errors: 1 }
+      }
+
+      it "does limit the number of errors" do
+        assert_equal(error_messages.length, 1)
+        assert_equal(error_messages, [
+          "Nullability mismatch on variable $badInt and argument id (Int / Int!)"
+        ])
+      end
+    end
+  end
 end

--- a/spec/graphql/static_validation/rules/variables_are_used_and_defined_spec.rb
+++ b/spec/graphql/static_validation/rules/variables_are_used_and_defined_spec.rb
@@ -110,4 +110,34 @@ describe GraphQL::StaticValidation::VariablesAreUsedAndDefined do
       assert_equal([], errors)
     end
   end
+
+  describe "with error limiting" do
+    describe("disabled") do
+      let(:args) {
+        { max_errors: nil }
+      }
+
+      it "does not limit the number of errors" do
+        assert_equal(error_messages.length, 3)
+        assert_equal(error_messages, [
+          "Variable $notUsedVar is declared by getCheese but not used",
+          "Variable $undefinedVar is used by getCheese but not declared",
+          "Variable $undefinedFragmentVar is used by innerCheeseFields but not declared"
+        ])
+      end
+    end
+
+    describe("enabled") do
+      let(:args) {
+        { max_errors: 1 }
+      }
+
+      it "does limit the number of errors" do
+        assert_equal(error_messages.length, 1)
+        assert_equal(error_messages, [
+          "Variable $notUsedVar is declared by getCheese but not used"
+        ])
+      end
+    end
+  end
 end

--- a/spec/integration/rails/graphql/schema_spec.rb
+++ b/spec/integration/rails/graphql/schema_spec.rb
@@ -464,6 +464,32 @@ type Query {
       errors = admin_schema.validate('query { adminOnlyMessage }', context: context)
       assert_equal([], errors)
     end
+
+    describe "with error limiting" do
+      describe("disabled") do
+        it "does not limit errors when not enabled" do
+          schema.define(validate_max_errors: nil) do
+            errors = schema.validate("{ cheese(id: 1) { flavor flavor: id, cow } }")
+            messages = errors.map { |e| e.message }
+            assert_equal([
+              "Field 'flavor' has a field conflict: flavor or id?",
+              "Field 'cow' doesn't exist on type 'Cheese'"
+            ], messages)
+          end
+        end
+      end
+      describe("enabled") do
+        it "does limit errors when enabled" do
+          schema.define(validate_max_errors: 1) do
+            errors = schema.validate("{ cheese(id: 1) { flavor flavor: id, cow } }")
+            messages = errors.map { |e| e.message }
+            assert_equal([
+              "Field 'flavor' has a field conflict: flavor or id?",
+            ], messages)
+          end
+        end
+      end
+    end
   end
 
   describe "#as_json / #to_json" do

--- a/spec/support/static_validation_helpers.rb
+++ b/spec/support/static_validation_helpers.rb
@@ -16,7 +16,7 @@ module StaticValidationHelpers
       target_schema = schema
       validator = GraphQL::StaticValidation::Validator.new(schema: target_schema)
       query = GraphQL::Query.new(target_schema, query_string)
-      validator.validate(query)[:errors].map(&:to_h)
+      validator.validate(query, **args)[:errors].map(&:to_h)
     end
   end
 
@@ -26,5 +26,9 @@ module StaticValidationHelpers
 
   def schema
     Dummy::Schema
+  end
+
+  def args
+    {}
   end
 end


### PR DESCRIPTION
Oops, these were lost when I released 1.11.11 because I recreated the 1.11.x branch from the wrong tag (I used 1.11.8 instead of 1.11.10). I'm getting these changes back on the branch and I'll cut 1.11.12 including _all_ this stuff.