### PR TITLE
Use the types from the superclass

### DIFF
--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -51,7 +51,7 @@ module GraphQL
             raise InvalidDocumentError.new('Must provide only one schema definition.')
           end
           schema_definition = schema_defns.first
-          types = {}
+          types = schema_superclass.types.dup
           directives = schema_superclass.directives.dup
           type_resolver = build_resolve_type(types, directives, ->(type_name) { types[type_name] ||= Schema::LateBoundType.new(type_name)})
           # Make a different type resolver because we need to coerce directive arguments


### PR DESCRIPTION
So if it's not needed you don't have to define the query type again.

First of all, I have no clue if what I'm doing here makes sense or not, but let me explain what I was after:

When creating a schema from a definition, I got into the case where I wanted to add a set of types to an existing schema, but I wanted to use the GraphQL IDL to do so (see below).

```ruby
graphql_string = %Q{
  type AdditionalType {
    test: String!
  }
}

GraphQL::Schema::BuildFromDefinition.from_document(OriginalSchema, graphql_string)
```

Originally I thought that I could do that by passing the `OriginalSchema.types` to `base types`, but that's not how these are passed. 

I also wanted to see if I can pass these types through extra_types, but I don't know how I get the types in a proper form from the `graphql_string`.