### PR TITLE
Hide deprecation warning when GraphQL::Schema::Visibility is included

### DIFF
--- a/lib/graphql/schema/warden.rb
+++ b/lib/graphql/schema/warden.rb
@@ -212,7 +212,7 @@ module GraphQL
           @visible_and_reachable_type = @unions = @unfiltered_interfaces =
           @reachable_type_set = @visibility_profile = @loadable_possible_types =
             nil
-        @skip_warning = schema.plugins.any? { |(plugin, _opts)| plugin == GraphQL::Schema::Warden }
+        @skip_warning = schema.plugins.any? { |(plugin, _opts)| plugin == GraphQL::Schema::Warden || plugin == GraphQL::Schema::Visibility }
       end
 
       attr_writer :skip_warning


### PR DESCRIPTION
right now i get this deprecation, even when i have Schema::Visibility
included in my schema

> DEPRECATION:  "Query.internalAdminUsers" field returned `false` for `.visible?` but `GraphQL::Schema::Visibility` isn't configured yet.
>
>   Address this warning by adding:
>
>       use GraphQL::Schema::Visibility
>
>   to the definition for your schema. (Future GraphQL-Ruby versions won't check `.visible?` methods by default.)
>
>   Alternatively, for legacy behavior, add:
>
>       use GraphQL::Schema::Warden # legacy visibility behavior
>
>   For more information see: https://graphql-ruby.org/authorization/visibility.html
>     /Users/schpet/.rbenv/versions/3.4.6/lib/ruby/gems/3.4.0/gems/graphql-2.5.13/lib/graphql/schema/warden.rb:207:in 'block in GraphQL::Schema::Warden#initialize'
