### PR TITLE
Sentry trace: handle nil current_span

### DIFF
--- a/lib/graphql/tracing/sentry_trace.rb
+++ b/lib/graphql/tracing/sentry_trace.rb
@@ -64,8 +64,7 @@ module GraphQL
 
         class Event < MonitorTrace::Monitor::Event
           def start
-            if Sentry.initialized?
-              @span = Sentry.get_current_scope.get_span
+            if Sentry.initialized? && (@span = Sentry.get_current_scope.get_span)
               span_name = @monitor.name_for(@keyword, @object)
               @span.start_child(op: span_name)
             end

--- a/spec/graphql/tracing/sentry_trace_spec.rb
+++ b/spec/graphql/tracing/sentry_trace_spec.rb
@@ -47,6 +47,13 @@ describe GraphQL::Tracing::SentryTrace do
     assert res.context[:other_trace_ran]
   end
 
+  it "handles cases when Sentry has no current span" do
+    Sentry.use_nil_span = true
+    assert SentryTraceTest::SchemaWithoutTransactionName.execute("{ int }")
+  ensure
+    Sentry.use_nil_span = false
+  end
+
   describe "When Sentry is not configured" do
     it "does not initialize any spans" do
       Sentry.stub(:initialized?, false) do

--- a/spec/support/sentry.rb
+++ b/spec/support/sentry.rb
@@ -11,6 +11,10 @@ module Sentry
   SPAN_DESCRIPTIONS = []
   TRANSACTION_NAMES = []
 
+  class << self
+    attr_accessor :use_nil_span
+  end
+
   def self.initialized?
     true
   end
@@ -24,7 +28,7 @@ module Sentry
   end
 
   def self.get_span
-    DummySpan
+    use_nil_span ? nil : DummySpan
   end
 
   def self.with_child_span(**args, &block)


### PR DESCRIPTION
Fixes https://github.com/rmosolgo/graphql-ruby/issues/2929#issuecomment-2771991624

Apparently Sentry's current_span is sometimes `nil`, the library itself is full of `nil` handling, for example:

https://github.com/getsentry/sentry-ruby/blob/a884caee95ddf3c29cec4761ab423ed56e0b16b5/sentry-ruby/lib/sentry/hub.rb#L137-L138

The previous code in GraphQL-Ruby had handling for `span` being nil, but my new code didn't. Now it does.