### PR TITLE
Adjust breadth interface hooks

### DIFF
--- a/lib/graphql/execution/interpreter/runtime/graphql_result.rb
+++ b/lib/graphql/execution/interpreter/runtime/graphql_result.rb
@@ -157,6 +157,11 @@ module GraphQL
               end
             end
           end
+
+          # hook for breadth-first implementations to signal when collecting results.
+          def collect_result(result_name, result_value)
+            false
+          end
         end
 
         class GraphQLResultArray


### PR DESCRIPTION
Small refactor to the breadth runtime interface... plugs a hole where argument errors were leaking out. This OO interface also feels a bit nicer by keeping the focus on the object scope rather than the runtime.

So – in the object sequence spanning `evaluate_selection ... evaluate_selection_with_resolved_keyword_args`, we basically just need to offer all values to `selection_result.collect_result` prior to calling `continue_value`. Seem reasonable?