### PR TITLE
Return hashes with correctly ordered keys

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -110,7 +110,7 @@ module GraphQL
 
         def each_gathered_selections(response_hash)
           ordered_result_keys = []
-          gathered_selections = gather_selections(response_hash.graphql_application_value, response_hash.graphql_result_type, response_hash.graphql_selections, ordered_result_keys)
+          gathered_selections = gather_selections(response_hash.graphql_application_value, response_hash.graphql_result_type, response_hash.graphql_selections, nil, {}, ordered_result_keys)
           ordered_result_keys.uniq!
           if gathered_selections.is_a?(Array)
             gathered_selections.each do |item|
@@ -121,7 +121,7 @@ module GraphQL
           end
         end
 
-        def gather_selections(owner_object, owner_type, selections, selections_to_run = nil, selections_by_name = {}, ordered_result_keys)
+        def gather_selections(owner_object, owner_type, selections, selections_to_run, selections_by_name, ordered_result_keys)
           selections.each do |node|
             # Skip gathering this if the directive says so
             if !directives_include?(node, owner_object, owner_type)

--- a/lib/graphql/execution/interpreter/runtime/graphql_result.rb
+++ b/lib/graphql/execution/interpreter/runtime/graphql_result.rb
@@ -69,13 +69,7 @@ module GraphQL
             @graphql_result_data[key] = value
 
             if @ordered_result_keys.index(key) < @graphql_result_data.size - 1
-              backup_data = @graphql_result_data.dup
-              @graphql_result_data.clear
-              @ordered_result_keys.each do |k|
-                if backup_data.key?(k)
-                  @graphql_result_data[k] = backup_data[k]
-                end
-              end
+              fix_result_order
             end
 
             # keep this up-to-date if it's been initialized
@@ -90,13 +84,7 @@ module GraphQL
             end
             @graphql_result_data[key] = value.graphql_result_data
             if @ordered_result_keys.index(key) < @graphql_result_data.size - 1
-              backup_data = @graphql_result_data.dup
-              @graphql_result_data.clear
-              @ordered_result_keys.each do |k|
-                if backup_data.key?(k)
-                  @graphql_result_data[k] = backup_data[k]
-                end
-              end
+              fix_result_order
             end
 
             # If we encounter some part of this response that requires metadata tracking,
@@ -147,6 +135,14 @@ module GraphQL
               end
             end
             @graphql_merged_into = into_result
+          end
+
+          def fix_result_order
+            @ordered_result_keys.each do |k|
+              if @graphql_result_data.key?(k)
+                @graphql_result_data[k] = @graphql_result_data.delete(k)
+              end
+            end
           end
         end
 

--- a/lib/graphql/execution/interpreter/runtime/graphql_result.rb
+++ b/lib/graphql/execution/interpreter/runtime/graphql_result.rb
@@ -44,8 +44,10 @@ module GraphQL
           def initialize(_result_name, _result_type, _application_value, _parent_result, _is_non_null_in_parent, _selections, _is_eager, _ast_node, _graphql_arguments, graphql_field) # rubocop:disable Metrics/ParameterLists
             super
             @graphql_result_data = {}
-            @ordered_result_keys = @graphql_selections.map { |s| s.alias || s.name }
+            @ordered_result_keys = nil
           end
+
+          attr_accessor :ordered_result_keys
 
           include GraphQLResult
 

--- a/lib/graphql/execution/interpreter/runtime/graphql_result.rb
+++ b/lib/graphql/execution/interpreter/runtime/graphql_result.rb
@@ -66,9 +66,10 @@ module GraphQL
               t.set_leaf(key, value)
             end
 
+            before_size = @graphql_result_data.size
             @graphql_result_data[key] = value
-
-            if @ordered_result_keys.index(key) < @graphql_result_data.size - 1
+            after_size = @graphql_result_data.size
+            if after_size > before_size && @ordered_result_keys[before_size] != key
               fix_result_order
             end
 
@@ -82,8 +83,10 @@ module GraphQL
             if (t = @graphql_merged_into)
               t.set_child_result(key, value)
             end
+            before_size = @graphql_result_data.size
             @graphql_result_data[key] = value.graphql_result_data
-            if @ordered_result_keys.index(key) < @graphql_result_data.size - 1
+            after_size = @graphql_result_data.size
+            if after_size > before_size && @ordered_result_keys[before_size] != key
               fix_result_order
             end
 

--- a/spec/graphql/backtrace_spec.rb
+++ b/spec/graphql/backtrace_spec.rb
@@ -327,7 +327,7 @@ describe GraphQL::Backtrace do
       {"data" => { "__typename" => "Query" }},
     ]
 
-    assert_equal expected_res, res
+    assert_graphql_equal expected_res, res
   end
 
   it "includes other trace modules when backtrace is active" do

--- a/spec/graphql/dataloader/async_dataloader_spec.rb
+++ b/spec/graphql/dataloader/async_dataloader_spec.rb
@@ -212,7 +212,7 @@ if RUBY_VERSION >= "3.1.1"
               "s2" => { "sleeper" => { "duration" => 0.1 } },
               "s3" => { "duration" => 0.3 }
             }
-            assert_equal expected_data, res["data"]
+            assert_graphql_equal expected_data, res["data"]
             assert_in_delta 0.5, ended_at - started_at, 0.06, "Each depth ran in parallel"
           end
 
@@ -256,7 +256,7 @@ if RUBY_VERSION >= "3.1.1"
               "w3" => { "waitFor" => { "waitFor" => { "tag" => "d" } } },
               "w4" => { "tag" => "e" }
             }
-            assert_equal expected_data, res["data"]
+            assert_graphql_equal expected_data, res["data"]
             # We've basically got two options here:
             # - Put all jobs in the same queue (fields and sources), but then you don't get predictable batching.
             # - Work one-layer-at-a-time, but then layers can get stuck behind one another. That's what's implemented here.

--- a/spec/graphql/dataloader/nonblocking_dataloader_spec.rb
+++ b/spec/graphql/dataloader/nonblocking_dataloader_spec.rb
@@ -182,7 +182,7 @@ if Fiber.respond_to?(:scheduler) # Ruby 3+
               "s2" => { "sleeper" => { "duration" => 0.1 } },
               "s3" => { "duration" => 0.3 }
             }
-            assert_equal expected_data, res["data"]
+            assert_graphql_equal expected_data, res["data"]
             assert_in_delta 0.3, ended_at - started_at, 0.06, "Fields ran without any waiting"
           end
 
@@ -228,7 +228,7 @@ if Fiber.respond_to?(:scheduler) # Ruby 3+
               "w3" => { "waitFor" => { "waitFor" => { "tag" => "d" } } },
               "w4" => { "tag" => "e" }
             }
-            assert_equal expected_data, res["data"]
+            assert_graphql_equal expected_data, res["data"]
             # We've basically got two options here:
             # - Put all jobs in the same queue (fields and sources), but then you don't get predictable batching.
             # - Work one-layer-at-a-time, but then layers can get stuck behind one another. That's what's implemented here.

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -599,7 +599,7 @@ describe GraphQL::Dataloader do
               ]
             }
           }
-          assert_equal expected_data, res
+          assert_graphql_equal expected_data, res
           assert_equal [[:mget, ["5", "6"]], [:mget, ["2", "3"]]], database_log
         end
 
@@ -707,7 +707,7 @@ describe GraphQL::Dataloader do
           GRAPHQL
 
           expected_data = { "i1" => { "name" => "Wheat" }, "i2" => { "name" => "Corn" } }
-          assert_equal expected_data, res["data"]
+          assert_graphql_equal expected_data, res["data"]
           assert_equal [[:mget, ["1", "2"]]], database_log
         end
 
@@ -725,7 +725,7 @@ describe GraphQL::Dataloader do
             "i2" => { "id" => "2" },
             "i3" => nil,
           }
-          assert_equal expected_data, res["data"]
+          assert_graphql_equal expected_data, res["data"]
           assert_equal [[:find_by, :name, ["Butter", "Corn", "Gummi Bears"]]], database_log
         end
 
@@ -828,7 +828,7 @@ describe GraphQL::Dataloader do
               {"name"=>"Butter"},
             ]
           }
-        assert_equal expected_data, res["data"]
+        assert_graphql_equal expected_data, res["data"]
 
           expected_log = [
             [:mget, ["5", "6"]],
@@ -854,7 +854,7 @@ describe GraphQL::Dataloader do
               "name" => "Wheat",
             }
           }
-          assert_equal expected_data, res["data"]
+          assert_graphql_equal expected_data, res["data"]
         end
 
         it "Works with analyzing arguments with `loads:`, even with .request" do
@@ -893,7 +893,7 @@ describe GraphQL::Dataloader do
               {"name"=>"Butter"},
             ]
           }
-          assert_equal expected_data, res["data"]
+          assert_graphql_equal expected_data, res["data"]
 
           expected_log = [
             [:mget, ["5", "6"]],
@@ -929,7 +929,7 @@ describe GraphQL::Dataloader do
           GRAPHQL
           res = schema.execute(query_str, variables: { id: nil })
           expected_data = { "recipe" => nil }
-          assert_equal expected_data, res["data"]
+          assert_graphql_equal expected_data, res["data"]
 
           query_str = <<-GRAPHQL
           query($ids: [ID]!) {
@@ -940,7 +940,7 @@ describe GraphQL::Dataloader do
           GRAPHQL
           res = schema.execute(query_str, variables: { ids: [nil] })
           expected_data = { "recipes" => nil }
-          assert_equal expected_data, res["data"]
+          assert_graphql_equal expected_data, res["data"]
         end
 
         it "Works with input objects using variables, load and request" do
@@ -958,7 +958,7 @@ describe GraphQL::Dataloader do
               {"name"=>"Butter"},
             ]
           }
-          assert_equal expected_data, res["data"]
+          assert_graphql_equal expected_data, res["data"]
 
           expected_log = [
             [:mget, ["5", "6"]],
@@ -1013,7 +1013,7 @@ describe GraphQL::Dataloader do
             "i3" => { "nameByScopedContext" => "Scoped:Butter" },
           }
           result = schema.execute(query_str)
-          assert_equal expected_data, result["data"]
+          assert_graphql_equal expected_data, result["data"]
         end
 
         it "works when the schema calls itself" do
@@ -1032,7 +1032,7 @@ describe GraphQL::Dataloader do
 
           res = schema.execute(query_str)
           expected_data = { "i1" => { "name" => "Wheat" }, "i2" => { "name" => "Corn" }, "i3" => { "name" => "Butter" } }
-          assert_equal expected_data, res["data"]
+          assert_graphql_equal expected_data, res["data"]
           expected_log = [
             # Each batch key is given to the source class:
             [:batch_key_for, "abc"],

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -690,7 +690,7 @@ describe GraphQL::Dataloader do
             {"data"=>{"i2"=>{"name"=>"Corn"}, "r1"=>{"ingredients"=>[{"name"=>"Wheat"}, {"name"=>"Corn"}, {"name"=>"Butter"}, {"name"=>"Baking Soda"}]}}},
             {"data"=>{"i1"=>{"name"=>"Wheat"}, "ri1"=>{"name"=>"Corn"}}},
           ]
-          assert_equal expected_result, result
+          assert_graphql_equal expected_result, result
           expected_log = [
             [:mget, ["1", "2", "5"]],
             [:mget, ["3", "4"]],
@@ -1328,7 +1328,7 @@ describe GraphQL::Dataloader do
         }
       }
 
-      assert_equal expected_result, result.to_h
+      assert_graphql_equal expected_result, result.to_h
     end
   end
 
@@ -1547,7 +1547,7 @@ describe GraphQL::Dataloader do
         }
       }
 
-      assert_equal expected_result, result.to_h
+      assert_graphql_equal expected_result, result.to_h
     end
   end
 
@@ -1602,7 +1602,7 @@ describe GraphQL::Dataloader do
         }
       }
 
-      assert_equal expected_result, result.to_h
+      assert_graphql_equal expected_result, result.to_h
     end
   end
 

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -626,11 +626,13 @@ describe GraphQL::Dataloader do
           assert_equal({"setCache" => "Salad", "getCache" => "1"}, res["data"])
         end
 
+        focus
         it "batch-loads" do
           res = schema.execute <<-GRAPHQL
           {
             i1: ingredient(id: 1) { id name }
             i2: ingredient(id: 2) { name }
+            __typename
             r1: recipe(id: 5) {
               # This loads Ingredients 3 and 4
               ingredients { name }
@@ -645,6 +647,7 @@ describe GraphQL::Dataloader do
           expected_data = {
             "i1" => { "id" => "1", "name" => "Wheat" },
             "i2" => { "name" => "Corn" },
+            "__typename" => "Query",
             "r1" => {
               "ingredients" => [
                 { "name" => "Wheat" },
@@ -657,7 +660,7 @@ describe GraphQL::Dataloader do
               "name" => "Cheese",
             },
           }
-          assert_equal(expected_data, res["data"])
+          assert_graphql_equal(expected_data, res["data"])
 
           expected_log = [
             [:mget, [
@@ -771,7 +774,7 @@ describe GraphQL::Dataloader do
               "name" => "Wheat",
             }
           }
-          assert_equal expected_data, res["data"]
+          assert_graphql_equal expected_data, res["data"]
         end
 
         it "Works when the parent field didn't yield" do
@@ -801,7 +804,7 @@ describe GraphQL::Dataloader do
               ]},
             ]
           }
-          assert_equal expected_data, res["data"]
+          assert_graphql_equal expected_data, res["data"]
 
           expected_log = [
             [:mget, ["5", "6"]],
@@ -826,7 +829,7 @@ describe GraphQL::Dataloader do
               {"name"=>"Butter"},
             ]
           }
-          assert_equal expected_data, res["data"]
+        assert_equal expected_data, res["data"]
 
           expected_log = [
             [:mget, ["5", "6"]],

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -626,7 +626,6 @@ describe GraphQL::Dataloader do
           assert_equal({"setCache" => "Salad", "getCache" => "1"}, res["data"])
         end
 
-        focus
         it "batch-loads" do
           res = schema.execute <<-GRAPHQL
           {

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -861,9 +861,6 @@ describe GraphQL::Execution::Interpreter do
 
       result = RaisedErrorSchema.execute(querystring)
       expected_result = {
-        "data" => {
-          "iface" => { "txn" => nil, "msg" => "THIS SHOULD SHOW UP" },
-        },
         "errors" => [
           {
             "message"=>"boom",
@@ -871,8 +868,11 @@ describe GraphQL::Execution::Interpreter do
             "path"=>["iface", "txn", "fails"]
           },
         ],
+        "data" => {
+          "iface" => { "txn" => nil, "msg" => "THIS SHOULD SHOW UP" },
+        },
       }
-      assert_equal expected_result, result.to_h
+      assert_graphql_equal expected_result, result.to_h
     end
   end
 

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -405,7 +405,7 @@ describe GraphQL::Execution::Interpreter do
       "i4" => { "value" => 4, "lazyValue" => 4},
       "i5" => { "value" => 5, "lazyValue" => 5},
     }
-    assert_equal expected_data, result["data"]
+    assert_graphql_equal expected_data, result["data"]
   end
 
   it "runs skip and include" do
@@ -427,7 +427,7 @@ describe GraphQL::Execution::Interpreter do
       "exp3" => {"name" => "Ravnica, City of Guilds"},
       "exp5" => {"name" => "Ravnica, City of Guilds"},
     }
-    assert_equal expected_data, result["data"]
+    assert_graphql_equal expected_data, result["data"]
     assert_nil Fiber[:__graphql_runtime_info]
   end
 

--- a/spec/graphql/execution/lazy_spec.rb
+++ b/spec/graphql/execution/lazy_spec.rb
@@ -74,7 +74,7 @@ describe GraphQL::Execution::Lazy do
         ],
       }
 
-      assert_equal expected_data, res["data"]
+      assert_graphql_equal expected_data, res["data"]
     end
 
     [
@@ -176,7 +176,7 @@ describe GraphQL::Execution::Lazy do
         "b" => nil,
         "c" => { "value" => 3 },
       }
-      assert_equal expected_data, res["data"]
+      assert_graphql_equal expected_data, res["data"]
 
       expected_errors = [{
         "message"=>"13 is unlucky",

--- a/spec/graphql/execution/multiplex_spec.rb
+++ b/spec/graphql/execution/multiplex_spec.rb
@@ -50,7 +50,7 @@ describe GraphQL::Execution::Multiplex do
       ]
 
       res = multiplex(queries)
-      assert_equal expected_data, res
+      assert_graphql_equal expected_data, res
     end
 
     it "returns responses in the same order as their respective requests" do

--- a/spec/graphql/execution/multiplex_spec.rb
+++ b/spec/graphql/execution/multiplex_spec.rb
@@ -105,20 +105,20 @@ describe GraphQL::Execution::Multiplex do
           "data"=>{"success"=>{"value"=>2}}
         },
         {
-          "data"=>{"runtimeError"=>nil},
           "errors"=>[{
             "message"=>"13 is unlucky",
             "locations"=>[{"line"=>1, "column"=>4}],
             "path"=>["runtimeError"]
-          }]
+          }],
+          "data"=>{"runtimeError"=>nil},
         },
         {
-          "data"=>{"invalidNestedNull"=>{"value" => 2,"nullableNestedSum" => nil}},
           "errors"=>[{
             "message"=>"Cannot return null for non-nullable field LazySum.nestedSum",
             "path"=>["invalidNestedNull", "nullableNestedSum", "nestedSum"],
             "locations"=>[{"line"=>5, "column"=>11}],
           }],
+          "data"=>{"invalidNestedNull"=>{"value" => 2,"nullableNestedSum" => nil}},
         },
         {
           "errors" => [{
@@ -136,7 +136,7 @@ describe GraphQL::Execution::Multiplex do
         {query: q3},
         {query: q4},
       ])
-      assert_equal expected_res, res.map(&:to_h)
+      assert_graphql_equal expected_res, res.map(&:to_h)
     end
   end
 

--- a/spec/graphql/language/visitor_spec.rb
+++ b/spec/graphql/language/visitor_spec.rb
@@ -229,7 +229,7 @@ query($lastName: String) {
 }
       GRAPHQL
       document, new_document = get_result(query)
-      assert_graphql_equal expected_result, new_document.to_query_string, "the result has changes"
+      assert_equal expected_result, new_document.to_query_string, "the result has changes"
       assert_equal query, document.to_query_string, "the original is unchanged"
     end
 

--- a/spec/graphql/language/visitor_spec.rb
+++ b/spec/graphql/language/visitor_spec.rb
@@ -229,7 +229,7 @@ query($lastName: String) {
 }
       GRAPHQL
       document, new_document = get_result(query)
-      assert_equal expected_result, new_document.to_query_string, "the result has changes"
+      assert_graphql_equal expected_result, new_document.to_query_string, "the result has changes"
       assert_equal query, document.to_query_string, "the original is unchanged"
     end
 

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -1458,7 +1458,7 @@ type ThingEdge {
             }
           }
         }
-        assert_equal expected_data, result["data"]
+        assert_graphql_equal expected_data, result["data"]
       end
 
       it "doesn't add arguments that aren't in the IDL" do

--- a/spec/graphql/schema/directive_spec.rb
+++ b/spec/graphql/schema/directive_spec.rb
@@ -236,7 +236,7 @@ Use `locations(OBJECT)` to update this directive's definition, or remove it from
         },
         "t5"=>{"n5"=>"t5", "t5d"=>{"t5dl"=>{"t5dln"=>"t5dl"}}},
       }
-      assert_equal expected_data, res["data"]
+      assert_graphql_equal expected_data, res["data"]
 
       expected_counts = {
         ["t1", "t1n"] => [1],
@@ -266,7 +266,7 @@ Use `locations(OBJECT)` to update this directive's definition, or remove it from
       GRAPHQL
       res = RuntimeDirectiveTest::Schema.execute(query_str)
       expected_data = { "t1" => { "name" => "t1"}, "t2" => { "name" => "t2" }, "t3" => { "name" => "t3" } }
-      assert_equal expected_data, res["data"]
+      assert_graphql_equal expected_data, res["data"]
 
       expected_counts = {
         [] => [2],

--- a/spec/graphql/schema/field_spec.rb
+++ b/spec/graphql/schema/field_spec.rb
@@ -614,7 +614,7 @@ describe GraphQL::Schema::Field do
           { "name" => "John Cleese" }
         ]
       }
-      assert_equal expected_result, result
+      assert_graphql_equal expected_result, result
     end
   end
 
@@ -678,18 +678,18 @@ describe GraphQL::Schema::Field do
 
       search_results = res["data"]["searchResults"]
       expected_result = {
+        "method" => "hash-key-works-when-underlying-object-responds-to-field-name",
         "lowercase" => "lowercase-works",
         "Capital" => "capital-camelize-false-works",
         "Other" => "capital-camelize-true-works",
         "OtherCapital" => "explicit-hash-key-works",
-        "method" => "hash-key-works-when-underlying-object-responds-to-field-name",
         "stringifiedHashKey" => "hash-key-is-tried-as-string",
         "booleanTrueWithHashKey" => true,
         "booleanFalseWithHashKey" => false,
         "booleanFalseWithSymbolizedHashKey" => false
 
       }
-      assert_equal expected_result, search_results
+      assert_graphql_equal expected_result, search_results
     end
 
     it "works with non-hash instances" do
@@ -711,17 +711,17 @@ describe GraphQL::Schema::Field do
 
       search_results = res["data"]["ostructResults"]
       expected_result = {
+        "method" => "hash-key-works-when-underlying-object-responds-to-field-name",
         "lowercase" => "lowercase-works",
         "Capital" => "capital-camelize-false-works",
         "Other" => "capital-camelize-true-works",
         "OtherCapital" => "explicit-hash-key-works",
-        "method" => "hash-key-works-when-underlying-object-responds-to-field-name",
         "stringifiedHashKey" => "hash-key-is-tried-as-string",
         "booleanTrueWithHashKey" => true,
         "booleanFalseWithHashKey" => false,
         "booleanFalseWithSymbolizedHashKey" => false
       }
-      assert_equal expected_result, search_results
+      assert_graphql_equal expected_result, search_results
     end
 
     it "populates `method_str`" do

--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -687,7 +687,7 @@ describe GraphQL::Schema::InputObject do
     it "handles camelized booleans" do
       res = Jazz::Schema.execute("query($input: CamelizedBooleanInput!){ inputObjectCamelization(input: $input) }", variables: { input: { camelizedBoolean: false } })
       expected_res = { camelized_boolean: false }.inspect
-      assert_equal expected_res, res["data"]["inputObjectCamelization"]
+      assert_graphql_equal expected_res, res["data"]["inputObjectCamelization"]
     end
   end
 

--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -687,7 +687,7 @@ describe GraphQL::Schema::InputObject do
     it "handles camelized booleans" do
       res = Jazz::Schema.execute("query($input: CamelizedBooleanInput!){ inputObjectCamelization(input: $input) }", variables: { input: { camelizedBoolean: false } })
       expected_res = { camelized_boolean: false }.inspect
-      assert_graphql_equal expected_res, res["data"]["inputObjectCamelization"]
+      assert_equal expected_res, res["data"]["inputObjectCamelization"]
     end
   end
 

--- a/spec/graphql/schema/interface_spec.rb
+++ b/spec/graphql/schema/interface_spec.rb
@@ -622,7 +622,7 @@ interface Timestamped implements Node {
             {"__typename"=>"Milk", "fatContent"=>0.04}
           ]
         }
-        assert_equal expected_result, result["data"]
+        assert_graphql_equal expected_result, result["data"]
       end
 
       describe "in definition_methods when implementing another interface" do

--- a/spec/graphql/schema/interface_spec.rb
+++ b/spec/graphql/schema/interface_spec.rb
@@ -576,7 +576,7 @@ interface Timestamped implements Node {
             {"__typename"=>"Milk", "origin"=>"Antiquity"},
           ]
 
-          assert_equal expected_data, result["data"]["allEdible"]
+          assert_graphql_equal expected_data, result["data"]["allEdible"]
         end
       end
     end

--- a/spec/graphql/schema/timeout_spec.rb
+++ b/spec/graphql/schema/timeout_spec.rb
@@ -94,7 +94,7 @@ describe GraphQL::Schema::Timeout do
           "path"=>["e"]
         },
       ]
-      assert_equal expected_data, result["data"]
+      assert_graphql_equal expected_data, result["data"]
       assert_equal expected_errors, result["errors"]
       assert_equal true, result.context[:other_trace_worked], "It works with other traces"
     end
@@ -150,7 +150,7 @@ describe GraphQL::Schema::Timeout do
         },
       ]
 
-      assert_equal expected_data, result["data"]
+      assert_graphql_equal expected_data, result["data"]
       assert_equal expected_errors, result["errors"]
     end
   end
@@ -180,7 +180,7 @@ describe GraphQL::Schema::Timeout do
         },
       ]
 
-      assert_equal expected_data, result["data"]
+      assert_graphql_equal expected_data, result["data"]
       assert_equal expected_errors, result["errors"]
     end
   end

--- a/spec/graphql/schema/union_spec.rb
+++ b/spec/graphql/schema/union_spec.rb
@@ -42,7 +42,7 @@ describe GraphQL::Schema::Union do
 
       res = Jazz::Schema.execute(query_str)
       expected_data = { "name" => "Bela Fleck and the Flecktones" }
-      assert_equal expected_data, res["data"]["nowPlaying"]
+      assert_graphql_equal expected_data, res["data"]["nowPlaying"]
     end
 
     it "does not allow querying filtered types" do

--- a/spec/graphql/schema/union_spec.rb
+++ b/spec/graphql/schema/union_spec.rb
@@ -332,7 +332,7 @@ describe GraphQL::Schema::Union do
             { "type" => "Cow", "name" => "Gilly" }
           ]
         }
-        assert_equal expected_result, result["data"]
+        assert_graphql_equal expected_result, result["data"]
       end
     end
 
@@ -359,7 +359,7 @@ describe GraphQL::Schema::Union do
           {"dairyName"=>"Cheese"},
           {"dairyName"=>"Milk", "bevName"=>"Milk", "flavors"=>["Natural", "Chocolate", "Strawberry"]},
         ]
-        assert_equal expected_result, result["data"]["allDairy"]
+        assert_graphql_equal expected_result, result["data"]["allDairy"]
       end
     end
 

--- a/spec/graphql/schema/validator_spec.rb
+++ b/spec/graphql/schema/validator_spec.rb
@@ -103,7 +103,7 @@ describe GraphQL::Schema::Validator do
     # Two fields with different errors
     res5 = schema.execute("{ v1: validated(value: \"0\") v2: validated(value: \"123456\") v3: validated(value: \"abcdefg\") }")
     expected_data = {"v1"=>nil, "v2"=>"123456", "v3"=>nil}
-    assert_equal expected_data, res5["data"]
+    assert_graphql_equal expected_data, res5["data"]
     errs = [
       {
         "message" => "value is too short (minimum is 5)",
@@ -128,7 +128,7 @@ describe GraphQL::Schema::Validator do
         { "validated" => 6 },
       ]
     }
-    assert_equal expected_data, res["data"]
+    assert_graphql_equal expected_data, res["data"]
 
     res = schema.execute("{ list { validated(value: 3) } }")
     expected_response = {

--- a/spec/graphql/static_validation/rules/variable_usages_are_allowed_spec.rb
+++ b/spec/graphql/static_validation/rules/variable_usages_are_allowed_spec.rb
@@ -356,15 +356,15 @@ describe GraphQL::StaticValidation::VariableUsagesAreAllowed do
 
       result = schema.execute("query($sort: SongSort) { songs(sort: $sort) { name } }", variables: {})
       expected_result = {"data" => {"songs" => [{"name" => "A"},{"name" => "B"}]}}
-      assert_equal expected_result, result
+      assert_graphql_equal expected_result, result
 
       result = schema.execute("query($sort: SongSort) { songs(sort: $sort) { name } }", variables: { sort: { name: "desc" } })
       expected_result = {"data" => {"songs" => [{"name" => "B"},{"name" => "A"}]}}
-      assert_equal expected_result, result
+      assert_graphql_equal expected_result, result
 
       result = schema.execute("query($sort: SongSort) { songs(sort: $sort) { name } }", variables: { sort: nil })
-      expected_result = {"data"=>nil, "errors"=>[{"message"=>"`null` is not a valid input for `SongSort!`, please provide a value for this argument.", "locations"=>[{"line"=>1, "column"=>26}], "path"=>["songs"]}]}
-      assert_equal expected_result, result
+      expected_result = {"errors"=>[{"message"=>"`null` is not a valid input for `SongSort!`, please provide a value for this argument.", "locations"=>[{"line"=>1, "column"=>26}], "path"=>["songs"]}], "data" => nil}
+      assert_graphql_equal expected_result, result
 
       result = schema.execute("{ topSong(input: {}) { name } }")
       assert_equal "Hey Ya!", result["data"]["topSong"]["name"]

--- a/spec/graphql/types/iso_8601_date_spec.rb
+++ b/spec/graphql/types/iso_8601_date_spec.rb
@@ -310,7 +310,7 @@ describe GraphQL::Types::ISO8601Date do
       GRAPHQL
 
       expected_res = { "name" => "ISO8601Date", "kind" => "SCALAR"}
-      assert_equal expected_res, introspection_res["data"]["__type"]
+      assert_graphql_equal expected_res, introspection_res["data"]["__type"]
     end
   end
 end

--- a/spec/graphql/types/iso_8601_date_time_spec.rb
+++ b/spec/graphql/types/iso_8601_date_time_spec.rb
@@ -276,7 +276,7 @@ describe GraphQL::Types::ISO8601DateTime do
       GRAPHQL
 
       expected_res = { "name" => "ISO8601DateTime", "kind" => "SCALAR"}
-      assert_equal expected_res, introspection_res["data"]["__type"]
+      assert_graphql_equal expected_res, introspection_res["data"]["__type"]
     end
   end
 end

--- a/spec/integration/rails/graphql/dataloader/async_dataloader_spec.rb
+++ b/spec/integration/rails/graphql/dataloader/async_dataloader_spec.rb
@@ -112,6 +112,6 @@ describe GraphQL::Dataloader::AsyncDataloader do
       RailsAsyncSchema.execute(query_str)
     end
     expected_res = { "role" => "reading", "query" => { "role" => "reading" }}
-    assert_equal expected_res, result["data"]
+    assert_graphql_equal expected_res, result["data"]
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -209,4 +209,20 @@ module Minitest
       end
     end
   end
+
+  module Assertions
+    def assert_graphql_equal(data1, data2, message = "GraphQL Result was equal")
+      case data1
+      when Hash
+        assert_equal(data1, data2, message)
+        assert_equal(data1.keys, data2.keys, "Order of keys matched (#{message})")
+      when Array
+        data1.each_with_index do |item1, idx|
+          assert_graphql_equal(item1, data2[idx], message + "[Item #{idx + 1}] ")
+        end
+      else
+        raise ArgumentError, "assert_graphql_equal doesn't support #{data1.class} yet"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Trying again at #5011 and #4252, replaces #5060

GraphQL-Ruby happens to return correctly-ordered results in simple cases because of Ruby's ordered Hash (results are inserted in the order they're encountered in the query). But a few things can cause it to be out-of-order: 

- Runtime directives (but not `@skip` or `@include`) are evaluated separately then merged back in -- merging causes mis-ordering
- Dataloaded values are written to the hash after non-Dataloaded values, therefore mis-ordered

`lazy_resolve(...)` values (like GraphQL-Batch's promises) don't have this problem because they're written immediately. But I'm trying to rebuild lazy resolve on top of dataloader to simplify execution code, so they might end up having this problem.

TODO: 

- [x] Make sure this performance is as good as it can be, especially minimal allocations on hot paths
  - Can it detect when order _might_ be wrong, and only re-sort in that case?
     - Yes, this worked out alright
  - Can it somehow re-order only once (currently reorders on every write which is silly)
    - No, it turns out this code doesn't really do what I thought -- it may well run before others have run. I think it could be removed altogether: https://github.com/rmosolgo/graphql-ruby/blob/96aeb2becbfc90930922735788ceb8b5a540e289/lib/graphql/execution/interpreter/runtime.rb#L221
  - Use a first-class ordered data structure (Array)? But current implementation depends on mutable hashes.
    - I think this is worth exploring down the line. The trick will be maintaining compatibility.