### PR TITLE
Support has_many in ActiveRecordAssociationSource

### DIFF
--- a/lib/graphql/dataloader/active_record_association_source.rb
+++ b/lib/graphql/dataloader/active_record_association_source.rb
@@ -23,11 +23,9 @@ module GraphQL
       def fetch(records)
         record_classes = Set.new.compare_by_identity
         associated_classes = Set.new.compare_by_identity
-        all_singular_associations = true
         records.each do |record|
           if record_classes.add?(record.class)
             reflection = record.class.reflect_on_association(@association)
-            all_singular_associations &= !reflection.collection?
             if !reflection.polymorphic? && reflection.klass
               associated_classes.add(reflection.klass)
             end
@@ -43,7 +41,6 @@ module GraphQL
         ::ActiveRecord::Associations::Preloader.new(records: records, associations: @association, available_records: available_records, scope: @scope).call
 
         loaded_associated_records = records.map { |r| r.public_send(@association) }
-
 
         if @scope.nil?
           # Don't cache records loaded via scope because they might have reduced `SELECT`s

--- a/lib/graphql/dataloader/active_record_association_source.rb
+++ b/lib/graphql/dataloader/active_record_association_source.rb
@@ -12,6 +12,14 @@ module GraphQL
         @scope = scope
       end
 
+      def self.batch_key_for(association, scope = nil)
+        if scope
+          [association, scope.to_sql]
+        else
+          [association]
+        end
+      end
+
       def load(record)
         if (assoc = record.association(@association)).loaded?
           assoc.target

--- a/lib/graphql/dataloader/active_record_association_source.rb
+++ b/lib/graphql/dataloader/active_record_association_source.rb
@@ -23,9 +23,11 @@ module GraphQL
       def fetch(records)
         record_classes = Set.new.compare_by_identity
         associated_classes = Set.new.compare_by_identity
+        all_singular_associations = true
         records.each do |record|
           if record_classes.add?(record.class)
             reflection = record.class.reflect_on_association(@association)
+            all_singular_associations &= !reflection.collection?
             if !reflection.polymorphic? && reflection.klass
               associated_classes.add(reflection.klass)
             end
@@ -41,17 +43,18 @@ module GraphQL
         ::ActiveRecord::Associations::Preloader.new(records: records, associations: @association, available_records: available_records, scope: @scope).call
 
         loaded_associated_records = records.map { |r| r.public_send(@association) }
-        records_by_model = {}
-        loaded_associated_records.each do |record|
-          if record
-            updates = records_by_model[record.class] ||= {}
-            updates[record.id] = record
-          end
-        end
+
 
         if @scope.nil?
           # Don't cache records loaded via scope because they might have reduced `SELECT`s
           # Could check .select_values here?
+          records_by_model = {}
+          loaded_associated_records.flatten.each do |record|
+            if record
+              updates = records_by_model[record.class] ||= {}
+              updates[record.id] = record
+            end
+          end
           records_by_model.each do |model_class, updates|
             dataloader.with(RECORD_SOURCE_CLASS, model_class).merge(updates)
           end

--- a/spec/graphql/dataloader/active_record_association_source_spec.rb
+++ b/spec/graphql/dataloader/active_record_association_source_spec.rb
@@ -115,6 +115,7 @@ describe GraphQL::Dataloader::ActiveRecordAssociationSource do
       end
 
       assert_equal [[6], [4, 5]], albums_by_band.map { |al| al.map(&:id) }
+      assert_includes log, 'SELECT "albums".* FROM "albums" WHERE "albums"."band_id" IN (?, ?)  [["band_id", 4], ["band_id", 3]]'
 
       albums = nil
       log = with_active_record_log(colorize: false) do

--- a/spec/support/active_record_setup.rb
+++ b/spec/support/active_record_setup.rb
@@ -70,6 +70,7 @@ if testing_rails?
       t.integer :band_id
       t.string :band_name
       t.integer :band_genre
+      t.timestamps
     end
 
     create_table :books do |t|


### PR DESCRIPTION
I have always argued _against_ batch-loading `has_many` associations, because I think it's better to paginate them (and you can't do both), but admittedly there _are_ legitimate reasons to not paginate them (when they're scoped in to other ways or somehow guaranteed to be not-huge), so this source should support them somehow.