### PR TITLE
Visibility: better duplicate name lookup

### DIFF
--- a/lib/graphql/schema/visibility/profile.rb
+++ b/lib/graphql/schema/visibility/profile.rb
@@ -281,9 +281,11 @@ module GraphQL
 
         def non_duplicate_items(definitions, visibility_cache)
           non_dups = []
+          names = Set.new
           definitions.each do |defn|
             if visibility_cache[defn]
-              if (dup_defn = non_dups.find { |d| d.graphql_name == defn.graphql_name })
+              if !names.add?(defn.graphql_name)
+                dup_defn = non_dups.find { |d| d.graphql_name == defn.graphql_name }
                 raise_duplicate_definition(dup_defn, defn)
               end
               non_dups << defn


### PR DESCRIPTION
Fixes #5324 

This code worked fine for small lists, where `.find` was trivial, but for large lists, it's better to use a `Set` (which uses a Hash under the hood). I think the memory overhead here won't be a problem since the cost here is basically one new Set per uniquely-named list in the current query (6 new objects in the example in #5324, 318 -> 324, but queries which use more distinct GraphQL types during execution will add more objects).