### PR TITLE
node and nodes scalar type configuration

### DIFF
--- a/lib/graphql/types/relay/has_node_field.rb
+++ b/lib/graphql/types/relay/has_node_field.rb
@@ -24,7 +24,7 @@ module GraphQL
             description: "Fetches an object given its ID.",
             relay_node_field: true
           ) do
-            argument :id, id_type, required: true, description: "ID of the object."
+            argument :id, id_type, description: "ID of the object."
 
             def resolve(_obj, args, ctx)
               ctx.schema.object_from_id(args[:id], ctx)

--- a/lib/graphql/types/relay/has_nodes_field.rb
+++ b/lib/graphql/types/relay/has_nodes_field.rb
@@ -24,7 +24,7 @@ module GraphQL
             description: "Fetches a list of objects given a list of IDs.",
             relay_nodes_field: true
           ) do
-            argument :ids, [id_type], required: true, description: "IDs of the objects."
+            argument :ids, [id_type], description: "IDs of the objects."
 
             def resolve(_obj, args, ctx)
               args[:ids].map { |id| ctx.schema.object_from_id(id, ctx) }


### PR DESCRIPTION
## PR Description

This PR makes it possible to configure the `node` and `nodes` scalar type through the `Configuration` class.

For example, you could do this in a Rails initializer:

```
GraphQL::Configuration.relay_node_id_type = "SomeScalar"
```

And the arguments to `node` and `nodes` would be `id: SomeScalar!` and `ids: [SomeScalar!]!` respectively. The returned `id` field would be `id: SomeScalar!`.

## Why is this needed?

We don't use the GraphQL Ruby `ID` scalar and instead use our own scalar for ID fields. Maybe we should consider going back to the `ID` scalar, but that's a different discussion/concern for if we ever want to go back in that direction 😄 This PR makes it possible to use our own scalar for the root `node` and `nodes` field.

## GraphQL Ruby doesn't support this type of configuration?

I ultimately need to be able to set the scalar type at Ruby load time. Here for example:

```
child_module.field(:id, Configuration.relay_node_id_type, null: false, description: "ID of the object.", resolver_method: :default_global_id)
```

And setting this in a configuration class was the easiest way for me to do this through a simple Rails initializer. I realize this isn't a pattern that GraphQL Ruby takes for configuration (unless I missed it!) and I'm open to any other approaches!

## Other approaches we considered

I realize I could also completely override the modules, but it felt much better to be able to configure/inject the type and save us from awkward monkey patching.