### PR TITLE
Redo pronto action to work on forks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,6 @@ jobs:
           - gemfile: gemfiles/rails_master.gemfile
             ruby: 3.3
             graphql_reject_numbers_followed_by_names: 1
-            coverage: 1
             redis: 1
           - gemfile: gemfiles/rails_master.gemfile
             ruby: 3.4
@@ -79,13 +78,6 @@ jobs:
         bundler-cache: true
     - run: bundle exec rake compile
     - run: bundle exec rake test
-    - run: git fetch --no-tags --prune --unshallow origin +refs/heads/*:refs/remotes/origin/*
-      if: ${{ !!matrix.coverage }}
-    - run: bundle exec pronto run -f github_pr -c origin/${{ github.base_ref }}
-      if: ${{ !!matrix.coverage }}
-      env:
-        PRONTO_PULL_REQUEST_ID: ${{ github.event.pull_request.number }}
-        PRONTO_GITHUB_ACCESS_TOKEN: "${{ github.token }}"
   javascript_test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pronto.yaml
+++ b/.github/workflows/pronto.yaml
@@ -1,0 +1,19 @@
+name: Pronto
+on:
+  - pull_request_target
+
+jobs:
+  pronto:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - run: git fetch --no-tags --prune --unshallow origin +refs/heads/*:refs/remotes/origin/*
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+      - name: Setup pronto
+        run: gem install undercover pronto pronto-rubocop pronto-undercover
+      - name: Run Pronto
+        run: PRONTO_PULL_REQUEST_ID="${{ github.event.pull_request.number }}" PRONTO_GITHUB_ACCESS_TOKEN="${{ github.token }}" pronto run -f github_pr -c origin/${{ github.base_ref }}

--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -44,8 +44,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "simplecov"
   s.add_development_dependency "simplecov-lcov"
   s.add_development_dependency "undercover"
-  s.add_development_dependency "pronto"
-  s.add_development_dependency "pronto-undercover"
   # website stuff
   s.add_development_dependency "jekyll"
   s.add_development_dependency "jekyll-sass-converter", "~>2.2"


### PR DESCRIPTION
Oops, it didn't work on PRs from forks because `on: pull_request` doesn't have permission to do that.