### PR TITLE
[2.4] Use a faster check for `loadable?`

### DIFF
--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -232,7 +232,7 @@ module GraphQL
 
       # @return [Boolean] True if this type is used for `loads:` but not in the schema otherwise and not _explicitly_ hidden.
       def loadable?(type, _ctx)
-        !reachable_type_set.include?(type) && visible_type?(type)
+        visible_type?(type) && !referenced?(type)
       end
 
       def loadable_possible_types(union_type, _ctx)


### PR DESCRIPTION
Fixes #5337 

This method can return without building `reachable_types_set`, instead using the schema cache of `@references`.

I wrote a little script to demonstrate the regression: 

<details>
<summary>Using an otherwise-unreferenced union as `loads:` in a large schema</summary>

<p>

```ruby
require "bundler/inline"

gemfile do
  # gem "graphql", "2.4.15"
  gem "graphql", path: "./"
  # gem "graphql", "2.3.22"
  gem "benchmark-ips"
  gem "stackprof"
  gem "memory_profiler"
end

class MySchema < GraphQL::Schema
  module Thing
    include GraphQL::Schema::Interface
    field :id, ID
  end

  all_object_types = []
  20.times do |i|
    obj_type = Class.new(GraphQL::Schema::Object) do
      i.times do |i2|
        field "f#{i2}", "MySchema::Object#{i2}"
      end
      implements Thing
    end
    const_set("Object#{i}", obj_type)
    all_object_types << obj_type
  end

  class AllObjects < GraphQL::Schema::Union
  end
  AllObjects.possible_types(*all_object_types)

  class Query < GraphQL::Schema::Object
    field :thing, Thing do
      argument :id, ID, loads: AllObjects, as: :thing
    end

    def thing(thing:)
      thing
    end
  end

  orphan_types(*all_object_types)

  def self.object_from_id(id, ctx)
    { id: "1001" }
  end

  def self.resolve_type(_abs_type, _obj, _ctx)
    Object0
  end

  query(Query)
end

document = GraphQL.parse("{ thing(id: \"5\") { id } }")

puts GraphQL::VERSION
pp MySchema.execute(document: document).to_h

Benchmark.ips do |x|
  x.report("run query") { MySchema.execute(document: document) }
end
```

</p>
</details>

This patch gets 2.4.x back on track: 


| Version | IPS |
|--------|--------|
| 2.3.22 | 2.428k (± 7.0%) i/s  |
| 2.4.16 | 745.511 (± 3.5%) i/s |
| this branch | 2.294k (± 4.5%) i/s |
