### PR TITLE
Fix monitor trace suffix method

### DIFF
--- a/lib/graphql/tracing/monitor_trace.rb
+++ b/lib/graphql/tracing/monitor_trace.rb
@@ -104,7 +104,7 @@ module GraphQL
             "#{type.graphql_name}.resolve_type.graphql"
           end
 
-          def platform_source_key(source_class)
+          def platform_source_class_key(source_class)
             "#{source_class.name.gsub("::", "_").name.underscore}.fetch.graphql"
           end
         end


### PR DESCRIPTION
Swaps in the "platform_source_class_key" method instead of the previously unused "platform_source_key" to prevent a NoMethodError on initialization.

Relates to

- https://github.com/rmosolgo/graphql-ruby/issues/5316