### PR TITLE
Fix LoadError for benchmark on Ruby 3.5

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,7 +44,7 @@ end
 
 require "rake"
 require "graphql/rake_task"
-require "benchmark"
+require "benchmark/ips"
 require "pry"
 require "minitest/autorun"
 require "minitest/focus"


### PR DESCRIPTION
# Overview

Fixed an issue where loading the benchmark library failed when running tests on Ruby 3.5.0dev.

# Background

Starting from Ruby 3.5.0dev (as of 2025-01-18 master), the benchmark library has been moved to bundled gems.
As a result, simply requiring benchmark without explicitly handling it leads to a LoadError.

Example error:

```
❯ bundle exec rake test
/Users/koyamasuda/.rbenv/versions/ruby-dev/lib/ruby/3.5.0+0/readline.rb:4: warning: reline was loaded from the standard library, but is not part of the default gems starting from Ruby 3.5.0.
You can add reline to your Gemfile or gemspec to silence this warning.
/Users/koyamasuda/.rbenv/versions/ruby-dev/lib/ruby/gems/3.5.0+0/gems/byebug-12.0.0/lib/byebug/commands/irb.rb:4: warning: irb was loaded from the standard library, but is not part of the default gems starting from Ruby 3.5.0.
You can add irb to your Gemfile or gemspec to silence this warning.
/Users/koyamasuda/.rbenv/versions/ruby-dev/lib/ruby/gems/3.5.0+0/gems/libev_scheduler-0.2/lib/libev_scheduler.rb:16: warning: method redefined; discarding old process_wait
/Users/koyamasuda/personal/graphql-ruby/spec/spec_helper.rb:47: warning: benchmark was loaded from the standard library, but is not part of the default gems starting from Ruby 3.5.0.
You can add benchmark to your Gemfile or gemspec to silence this warning.
Coverage report generated for RSpec to /Users/koyamasuda/personal/graphql-ruby/coverage.
Line Coverage: 52.43% (108 / 206)
Branch Coverage: 8.7% (2 / 23)
Lcov style coverage report generated for RSpec to /Users/koyamasuda/personal/graphql-ruby/coverage/lcov/graphql-ruby.lcov
Stopped processing SimpleCov as a previous error not related to SimpleCov has been detected
/Users/koyamasuda/.rbenv/versions/ruby-dev/lib/ruby/3.5.0+0/bundled_gems.rb:76:in 'Kernel.require': cannot load such file -- benchmark (LoadError)
Did you mean?  benchmark/ips
        from /Users/koyamasuda/.rbenv/versions/ruby-dev/lib/ruby/3.5.0+0/bundled_gems.rb:76:in 'block (2 levels) in Kernel#replace_require'
        from /Users/koyamasuda/personal/graphql-ruby/spec/spec_helper.rb:47:in '<top (required)>'
        from /Users/koyamasuda/.rbenv/versions/ruby-dev/lib/ruby/3.5.0+0/bundled_gems.rb:76:in 'Kernel.require'
        from /Users/koyamasuda/.rbenv/versions/ruby-dev/lib/ruby/3.5.0+0/bundled_gems.rb:76:in 'block (2 levels) in Kernel#replace_require'
        from /Users/koyamasuda/personal/graphql-ruby/spec/graphql/analysis/field_usage_spec.rb:2:in '<top (required)>'
        from /Users/koyamasuda/.rbenv/versions/ruby-dev/lib/ruby/3.5.0+0/bundled_gems.rb:76:in 'Kernel.require'
        from /Users/koyamasuda/.rbenv/versions/ruby-dev/lib/ruby/3.5.0+0/bundled_gems.rb:76:in 'block (2 levels) in Kernel#replace_require'
        from /Users/koyamasuda/.rbenv/versions/ruby-dev/lib/ruby/gems/3.5.0+0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:21:in 'block in <main>'
        from /Users/koyamasuda/.rbenv/versions/ruby-dev/lib/ruby/gems/3.5.0+0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:6:in 'Array#select'
        from /Users/koyamasuda/.rbenv/versions/ruby-dev/lib/ruby/gems/3.5.0+0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:6:in '<main>'
rake aborted!
Command failed with status (1)
/Users/koyamasuda/.rbenv/versions/ruby-dev/bin/bundle:25:in 'Kernel#load'
/Users/koyamasuda/.rbenv/versions/ruby-dev/bin/bundle:25:in '<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
```
# Environment

```sh
❯ ruby -v
ruby 3.5.0dev (2025-01-18T00:19:17Z master 65a7c69188) +PRISM [arm64-darwin23]

❯ bundle -v
Bundler version 2.7.0.dev
```

# Changes

Updated how the benchmark library is required to work correctly with Ruby 3.5 and later.

# Notes

Other libraries such as reline and irb have also been moved to bundled gems in Ruby 3.5.0. You might see similar warnings, but this PR specifically addresses only the benchmark issue.
I didn't fix `ostruct` at this time because relative PR (https://github.com/rmosolgo/graphql-ruby/pull/5208) was closed.

Future updates might be necessary to handle other bundled gems as well.
 Thank you for reviewing this PR!