### PR TITLE
Update other monitoring platform traces to handle fiber stops and starts

### DIFF
--- a/lib/graphql/tracing/appoptics_tracing.rb
+++ b/lib/graphql/tracing/appoptics_tracing.rb
@@ -22,6 +22,11 @@ module GraphQL
       # These GraphQL events will show up as 'graphql.execute' spans
       EXEC_KEYS = ['execute_multiplex', 'execute_query', 'execute_query_lazy'].freeze
 
+      def initialize(...)
+        warn "GraphQL::Tracing::AppOptics tracing is deprecated; update to SolarWindsAPM instead, which uses OpenTelemetry."
+        super
+      end
+
       # During auto-instrumentation this version of AppOpticsTracing is compared
       # with the version provided in the appoptics_apm gem, so that the newer
       # version of the class can be used

--- a/lib/graphql/tracing/appsignal_trace.rb
+++ b/lib/graphql/tracing/appsignal_trace.rb
@@ -34,30 +34,7 @@ module GraphQL
           end
         end
 
-        PARSE_NAME = "parse.graphql"
-        LEX_NAME = "lex.graphql"
-        VALIDATE_NAME = "validate.graphql"
-        EXECUTE_NAME = "execute.graphql"
-        ANALYZE_NAME = "analyze.graphql"
-
-        private
-
-        def platform_field_key(field)
-          "#{field.owner.graphql_name}.#{field.graphql_name}.graphql"
-        end
-
-        def platform_authorized_key(type)
-          "#{type.graphql_name}.authorized.graphql"
-        end
-
-        def platform_resolve_type_key(type)
-          "#{type.graphql_name}.resolve_type.graphql"
-        end
-
-        def platform_source_class_key(source_class)
-          "#{source_class.name.gsub("::", "_")}.source.graphql"
-        end
-
+        include MonitorTrace::Monitor::GraphQLSuffixNames
         class Event < GraphQL::Tracing::MonitorTrace::Monitor::Event
           def start
             Appsignal::Transaction.current.start_event

--- a/lib/graphql/tracing/appsignal_trace.rb
+++ b/lib/graphql/tracing/appsignal_trace.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
-
-require "graphql/tracing/platform_trace"
+require "graphql/tracing/monitor_trace"
 
 module GraphQL
   module Tracing
@@ -10,79 +9,69 @@ module GraphQL
     #   class MySchema < GraphQL::Schema
     #     trace_with GraphQL::Tracing::AppsignalTrace
     #   end
+    AppsignalTrace = MonitorTrace.create_module("appsignal")
     module AppsignalTrace
-      include PlatformTrace
-
+      alias :old_initialize :initialize
       # @param set_action_name [Boolean] If true, the GraphQL operation name will be used as the transaction name.
       #   This is not advised if you run more than one query per HTTP request, for example, with `graphql-client` or multiplexing.
       #   It can also be specified per-query with `context[:set_appsignal_action_name]`.
       def initialize(set_action_name: false, **rest)
-        @set_action_name = set_action_name
-        super
+        rest[:set_transaction_name] ||= set_action_name
+        old_initialize(**rest)
+        super(**rest)
       end
 
-      # rubocop:disable Development/NoEvalCop This eval takes static inputs at load-time
-
-      {
-        "lex" => "lex.graphql",
-        "parse" => "parse.graphql",
-        "validate" => "validate.graphql",
-        "analyze_query" => "analyze.graphql",
-        "analyze_multiplex" => "analyze.graphql",
-        "execute_multiplex" => "execute.graphql",
-        "execute_query" => "execute.graphql",
-        "execute_query_lazy" => "execute.graphql",
-      }.each do |trace_method, platform_key|
-        module_eval <<-RUBY, __FILE__, __LINE__
-          def #{trace_method}(**data)
-            #{
-              if trace_method == "execute_query"
-                <<-RUBY
-                set_this_txn_name =  data[:query].context[:set_appsignal_action_name]
-                if set_this_txn_name == true || (set_this_txn_name.nil? && @set_action_name)
-                  Appsignal::Transaction.current.set_action(transaction_name(data[:query]))
-                end
-                RUBY
-              end
-            }
-
-            Appsignal.instrument("#{platform_key}") do
-              super
+      class AppsignalMonitor < MonitorTrace::Monitor
+        def instrument(keyword, object)
+          if keyword == :execute
+            query = object.queries.first
+            set_this_txn_name =  query.context[:set_appsignal_action_name]
+            if set_this_txn_name == true || (set_this_txn_name.nil? && @set_transaction_name)
+              Appsignal::Transaction.current.set_action(transaction_name(query))
             end
           end
-        RUBY
-      end
-
-      # rubocop:enable Development/NoEvalCop
-
-      def platform_execute_field(platform_key)
-        Appsignal.instrument(platform_key) do
-          yield
+          Appsignal.instrument(name_for(keyword, object)) do
+            yield
+          end
         end
-      end
 
-      def platform_authorized(platform_key)
-        Appsignal.instrument(platform_key) do
-          yield
+        PARSE_NAME = "parse.graphql"
+        LEX_NAME = "lex.graphql"
+        VALIDATE_NAME = "validate.graphql"
+        EXECUTE_NAME = "execute.graphql"
+        ANALYZE_NAME = "analyze.graphql"
+
+        private
+
+        def platform_field_key(field)
+          "#{field.owner.graphql_name}.#{field.graphql_name}.graphql"
         end
-      end
 
-      def platform_resolve_type(platform_key)
-        Appsignal.instrument(platform_key) do
-          yield
+        def platform_authorized_key(type)
+          "#{type.graphql_name}.authorized.graphql"
         end
-      end
 
-      def platform_field_key(field)
-        "#{field.owner.graphql_name}.#{field.graphql_name}.graphql"
-      end
+        def platform_resolve_type_key(type)
+          "#{type.graphql_name}.resolve_type.graphql"
+        end
 
-      def platform_authorized_key(type)
-        "#{type.graphql_name}.authorized.graphql"
-      end
+        def platform_source_class_key(source_class)
+          "#{source_class.name.gsub("::", "_")}.source.graphql"
+        end
 
-      def platform_resolve_type_key(type)
-        "#{type.graphql_name}.resolve_type.graphql"
+        class Event < GraphQL::Tracing::MonitorTrace::Monitor::Event
+          def start
+            Appsignal::Transaction.current.start_event
+          end
+
+          def finish
+            Appsignal::Transaction.current.finish_event(
+              @monitor.name_for(@keyword, @object),
+              "",
+              ""
+            )
+          end
+        end
       end
     end
   end

--- a/lib/graphql/tracing/appsignal_trace.rb
+++ b/lib/graphql/tracing/appsignal_trace.rb
@@ -11,14 +11,13 @@ module GraphQL
     #   end
     AppsignalTrace = MonitorTrace.create_module("appsignal")
     module AppsignalTrace
-      alias :old_initialize :initialize
       # @param set_action_name [Boolean] If true, the GraphQL operation name will be used as the transaction name.
       #   This is not advised if you run more than one query per HTTP request, for example, with `graphql-client` or multiplexing.
       #   It can also be specified per-query with `context[:set_appsignal_action_name]`.
       def initialize(set_action_name: false, **rest)
         rest[:set_transaction_name] ||= set_action_name
-        old_initialize(**rest)
-        super(**rest)
+        setup_appsignal_monitor(**rest)
+        super
       end
 
       class AppsignalMonitor < MonitorTrace::Monitor

--- a/lib/graphql/tracing/data_dog_trace.rb
+++ b/lib/graphql/tracing/data_dog_trace.rb
@@ -9,7 +9,7 @@ module GraphQL
     #     trace_with GraphQL::Tracing::DataDogTrace
     #   end
     # @example Skipping `resolve_type` and `authorized` events
-    #   trace_with GraphQL::Tracing::DataDogTrace, skip_authorized: true, skip_resolve_type: true
+    #   trace_with GraphQL::Tracing::DataDogTrace, trace_authorized: false, trace_resolve_type: false
     DataDogTrace = MonitorTrace.create_module("datadog")
     module DataDogTrace
       class DatadogMonitor < MonitorTrace::Monitor

--- a/lib/graphql/tracing/data_dog_trace.rb
+++ b/lib/graphql/tracing/data_dog_trace.rb
@@ -54,29 +54,7 @@ module GraphQL
           end
         end
 
-        PARSE_NAME = "parse.graphql"
-        LEX_NAME = "lex.graphql"
-        VALIDATE_NAME = "validate.graphql"
-        EXECUTE_NAME = "execute.graphql"
-        ANALYZE_NAME = "analyze.graphql"
-
-        private
-
-        def platform_field_key(field)
-          field.path
-        end
-
-        def platform_authorized_key(type)
-          "#{type.graphql_name}.authorized"
-        end
-
-        def platform_resolve_type_key(type)
-          "#{type.graphql_name}.resolve_type"
-        end
-
-        def platform_source_key(source_class)
-          "#{source_class.name.gsub("::", "_").name.underscore}.fetch"
-        end
+        include MonitorTrace::Monitor::GraphQLSuffixNames
         class Event < MonitorTrace::Monitor::Event
           def start
             name = @monitor.name_for(keyword, object)

--- a/lib/graphql/tracing/monitor_trace.rb
+++ b/lib/graphql/tracing/monitor_trace.rb
@@ -82,6 +82,56 @@ module GraphQL
             raise "Implement #{self.class}#finish to end this event (#{inspect})"
           end
         end
+
+        module GraphQLSuffixNames
+          PARSE_NAME = "parse.graphql"
+          LEX_NAME = "lex.graphql"
+          VALIDATE_NAME = "validate.graphql"
+          EXECUTE_NAME = "execute.graphql"
+          ANALYZE_NAME = "analyze.graphql"
+
+          private
+
+          def platform_field_key(field)
+            "#{field.path}.graphql"
+          end
+
+          def platform_authorized_key(type)
+            "#{type.graphql_name}.authorized.graphql"
+          end
+
+          def platform_resolve_type_key(type)
+            "#{type.graphql_name}.resolve_type.graphql"
+          end
+
+          def platform_source_key(source_class)
+            "#{source_class.name.gsub("::", "_").name.underscore}.fetch.graphql"
+          end
+        end
+
+        module GraphQLPrefixNames
+          PARSE_NAME = "graphql.parse"
+          LEX_NAME = "graphql.lex"
+          VALIDATE_NAME = "graphql.validate"
+          EXECUTE_NAME = "graphql.execute"
+          ANALYZE_NAME = "graphql.analyze"
+
+          def platform_field_key(field)
+            "graphql.#{field.path}"
+          end
+
+          def platform_authorized_key(type)
+            "graphql.authorized.#{type.graphql_name}"
+          end
+
+          def platform_resolve_type_key(type)
+            "graphql.resolve_type.#{type.graphql_name}"
+          end
+
+          def platform_source_class_key(source_class)
+            "graphql.fetch.#{source_class.name.gsub("::", "_")}"
+          end
+        end
       end
 
       def self.create_module(monitor_name)

--- a/lib/graphql/tracing/monitor_trace.rb
+++ b/lib/graphql/tracing/monitor_trace.rb
@@ -103,13 +103,17 @@ module GraphQL
         # @param trace_scalars [Boolean] If `true`, leaf fields will be traced too (Scalars _and_ Enums)
         # @param trace_authorized [Boolean] If `false`, skip tracing `authorized?` calls
         # @param trace_resolve_type [Boolean] If `false`, skip tracing `resolve_type?` calls
-        def initialize(set_transaction_name: false, trace_scalars: false, trace_authorized: true, trace_resolve_type: true, **rest)
+        def initialize(...)
+          setup_%{monitor}_monitor(...)
+          super
+        end
+
+        def setup_%{monitor}_monitor(trace_scalars: false, trace_authorized: true, trace_resolve_type: true, set_transaction_name: false, **kwargs)
           @trace_scalars = trace_scalars
           @trace_authorized = trace_authorized
           @trace_resolve_type = trace_resolve_type
           @set_transaction_name = set_transaction_name
-          @%{monitor} = %{monitor_class}.new(trace: self, set_transaction_name: @set_transaction_name, **rest)
-          super
+          @%{monitor} = %{monitor_class}.new(trace: self, set_transaction_name: @set_transaction_name, **kwargs)
         end
 
         def parse(query_string:)

--- a/lib/graphql/tracing/prometheus_trace.rb
+++ b/lib/graphql/tracing/prometheus_trace.rb
@@ -73,27 +73,7 @@ module GraphQL
           )
         end
 
-        PARSE_NAME = "graphql.parse"
-        LEX_NAME = "graphql.lex"
-        VALIDATE_NAME = "graphql.validate"
-        EXECUTE_NAME = "graphql.execute"
-        ANALYZE_NAME = "graphql.analyze"
-
-        def platform_field_key(field)
-          field.path
-        end
-
-        def platform_authorized_key(type)
-          "#{type.graphql_name}.authorized"
-        end
-
-        def platform_resolve_type_key(type)
-          "#{type.graphql_name}.resolve_type"
-        end
-
-        def platform_source_class_key(source_class)
-          "#{source_class.name.gsub("::", "_")}.fetch"
-        end
+        include MonitorTrace::Monitor::GraphQLPrefixNames
 
         class Event < MonitorTrace::Monitor::Event
           def start

--- a/lib/graphql/tracing/prometheus_trace.rb
+++ b/lib/graphql/tracing/prometheus_trace.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "graphql/tracing/platform_trace"
+require "graphql/tracing/monitor_trace"
 
 module GraphQL
   module Tracing
@@ -26,93 +26,88 @@ module GraphQL
     #
     #    # Then run:
     #    # bundle exec prometheus_exporter -a lib/graphql_collector.rb
+    PrometheusTrace = MonitorTrace.create_module("prometheus")
     module PrometheusTrace
       if defined?(PrometheusExporter::Server)
         autoload :GraphQLCollector, "graphql/tracing/prometheus_trace/graphql_collector"
       end
-      include PlatformTrace
 
-      def initialize(client: PrometheusExporter::Client.default, keys_whitelist: ["execute_field", "execute_field_lazy"], collector_type: "graphql", **rest)
-        @client = client
-        @keys_whitelist = keys_whitelist
-        @collector_type = collector_type
+      alias :old_initialize :initialize
 
+      def initialize(client: PrometheusExporter::Client.default, keys_whitelist: [:execute_field], collector_type: "graphql", **rest)
+        @prometheus_client = client
+        @prometheus_keys_whitelist = keys_whitelist.map(&:to_sym) # handle previous string keys
+        @prometheus_collector_type = collector_type
+        old_initialize(**rest)
         super(**rest)
       end
 
-      # rubocop:disable Development/NoEvalCop This eval takes static inputs at load-time
+      attr_reader :prometheus_collector_type, :prometheus_client, :prometheus_keys_whitelist
 
-      {
-        'lex' => "graphql.lex",
-        'parse' => "graphql.parse",
-        'validate' => "graphql.validate",
-        'analyze_query' => "graphql.analyze",
-        'analyze_multiplex' => "graphql.analyze",
-        'execute_multiplex' => "graphql.execute",
-        'execute_query' => "graphql.execute",
-        'execute_query_lazy' => "graphql.execute",
-      }.each do |trace_method, platform_key|
-        module_eval <<-RUBY, __FILE__, __LINE__
-          def #{trace_method}(**data)
-            instrument_prometheus_execution("#{platform_key}", "#{trace_method}") { super }
+      class PrometheusMonitor < MonitorTrace::Monitor
+        def instrument(keyword, object)
+          if active?(keyword)
+            start = gettime
+            result = yield
+            duration = gettime - start
+            send_json(duration, keyword, object)
+            result
+          else
+            yield
           end
-        RUBY
-      end
+        end
 
-      # rubocop:enable Development/NoEvalCop
+        def active?(keyword)
+          @trace.prometheus_keys_whitelist.include?(keyword)
+        end
 
-      def platform_execute_field(platform_key, &block)
-        instrument_prometheus_execution(platform_key, "execute_field", &block)
-      end
+        def gettime
+          ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+        end
 
-      def platform_execute_field_lazy(platform_key, &block)
-        instrument_prometheus_execution(platform_key, "execute_field_lazy", &block)
-      end
-
-      def platform_authorized(platform_key, &block)
-        instrument_prometheus_execution(platform_key, "authorized", &block)
-      end
-
-      def platform_authorized_lazy(platform_key, &block)
-        instrument_prometheus_execution(platform_key, "authorized_lazy", &block)
-      end
-
-      def platform_resolve_type(platform_key, &block)
-        instrument_prometheus_execution(platform_key, "resolve_type", &block)
-      end
-
-      def platform_resolve_type_lazy(platform_key, &block)
-        instrument_prometheus_execution(platform_key, "resolve_type_lazy", &block)
-      end
-
-      def platform_field_key(field)
-        field.path
-      end
-
-      def platform_authorized_key(type)
-        "#{type.graphql_name}.authorized"
-      end
-
-      def platform_resolve_type_key(type)
-        "#{type.graphql_name}.resolve_type"
-      end
-
-      private
-
-      def instrument_prometheus_execution(platform_key, key, &block)
-        if @keys_whitelist.include?(key)
-          start = ::Process.clock_gettime ::Process::CLOCK_MONOTONIC
-          result = block.call
-          duration = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) - start
-          @client.send_json(
-            type: @collector_type,
+        def send_json(duration, keyword, object)
+          event_name = name_for(keyword, object)
+          @trace.prometheus_client.send_json(
+            type: @trace.prometheus_collector_type,
             duration: duration,
-            platform_key: platform_key,
-            key: key
+            platform_key: event_name,
+            key: keyword
           )
-          result
-        else
-          yield
+        end
+
+        PARSE_NAME = "graphql.parse"
+        LEX_NAME = "graphql.lex"
+        VALIDATE_NAME = "graphql.validate"
+        EXECUTE_NAME = "graphql.execute"
+        ANALYZE_NAME = "graphql.analyze"
+
+        def platform_field_key(field)
+          field.path
+        end
+
+        def platform_authorized_key(type)
+          "#{type.graphql_name}.authorized"
+        end
+
+        def platform_resolve_type_key(type)
+          "#{type.graphql_name}.resolve_type"
+        end
+
+        def platform_source_class_key(source_class)
+          "#{source_class.name.gsub("::", "_")}.fetch"
+        end
+
+        class Event < MonitorTrace::Monitor::Event
+          def start
+            @start_time = @monitor.gettime
+          end
+
+          def finish
+            if @monitor.active?(keyword)
+              duration = @monitor.gettime - @start_time
+              @monitor.send_json(duration, keyword, object)
+            end
+          end
         end
       end
     end

--- a/lib/graphql/tracing/prometheus_trace.rb
+++ b/lib/graphql/tracing/prometheus_trace.rb
@@ -32,14 +32,12 @@ module GraphQL
         autoload :GraphQLCollector, "graphql/tracing/prometheus_trace/graphql_collector"
       end
 
-      alias :old_initialize :initialize
-
       def initialize(client: PrometheusExporter::Client.default, keys_whitelist: [:execute_field], collector_type: "graphql", **rest)
         @prometheus_client = client
         @prometheus_keys_whitelist = keys_whitelist.map(&:to_sym) # handle previous string keys
         @prometheus_collector_type = collector_type
-        old_initialize(**rest)
-        super(**rest)
+        setup_prometheus_monitor(**rest)
+        super
       end
 
       attr_reader :prometheus_collector_type, :prometheus_client, :prometheus_keys_whitelist

--- a/lib/graphql/tracing/scout_trace.rb
+++ b/lib/graphql/tracing/scout_trace.rb
@@ -27,28 +27,9 @@ module GraphQL
           end
         end
 
-        PARSE_NAME = "parse.graphql"
-        LEX_NAME = "lex.graphql"
-        VALIDATE_NAME = "validate.graphql"
-        EXECUTE_NAME = "execute.graphql"
-        ANALYZE_NAME = "analyze.graphql"
         INSTRUMENT_OPTS = { scope: true }
 
-        def platform_field_key(field)
-          field.path
-        end
-
-        def platform_authorized_key(type)
-          "#{type.graphql_name}.authorized"
-        end
-
-        def platform_resolve_type_key(type)
-          "#{type.graphql_name}.resolve_type"
-        end
-
-        def platform_source_class_key(source_class)
-          "#{source_class.name.gsub("::", "_")}.fetch"
-        end
+        include MonitorTrace::Monitor::GraphQLSuffixNames
 
         class Event < MonitorTrace::Monitor::Event
           def start

--- a/lib/graphql/tracing/scout_trace.rb
+++ b/lib/graphql/tracing/scout_trace.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "graphql/tracing/platform_trace"
+require "graphql/tracing/monitor_trace"
 
 module GraphQL
   module Tracing
@@ -10,73 +10,58 @@ module GraphQL
     #   class MySchema < GraphQL::Schema
     #     trace_with GraphQL::Tracing::ScoutTrace
     #   end
+    ScoutTrace = MonitorTrace.create_module("scout")
     module ScoutTrace
-      include PlatformTrace
-
-      INSTRUMENT_OPTS = { scope: true }
-
-      # @param set_transaction_name [Boolean] If true, the GraphQL operation name will be used as the transaction name.
-      #   This is not advised if you run more than one query per HTTP request, for example, with `graphql-client` or multiplexing.
-      #   It can also be specified per-query with `context[:set_scout_transaction_name]`.
-      def initialize(set_transaction_name: false, **_rest)
-        self.class.include(ScoutApm::Tracer)
-        @set_transaction_name = set_transaction_name
-        super
-      end
-
-      # rubocop:disable Development/NoEvalCop This eval takes static inputs at load-time
-
-      {
-        "lex" => "lex.graphql",
-        "parse" => "parse.graphql",
-        "validate" => "validate.graphql",
-        "analyze_query" => "analyze.graphql",
-        "analyze_multiplex" => "analyze.graphql",
-        "execute_multiplex" => "execute.graphql",
-        "execute_query" => "execute.graphql",
-        "execute_query_lazy" => "execute.graphql",
-      }.each do |trace_method, platform_key|
-        module_eval <<-RUBY, __FILE__, __LINE__
-        def #{trace_method}(**data)
-          #{
-            if trace_method == "execute_query"
-              <<-RUBY
-              set_this_txn_name = data[:query].context[:set_scout_transaction_name]
-              if set_this_txn_name == true || (set_this_txn_name.nil? && @set_transaction_name)
-                ScoutApm::Transaction.rename(transaction_name(data[:query]))
-              end
-              RUBY
+      class ScoutMonitor < MonitorTrace::Monitor
+        def instrument(keyword, object)
+          if keyword == :execute
+            query = object.queries.first
+            set_this_txn_name = query.context[:set_scout_transaction_name]
+            if set_this_txn_name == true || (set_this_txn_name.nil? && @set_transaction_name)
+              ScoutApm::Transaction.rename(transaction_name(query))
             end
-          }
+          end
 
-          self.class.instrument("GraphQL", "#{platform_key}", INSTRUMENT_OPTS) do
-            super
+          ScoutApm::Tracer.instrument("GraphQL", name_for(keyword, object), INSTRUMENT_OPTS) do
+            yield
           end
         end
-        RUBY
-      end
-      # rubocop:enable Development/NoEvalCop
 
-      def platform_execute_field(platform_key, &block)
-        self.class.instrument("GraphQL", platform_key, INSTRUMENT_OPTS, &block)
-      end
+        PARSE_NAME = "parse.graphql"
+        LEX_NAME = "lex.graphql"
+        VALIDATE_NAME = "validate.graphql"
+        EXECUTE_NAME = "execute.graphql"
+        ANALYZE_NAME = "analyze.graphql"
+        INSTRUMENT_OPTS = { scope: true }
 
-      def platform_authorized(platform_key, &block)
-        self.class.instrument("GraphQL", platform_key, INSTRUMENT_OPTS, &block)
-      end
+        def platform_field_key(field)
+          field.path
+        end
 
-      alias :platform_resolve_type :platform_authorized
+        def platform_authorized_key(type)
+          "#{type.graphql_name}.authorized"
+        end
 
-      def platform_field_key(field)
-        field.path
-      end
+        def platform_resolve_type_key(type)
+          "#{type.graphql_name}.resolve_type"
+        end
 
-      def platform_authorized_key(type)
-        "#{type.graphql_name}.authorized"
-      end
+        def platform_source_class_key(source_class)
+          "#{source_class.name.gsub("::", "_")}.fetch"
+        end
 
-      def platform_resolve_type_key(type)
-        "#{type.graphql_name}.resolve_type"
+        class Event < MonitorTrace::Monitor::Event
+          def start
+            layer = ScoutApm::Layer.new("GraphQL", @monitor.name_for(keyword, object))
+            layer.subscopable!
+            @scout_req = ScoutApm::RequestManager.lookup
+            @scout_req.start_layer(layer)
+          end
+
+          def finish
+            @scout_req.stop_layer
+          end
+        end
       end
     end
   end

--- a/lib/graphql/tracing/sentry_trace.rb
+++ b/lib/graphql/tracing/sentry_trace.rb
@@ -49,11 +49,7 @@ module GraphQL
           end
         end
 
-        PARSE_NAME = "graphql.parse"
-        LEX_NAME = "graphql.lex"
-        VALIDATE_NAME = "graphql.validate"
-        EXECUTE_NAME = "graphql.execute"
-        ANALYZE_NAME = "graphql.analyze"
+        include MonitorTrace::Monitor::GraphQLPrefixNames
 
         private
 
@@ -64,22 +60,6 @@ module GraphQL
           else
             'GraphQL Operation'
           end
-        end
-
-        def platform_field_key(field)
-          "graphql.field.#{field.path}"
-        end
-
-        def platform_authorized_key(type)
-          "graphql.authorized.#{type.graphql_name}"
-        end
-
-        def platform_resolve_type_key(type)
-          "graphql.resolve_type.#{type.graphql_name}"
-        end
-
-        def platform_source_class_key(source_class)
-          "graphql.source.#{source_class.name.gsub("::", ".")}"
         end
 
         class Event < MonitorTrace::Monitor::Event

--- a/lib/graphql/tracing/statsd_trace.rb
+++ b/lib/graphql/tracing/statsd_trace.rb
@@ -30,27 +30,7 @@ module GraphQL
           end
         end
 
-        PARSE_NAME = "graphql.parse"
-        LEX_NAME = "graphql.lex"
-        VALIDATE_NAME = "graphql.validate"
-        EXECUTE_NAME = "graphql.execute"
-        ANALYZE_NAME = "graphql.analyze"
-
-        def platform_field_key(field)
-          "graphql.#{field.path}"
-        end
-
-        def platform_authorized_key(type)
-          "graphql.authorized.#{type.graphql_name}"
-        end
-
-        def platform_resolve_type_key(type)
-          "graphql.resolve_type.#{type.graphql_name}"
-        end
-
-        def platform_source_class_key(source_class)
-          "graphql.fetch.#{source_class.name.gsub("::", "_")}"
-        end
+        include MonitorTrace::Monitor::GraphQLPrefixNames
 
         class Event < MonitorTrace::Monitor::Event
           def start

--- a/lib/graphql/tracing/statsd_trace.rb
+++ b/lib/graphql/tracing/statsd_trace.rb
@@ -5,7 +5,8 @@ require "graphql/tracing/platform_trace"
 module GraphQL
   module Tracing
     # A tracer for reporting GraphQL-Ruby times to Statsd.
-    # Passing any Statsd client that implements `.time(name) { ... }` will work.
+    # Passing any Statsd client that implements `.time(name) { ... }`
+    # and `.timing(name, ms)` will work.
     #
     # @example Installing this tracer
     #   # eg:
@@ -13,58 +14,54 @@ module GraphQL
     #   class MySchema < GraphQL::Schema
     #     use GraphQL::Tracing::StatsdTrace, statsd: $statsd
     #   end
+    StatsdTrace = MonitorTrace.create_module("statsd")
     module StatsdTrace
-      include PlatformTrace
+      class StatsdMonitor < MonitorTrace::Monitor
+        def initialize(statsd:, **_rest)
+          @statsd = statsd
+          super
+        end
 
-      # @param statsd [Object] A statsd client
-      def initialize(statsd:, **rest)
-        @statsd = statsd
-        super(**rest)
-      end
+        attr_reader :statsd
 
-      # rubocop:disable Development/NoEvalCop This eval takes static inputs at load-time
-
-      {
-        'lex' => "graphql.lex",
-        'parse' => "graphql.parse",
-        'validate' => "graphql.validate",
-        'analyze_query' => "graphql.analyze_query",
-        'analyze_multiplex' => "graphql.analyze_multiplex",
-        'execute_multiplex' => "graphql.execute_multiplex",
-        'execute_query' => "graphql.execute_query",
-        'execute_query_lazy' => "graphql.execute_query_lazy",
-      }.each do |trace_method, platform_key|
-        module_eval <<-RUBY, __FILE__, __LINE__
-          def #{trace_method}(**data)
-            @statsd.time("#{platform_key}") do
-              super
-            end
+        def instrument(keyword, object)
+          @statsd.time(name_for(keyword, object)) do
+            yield
           end
-        RUBY
-      end
+        end
 
-      # rubocop:enable Development/NoEvalCop
+        PARSE_NAME = "graphql.parse"
+        LEX_NAME = "graphql.lex"
+        VALIDATE_NAME = "graphql.validate"
+        EXECUTE_NAME = "graphql.execute"
+        ANALYZE_NAME = "graphql.analyze"
 
-      def platform_execute_field(platform_key, &block)
-        @statsd.time(platform_key, &block)
-      end
+        def platform_field_key(field)
+          "graphql.#{field.path}"
+        end
 
-      def platform_authorized(key, &block)
-        @statsd.time(key, &block)
-      end
+        def platform_authorized_key(type)
+          "graphql.authorized.#{type.graphql_name}"
+        end
 
-      alias :platform_resolve_type :platform_authorized
+        def platform_resolve_type_key(type)
+          "graphql.resolve_type.#{type.graphql_name}"
+        end
 
-      def platform_field_key(field)
-        "graphql.#{field.path}"
-      end
+        def platform_source_class_key(source_class)
+          "graphql.fetch.#{source_class.name.gsub("::", "_")}"
+        end
 
-      def platform_authorized_key(type)
-        "graphql.authorized.#{type.graphql_name}"
-      end
+        class Event < MonitorTrace::Monitor::Event
+          def start
+            @start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          end
 
-      def platform_resolve_type_key(type)
-        "graphql.resolve_type.#{type.graphql_name}"
+          def finish
+            elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - @start_time
+            @monitor.statsd.timing(@monitor.name_for(keyword, object), elapsed)
+          end
+        end
       end
     end
   end

--- a/lib/graphql/tracing/statsd_trace.rb
+++ b/lib/graphql/tracing/statsd_trace.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "graphql/tracing/platform_trace"
+require "graphql/tracing/monitor_trace"
 
 module GraphQL
   module Tracing

--- a/spec/graphql/tracing/appsignal_trace_spec.rb
+++ b/spec/graphql/tracing/appsignal_trace_spec.rb
@@ -13,6 +13,20 @@ module Appsignal
   def instrumented
     @instrumented ||= []
   end
+
+  def current
+    self
+  end
+
+  def start_event
+    # pass
+  end
+
+  def finish_event(name, title, body)
+    instrumented << name
+  end
+
+  Transaction = self
 end
 
 describe GraphQL::Tracing::AppsignalTrace do
@@ -67,19 +81,16 @@ describe GraphQL::Tracing::AppsignalTrace do
     _res = AppsignalTraceTest::TestSchema.execute("{ int thing { str } named { ... on Thing { str } } }")
     expected_trace = [
       "execute.graphql",
-      "analyze.graphql",
       (USING_C_PARSER ? "lex.graphql" : nil),
       "parse.graphql",
       "validate.graphql",
       "analyze.graphql",
-      "execute.graphql",
       "Query.authorized.graphql",
       "Query.thing.graphql",
       "Thing.authorized.graphql",
       "Query.named.graphql",
       "Named.resolve_type.graphql",
       "Thing.authorized.graphql",
-      "execute.graphql",
     ].compact
     assert_equal expected_trace, Appsignal.instrumented
   end
@@ -111,17 +122,14 @@ describe GraphQL::Tracing::AppsignalTrace do
         "execute.graphql",
         (USING_C_PARSER ? "lex.graphql" : nil),
         "parse.graphql",
-        "analyze.graphql",
         "validate.graphql",
         "analyze.graphql",
-        "execute.graphql",
         "Query.authorized.graphql",
         "Query.thing.graphql",
         "Thing.authorized.graphql",
         "Query.named.graphql",
         "Named.resolve_type.graphql",
         "Thing.authorized.graphql",
-        "execute.graphql",
       ].compact
 
       expected_datadog_trace = [
@@ -147,17 +155,14 @@ describe GraphQL::Tracing::AppsignalTrace do
         (USING_C_PARSER ? "lex.graphql" : nil),
         "parse.graphql",
         "execute.graphql",
-        "analyze.graphql",
         "validate.graphql",
         "analyze.graphql",
-        "execute.graphql",
         "Query.authorized.graphql",
         "Query.thing.graphql",
         "Thing.authorized.graphql",
         "Query.named.graphql",
         "Named.resolve_type.graphql",
         "Thing.authorized.graphql",
-        "execute.graphql",
       ].compact
 
       expected_datadog_trace = [

--- a/spec/graphql/tracing/prometheus_trace_spec.rb
+++ b/spec/graphql/tracing/prometheus_trace_spec.rb
@@ -21,10 +21,11 @@ describe GraphQL::Tracing::PrometheusTracing do
   describe "Observing" do
     it "sends JSON to Prometheus client" do
       client = Minitest::Mock.new
-
+      send_json_called = false
       client.expect :send_json, true do |obj|
+        send_json_called = true
         obj[:type] == 'graphql' &&
-          obj[:key] == 'execute_field' &&
+          obj[:key] == :execute_field &&
           obj[:platform_key] == 'Query.int'
       end
 
@@ -32,7 +33,8 @@ describe GraphQL::Tracing::PrometheusTracing do
         client: client,
         trace_scalars: true
 
-        PrometheusTraceTest::Schema.execute "query X { int }"
+      PrometheusTraceTest::Schema.execute "query X { int }"
+      assert send_json_called, "send_json was called"
     end
   end
 end

--- a/spec/graphql/tracing/prometheus_trace_spec.rb
+++ b/spec/graphql/tracing/prometheus_trace_spec.rb
@@ -26,7 +26,7 @@ describe GraphQL::Tracing::PrometheusTracing do
         send_json_called = true
         obj[:type] == 'graphql' &&
           obj[:key] == :execute_field &&
-          obj[:platform_key] == 'Query.int'
+          obj[:platform_key] == 'graphql.Query.int'
       end
 
       PrometheusTraceTest::Schema.trace_with GraphQL::Tracing::PrometheusTrace,

--- a/spec/graphql/tracing/prometheus_tracing_spec.rb
+++ b/spec/graphql/tracing/prometheus_tracing_spec.rb
@@ -30,7 +30,8 @@ describe GraphQL::Tracing::PrometheusTracing do
       PrometheusTracingTest::Schema.use(
         GraphQL::Tracing::PrometheusTracing,
         client: client,
-        trace_scalars: true
+        trace_scalars: true,
+        legacy_tracing: true,
       )
 
       PrometheusTracingTest::Schema.execute "query X { int }"

--- a/spec/graphql/tracing/scout_trace_spec.rb
+++ b/spec/graphql/tracing/scout_trace_spec.rb
@@ -23,7 +23,7 @@ describe GraphQL::Tracing::ScoutTrace do
     end
 
     class SchemaWithTransactionName < ScoutSchemaBase
-      trace_with GraphQL::Tracing::ScoutTrace, set_transaction_name: true
+      trace_with GraphQL::Tracing::ScoutTrace, set_transaction_name: true, trace_authorized: false, trace_scalars: true
     end
   end
 
@@ -34,11 +34,27 @@ describe GraphQL::Tracing::ScoutTrace do
   it "can leave the transaction name in place" do
     ScoutApmTraceTest::SchemaWithoutTransactionName.execute "query X { int }"
     assert_equal [], ScoutApm::TRANSACTION_NAMES
+    expected_events = [
+      "execute.graphql",
+      "analyze.graphql",
+      "parse.graphql",
+      "validate.graphql",
+      "Query.authorized"
+    ]
+    assert_equal expected_events, ScoutApm::EVENTS
   end
 
-  it "can override the transaction name" do
+  it "can override the transaction name, skip authorized, and trace scalars" do
     ScoutApmTraceTest::SchemaWithTransactionName.execute "query X { int }"
     assert_equal ["GraphQL/query.X"], ScoutApm::TRANSACTION_NAMES
+    expected_events = [
+      "parse.graphql",
+      "execute.graphql",
+      "analyze.graphql",
+      "validate.graphql",
+      "Query.int"
+    ]
+    assert_equal expected_events, ScoutApm::EVENTS
   end
 
   it "can override the transaction name per query" do

--- a/spec/graphql/tracing/scout_trace_spec.rb
+++ b/spec/graphql/tracing/scout_trace_spec.rb
@@ -40,7 +40,7 @@ describe GraphQL::Tracing::ScoutTrace do
       (USING_C_PARSER ? "lex.graphql" : nil),
       "parse.graphql",
       "validate.graphql",
-      "Query.authorized"
+      "Query.authorized.graphql"
     ].compact
     assert_equal expected_events, ScoutApm::EVENTS
   end
@@ -54,7 +54,7 @@ describe GraphQL::Tracing::ScoutTrace do
       "execute.graphql",
       "analyze.graphql",
       "validate.graphql",
-      "Query.int"
+      "Query.int.graphql"
     ].compact
     assert_equal expected_events, ScoutApm::EVENTS
   end

--- a/spec/graphql/tracing/scout_trace_spec.rb
+++ b/spec/graphql/tracing/scout_trace_spec.rb
@@ -37,10 +37,11 @@ describe GraphQL::Tracing::ScoutTrace do
     expected_events = [
       "execute.graphql",
       "analyze.graphql",
+      (USING_C_PARSER ? "lex.graphql" : nil),
       "parse.graphql",
       "validate.graphql",
       "Query.authorized"
-    ]
+    ].compact
     assert_equal expected_events, ScoutApm::EVENTS
   end
 
@@ -48,12 +49,13 @@ describe GraphQL::Tracing::ScoutTrace do
     ScoutApmTraceTest::SchemaWithTransactionName.execute "query X { int }"
     assert_equal ["GraphQL/query.X"], ScoutApm::TRANSACTION_NAMES
     expected_events = [
+      (USING_C_PARSER ? "lex.graphql" : nil),
       "parse.graphql",
       "execute.graphql",
       "analyze.graphql",
       "validate.graphql",
       "Query.int"
-    ]
+    ].compact
     assert_equal expected_events, ScoutApm::EVENTS
   end
 

--- a/spec/graphql/tracing/sentry_trace_spec.rb
+++ b/spec/graphql/tracing/sentry_trace_spec.rb
@@ -80,7 +80,7 @@ describe GraphQL::Tracing::SentryTrace do
       "graphql.parse",
       "graphql.validate",
       "graphql.authorized.Query",
-      "graphql.field.Query.thing",
+      "graphql.Query.thing",
       "graphql.authorized.Thing",
     ].compact
 

--- a/spec/graphql/tracing/statsd_trace_spec.rb
+++ b/spec/graphql/tracing/statsd_trace_spec.rb
@@ -9,6 +9,10 @@ describe GraphQL::Tracing::StatsdTracing do
         yield
       end
 
+      def timing(key, ms)
+        self.timings << key
+      end
+
       attr_reader :timings
 
       def clear
@@ -46,17 +50,14 @@ describe GraphQL::Tracing::StatsdTracing do
   it "gathers timings" do
     StatsdTraceTestSchema.execute("query X { int thing { str } }")
     expected_timings = [
-      "graphql.execute_multiplex",
-      "graphql.analyze_multiplex",
+      "graphql.execute",
       (USING_C_PARSER ? "graphql.lex" : nil),
       "graphql.parse",
       "graphql.validate",
-      "graphql.analyze_query",
-      "graphql.execute_query",
+      "graphql.analyze",
       "graphql.authorized.Query",
       "graphql.Query.thing",
       "graphql.authorized.Thing",
-      "graphql.execute_query_lazy"
     ].compact
     assert_equal expected_timings, TraceMockStatsd.timings
   end

--- a/spec/graphql/tracing/statsd_tracing_spec.rb
+++ b/spec/graphql/tracing/statsd_tracing_spec.rb
@@ -36,7 +36,7 @@ describe GraphQL::Tracing::StatsdTracing do
 
     query(Query)
 
-    use GraphQL::Tracing::StatsdTracing, statsd: MockStatsd
+    use GraphQL::Tracing::StatsdTracing, statsd: MockStatsd, legacy_tracing: true
   end
 
   before do

--- a/spec/support/scout_apm.rb
+++ b/spec/support/scout_apm.rb
@@ -6,20 +6,41 @@ end
 
 class ScoutApm
   TRANSACTION_NAMES = []
+  EVENTS = []
 
   def self.clear_all
     TRANSACTION_NAMES.clear
+    EVENTS.clear
   end
 
   module Tracer
-    def self.included(klass)
-      klass.extend ClassMethods
+    def self.instrument(type, name, options = {})
+      EVENTS << name
+      yield
+    end
+  end
+
+  class Layer
+    def initialize(type, name)
+      EVENTS << name
     end
 
-    module ClassMethods
-      def instrument(type, name, options = {})
-        yield
-      end
+    def subscopable!
+      nil
+    end
+  end
+
+  module RequestManager
+    def self.lookup
+      self
+    end
+
+    def self.start_layer(_layer)
+      nil
+    end
+
+    def self.stop_layer
+      nil
     end
   end
 


### PR DESCRIPTION
- ~~Appoptics~~ deprecated instead, this has been out of use for a long time 
- [x] Appsignal
- [x] Statsd
- [x] Prometheus
- [x] Scout
- Datadog: revisit `prepare_span` compatibility -- it's broken right now but shouldn't be.
  - I'm going to release this in 2.5 instead with a breaking change note
- [x] DRY event name constants and methods -- many begin with `graphql.` or end with `.graphql`, these could be shared instead.