### PR TITLE
Simplify check for non-null input object arguments

### DIFF
--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -179,16 +179,6 @@ module GraphQL
 
           result = nil
 
-          # Check for missing non-null arguments
-          ctx.types.arguments(self).each do |argument|
-            if !input.key?(argument.graphql_name) && argument.type.non_null? && !argument.default_value?
-              result ||= Query::InputValidationResult.new
-              argument_result = argument.type.validate_input(value, ctx)
-              if !argument_result.valid?
-                result.merge_result!(argument_name, argument_result)
-              end
-            end
-          end
 
           input.each do |argument_name, value|
             argument = types.argument(self, argument_name)
@@ -202,6 +192,17 @@ module GraphQL
               if !argument_result.valid?
                 result ||= Query::InputValidationResult.new
                 result.merge_result!(argument_name, argument_result)
+              end
+            end
+          end
+
+          # Check for missing non-null arguments
+          ctx.types.arguments(self).each do |argument|
+            if !input.key?(argument.graphql_name) && argument.type.non_null? && !argument.default_value?
+              result ||= Query::InputValidationResult.new
+              argument_result = argument.type.validate_input(nil, ctx)
+              if !argument_result.valid?
+                result.merge_result!(argument.graphql_name, argument_result)
               end
             end
           end


### PR DESCRIPTION
Fixes #2994


(Technically, there are two points in that issue -- but I'm sure point #2, benchmarking `get_argument`, has been done!)


This exposes an interesting bug where the first error created by an input object argument would give its name to the error message, while subsequent error messages add "problems." Reordering this code means that a new argument name may appear in the error message and the problems may appear in a different order.