### PR TITLE
Ensure `data` entry exists for execution errors

### DIFF
--- a/lib/graphql/execution/interpreter.rb
+++ b/lib/graphql/execution/interpreter.rb
@@ -80,7 +80,6 @@ module GraphQL
                       end
                     rescue GraphQL::ExecutionError => err
                       query.context.errors << err
-                      NO_OPERATION
                     end
                   end
                   results[idx] = result

--- a/spec/graphql/authorization_spec.rb
+++ b/spec/graphql/authorization_spec.rb
@@ -909,8 +909,11 @@ describe "GraphQL::Authorization" do
         assert_equal "Query", res["data"]["__typename"]
 
         unauth_res = auth_execute(query, context: { query_unauthorized: true })
-        assert_nil unauth_res["data"]
-        assert_equal [{"message"=>"Unauthorized Query: nil"}], unauth_res["errors"]
+
+        assert_equal({
+          "errors" => [{"message"=>"Unauthorized Query: nil"}],
+          "data" => nil,
+        }, unauth_res.to_h)
       end
 
       describe "when the object authorization raises an UnauthorizedFieldError" do

--- a/spec/graphql/execution/instrumentation_spec.rb
+++ b/spec/graphql/execution/instrumentation_spec.rb
@@ -128,8 +128,13 @@ describe GraphQL::Schema do
       it "rescues execution errors from execute_query" do
         context = {raise_execution_error: true}
         res = schema.execute(" { int(value: 2) } ", context: context)
-        assert_equal "Raised from trace execute_query", res["errors"].first["message"]
-        refute res.key?("data"), "The query doesn't run"
+
+        assert_equal({
+          "data" => nil,
+          "errors" => [
+            { "message" => "Raised from trace execute_query" },
+          ]
+        }, res.to_h)
       end
 
       it "can assign a query string there" do


### PR DESCRIPTION
According to the spec, the `data` entry should always exist once execution starts. Only if an error is raised _before_ execution starts should the `data` key be omitted.

The only test that needed updating was when an `ExecutionError` was raised during the `execute_query` trace hook. Despite this running before `super`, this still happens "during execution" and should have the `data` key present.

Ref: https://spec.graphql.org/draft/#sec-Data

> If an error was raised before execution begins, the [response](https://spec.graphql.org/draft/#response) must be a [request error result](https://spec.graphql.org/draft/#request-error-result) which will result in no response data.

> If an error was raised during the execution that prevented a valid response, the "data" entry in the response should be null.

Arguably, this should have a better test case to show the issue beyond just a trace hook. In our case, we raised an `ExecutionError` within a root mutation's `authorized?` method and it resulted in no `data` key which is clearly incorrect.

@rmosolgo any idea where that test case should go?