### PR TITLE
Fix typos in complexity cost mode note

### DIFF
--- a/lib/graphql/analysis/query_complexity.rb
+++ b/lib/graphql/analysis/query_complexity.rb
@@ -28,7 +28,7 @@ module GraphQL
           end
         when nil
           subject.logger.warn <<~GRAPHQL
-            GraphQL-Ruby's complexity cost system is getting some "breaking fixes" in a future version. See the migration notes at https://graphql-ruby.org/api-docs/#{GraphQL::VERSION}/Schema.html#complexity_cost_cacluation_mode-class_method
+            GraphQL-Ruby's complexity cost system is getting some "breaking fixes" in a future version. See the migration notes at https://graphql-ruby.org/api-doc/#{GraphQL::VERSION}/GraphQL/Schema.html#complexity_cost_calculation_mode_for-class_method
 
             To opt into the future behavior, configure your schema (#{subject.schema.name ? subject.schema.name : subject.schema.ancestors}) with:
 


### PR DESCRIPTION
I was upgrading from 2.5.2 to 2.5.3 and notice the message about breaking fixes in complexity cost system. When I tried to open the url I noticed it is not working so I updated it to the correct one.