### PR TITLE
Improve scalar result coercion execution errors

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -675,6 +675,8 @@ module GraphQL
           when "SCALAR", "ENUM"
             r = begin
               current_type.coerce_result(value, context)
+            rescue GraphQL::ExecutionError => ex_err
+              return continue_value(ex_err, field, is_non_null, ast_node, result_name, selection_result)
             rescue StandardError => err
               query.handle_or_reraise(err)
             end


### PR DESCRIPTION
Adds improved handling for `coerce_result` errors which results in more spec compliant errors with `path` and `locations` present.

Separated out from https://github.com/rmosolgo/graphql-ruby/pull/5306 because this can be merged more easily.