### PR TITLE
Improve nullable array element type error reporting

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -471,9 +471,10 @@ module GraphQL
             if is_non_null
               set_result(selection_result, result_name, nil, false, is_non_null) do
                 # When this comes from a list item, use the parent object:
-                parent_type = selection_result.is_a?(GraphQLResultArray) ? selection_result.graphql_parent.graphql_result_type : selection_result.graphql_result_type
+                is_from_array = selection_result.is_a?(GraphQLResultArray)
+                parent_type = is_from_array ? selection_result.graphql_parent.graphql_result_type : selection_result.graphql_result_type
                 # This block is called if `result_name` is not dead. (Maybe a previous invalid nil caused it be marked dead.)
-                err = parent_type::InvalidNullError.new(parent_type, field, ast_node)
+                err = parent_type::InvalidNullError.new(parent_type, field, ast_node, is_from_array: is_from_array)
                 schema.type_error(err, context)
               end
             else

--- a/spec/graphql/execution/errors_spec.rb
+++ b/spec/graphql/execution/errors_spec.rb
@@ -307,7 +307,7 @@ describe "GraphQL::Execution::Errors" do
       it "outputs the appropriate error message when using non-interpreter schema" do
         res = ErrorsTestSchemaWithoutInterpreter.execute("{ nonNullableArray }")
         expected_error = {
-          "message" => "Cannot return null for non-nullable field Query.nonNullableArray",
+          "message" => "Cannot return null for non-nullable element of type 'String!' for Query.nonNullableArray",
           "path" => ["nonNullableArray", 0],
           "locations" => [{ "line" => 1, "column" => 3 }]
         }
@@ -317,7 +317,7 @@ describe "GraphQL::Execution::Errors" do
       it "outputs the appropriate error message when using interpreter schema" do
         res = ErrorsTestSchema.execute("{ nonNullableArray }")
         expected_error = {
-          "message" => "Cannot return null for non-nullable field Query.nonNullableArray",
+          "message" => "Cannot return null for non-nullable element of type 'String!' for Query.nonNullableArray",
           "path" => ["nonNullableArray", 0],
           "locations" => [{ "line" => 1, "column" => 3 }]
         }

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -511,7 +511,7 @@ describe GraphQL::Execution::Interpreter do
         }
       }
       GRAPHQL
-      assert_equal ["Cannot return null for non-nullable field Query.find"], res["errors"].map { |e| e["message"] }
+      assert_equal ["Cannot return null for non-nullable element of type 'Entity!' for Query.find"], res["errors"].map { |e| e["message"] }
     end
 
     it "works with lists of unions" do

--- a/spec/graphql/schema/list_spec.rb
+++ b/spec/graphql/schema/list_spec.rb
@@ -116,6 +116,12 @@ describe GraphQL::Schema::List do
         def nil_echoes(items:)
           items.first[:items]
         end
+
+        field :invalid_result, [String], null: false
+
+        def invalid_result
+          ["A", "B", nil]
+        end
       end
 
       query(Query)
@@ -124,6 +130,12 @@ describe GraphQL::Schema::List do
     it "checks non-null lists of enums" do
       res = ListValidationSchema.execute "{ echo(items: [A, B, \"C\"]) }"
       expected_error = "Argument 'items' on Field 'echo' has an invalid value ([A, B, \"C\"]). Expected type '[Item!]!'."
+      assert_equal [expected_error], res["errors"].map { |e| e["message"] }
+    end
+
+    it "reports when an element must be non-nil" do
+      res = ListValidationSchema.execute "{ invalidResult }"
+      expected_error = "Cannot return null for non-nullable element of type 'String!' for Query.invalidResult"
       assert_equal [expected_error], res["errors"].map { |e| e["message"] }
     end
 


### PR DESCRIPTION
Hello and thanks for the gem!

Currently for a field like

```ruby
field :dog_names, [String], null: false
def dog_names
  ["wedge", nil]
end
```

You would get an error message like `Cannot return null for non-nullable field Query.dogNames`.  The phrasing of that message leads a person to think that the problem is that the return value of the `dog_names` method is `nil` when the error is actually referring to the value at index 1 of the returned array.

The purpose of this PR is to change the messaging so that, if the error is caused by a list value with an invalid element, it says that explicitly.

I had hoped to include the path to the element so the user would know the index of the failing element, but I couldn't figure out how to best do that.  It seems like the `idx` int the `continue_field` method in `runtime.rb` is the main place the index of the value is known but is lost before the value gets inspected.