### PR TITLE
ActiveRecordSource: Improve composite primary key support

### DIFF
--- a/lib/graphql/dataloader/active_record_source.rb
+++ b/lib/graphql/dataloader/active_record_source.rb
@@ -7,18 +7,35 @@ module GraphQL
       def initialize(model_class, find_by: model_class.primary_key)
         @model_class = model_class
         @find_by = find_by
-        @type_for_column = @model_class.type_for_attribute(@find_by)
+        @find_by_many = find_by.is_a?(Array)
+        if @find_by_many
+          @type_for_column = @find_by.map { |fb| @model_class.type_for_attribute(fb) }
+        else
+          @type_for_column = @model_class.type_for_attribute(@find_by)
+        end
       end
 
-      def load(requested_key)
-        casted_key = @type_for_column.cast(requested_key)
-        super(casted_key)
+      def result_key_for(requested_key)
+        if @find_by_many
+          requested_key.each_with_index.map do |k, idx|
+            @type_for_column[idx].cast(k)
+          end
+        else
+          @type_for_column.cast(requested_key)
+        end
       end
 
       def fetch(record_ids)
         records = @model_class.where(@find_by => record_ids)
         record_lookup = {}
-        records.each { |r| record_lookup[r.public_send(@find_by)] = r }
+        if @find_by_many
+          records.each do |r|
+            key = @find_by.map { |fb| r.public_send(fb) }
+            record_lookup[key] = r
+          end
+        else
+          records.each { |r| record_lookup[r.public_send(@find_by)] = r }
+        end
         record_ids.map { |id| record_lookup[id] }
       end
     end

--- a/lib/graphql/dataloader/active_record_source.rb
+++ b/lib/graphql/dataloader/active_record_source.rb
@@ -16,6 +16,10 @@ module GraphQL
       end
 
       def result_key_for(requested_key)
+        normalize_fetch_key(requested_key)
+      end
+
+      def normalize_fetch_key(requested_key)
         if @find_by_many
           requested_key.each_with_index.map do |k, idx|
             @type_for_column[idx].cast(k)

--- a/lib/graphql/dataloader/source.rb
+++ b/lib/graphql/dataloader/source.rb
@@ -133,7 +133,7 @@ module GraphQL
         fetch_h = @pending
         @pending = {}
         @fetching.merge!(fetch_h)
-        results = fetch(fetch_h.values)
+        results = fetch(fetch_h.keys)
         fetch_h.each_with_index do |(key, _value), idx|
           @results[key] = results[idx]
         end

--- a/lib/graphql/dataloader/source.rb
+++ b/lib/graphql/dataloader/source.rb
@@ -21,7 +21,7 @@ module GraphQL
       def request(value)
         res_key = result_key_for(value)
         if !@results.key?(res_key)
-          @pending[res_key] ||= value
+          @pending[res_key] ||= normalize_fetch_key(value)
         end
         Dataloader::Request.new(self, value)
       end
@@ -35,12 +35,24 @@ module GraphQL
         value
       end
 
+      # Implement this method if varying values given to {load} (etc) should be consolidated
+      # or normalized before being handed off to your {fetch} implementation.
+      #
+      # This is different than {result_key_for} because _that_ method handles unification inside Dataloader's cache,
+      # but this method changes the value passed into {fetch}.
+      #
+      # @param value [Object] The value passed to {load}, {load_all}, {request}, or {request_all}
+      # @return [Object] The value given to {fetch}
+      def normalize_fetch_key(value)
+        value
+      end
+
       # @return [Dataloader::Request] a pending request for a values from `keys`. Call `.load` on that object to wait for the results.
       def request_all(values)
         values.each do |v|
           res_key = result_key_for(v)
           if !@results.key?(res_key)
-            @pending[res_key] ||= v
+            @pending[res_key] ||= normalize_fetch_key(v)
           end
         end
         Dataloader::RequestAll.new(self, values)
@@ -53,7 +65,7 @@ module GraphQL
         if @results.key?(result_key)
           result_for(result_key)
         else
-          @pending[result_key] ||= value
+          @pending[result_key] ||= normalize_fetch_key(value)
           sync([result_key])
           result_for(result_key)
         end
@@ -68,7 +80,7 @@ module GraphQL
           k = result_key_for(v)
           result_keys << k
           if !@results.key?(k)
-            @pending[k] ||= v
+            @pending[k] ||= normalize_fetch_key(v)
             pending_keys << k
           end
         }
@@ -133,7 +145,7 @@ module GraphQL
         fetch_h = @pending
         @pending = {}
         @fetching.merge!(fetch_h)
-        results = fetch(fetch_h.keys)
+        results = fetch(fetch_h.values)
         fetch_h.each_with_index do |(key, _value), idx|
           @results[key] = results[idx]
         end

--- a/spec/graphql/dataloader/active_record_association_source_spec.rb
+++ b/spec/graphql/dataloader/active_record_association_source_spec.rb
@@ -105,5 +105,24 @@ describe GraphQL::Dataloader::ActiveRecordAssociationSource do
       vulfpeck = d.with(GraphQL::Dataloader::ActiveRecordAssociationSource, :thing).load(wilco)
       assert_equal ::Band.find(1), vulfpeck
     end
+
+    it_dataloads "loads with composite primary keys and warms the cache" do |d|
+      my_first_car = ::Album.find(2)
+      homey = ::Album.find(4)
+      log = with_active_record_log(colorize: false) do
+        vulfpeck, chon = d.with(GraphQL::Dataloader::ActiveRecordAssociationSource, :composite_band).load_all([my_first_car, homey])
+        assert_equal "Vulfpeck", vulfpeck.name
+        assert_equal "Chon", chon.name
+      end
+
+      assert_includes log, '[["name", "Vulfpeck"], ["name", "Chon"], ["genre", 0]]'
+
+
+      log = with_active_record_log(colorize: false) do
+        d.with(GraphQL::Dataloader::ActiveRecordSource, CompositeBand).load_all([["Vulfpeck", "rock"], ["Chon", :rock]])
+      end
+
+      assert_equal "", log
+    end
   end
 end

--- a/spec/graphql/dataloader/active_record_source_spec.rb
+++ b/spec/graphql/dataloader/active_record_source_spec.rb
@@ -64,19 +64,21 @@ describe GraphQL::Dataloader::ActiveRecordSource do
         assert_includes log, 'SELECT "bands".* FROM "bands" WHERE "bands"."name" = ?  [["name", "Vulfpeck"]]'
       end
 
-      it_dataloads "uses composite primary keys" do |d|
-        log = with_active_record_log(colorize: false) do
-          r1 = d.with(GraphQL::Dataloader::ActiveRecordSource, CompositeBand).load(["Chon", :rock])
-          assert_equal "Chon", r1.name
-          assert_equal ["Chon", "rock"], r1.id
-          if Rails::VERSION::STRING > "8"
-            assert_equal 3, r1["id"]
-          else
-            assert_equal 3, r1._read_attribute("id")
+      if Rails::VERSION::STRING > "7.1" # not supported in <7.1
+        it_dataloads "uses composite primary keys" do |d|
+          log = with_active_record_log(colorize: false) do
+            r1 = d.with(GraphQL::Dataloader::ActiveRecordSource, CompositeBand).load(["Chon", :rock])
+            assert_equal "Chon", r1.name
+            assert_equal ["Chon", "rock"], r1.id
+            if Rails::VERSION::STRING > "8"
+              assert_equal 3, r1["id"]
+            else
+              assert_equal 3, r1._read_attribute("id")
+            end
           end
-        end
 
-        assert_includes log, 'SELECT "bands".* FROM "bands" WHERE "bands"."name" = ? AND "bands"."genre" = ?  [["name", "Chon"], ["genre", 0]]'
+          assert_includes log, 'SELECT "bands".* FROM "bands" WHERE "bands"."name" = ? AND "bands"."genre" = ?  [["name", "Chon"], ["genre", 0]]'
+        end
       end
 
       it_dataloads "uses specified find_by columns" do |d|

--- a/spec/graphql/dataloader/active_record_source_spec.rb
+++ b/spec/graphql/dataloader/active_record_source_spec.rb
@@ -64,6 +64,21 @@ describe GraphQL::Dataloader::ActiveRecordSource do
         assert_includes log, 'SELECT "bands".* FROM "bands" WHERE "bands"."name" = ?  [["name", "Vulfpeck"]]'
       end
 
+      it_dataloads "uses composite primary keys" do |d|
+        log = with_active_record_log(colorize: false) do
+          r1 = d.with(GraphQL::Dataloader::ActiveRecordSource, CompositeBand).load(["Chon", :rock])
+          assert_equal "Chon", r1.name
+          assert_equal ["Chon", "rock"], r1.id
+          if Rails::VERSION::STRING > "8"
+            assert_equal 3, r1["id"]
+          else
+            assert_equal 3, r1._read_attribute("id")
+          end
+        end
+
+        assert_includes log, 'SELECT "bands".* FROM "bands" WHERE "bands"."name" = ? AND "bands"."genre" = ?  [["name", "Chon"], ["genre", 0]]'
+      end
+
       it_dataloads "uses specified find_by columns" do |d|
         log = with_active_record_log(colorize: false) do
           r1 = d.with(GraphQL::Dataloader::ActiveRecordSource, Band, find_by: :name).load("Chon")
@@ -98,12 +113,6 @@ describe GraphQL::Dataloader::ActiveRecordSource do
         end
         assert_equal "", log
       end
-    end
-
-    describe "in queries" do
-      it "loads records with dataload_record"
-
-      it "accepts custom find-by with dataload_record"
     end
   end
 end

--- a/spec/graphql/tracing/snapshots/example-rails-7-0.json
+++ b/spec/graphql/tracing/snapshots/example-rails-7-0.json
@@ -1487,13 +1487,13 @@
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "object",
-            "stringValue": "id"
+            "stringValue": "@type_for_column"
           },
           {
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "result",
-            "stringValue": "resolved_type"
+            "stringValue": "id"
           }
         ],
         "type": "TYPE_SLICE_BEGIN",
@@ -1556,13 +1556,13 @@
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "object",
-            "stringValue": "id"
+            "stringValue": "@type_for_column"
           },
           {
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "result",
-            "stringValue": null
+            "stringValue": "resolved_type"
           }
         ],
         "type": "TYPE_SLICE_BEGIN",
@@ -2963,6 +2963,11 @@
           },
           {
             "nameIid": "10101010101010",
+            "boolValue": false,
+            "name": "@find_by_many"
+          },
+          {
+            "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "@model_class",
             "stringValue": "record_count"
@@ -3013,6 +3018,10 @@
           {
             "iid": "10101010101010",
             "name": "@find_by"
+          },
+          {
+            "iid": "10101010101010",
+            "name": "@find_by_many"
           },
           {
             "iid": "10101010101010",
@@ -3609,6 +3618,11 @@
             "stringValueIid": "10101010101010",
             "name": "@find_by",
             "stringValue": null
+          },
+          {
+            "nameIid": "10101010101010",
+            "boolValue": false,
+            "name": "@find_by_many"
           },
           {
             "nameIid": "10101010101010",
@@ -5770,6 +5784,11 @@
           },
           {
             "nameIid": "10101010101010",
+            "boolValue": false,
+            "name": "@find_by_many"
+          },
+          {
+            "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "@model_class",
             "stringValue": "record_count"
@@ -6876,7 +6895,7 @@
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "result",
-            "stringValue": "id"
+            "stringValue": "@type_for_column"
           }
         ],
         "type": "TYPE_SLICE_BEGIN",
@@ -7847,6 +7866,11 @@
           },
           {
             "nameIid": "10101010101010",
+            "boolValue": false,
+            "name": "@find_by_many"
+          },
+          {
+            "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "@model_class",
             "stringValue": "record_count"
@@ -8291,7 +8315,7 @@
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "result",
-            "stringValue": "id"
+            "stringValue": "@type_for_column"
           }
         ],
         "type": "TYPE_SLICE_BEGIN",
@@ -10573,13 +10597,13 @@
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "object",
-            "stringValue": "id"
+            "stringValue": "@type_for_column"
           },
           {
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "result",
-            "stringValue": "resolved_type"
+            "stringValue": "id"
           }
         ],
         "type": "TYPE_SLICE_BEGIN",
@@ -11035,13 +11059,13 @@
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "object",
-            "stringValue": "id"
+            "stringValue": "@type_for_column"
           },
           {
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "result",
-            "stringValue": "resolved_type"
+            "stringValue": "id"
           }
         ],
         "type": "TYPE_SLICE_BEGIN",
@@ -11659,6 +11683,11 @@
             "stringValueIid": "10101010101010",
             "name": "@find_by",
             "stringValue": null
+          },
+          {
+            "nameIid": "10101010101010",
+            "boolValue": false,
+            "name": "@find_by_many"
           },
           {
             "nameIid": "10101010101010",

--- a/spec/graphql/tracing/snapshots/example-rails-7-1.json
+++ b/spec/graphql/tracing/snapshots/example-rails-7-1.json
@@ -1483,13 +1483,13 @@
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "object",
-            "stringValue": "@type_for_column"
+            "stringValue": "@find_by_many"
           },
           {
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "result",
-            "stringValue": "id"
+            "stringValue": "@type_for_column"
           }
         ],
         "type": "TYPE_SLICE_BEGIN",
@@ -1552,13 +1552,13 @@
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "object",
-            "stringValue": "@type_for_column"
+            "stringValue": "@find_by_many"
           },
           {
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "result",
-            "stringValue": "resolved_type"
+            "stringValue": "id"
           }
         ],
         "type": "TYPE_SLICE_BEGIN",
@@ -2959,6 +2959,11 @@
           },
           {
             "nameIid": "10101010101010",
+            "boolValue": false,
+            "name": "@find_by_many"
+          },
+          {
+            "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "@model_class",
             "stringValue": "connection"
@@ -3009,6 +3014,10 @@
           {
             "iid": "10101010101010",
             "name": "@find_by"
+          },
+          {
+            "iid": "10101010101010",
+            "name": "@find_by_many"
           },
           {
             "iid": "10101010101010",
@@ -3605,6 +3614,11 @@
             "stringValueIid": "10101010101010",
             "name": "@find_by",
             "stringValue": null
+          },
+          {
+            "nameIid": "10101010101010",
+            "boolValue": false,
+            "name": "@find_by_many"
           },
           {
             "nameIid": "10101010101010",
@@ -5766,6 +5780,11 @@
           },
           {
             "nameIid": "10101010101010",
+            "boolValue": false,
+            "name": "@find_by_many"
+          },
+          {
+            "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "@model_class",
             "stringValue": "connection"
@@ -6872,7 +6891,7 @@
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "result",
-            "stringValue": "@type_for_column"
+            "stringValue": "@find_by_many"
           }
         ],
         "type": "TYPE_SLICE_BEGIN",
@@ -7843,6 +7862,11 @@
           },
           {
             "nameIid": "10101010101010",
+            "boolValue": false,
+            "name": "@find_by_many"
+          },
+          {
+            "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "@model_class",
             "stringValue": "connection"
@@ -8287,7 +8311,7 @@
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "result",
-            "stringValue": "@type_for_column"
+            "stringValue": "@find_by_many"
           }
         ],
         "type": "TYPE_SLICE_BEGIN",
@@ -10569,13 +10593,13 @@
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "object",
-            "stringValue": "@type_for_column"
+            "stringValue": "@find_by_many"
           },
           {
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "result",
-            "stringValue": "id"
+            "stringValue": "@type_for_column"
           }
         ],
         "type": "TYPE_SLICE_BEGIN",
@@ -11031,13 +11055,13 @@
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "object",
-            "stringValue": "@type_for_column"
+            "stringValue": "@find_by_many"
           },
           {
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "result",
-            "stringValue": "id"
+            "stringValue": "@type_for_column"
           }
         ],
         "type": "TYPE_SLICE_BEGIN",
@@ -11655,6 +11679,11 @@
             "stringValueIid": "10101010101010",
             "name": "@find_by",
             "stringValue": null
+          },
+          {
+            "nameIid": "10101010101010",
+            "boolValue": false,
+            "name": "@find_by_many"
           },
           {
             "nameIid": "10101010101010",

--- a/spec/graphql/tracing/snapshots/example-rails-8-1.json
+++ b/spec/graphql/tracing/snapshots/example-rails-8-1.json
@@ -2115,13 +2115,13 @@
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "object",
-            "stringValue": "resolved_type"
+            "stringValue": "id"
           },
           {
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "result",
-            "stringValue": null
+            "stringValue": "resolved_type"
           }
         ],
         "type": "TYPE_SLICE_BEGIN",
@@ -2184,7 +2184,7 @@
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "object",
-            "stringValue": "resolved_type"
+            "stringValue": "id"
           },
           {
             "nameIid": "10101010101010",
@@ -2506,7 +2506,7 @@
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "object",
-            "stringValue": "resolved_type"
+            "stringValue": "id"
           },
           {
             "nameIid": "10101010101010",
@@ -3061,6 +3061,11 @@
           },
           {
             "nameIid": "10101010101010",
+            "boolValue": false,
+            "name": "@find_by_many"
+          },
+          {
+            "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "@model_class",
             "stringValue": "connection"
@@ -3111,6 +3116,10 @@
           {
             "iid": "10101010101010",
             "name": "@find_by"
+          },
+          {
+            "iid": "10101010101010",
+            "name": "@find_by_many"
           },
           {
             "iid": "10101010101010",
@@ -3755,6 +3764,11 @@
           },
           {
             "nameIid": "10101010101010",
+            "boolValue": false,
+            "name": "@find_by_many"
+          },
+          {
+            "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "@model_class",
             "stringValue": "connection"
@@ -4117,7 +4131,7 @@
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "result",
-            "stringValue": "resolved_type"
+            "stringValue": "id"
           }
         ],
         "type": "TYPE_SLICE_BEGIN",
@@ -4447,7 +4461,7 @@
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "object",
-            "stringValue": "resolved_type"
+            "stringValue": "id"
           },
           {
             "nameIid": "10101010101010",
@@ -4856,7 +4870,7 @@
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "object",
-            "stringValue": "resolved_type"
+            "stringValue": "id"
           },
           {
             "nameIid": "10101010101010",
@@ -5985,6 +5999,11 @@
             "stringValueIid": "10101010101010",
             "name": "@find_by",
             "stringValue": null
+          },
+          {
+            "nameIid": "10101010101010",
+            "boolValue": false,
+            "name": "@find_by_many"
           },
           {
             "nameIid": "10101010101010",
@@ -8140,6 +8159,11 @@
           },
           {
             "nameIid": "10101010101010",
+            "boolValue": false,
+            "name": "@find_by_many"
+          },
+          {
+            "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "@model_class",
             "stringValue": "connection"
@@ -9725,13 +9749,13 @@
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "object",
-            "stringValue": "resolved_type"
+            "stringValue": "id"
           },
           {
             "nameIid": "10101010101010",
             "stringValueIid": "10101010101010",
             "name": "result",
-            "stringValue": null
+            "stringValue": "resolved_type"
           }
         ],
         "type": "TYPE_SLICE_BEGIN",
@@ -11982,6 +12006,11 @@
             "stringValueIid": "10101010101010",
             "name": "@find_by",
             "stringValue": null
+          },
+          {
+            "nameIid": "10101010101010",
+            "boolValue": false,
+            "name": "@find_by_many"
           },
           {
             "nameIid": "10101010101010",

--- a/spec/support/active_record_setup.rb
+++ b/spec/support/active_record_setup.rb
@@ -68,6 +68,8 @@ if testing_rails?
     create_table :albums, force: true do |t|
       t.string :name
       t.integer :band_id
+      t.string :band_name
+      t.integer :band_genre
     end
 
     create_table :books do |t|
@@ -111,6 +113,15 @@ if testing_rails?
 
   class Album < ActiveRecord::Base
     belongs_to :band
+    enum :band_genre, [:rock, :country, :jazz]
+    belongs_to :composite_band, foreign_key: [:band_name, :band_genre]
+
+    before_save :populate_band_fields
+
+    def populate_band_fields
+      self.band_name = self.band.name
+      self.band_genre = self.band.genre
+    end
   end
   class Band < ActiveRecord::Base
     has_many :albums
@@ -121,6 +132,11 @@ if testing_rails?
   class AlternativeBand < Band
     self.table_name = :bands
     self.primary_key = :name
+  end
+
+  class CompositeBand < Band
+    self.table_name = :bands
+    self.primary_key = [:name, :genre]
   end
 
   v = Band.create!(id: 1, name: "Vulfpeck", genre: :rock)

--- a/spec/support/active_record_setup.rb
+++ b/spec/support/active_record_setup.rb
@@ -114,7 +114,11 @@ if testing_rails?
   class Album < ActiveRecord::Base
     belongs_to :band
     enum :band_genre, [:rock, :country, :jazz]
-    belongs_to :composite_band, foreign_key: [:band_name, :band_genre]
+    if Rails::VERSION::STRING > "8"
+      belongs_to :composite_band, foreign_key: [:band_name, :band_genre]
+    elsif Rails::VERSION::STRING > "7.1"
+      belongs_to :composite_band, query_constraints: [:band_name, :band_genre]
+    end
 
     before_save :populate_band_fields
 


### PR DESCRIPTION
This makes ActiveRecordSource and ActiveRecordAssociationSource work with composite primary keys.