### PR TITLE
Require selections on Unions, with backwards compat

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -1670,6 +1670,36 @@ module GraphQL
         end
       end
 
+
+      # If you need to support previous, non-spec behavior which allowed selecting union fields
+      # but *not* selecting any fields on that union, set this to `true` to continue allowing that behavior.
+      #
+      # If this is `true`, then {.legacy_invalid_empty_selections_on_union} will be called with {Query} objects
+      # with that kind of selections. You must implement that method
+      # @param new_value [Boolean]
+      # @return [true, false, nil]
+      def allow_legacy_invalid_empty_selections_on_union(new_value = NOT_CONFIGURED)
+        if NOT_CONFIGURED.equal?(new_value)
+          @allow_legacy_invalid_empty_selections_on_union
+        else
+          @allow_legacy_invalid_empty_selections_on_union = new_value
+        end
+      end
+
+      # This method is called during validation when a previously-allowed, but non-spec
+      # query is encountered where a union field has no child selections on it.
+      #
+      # You should implement this method to log the violation so that you can contact clients
+      # and notify them about changing their queries. Then return a suitable value to
+      # tell GraphQL-Ruby how to continue.
+      # @param query [GraphQL::Query]
+      # @return [:return_validation_error] Let GraphQL-Ruby return the (new) normal validation error for this query
+      # @return [String] A validation error to return for this query
+      # @return [nil] Don't send the client an error, continue the legacy behavior (allow this query to execute)
+      def legacy_invalid_empty_selections_on_union(query)
+        raise "Implement `def self.legacy_invalid_empty_selections_on_union(query)` to handle this scenario"
+      end
+
       private
 
       def add_trace_options_for(mode, new_options)

--- a/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb
+++ b/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb
@@ -25,22 +25,56 @@ module GraphQL
       def validate_field_selections(ast_node, resolved_type)
         msg = if resolved_type.nil?
           nil
-        elsif !ast_node.selections.empty? && resolved_type.kind.leaf?
-          selection_strs = ast_node.selections.map do |n|
-            case n
-            when GraphQL::Language::Nodes::InlineFragment
-              "\"... on #{n.type.name} { ... }\""
-            when GraphQL::Language::Nodes::Field
-              "\"#{n.name}\""
-            when GraphQL::Language::Nodes::FragmentSpread
-              "\"#{n.name}\""
+        elsif resolved_type.kind.leaf?
+          if !ast_node.selections.empty?
+            selection_strs = ast_node.selections.map do |n|
+              case n
+              when GraphQL::Language::Nodes::InlineFragment
+                "\"... on #{n.type.name} { ... }\""
+              when GraphQL::Language::Nodes::Field
+                "\"#{n.name}\""
+              when GraphQL::Language::Nodes::FragmentSpread
+                "\"#{n.name}\""
+              else
+                raise "Invariant: unexpected selection node: #{n}"
+              end
+            end
+            "Selections can't be made on #{resolved_type.kind.name.sub("_", " ").downcase}s (%{node_name} returns #{resolved_type.graphql_name} but has selections [#{selection_strs.join(", ")}])"
+          else
+            nil
+          end
+        elsif ast_node.selections.empty?
+          return_validation_error = true
+          legacy_invalid_empty_selection_result = nil
+          if !resolved_type.kind.fields?
+            case @schema.allow_legacy_invalid_empty_selections_on_union
+            when true
+              legacy_invalid_empty_selection_result = @schema.legacy_invalid_empty_selections_on_union(@context.query)
+              case legacy_invalid_empty_selection_result
+              when :return_validation_error
+                # keep `return_validation_error = true`
+              when String
+                return_validation_error = false
+                # the string is returned below
+              when nil
+                # No error:
+                return_validation_error = false
+                legacy_invalid_empty_selection_result = nil
+              else
+                raise GraphQL::InvariantError, "Unexpected return value from legacy_invalid_empty_selections_on_union, must be `:return_validation_error`, String, or nil (got: #{legacy_invalid_empty_selection_result.inspect})"
+              end
+            when false
+              # pass -- error below
             else
-              raise "Invariant: unexpected selection node: #{n}"
+              return_validation_error = false
+              @context.query.logger.warn("Unions require selections but #{ast_node.alias || ast_node.name} (#{resolved_type.graphql_name}) doesn't have any. This will fail with a validation error on a future GraphQL-Ruby version. More info: https://graphql-ruby.org/api-doc/#{GraphQL::VERSION}/GraphQL/Schema.html#allow_legacy_invalid_empty_selections_on_union-class_method")
             end
           end
-          "Selections can't be made on #{resolved_type.kind.name.sub("_", " ").downcase}s (%{node_name} returns #{resolved_type.graphql_name} but has selections [#{selection_strs.join(", ")}])"
-        elsif resolved_type.kind.fields? && ast_node.selections.empty?
-          "Field must have selections (%{node_name} returns #{resolved_type.graphql_name} but has no selections. Did you mean '#{ast_node.name} { ... }'?)"
+          if return_validation_error
+            "Field must have selections (%{node_name} returns #{resolved_type.graphql_name} but has no selections. Did you mean '#{ast_node.name} { ... }'?)"
+          else
+            legacy_invalid_empty_selection_result
+          end
         else
           nil
         end

--- a/spec/graphql/static_validation/rules/fields_have_appropriate_selections_spec.rb
+++ b/spec/graphql/static_validation/rules/fields_have_appropriate_selections_spec.rb
@@ -87,4 +87,73 @@ describe GraphQL::StaticValidation::FieldsHaveAppropriateSelections do
       assert_includes(errors.map { |e| e["message"] }, expected_err)
     end
   end
+
+  describe "selections on unions" do
+    let(:query_string) { "{ searchDairy }"}
+    describe "When the schema has custom handling to return the message" do
+      let(:schema) { Class.new(Dummy::Schema) {
+          allow_legacy_invalid_empty_selections_on_union(true)
+          def self.legacy_invalid_empty_selections_on_union(query)
+            :return_validation_error
+          end
+        }
+      }
+
+      it "returns the default message" do
+        expected_err = "Field must have selections (field 'searchDairy' returns DairyProduct but has no selections. Did you mean 'searchDairy { ... }'?)"
+        assert_includes(errors.map { |e| e["message"] }, expected_err)
+      end
+    end
+
+    describe "When the schema has custom handling to return a custom message" do
+      let(:schema) { Class.new(Dummy::Schema) {
+          allow_legacy_invalid_empty_selections_on_union(true)
+          def self.legacy_invalid_empty_selections_on_union(query)
+            "Boo, hiss!"
+          end
+        }
+      }
+
+      it "returns the custom message" do
+        expected_err = "Boo, hiss!"
+        assert_includes(errors.map { |e| e["message"] }, expected_err)
+      end
+    end
+
+    describe "When the schema has custom handling to allow the query" do
+      let(:schema) { Class.new(Dummy::Schema) {
+          allow_legacy_invalid_empty_selections_on_union(true)
+          def self.legacy_invalid_empty_selections_on_union(query)
+            nil
+          end
+        }
+      }
+
+      it "returns no errors" do
+        assert_equal [], errors
+      end
+    end
+
+    describe "When the schema has no setting" do
+      it "allows it with a warning to query.logger" do
+        expected_warning = "Unions require selections but searchDairy (DairyProduct) doesn't have any. This will fail with a validation error on a future GraphQL-Ruby version. More info: https://graphql-ruby.org/api-doc/2.5.2/GraphQL/Schema.html#allow_legacy_invalid_empty_selections_on_union-class_method"
+        stdout, _stderr = capture_io do
+          assert_equal [], errors
+        end
+        assert_includes stdout, expected_warning
+      end
+    end
+
+    describe "When the schema has legacy mode disabled" do
+      let(:schema) { Class.new(Dummy::Schema) {
+          allow_legacy_invalid_empty_selections_on_union(false)
+        }
+      }
+
+      it "requires some" do
+        expected_err = "Field must have selections (field 'searchDairy' returns DairyProduct but has no selections. Did you mean 'searchDairy { ... }'?)"
+        assert_includes(errors.map { |e| e["message"] }, expected_err)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #4351 


This implementation: 

- Warns if an invalid query is encountered and no compat mode is selected;
- Provides a hook for handing invalid queries (which can permit, deny, or provide a custom message) 
- Provides a config to reject invalid queries 

I think this is a safe default to roll out to anyone already using the gem.


cc @gmac -- finally...