### PR TITLE
Refactor AlwaysVisible to use Schema::Visibility under the hood

### DIFF
--- a/lib/graphql/schema/always_visible.rb
+++ b/lib/graphql/schema/always_visible.rb
@@ -3,6 +3,7 @@ module GraphQL
   class Schema
     module AlwaysVisible
       def self.use(schema, **opts)
+        schema.use(GraphQL::Schema::Visibility, profiles: { nil => {} })
         schema.extend(self)
       end
 


### PR DESCRIPTION
This will be faster since the schema won't build any caches during execution. See benchmarks in https://github.com/rmosolgo/graphql-ruby/issues/5324#issuecomment-2789785528