### PR TITLE
Fix loading directives from SDL

### DIFF
--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -266,6 +266,8 @@ module GraphQL
             build_scalar_type(definition, type_resolver, base_types[:scalar], default_resolve: default_resolve)
           when GraphQL::Language::Nodes::InputObjectTypeDefinition
             build_input_object_type(definition, type_resolver, base_types[:input_object])
+          when GraphQL::Language::Nodes::DirectiveDefinition
+            build_directive(definition, type_resolver)
           end
         end
 
@@ -544,7 +546,7 @@ module GraphQL
             when GraphQL::Language::Nodes::ListType
               resolve_type_proc.call(ast_node.of_type).to_list_type
             when String
-              directives[ast_node]
+              directives[ast_node] ||= missing_type_handler.call(ast_node)
             else
               raise "Unexpected ast_node: #{ast_node.inspect}"
             end

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -1905,4 +1905,20 @@ type ReachableType implements Node {
       assert schema_class.query.ast_node.name.frozen?
     end
   end
+
+  it "works when directives use argument types defined after them" do
+    schema_sdl = <<~GRAPHQL
+      directive @foo(value: SomeEnum!) on OBJECT
+      directive @bar on ENUM_VALUE
+
+      enum SomeEnum {
+        BAZ @bar
+      }
+
+      type Query {
+        someEnum: SomeEnum!
+      }
+    GRAPHQL
+    GraphQL::Schema.from_definition(schema_sdl)
+  end
 end


### PR DESCRIPTION
Fixes #5366 

This supports the case that a directive definition references a later type in the schema _and_ that type references a directive which is _also_ later in the document.