### PR TITLE
Move Lazy resolution into Dataloader

### DIFF
--- a/lib/graphql/dataloader/lazy_source.rb
+++ b/lib/graphql/dataloader/lazy_source.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require "graphql/dataloader/source"
+
+module GraphQL
+  class Dataloader
+    class LazySource < GraphQL::Dataloader::Source
+      def initialize(phase, context)
+        @context = context
+        @phase = phase
+      end
+
+      def fetch(lazies)
+        lazies.map do |l|
+          @context.schema.sync_lazy(l)
+        rescue StandardError => err
+          err
+        end
+      end
+
+      attr_reader :phase
+
+      def defer?
+        @phase == :field_resolve && dataloader.source_cache[self.class].any? { |k, v| v.phase == :object_wrap && v.pending? }
+      end
+    end
+  end
+end

--- a/lib/graphql/dataloader/source.rb
+++ b/lib/graphql/dataloader/source.rb
@@ -80,6 +80,10 @@ module GraphQL
         result_keys.map { |k| result_for(k) }
       end
 
+      def defer?
+        false
+      end
+
       # Subclasses must implement this method to return a value for each of `keys`
       # @param keys [Array<Object>] keys passed to {#load}, {#load_all}, {#request}, or {#request_all}
       # @return [Array<Object>] A loaded value for each of `keys`. The array must match one-for-one to the list of `keys`.

--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -54,6 +54,7 @@ module GraphQL
           end
           # { Class => Boolean }
           @lazy_cache = {}.compare_by_identity
+          @default_lazy_legacy = @schema.legacy_sync_lazy
         end
 
         def final_result
@@ -884,13 +885,17 @@ module GraphQL
           end
         end
 
-        def lazy?(object)
-          obj_class = object.class
-          is_lazy = @lazy_cache[obj_class]
-          if is_lazy.nil?
-            is_lazy = @lazy_cache[obj_class] = @schema.lazy?(object)
+        def lazy?(object, legacy: @default_lazy_legacy)
+          if legacy
+            obj_class = object.class
+            is_lazy = @lazy_cache[obj_class]
+            if is_lazy.nil?
+              is_lazy = @lazy_cache[obj_class] = @schema.lazy?(object, legacy: true)
+            end
+            is_lazy
+          else
+            false
           end
-          is_lazy
         end
       end
     end

--- a/lib/graphql/query/context.rb
+++ b/lib/graphql/query/context.rb
@@ -270,6 +270,11 @@ module GraphQL
         Scoped.new(@scoped_context, current_path)
       end
 
+      # @api private
+      def runtime
+        @runtime ||= namespace(:interpreter_runtime)[:runtime]
+      end
+
       class Scoped
         def initialize(scoped_context, path)
           @path = path

--- a/spec/graphql/authorization_spec.rb
+++ b/spec/graphql/authorization_spec.rb
@@ -351,6 +351,7 @@ describe "GraphQL::Authorization" do
       mutation(Mutation)
       directive(Nothing)
       use GraphQL::Schema::Warden if ADD_WARDEN
+      legacy_sync_lazy(true)
       lazy_resolve(Box, :value)
 
       def self.unauthorized_object(err)
@@ -369,6 +370,7 @@ describe "GraphQL::Authorization" do
     class SchemaWithFieldHook < GraphQL::Schema
       query(Query)
       use GraphQL::Schema::Warden if ADD_WARDEN
+      legacy_sync_lazy(true)
       lazy_resolve(Box, :value)
 
       def self.unauthorized_field(err)
@@ -651,6 +653,7 @@ describe "GraphQL::Authorization" do
             it "returns nil if not authorized" do
               query = "{ unauthorized }"
               response = AuthTest::SchemaWithFieldHook.execute(query, root_value: 34, context: { lazy_field_authorized: false })
+
               assert_nil response["data"].fetch("unauthorized")
               assert_equal ["Unauthorized field unauthorized on Query: 34"], response["errors"].map { |e| e["message"] }
             end

--- a/spec/graphql/execution/errors_spec.rb
+++ b/spec/graphql/execution/errors_spec.rb
@@ -171,6 +171,7 @@ describe "GraphQL::Execution::Errors" do
     end
 
     query(Query)
+    legacy_sync_lazy(true)
     lazy_resolve(Proc, :call)
 
     def self.object_from_id(id, ctx)

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -276,6 +276,7 @@ describe GraphQL::Execution::Interpreter do
     class Schema < GraphQL::Schema
       query(Query)
       mutation(Mutation)
+      legacy_sync_lazy(true)
       lazy_resolve(Box, :value)
 
       use GraphQL::Schema::AlwaysVisible
@@ -674,6 +675,7 @@ describe GraphQL::Execution::Interpreter do
       query Query
       subscription Subscription
       use InMemoryBackend::Subscriptions, extra: nil
+      legacy_sync_lazy(true)
       lazy_resolve Proc, :call
     end
 

--- a/spec/graphql/query/context/scoped_context_spec.rb
+++ b/spec/graphql/query/context/scoped_context_spec.rb
@@ -78,6 +78,7 @@ describe GraphQL::Query::Context::ScopedContext do
     end
 
     query(Query)
+    legacy_sync_lazy(true)
     lazy_resolve(Promise, :value)
   end
 

--- a/spec/graphql/query/context_spec.rb
+++ b/spec/graphql/query/context_spec.rb
@@ -227,6 +227,7 @@ describe GraphQL::Query::Context do
 
     class ContextSchema < GraphQL::Schema
       query(ContextQuery)
+      legacy_sync_lazy(true)
       lazy_resolve(LazyBlock, :value)
       use GraphQL::Dataloader
     end

--- a/spec/graphql/schema/argument_spec.rb
+++ b/spec/graphql/schema/argument_spec.rb
@@ -87,6 +87,7 @@ describe GraphQL::Schema::Argument do
 
     class Schema < GraphQL::Schema
       query(Query)
+      legacy_sync_lazy(true)
       lazy_resolve(Proc, :call)
 
       def self.object_from_id(id, ctx)

--- a/spec/graphql/schema/directive_spec.rb
+++ b/spec/graphql/schema/directive_spec.rb
@@ -184,6 +184,7 @@ Use `locations(OBJECT)` to update this directive's definition, or remove it from
     class Schema < GraphQL::Schema
       query(Query)
       directive(CountFields)
+      legacy_sync_lazy(true)
       lazy_resolve(Proc, :call)
       use GraphQL::Dataloader
     end

--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -222,6 +222,7 @@ describe GraphQL::Schema::InputObject do
       class Schema < GraphQL::Schema
         query(Query)
         mutation(Mutation)
+        legacy_sync_lazy(true)
         lazy_resolve(Proc, :call)
 
         def self.object_from_id(id, ctx)
@@ -1275,7 +1276,7 @@ describe GraphQL::Schema::InputObject do
       def self.object_from_id(id, ctx)
         -> { nil }
       end
-
+      legacy_sync_lazy(true)
       lazy_resolve(Proc, :call)
 
       rescue_from(StandardError) {

--- a/spec/graphql/schema/member/scoped_spec.rb
+++ b/spec/graphql/schema/member/scoped_spec.rb
@@ -120,6 +120,7 @@ describe GraphQL::Schema::Member::Scoped do
     end
 
     query(Query)
+    legacy_sync_lazy(true)
     lazy_resolve(Proc, :call)
   end
 

--- a/spec/graphql/schema/resolver_spec.rb
+++ b/spec/graphql/schema/resolver_spec.rb
@@ -500,6 +500,7 @@ describe GraphQL::Schema::Resolver do
     class Schema < GraphQL::Schema
       query(Query)
       mutation(Mutation)
+      legacy_sync_lazy(true)
       lazy_resolve LazyBlock, :value
       orphan_types IntegerWrapper
 

--- a/spec/graphql/tracing/appsignal_trace_spec.rb
+++ b/spec/graphql/tracing/appsignal_trace_spec.rb
@@ -69,6 +69,7 @@ describe GraphQL::Tracing::AppsignalTrace do
     class TestSchema < GraphQL::Schema
       query(Query)
       trace_with(GraphQL::Tracing::AppsignalTrace)
+      legacy_sync_lazy(true)
       lazy_resolve(IntBox, :value)
     end
   end
@@ -100,6 +101,7 @@ describe GraphQL::Tracing::AppsignalTrace do
       query(AppsignalTraceTest::Query)
       trace_with(GraphQL::Tracing::DataDogTrace)
       trace_with(GraphQL::Tracing::AppsignalTrace)
+      legacy_sync_lazy(true)
       lazy_resolve(IntBox, :value)
     end
 
@@ -108,6 +110,7 @@ describe GraphQL::Tracing::AppsignalTrace do
       # Include these modules in different order than above:
       trace_with(GraphQL::Tracing::AppsignalTrace)
       trace_with(GraphQL::Tracing::DataDogTrace)
+      legacy_sync_lazy(true)
       lazy_resolve(IntBox, :value)
     end
 

--- a/spec/graphql/tracing/data_dog_trace_spec.rb
+++ b/spec/graphql/tracing/data_dog_trace_spec.rb
@@ -33,6 +33,7 @@ describe GraphQL::Tracing::DataDogTrace do
     class TestSchema < GraphQL::Schema
       query(Query)
       trace_with(GraphQL::Tracing::DataDogTrace)
+      legacy_sync_lazy(true)
       lazy_resolve(Box, :value)
     end
 
@@ -45,6 +46,7 @@ describe GraphQL::Tracing::DataDogTrace do
       end
       query(Query)
       trace_with(CustomDataDogTracing)
+      legacy_sync_lazy(true)
       lazy_resolve(Box, :value)
     end
   end

--- a/spec/graphql/tracing/trace_modes_spec.rb
+++ b/spec/graphql/tracing/trace_modes_spec.rb
@@ -286,6 +286,7 @@ describe "Trace modes for schemas" do
   CustomTraceClass = Class.new(GraphQL::Tracing::Trace)
 
   class BaseSchemaWithCustomTraceClass < GraphQL::Schema
+    legacy_sync_lazy(true)
     use(GraphQL::Batch)
     trace_class(CustomTraceClass)
     trace_with(SomeTraceMod)

--- a/spec/support/dummy/schema.rb
+++ b/spec/support/dummy/schema.rb
@@ -569,7 +569,7 @@ module Dummy
     end
 
     use GraphQL::Dataloader
-
+    legacy_sync_lazy(true)
     lazy_resolve(Proc, :call)
   end
 

--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -420,7 +420,7 @@ module StarWars
     def self.id_from_object(object, type, ctx)
       GraphQL::Schema::UniqueWithinType.encode(type.graphql_name, object.id)
     end
-
+    legacy_sync_lazy(true)
     lazy_resolve(LazyWrapper, :value)
     lazy_resolve(LazyLoader, :value)
   end


### PR DESCRIPTION
This is a moonshot but I want to see if the runtime code can be simplified by rebuilding `lazy_resolve` on top of `GraphQL::Dataloader`. Some hard requirements: 

- [ ] No (or minimal...) performance hit for adopting Dataloader (not in speed or memory usage)
- [ ] Behavioral parity  -- same batching performance and behavior
- [ ] Swappable per-query, so that you can try the new way or the old way while the app is running. This is essential for adoption: you have to be able to fall back to the old way if something goes wrong. 

------------------------

My todos: 

- [ ] Make sure all existing `legacy_sync_lazy(true)` can be replaced with Dataloader
- [ ] Run builds with both legacy and Dataloader implementations
...
- [ ] Revisit API and write docs
