### PR TITLE
Inherit validation allowances

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -1695,7 +1695,11 @@ module GraphQL
       # @return [true, false, nil]
       def allow_legacy_invalid_empty_selections_on_union(new_value = NOT_CONFIGURED)
         if NOT_CONFIGURED.equal?(new_value)
-          @allow_legacy_invalid_empty_selections_on_union
+          if defined?(@allow_legacy_invalid_empty_selections_on_union)
+            @allow_legacy_invalid_empty_selections_on_union
+          else
+            find_inherited_value(:allow_legacy_invalid_empty_selections_on_union)
+          end
         else
           @allow_legacy_invalid_empty_selections_on_union = new_value
         end
@@ -1726,7 +1730,11 @@ module GraphQL
       # @return [true, false, nil]
       def allow_legacy_invalid_return_type_conflicts(new_value = NOT_CONFIGURED)
         if NOT_CONFIGURED.equal?(new_value)
-          @allow_legacy_invalid_return_type_conflicts
+          if defined?(@allow_legacy_invalid_return_type_conflicts)
+            @allow_legacy_invalid_return_type_conflicts
+          else
+            find_inherited_value(:allow_legacy_invalid_return_type_conflicts)
+          end
         else
           @allow_legacy_invalid_return_type_conflicts = new_value
         end
@@ -1774,7 +1782,11 @@ module GraphQL
       #   complexity_cost_calculation_mode(:compare)
       def complexity_cost_calculation_mode(new_mode = NOT_CONFIGURED)
         if NOT_CONFIGURED.equal?(new_mode)
-          @complexity_cost_calculation_mode
+          if defined?(@complexity_cost_calculation_mode)
+            @complexity_cost_calculation_mode
+          else
+            find_inherited_value(:complexity_cost_calculation_mode)
+          end
         else
           @complexity_cost_calculation_mode = new_mode
         end

--- a/spec/graphql/analysis/query_complexity_spec.rb
+++ b/spec/graphql/analysis/query_complexity_spec.rb
@@ -638,6 +638,11 @@ describe GraphQL::Analysis::QueryComplexity do
       }
     |}
 
+    it "inherits complexity_cost_calculation_mode" do
+      schema = Class.new(CustomComplexityByMethodSchema)
+      assert_equal CustomComplexityByMethodSchema.complexity_cost_calculation_mode, schema.complexity_cost_calculation_mode
+    end
+
     it "sums the complexity" do
       complexity = reduce_result.first
       # 10 from `complexity`, `0.3` from `value`

--- a/spec/graphql/static_validation/rules/fields_have_appropriate_selections_spec.rb
+++ b/spec/graphql/static_validation/rules/fields_have_appropriate_selections_spec.rb
@@ -155,5 +155,16 @@ describe GraphQL::StaticValidation::FieldsHaveAppropriateSelections do
         assert_includes(errors.map { |e| e["message"] }, expected_err)
       end
     end
+
+    describe "With inherited setting" do
+      let(:schema) { Class.new(Class.new(Dummy::Schema) {
+          allow_legacy_invalid_empty_selections_on_union(true)
+        })
+      }
+
+      it "has correct value" do
+        assert schema.allow_legacy_invalid_empty_selections_on_union
+      end
+    end
   end
 end

--- a/spec/graphql/static_validation/rules/fields_will_merge_spec.rb
+++ b/spec/graphql/static_validation/rules/fields_will_merge_spec.rb
@@ -1073,6 +1073,12 @@ describe GraphQL::StaticValidation::FieldsWillMerge do
         }
       assert_equal [expected_error], res.map(&:to_h)
     end
+
+    it "inherits allow_legacy_invalid_empty_selections_on_union" do
+      base_schema = Class.new(schema) { allow_legacy_invalid_return_type_conflicts(true) }
+      ext_schema = Class.new(base_schema)
+      assert ext_schema.allow_legacy_invalid_return_type_conflicts
+    end
   end
 
   describe "conflicting list / non-list fields" do


### PR DESCRIPTION
The new validation and complexity allowances do not inherit from a base class down to subclasses like other similar settings. This fixes that.

- Adds inheritance for:
   - `allow_legacy_invalid_empty_selections_on_union` 
   - `allow_legacy_invalid_return_type_conflicts`
   - `complexity_cost_calculation_mode`
- Inheritance tests for each setting.
- Confirmed no use in hot paths.