### PR TITLE
Fix monitor trace suffix method

### DIFF
--- a/gemfiles/rails_master.gemfile
+++ b/gemfiles/rails_master.gemfile
@@ -25,7 +25,7 @@ gem 'selenium-webdriver'
 
 gemspec path: "../"
 
-if Bundler.settings["GEMS__GRAPHQL__PRO"]
+if (cred = Bundler.settings["GEMS__GRAPHQL__PRO"]) && !cred.empty?
   gem "graphql-pro", source: "https://gems.graphql.pro"
   gem "graphql-enterprise", source: "https://gems.graphql.pro"
 end

--- a/lib/graphql/tracing/monitor_trace.rb
+++ b/lib/graphql/tracing/monitor_trace.rb
@@ -103,7 +103,7 @@ module GraphQL
           end
 
           def platform_source_class_key(source_class)
-            "#{source_class.name.gsub("::", "_").underscore}.fetch.graphql"
+            "#{source_class.name.gsub("::", "_")}.fetch.graphql"
           end
         end
 

--- a/lib/graphql/tracing/monitor_trace.rb
+++ b/lib/graphql/tracing/monitor_trace.rb
@@ -90,8 +90,6 @@ module GraphQL
           EXECUTE_NAME = "execute.graphql"
           ANALYZE_NAME = "analyze.graphql"
 
-          private
-
           def platform_field_key(field)
             "#{field.path}.graphql"
           end
@@ -104,8 +102,8 @@ module GraphQL
             "#{type.graphql_name}.resolve_type.graphql"
           end
 
-          def platform_source_key(source_class)
-            "#{source_class.name.gsub("::", "_").name.underscore}.fetch.graphql"
+          def platform_source_class_key(source_class)
+            "#{source_class.name.gsub("::", "_").underscore}.fetch.graphql"
           end
         end
 

--- a/spec/dummy/test/controllers/dashboard/limiters/limiters_controller_test.rb
+++ b/spec/dummy/test/controllers/dashboard/limiters/limiters_controller_test.rb
@@ -1,35 +1,37 @@
 # frozen_string_literal: true
 require "test_helper"
 
-class DashboardLimitersLimitersControllerTest < ActionDispatch::IntegrationTest
-  def test_it_checks_installed
-    get graphql_dashboard.limiters_limiter_path("runtime", { schema: "GraphQL::Schema" })
-    assert_includes response.body, CGI::escapeHTML("Rate limiters aren't installed on this schema yet.")
-    refute_includes response.headers["Content-Security-Policy"], "nonce-"
-  end
-
-  def test_it_shows_limiters
-    Redis.new(db: DummySchema::DB_NUMBER).flushdb
-
-    3.times do
-      DummySchema.execute("{ sleep(seconds: 0.02) }", context: { limiter_key: "client-1" }).to_h
-    end
-    4.times do
-      DummySchema.execute("{ sleep(seconds: 0.110) }", context: { limiter_key: "client-2" }).to_h
+if defined?(GraphQL::Pro)
+  class DashboardLimitersLimitersControllerTest < ActionDispatch::IntegrationTest
+    def test_it_checks_installed
+      get graphql_dashboard.limiters_limiter_path("runtime", { schema: "GraphQL::Schema" })
+      assert_includes response.body, CGI::escapeHTML("Rate limiters aren't installed on this schema yet.")
+      refute_includes response.headers["Content-Security-Policy"], "nonce-"
     end
 
-    get graphql_dashboard.limiters_limiter_path("runtime")
-    assert_includes response.body, "<span class=\"data\">4</span>"
-    assert_includes response.body, "<span class=\"data\">3</span>"
-    assert_includes response.body, "Disable Soft Limiting"
-    assert_includes response.headers["Content-Security-Policy"], "nonce-"
+    def test_it_shows_limiters
+      Redis.new(db: DummySchema::DB_NUMBER).flushdb
 
-    patch graphql_dashboard.limiters_limiter_path("runtime")
-    get graphql_dashboard.limiters_limiter_path("runtime")
-    assert_includes response.body, "Enable Soft Limiting"
+      3.times do
+        DummySchema.execute("{ sleep(seconds: 0.02) }", context: { limiter_key: "client-1" }).to_h
+      end
+      4.times do
+        DummySchema.execute("{ sleep(seconds: 0.110) }", context: { limiter_key: "client-2" }).to_h
+      end
 
-    get graphql_dashboard.limiters_limiter_path("active_operations")
-    assert_includes response.body, "It looks like this limiter isn't installed yet."
+      get graphql_dashboard.limiters_limiter_path("runtime")
+      assert_includes response.body, "<span class=\"data\">4</span>"
+      assert_includes response.body, "<span class=\"data\">3</span>"
+      assert_includes response.body, "Disable Soft Limiting"
+      assert_includes response.headers["Content-Security-Policy"], "nonce-"
 
+      patch graphql_dashboard.limiters_limiter_path("runtime")
+      get graphql_dashboard.limiters_limiter_path("runtime")
+      assert_includes response.body, "Enable Soft Limiting"
+
+      get graphql_dashboard.limiters_limiter_path("active_operations")
+      assert_includes response.body, "It looks like this limiter isn't installed yet."
+
+    end
   end
 end

--- a/spec/dummy/test/controllers/dashboard/operation_store/clients_controller_test.rb
+++ b/spec/dummy/test/controllers/dashboard/operation_store/clients_controller_test.rb
@@ -1,63 +1,65 @@
 # frozen_string_literal: true
 require "test_helper"
 
-class DashboardOperationStoreClientsControllerTest < ActionDispatch::IntegrationTest
-  def test_it_manages_clients
-    assert_equal 0, DummySchema.operation_store.all_clients(page: 1, per_page: 1).total_count
-    get graphql_dashboard.operation_store_clients_path
-    assert_includes response.body, "0 Clients"
-    assert_includes response.body, "To get started, create"
+if defined?(GraphQL::Pro)
+  class DashboardOperationStoreClientsControllerTest < ActionDispatch::IntegrationTest
+    def test_it_manages_clients
+      assert_equal 0, DummySchema.operation_store.all_clients(page: 1, per_page: 1).total_count
+      get graphql_dashboard.operation_store_clients_path
+      assert_includes response.body, "0 Clients"
+      assert_includes response.body, "To get started, create"
 
-    get graphql_dashboard.new_operation_store_client_path
-    assert_includes response.body, "New Client"
+      get graphql_dashboard.new_operation_store_client_path
+      assert_includes response.body, "New Client"
 
-    post graphql_dashboard.operation_store_clients_path, params: {
-      client: {
-        name: "client-1",
-        secret: "abcdefedcba"
+      post graphql_dashboard.operation_store_clients_path, params: {
+        client: {
+          name: "client-1",
+          secret: "abcdefedcba"
+        }
       }
-    }
 
-    get graphql_dashboard.operation_store_clients_path
-    assert_includes response.body, "1 Client"
+      get graphql_dashboard.operation_store_clients_path
+      assert_includes response.body, "1 Client"
 
-    get graphql_dashboard.edit_operation_store_client_path(name: "client-1")
-    assert_includes response.body, "abcdefedcba"
+      get graphql_dashboard.edit_operation_store_client_path(name: "client-1")
+      assert_includes response.body, "abcdefedcba"
 
-    patch graphql_dashboard.operation_store_client_path(name: "client-1"), params: { client: { secret: "123456789" } }
-    get graphql_dashboard.edit_operation_store_client_path(name: "client-1")
-    assert_includes response.body, "123456789"
+      patch graphql_dashboard.operation_store_client_path(name: "client-1"), params: { client: { secret: "123456789" } }
+      get graphql_dashboard.edit_operation_store_client_path(name: "client-1")
+      assert_includes response.body, "123456789"
 
-    delete graphql_dashboard.operation_store_client_path(name: "client-1")
-    assert_equal 0, DummySchema.operation_store.all_clients(page: 1, per_page: 1).total_count
-  ensure
-    DummySchema.operation_store.delete_client("client-1")
-  end
-
-  def test_it_paginates
-    5.times do |i|
-      DummySchema.operation_store.upsert_client("client-#{i}", "abcdef")
+      delete graphql_dashboard.operation_store_client_path(name: "client-1")
+      assert_equal 0, DummySchema.operation_store.all_clients(page: 1, per_page: 1).total_count
+    ensure
+      DummySchema.operation_store.delete_client("client-1")
     end
-    get graphql_dashboard.operation_store_clients_path(per_page: 2)
-    assert_includes response.body, "5 Clients"
-    assert_includes response.body, "?page=2&amp;per_page=2"
-    assert_includes response.body, "disabled>« prev</button>"
 
-    get graphql_dashboard.operation_store_clients_path(per_page: 2, page: 2)
-    assert_includes response.body, "?page=1&amp;per_page=2"
-    assert_includes response.body, "?page=3&amp;per_page=2"
+    def test_it_paginates
+      5.times do |i|
+        DummySchema.operation_store.upsert_client("client-#{i}", "abcdef")
+      end
+      get graphql_dashboard.operation_store_clients_path(per_page: 2)
+      assert_includes response.body, "5 Clients"
+      assert_includes response.body, "?page=2&amp;per_page=2"
+      assert_includes response.body, "disabled>« prev</button>"
 
-    get graphql_dashboard.operation_store_clients_path(per_page: 2, page: 3)
-    assert_includes response.body, "disabled>next »</button>"
-    assert_includes response.body, "?page=2&amp;per_page=2"
-  ensure
-    5.times do |i|
-      DummySchema.operation_store.delete_client("client-#{i}")
+      get graphql_dashboard.operation_store_clients_path(per_page: 2, page: 2)
+      assert_includes response.body, "?page=1&amp;per_page=2"
+      assert_includes response.body, "?page=3&amp;per_page=2"
+
+      get graphql_dashboard.operation_store_clients_path(per_page: 2, page: 3)
+      assert_includes response.body, "disabled>next »</button>"
+      assert_includes response.body, "?page=2&amp;per_page=2"
+    ensure
+      5.times do |i|
+        DummySchema.operation_store.delete_client("client-#{i}")
+      end
     end
-  end
 
-  def test_it_checks_installed
-    get graphql_dashboard.new_operation_store_client_path, params: { schema: GraphQL::Schema }
-    assert_includes response.body, "isn't installed for this schema yet"
+    def test_it_checks_installed
+      get graphql_dashboard.new_operation_store_client_path, params: { schema: GraphQL::Schema }
+      assert_includes response.body, "isn't installed for this schema yet"
+    end
   end
 end

--- a/spec/dummy/test/controllers/dashboard/operation_store/index_entries_controller_test.rb
+++ b/spec/dummy/test/controllers/dashboard/operation_store/index_entries_controller_test.rb
@@ -1,30 +1,32 @@
 # frozen_string_literal: true
 require "test_helper"
 
-class DashboardOperationStoreIndexEntriesControllerTest < ActionDispatch::IntegrationTest
-  def test_it_shows_entries
-    DummySchema.operation_store.upsert_client("client-1", "abcdef")
-    DummySchema.operation_store.add(body: "query GetTypename { __type(name: \"Query\") { name @skip(if: true) } }", operation_alias: "GetTypename", client_name: "client-1")
+if defined?(GraphQL::Pro)
+  class DashboardOperationStoreIndexEntriesControllerTest < ActionDispatch::IntegrationTest
+    def test_it_shows_entries
+      DummySchema.operation_store.upsert_client("client-1", "abcdef")
+      DummySchema.operation_store.add(body: "query GetTypename { __type(name: \"Query\") { name @skip(if: true) } }", operation_alias: "GetTypename", client_name: "client-1")
 
-    get graphql_dashboard.operation_store_index_entries_path
-    assert_includes response.body, "Query.__type.name"
-    assert_includes response.body, "7 entries"
+      get graphql_dashboard.operation_store_index_entries_path
+      assert_includes response.body, "Query.__type.name"
+      assert_includes response.body, "7 entries"
 
-    get graphql_dashboard.operation_store_index_entries_path(q: "Query")
-    assert_includes response.body, "3 results"
-    assert_includes response.body, ">Query</a>"
-    assert_includes response.body, ">Query.__type</a>"
-    assert_includes response.body, ">Query.__type.name</a>"
+      get graphql_dashboard.operation_store_index_entries_path(q: "Query")
+      assert_includes response.body, "3 results"
+      assert_includes response.body, ">Query</a>"
+      assert_includes response.body, ">Query.__type</a>"
+      assert_includes response.body, ">Query.__type.name</a>"
 
-    get graphql_dashboard.operation_store_index_entries_path(q: "Query", per_page: 1, page: 2)
-    assert_includes response.body, "3 results"
-    refute_includes response.body, ">Query</a>"
-    assert_includes response.body, ">Query.__type</a>"
-    refute_includes response.body, ">Query.__type.name</a>"
+      get graphql_dashboard.operation_store_index_entries_path(q: "Query", per_page: 1, page: 2)
+      assert_includes response.body, "3 results"
+      refute_includes response.body, ">Query</a>"
+      assert_includes response.body, ">Query.__type</a>"
+      refute_includes response.body, ">Query.__type.name</a>"
 
-    get graphql_dashboard.operation_store_index_entry_path(name: "Query.__type.name")
-    assert_includes response.body, "GetTypename"
-  ensure
-    DummySchema.operation_store.delete_client("client-1")
+      get graphql_dashboard.operation_store_index_entry_path(name: "Query.__type.name")
+      assert_includes response.body, "GetTypename"
+    ensure
+      DummySchema.operation_store.delete_client("client-1")
+    end
   end
 end

--- a/spec/dummy/test/controllers/dashboard/operation_store/operations_controller_test.rb
+++ b/spec/dummy/test/controllers/dashboard/operation_store/operations_controller_test.rb
@@ -1,74 +1,76 @@
 # frozen_string_literal: true
 require "test_helper"
 
-class DashboardOperationStoreOperationsControllerTest < ActionDispatch::IntegrationTest
-  def teardown
-    DummySchema.operation_store.delete_client("client-1")
-    DummySchema.operation_store.delete_client("client-2")
-    super
-  end
-  def test_it_lists_shows_and_archives_operations
-    get graphql_dashboard.operation_store_operations_path
-    assert_includes response.body, "Add your first stored operations with"
+if defined?(GraphQL::Pro)
+  class DashboardOperationStoreOperationsControllerTest < ActionDispatch::IntegrationTest
+    def teardown
+      DummySchema.operation_store.delete_client("client-1")
+      DummySchema.operation_store.delete_client("client-2")
+      super
+    end
+    def test_it_lists_shows_and_archives_operations
+      get graphql_dashboard.operation_store_operations_path
+      assert_includes response.body, "Add your first stored operations with"
 
-    get graphql_dashboard.operation_store_operations_path(client_name: "client-5000")
-    assert_includes response.body, "Add your first stored operations with"
+      get graphql_dashboard.operation_store_operations_path(client_name: "client-5000")
+      assert_includes response.body, "Add your first stored operations with"
 
-    get graphql_dashboard.archived_operation_store_operations_path
-    assert_includes response.body, "Archived operations</a> will appear here."
+      get graphql_dashboard.archived_operation_store_operations_path
+      assert_includes response.body, "Archived operations</a> will appear here."
 
-    get graphql_dashboard.archived_operation_store_client_operations_path(client_name: "client-5000")
-    assert_includes response.body, "Archived operations</a> will appear here."
+      get graphql_dashboard.archived_operation_store_client_operations_path(client_name: "client-5000")
+      assert_includes response.body, "Archived operations</a> will appear here."
 
-    os = DummySchema.operation_store
-    os.upsert_client("client-1", "abcdef")
-    os.add(body: "query GetTypename { __typename }", operation_alias: "GetTypename", client_name: "client-1")
-    os.add(body: "query GetAliasedTypename { t: __typename }", operation_alias: "get-aliased-typename", client_name: "client-1")
+      os = DummySchema.operation_store
+      os.upsert_client("client-1", "abcdef")
+      os.add(body: "query GetTypename { __typename }", operation_alias: "GetTypename", client_name: "client-1")
+      os.add(body: "query GetAliasedTypename { t: __typename }", operation_alias: "get-aliased-typename", client_name: "client-1")
 
-    os.upsert_client("client-2", "abcdef")
-    os.add(body: "query GetTypename { __typename }", operation_alias: "GetTypename2", client_name: "client-2")
+      os.upsert_client("client-2", "abcdef")
+      os.add(body: "query GetTypename { __typename }", operation_alias: "GetTypename2", client_name: "client-2")
 
-    get graphql_dashboard.operation_store_operations_path
-    assert_includes response.body, "2 Active"
-    assert_includes response.body, "GetTypename"
-    assert_includes response.body, "GetAliasedTypename"
+      get graphql_dashboard.operation_store_operations_path
+      assert_includes response.body, "2 Active"
+      assert_includes response.body, "GetTypename"
+      assert_includes response.body, "GetAliasedTypename"
 
-    get graphql_dashboard.operation_store_operations_path(sort_by: "name", order_dir: "asc", per_page: 1)
-    refute_includes response.body, "GetTypename"
-    assert_includes response.body, "GetAliasedTypename"
+      get graphql_dashboard.operation_store_operations_path(sort_by: "name", order_dir: "asc", per_page: 1)
+      refute_includes response.body, "GetTypename"
+      assert_includes response.body, "GetAliasedTypename"
 
-    get graphql_dashboard.operation_store_operations_path(sort_by: "name", order_dir: "desc", per_page: 1)
-    assert_includes response.body, "GetTypename"
-    refute_includes response.body, "GetAliasedTypename"
+      get graphql_dashboard.operation_store_operations_path(sort_by: "name", order_dir: "desc", per_page: 1)
+      assert_includes response.body, "GetTypename"
+      refute_includes response.body, "GetAliasedTypename"
 
-    get graphql_dashboard.operation_store_operations_path(client_name: "client-2")
-    assert_includes response.body, "1 Active"
-    assert_includes response.body, "GetTypename"
-    refute_includes response.body, "GetAliasedTypename"
+      get graphql_dashboard.operation_store_operations_path(client_name: "client-2")
+      assert_includes response.body, "1 Active"
+      assert_includes response.body, "GetTypename"
+      refute_includes response.body, "GetAliasedTypename"
 
-    get graphql_dashboard.operation_store_operation_path(digest: "4cd12cc333c91f78e8f781933ecc783d")
-    assert_includes response.body, "GetAliasedTypename"
-    assert_includes response.body, "client-1"
-    assert_includes response.body, "Query.__typename"
+      get graphql_dashboard.operation_store_operation_path(digest: "4cd12cc333c91f78e8f781933ecc783d")
+      assert_includes response.body, "GetAliasedTypename"
+      assert_includes response.body, "client-1"
+      assert_includes response.body, "Query.__typename"
 
-    post graphql_dashboard.archive_operation_store_client_operations_path(client_name: "client-1", operation_aliases: ["get-aliased-typename"])
-    post graphql_dashboard.archive_operation_store_operations_path(digests: ["b161214b11847649e7f36cc50e1257a1"])
+      post graphql_dashboard.archive_operation_store_client_operations_path(client_name: "client-1", operation_aliases: ["get-aliased-typename"])
+      post graphql_dashboard.archive_operation_store_operations_path(digests: ["b161214b11847649e7f36cc50e1257a1"])
 
-    get graphql_dashboard.operation_store_operations_path
-    assert_includes response.body, "0 Active"
-    assert_includes response.body, "2 Archived"
+      get graphql_dashboard.operation_store_operations_path
+      assert_includes response.body, "0 Active"
+      assert_includes response.body, "2 Archived"
 
-    get graphql_dashboard.archived_operation_store_operations_path
-    assert_includes response.body, "2 Archived"
-    assert_includes response.body, "0 Active"
+      get graphql_dashboard.archived_operation_store_operations_path
+      assert_includes response.body, "2 Archived"
+      assert_includes response.body, "0 Active"
 
-    get graphql_dashboard.operation_store_operations_path(client_name: "client-2")
-    assert_includes response.body, "0 Active"
-    assert_includes response.body, "1 Archived"
-  end
+      get graphql_dashboard.operation_store_operations_path(client_name: "client-2")
+      assert_includes response.body, "0 Active"
+      assert_includes response.body, "1 Archived"
+    end
 
-  def test_it_checks_installed
-    get graphql_dashboard.new_operation_store_client_path, params: { schema: GraphQL::Schema }
-    assert_includes response.body, "isn't installed for this schema yet"
+    def test_it_checks_installed
+      get graphql_dashboard.new_operation_store_client_path, params: { schema: GraphQL::Schema }
+      assert_includes response.body, "isn't installed for this schema yet"
+    end
   end
 end

--- a/spec/dummy/test/controllers/dashboard/subscriptions/topics_controller_test.rb
+++ b/spec/dummy/test/controllers/dashboard/subscriptions/topics_controller_test.rb
@@ -1,46 +1,49 @@
 # frozen_string_literal: true
 require "test_helper"
 require "ostruct" # TODO use a real class in RedisBackend
-class DashboardSubscriptionsTopicsControllerTest < ActionDispatch::IntegrationTest
-  def test_it_checks_installed
-    get graphql_dashboard.subscriptions_topics_path, params: { schema: GraphQL::Schema }
-    assert_includes response.body, "GraphQL-Pro Subscriptions aren't installed on this schema yet."
-  end
 
-  def test_it_renders_empty_state_and_not_found_states
-    get graphql_dashboard.subscriptions_topics_path
-    assert_includes response.body, "There aren't any subscriptions right now."
-    get graphql_dashboard.subscriptions_topic_path(":something:")
-    assert_includes response.body, ":something:"
-    assert_includes response.body, "Last triggered: none"
-    assert_includes response.body, "0 Subscriptions"
-    get graphql_dashboard.subscriptions_subscription_path("abcd-efg")
-    assert_includes response.body, "abcd-efg"
-    assert_includes response.body, "This subscription was not found or is no longer active."
-  end
+if defined?(GraphQL::Pro)
+  class DashboardSubscriptionsTopicsControllerTest < ActionDispatch::IntegrationTest
+    def test_it_checks_installed
+      get graphql_dashboard.subscriptions_topics_path, params: { schema: GraphQL::Schema }
+      assert_includes response.body, "GraphQL-Pro Subscriptions aren't installed on this schema yet."
+    end
 
-  def test_it_lists_topics_and_shows_detail
-    DummySchema.subscriptions.clear
-    _res1 = DummySchema.execute("subscription { message(channel: \"cats\") }")
-    res2 = DummySchema.execute("subscription { message(channel: \"dogs\") }")
-    DummySchema.subscriptions.trigger(:message, { channel: "dogs"}, "Woof!")
-    get graphql_dashboard.subscriptions_topics_path
-    assert_includes response.body, ":message:channel:cats"
-    assert_includes response.body, ":message:channel:dogs"
-    assert_includes response.body, Time.now.strftime("%Y-%m-%d %H:%M:%S")
+    def test_it_renders_empty_state_and_not_found_states
+      get graphql_dashboard.subscriptions_topics_path
+      assert_includes response.body, "There aren't any subscriptions right now."
+      get graphql_dashboard.subscriptions_topic_path(":something:")
+      assert_includes response.body, ":something:"
+      assert_includes response.body, "Last triggered: none"
+      assert_includes response.body, "0 Subscriptions"
+      get graphql_dashboard.subscriptions_subscription_path("abcd-efg")
+      assert_includes response.body, "abcd-efg"
+      assert_includes response.body, "This subscription was not found or is no longer active."
+    end
 
-    get graphql_dashboard.subscriptions_topic_path(":message:channel:dogs")
-    assert_includes response.body, res2.context[:subscription_id]
-    assert_includes response.body, Time.now.strftime("%Y-%m-%d %H:%M:%S")
+    def test_it_lists_topics_and_shows_detail
+      DummySchema.subscriptions.clear
+      _res1 = DummySchema.execute("subscription { message(channel: \"cats\") }")
+      res2 = DummySchema.execute("subscription { message(channel: \"dogs\") }")
+      DummySchema.subscriptions.trigger(:message, { channel: "dogs"}, "Woof!")
+      get graphql_dashboard.subscriptions_topics_path
+      assert_includes response.body, ":message:channel:cats"
+      assert_includes response.body, ":message:channel:dogs"
+      assert_includes response.body, Time.now.strftime("%Y-%m-%d %H:%M:%S")
 
-    get graphql_dashboard.subscriptions_subscription_path(res2.context[:subscription_id])
-    assert_includes response.body, res2.context[:subscription_id]
-    assert_includes response.body, CGI::escapeHTML('subscription { message(channel: "dogs") }')
+      get graphql_dashboard.subscriptions_topic_path(":message:channel:dogs")
+      assert_includes response.body, res2.context[:subscription_id]
+      assert_includes response.body, Time.now.strftime("%Y-%m-%d %H:%M:%S")
 
-    post graphql_dashboard.subscriptions_clear_all_path
-    get graphql_dashboard.subscriptions_topics_path
-    refute_includes response.body, ":message:"
-  ensure
-    DummySchema.subscriptions.clear
+      get graphql_dashboard.subscriptions_subscription_path(res2.context[:subscription_id])
+      assert_includes response.body, res2.context[:subscription_id]
+      assert_includes response.body, CGI::escapeHTML('subscription { message(channel: "dogs") }')
+
+      post graphql_dashboard.subscriptions_clear_all_path
+      get graphql_dashboard.subscriptions_topics_path
+      refute_includes response.body, ":message:"
+    ensure
+      DummySchema.subscriptions.clear
+    end
   end
 end

--- a/spec/graphql/tracing/data_dog_trace_spec.rb
+++ b/spec/graphql/tracing/data_dog_trace_spec.rb
@@ -93,12 +93,13 @@ describe GraphQL::Tracing::DataDogTrace do
     DataDogTraceTest::TestSchema.execute("{ str }")
     expected_keys = [
       "execute.graphql",
+      (USING_C_PARSER ? "lex.graphql" : nil),
       "parse.graphql",
       "analyze.graphql",
       "validate.graphql",
       "Query.authorized.graphql",
       "DataDogTraceTest_EchoSource.fetch.graphql"
-    ]
+    ].compact
     assert_equal expected_keys, Datadog::TRACE_KEYS
   end
 

--- a/spec/graphql/tracing/data_dog_trace_spec.rb
+++ b/spec/graphql/tracing/data_dog_trace_spec.rb
@@ -28,10 +28,22 @@ describe GraphQL::Tracing::DataDogTrace do
 
       field :thing, Thing
       def thing; :thing; end
+
+      field :str, String
+      def str
+        dataloader.with(EchoSource).load("hello")
+      end
+    end
+
+    class EchoSource < GraphQL::Dataloader::Source
+      def fetch(strs)
+        strs
+      end
     end
 
     class TestSchema < GraphQL::Schema
       query(Query)
+      use GraphQL::Dataloader
       trace_with(GraphQL::Tracing::DataDogTrace)
       lazy_resolve(Box, :value)
     end
@@ -75,6 +87,19 @@ describe GraphQL::Tracing::DataDogTrace do
     DataDogTraceTest::TestSchema.execute("{ int }")
     assert_includes Datadog::SPAN_TAGS, ['component', 'graphql']
     assert_includes Datadog::SPAN_TAGS, ['operation', 'execute']
+  end
+
+  it "works with dataloader" do
+    DataDogTraceTest::TestSchema.execute("{ str }")
+    expected_keys = [
+      "execute.graphql",
+      "parse.graphql",
+      "analyze.graphql",
+      "validate.graphql",
+      "Query.authorized.graphql",
+      "DataDogTraceTest_EchoSource.fetch.graphql"
+    ]
+    assert_equal expected_keys, Datadog::TRACE_KEYS
   end
 
   it "sets custom tags" do

--- a/spec/support/datadog.rb
+++ b/spec/support/datadog.rb
@@ -7,6 +7,7 @@ end
 module Datadog
   SPAN_RESOURCE_NAMES = []
   SPAN_TAGS = []
+  TRACE_KEYS = []
 
   def self.tracer
     DummyTracer.new
@@ -15,10 +16,12 @@ module Datadog
   def self.clear_all
     SPAN_RESOURCE_NAMES.clear
     SPAN_TAGS.clear
+    TRACE_KEYS.clear
   end
 
   class DummyTracer
     def trace(platform_key, *args)
+      TRACE_KEYS << platform_key
       yield DummySpan.new
     end
   end
@@ -38,6 +41,7 @@ module Datadog
 
   module Tracing
     def self.trace(platform_key, *args)
+      TRACE_KEYS << platform_key
       if block_given?
         yield DummySpan.new
       else


### PR DESCRIPTION
Swaps in the "platform_source_class_key" method instead of the previously unused "platform_source_key" to prevent a NoMethodError on initialization.

## Demo

With the fix, suffix tracing works as expected

![dd-demo](https://github.com/user-attachments/assets/1e7762e6-dc32-48ef-af80-44c32985d7b7)

Relates to

- https://github.com/rmosolgo/graphql-ruby/issues/5316