### PR TITLE
Don't run duplicate directives twice

### DIFF
--- a/lib/graphql/execution/interpreter/arguments.rb
+++ b/lib/graphql/execution/interpreter/arguments.rb
@@ -82,6 +82,10 @@ module GraphQL
 
         NO_ARGS = GraphQL::EmptyObjects::EMPTY_HASH
         EMPTY = self.new(argument_values: nil, keyword_arguments: NO_ARGS).freeze
+
+        def ==(other)
+          other.class == self.class && @keyword_arguments.all? { |(k, v)| other[k] == v }
+        end
       end
     end
   end


### PR DESCRIPTION
I wrote this up as a fix for #5434 but I'm not sure it's actually right. The spec doesn't say anything about deduplicating non-repeatable directives. 

I'm going to address this inside `@defer` instead.