### PR TITLE
Mark load_application_object_failed as public API

### DIFF
--- a/lib/graphql/schema/member/has_arguments.rb
+++ b/lib/graphql/schema/member/has_arguments.rb
@@ -413,6 +413,12 @@ module GraphQL
             end
           end
 
+          # Called when an argument's `loads:` configuration fails to fetch an application object.
+          # By default, this method raises the given error, but you can override it to handle failures differently.
+          #
+          # @param err [GraphQL::LoadApplicationObjectFailedError] The error that occurred
+          # @return [Object, nil] If a value is returned, it will be used instead of the failed load
+          # @api public
           def load_application_object_failed(err)
             raise err
           end


### PR DESCRIPTION
## Summary
Add explicit `@api public` documentation to the `load_application_object_failed` method to clarify that it's a public hook intended to be overridden by users

## Context
As noted in #5418, the `load_application_object_failed` method appears to be marked as a private API in the generated documentation, which conflicts with the mutation guides that explicitly recommend overriding this method for custom error handling.

**In prod:** 

<img width="1919" height="1011" alt="image" src="https://github.com/user-attachments/assets/9e1233a4-151e-46aa-82d1-10888acc4516" />


**Local yard server:**

<img width="1920" height="907" alt="image" src="https://github.com/user-attachments/assets/2ca999dd-d92b-4919-9ab8-374004ecd837" />
