### PR TITLE
Conditionally add fiber-storage dependency for Ruby < 3.2

### DIFF
--- a/gemfiles/mongoid_8.gemfile
+++ b/gemfiles/mongoid_8.gemfile
@@ -11,7 +11,6 @@ gem "mongoid", "~> 8.0"
 gem "libev_scheduler"
 gem "evt"
 gem "async"
-gem "fiber-storage"
 gem "concurrent-ruby", "1.3.4"
 
 gemspec path: "../"

--- a/gemfiles/mongoid_9.gemfile
+++ b/gemfiles/mongoid_9.gemfile
@@ -10,6 +10,5 @@ gem "mongoid", "~> 9.0"
 gem "libev_scheduler"
 gem "evt"
 gem "async"
-gem "fiber-storage"
 
 gemspec path: "../"

--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{lib}/**/*", "MIT-LICENSE", "readme.md", ".yardopts"]
 
   s.add_runtime_dependency "base64"
-  s.add_runtime_dependency "fiber-storage"
+  s.add_runtime_dependency "fiber-storage" if RUBY_VERSION < "3.2.0"
   s.add_runtime_dependency "logger"
 
   s.add_development_dependency "benchmark-ips"

--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -4,7 +4,7 @@ require "json"
 require "set"
 require "singleton"
 require "forwardable"
-require "fiber/storage"
+require "fiber/storage" if RUBY_VERSION < "3.2.0"
 require "graphql/autoload"
 
 module GraphQL

--- a/spec/graphql_spec.rb
+++ b/spec/graphql_spec.rb
@@ -4,7 +4,7 @@ require "open3"
 
 describe GraphQL do
   it "loads without warnings" do
-    stderr_and_stdout, _status = Open3.capture2e(%|ruby -Ilib -e "require 'bundler/inline'; gemfile(true, quiet: true) { source('https://rubygems.org'); gem('fiber-storage'); gem('graphql', path: './') }; GraphQL.eager_load!"|)
+    stderr_and_stdout, _status = Open3.capture2e(%|ruby -Ilib -e "require 'bundler/inline'; gemfile(true, quiet: true) { source('https://rubygems.org'); gem('graphql', path: './') }; GraphQL.eager_load!"|)
     assert_equal "", stderr_and_stdout
   end
 
@@ -18,7 +18,6 @@ describe GraphQL do
       gemfile(true, quiet: true) do
         source('https://rubygems.org')
         gem 'graphql', path: './'
-        gem 'fiber-storage'
       end
 
       class MySchema < GraphQL::Schema


### PR DESCRIPTION
The `fiber-storage` dependency only was introduced in Ruby versions prior to 3.2.