### PR TITLE
Fix fiber-storage in gemspec

### DIFF
--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{lib}/**/*", "MIT-LICENSE", "readme.md", ".yardopts"]
 
   s.add_runtime_dependency "base64"
-  s.add_runtime_dependency "fiber-storage" if RUBY_VERSION < "3.2.0"
+  s.add_runtime_dependency "fiber-storage"
   s.add_runtime_dependency "logger"
 
   s.add_development_dependency "benchmark-ips"


### PR DESCRIPTION
Oops, this was modified in #5456 , but I misunderstood how gemspecs work. They are evaluated once, at build-time. So when I built the gem on my machine, it sent a finished gemspec to Rubygems without fiber-storage.

Fixes #5483 