### PR TITLE
Support dataloader calls after batched lazy resolve

### DIFF
--- a/lib/graphql/execution/interpreter/resolve.rb
+++ b/lib/graphql/execution/interpreter/resolve.rb
@@ -23,9 +23,9 @@ module GraphQL
           if smallest_depth
             lazies = lazies_at_depth.delete(smallest_depth)
             if !lazies.empty?
-              dataloader.append_job {
-                lazies.each(&:value) # resolve these Lazy instances
-              }
+              lazies.each do |l|
+                dataloader.append_job { l.value }
+              end
               # Run lazies _and_ dataloader, see if more are enqueued
               dataloader.run
               resolve_each_depth(lazies_at_depth, dataloader)


### PR DESCRIPTION
Fixes #5399 

Previously, the promises were all resolved inside a single fiber, so when a promise led to a Dataloader `.load` call, that fiber would pause until Dataloader ran. Then that fiber would resume again, make the next `.load` call, then pause again. 

Now, each promise is handled in a separate fiber, so when it calls `.load`, Dataloader can continue running other fibers (and then it can accumulate other `.load` calls before running `#fetch`).