### PR TITLE
Improve schema directive validations

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -826,6 +826,13 @@ module GraphQL
           else
             dir_defn = @schema_directives.fetch(dir_node.name)
             raw_dir_args = arguments(nil, dir_defn, dir_node)
+            if !raw_dir_args.is_a?(GraphQL::ExecutionError)
+              begin
+                dir_defn.validate!(raw_dir_args, context)
+              rescue GraphQL::ExecutionError => err
+                raw_dir_args = err
+              end
+            end
             dir_args = continue_value(
               raw_dir_args, # value
               nil, # field

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -182,6 +182,10 @@ module GraphQL
 
           input.each do |argument_name, value|
             argument = types.argument(self, argument_name)
+            if argument.nil? && ctx.is_a?(Query::NullContext) && argument_name.is_a?(Symbol)
+              # Validating definition directive arguments which come in as Symbols
+              argument = types.arguments(self).find { |arg| arg.keyword == argument_name }
+            end
             # Items in the input that are unexpected
             if argument.nil?
               result ||= Query::InputValidationResult.new


### PR DESCRIPTION
- Fix error handling when SDL directive has an invalid argument value 

  Fixes #5363 

- Fix error handling on directive argument validators; add validation step for `:required`

  Fixes #5209 