### PR TITLE
Improve SDL directive argument coercion

### DIFF
--- a/lib/graphql/schema/directive.rb
+++ b/lib/graphql/schema/directive.rb
@@ -142,7 +142,14 @@ module GraphQL
                 # However, we're using result coercion here to go from Ruby value
                 # to GraphQL value, so it doesn't have that feature.
                 # Keep the GraphQL-type behavior but implement it manually:
-                coerce_value = [coerce_value]
+                wrap_type = arg_type
+                while wrap_type.list?
+                  if wrap_type.non_null?
+                    wrap_type = wrap_type.of_type
+                  end
+                  wrap_type = wrap_type.of_type
+                  coerce_value = [coerce_value]
+                end
               end
               arg_type.coerce_isolated_result(coerce_value)
             rescue GraphQL::Schema::Enum::UnresolvedValueError

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -1921,4 +1921,20 @@ type ReachableType implements Node {
     GRAPHQL
     GraphQL::Schema.from_definition(schema_sdl)
   end
+
+  it "works with invalid directive argument value" do
+    sdl = <<~EOS
+      directive @requiresScopes(scopes: [[String]]) on FIELD_DEFINITION
+
+      type Query {
+        product: Product
+      }
+
+      type Product {
+        shippingEstimate: String @requiresScopes(scopes: "shipping")
+      }
+    EOS
+
+    assert GraphQL::Schema.from_definition(sdl).to_definition
+  end
 end


### PR DESCRIPTION
#5440 added _some_ list-type handling here, but it was only one layer deep. The spec specifically says: 

>  (note this may apply recursively for nested lists)

(https://spec.graphql.org/October2021/#sel-GAHjBJFEBrFB_Gtmd)

And has an example in it very similar to this one. 

Now, SDL directive arguments will be wrapped in arrays as much as necessary.

Fixes #5466 