### PR TITLE
Don't modify cached array from types.interfaces

### DIFF
--- a/lib/graphql/language/document_from_schema_definition.rb
+++ b/lib/graphql/language/document_from_schema_definition.rb
@@ -52,8 +52,9 @@ module GraphQL
 
       def build_object_type_node(object_type)
         ints = @types.interfaces(object_type)
+
         if !ints.empty?
-          ints.sort_by!(&:graphql_name)
+          ints = ints.sort_by(&:graphql_name)
           ints.map! { |iface| build_type_name_node(iface) }
         end
 

--- a/spec/graphql/schema/printer_spec.rb
+++ b/spec/graphql/schema/printer_spec.rb
@@ -1006,4 +1006,34 @@ enum Thing {
       assert_equal expected_defn, Class.new(GraphQL::Schema) { extra_types(union_type, obj_1, obj_2) }.to_definition
     end
   end
+
+  it "works with interfaces and @oneOf directive" do
+    class SomeInputObject < GraphQL::Schema::InputObject
+      one_of
+      argument :a, Integer, required: false
+      argument :b, String, required: false
+    end
+
+    module SomeInterface
+      include GraphQL::Schema::Interface
+      field :id, ID
+    end
+
+    class SomeObject < GraphQL::Schema::Object
+      implements SomeInterface
+      field :some_field, Boolean do
+        argument :input, SomeInputObject
+      end
+    end
+
+    class SomeQueryType < GraphQL::Schema::Object
+      field :some_object, SomeObject, method: :some_object
+    end
+
+    class SomeSchema < GraphQL::Schema
+      query SomeQueryType
+    end
+
+    GraphQL::Schema::Printer.new(SomeSchema).print_type(SomeObject)
+  end
 end


### PR DESCRIPTION
Fixes #5453 

The problem was that `@types.interfaces(...)` returned the same array when it was called a second time, but this code had modified the array in place during the first pass. 

Now it makes a single, shallow copy when using it. 