### PR TITLE
Fix typo in date enconding error

### DIFF
--- a/lib/graphql/date_encoding_error.rb
+++ b/lib/graphql/date_encoding_error.rb
@@ -10,7 +10,7 @@ module GraphQL
 
     def initialize(value)
       @date_value = value
-      super("Date cannot be parsed: #{value}. \nDate must be be able to be parsed as a Ruby Date object.")
+      super("Date cannot be parsed: #{value}. \nDate must be able to be parsed as a Ruby Date object.")
     end
   end
 end

--- a/spec/graphql/types/iso_8601_date_spec.rb
+++ b/spec/graphql/types/iso_8601_date_spec.rb
@@ -157,7 +157,7 @@ describe GraphQL::Types::ISO8601Date do
       assert_equal expected_errors, parse_date("xyz").map { |e| e["message"] }
       assert_equal expected_errors, parse_date(nil).map { |e| e["message"] }
       assert_equal expected_errors, parse_date([1, 2, 3]).map { |e| e["message"] }
-      assert_equal "A type error was raised: Date cannot be parsed: blah. \nDate must be be able to be parsed as a Ruby Date object.", parse_date("blah", context: { raise_type_error: true })[0]["extensions"]["problems"][0]["explanation"].strip
+      assert_equal "A type error was raised: Date cannot be parsed: blah. \nDate must be able to be parsed as a Ruby Date object.", parse_date("blah", context: { raise_type_error: true })[0]["extensions"]["problems"][0]["explanation"].strip
       assert_equal "Could not coerce value \"blah\" to ISO8601Date", parse_date("blah", context: { raise_type_error: false })[0]["extensions"]["problems"][0]["explanation"]
     end
 


### PR DESCRIPTION
I believe the word be is duplicated when setting the error message for date enconding and can be removed