### PR TITLE
Subscription initial response should be nil

### DIFF
--- a/guides/subscriptions/subscription_classes.md
+++ b/guides/subscriptions/subscription_classes.md
@@ -137,11 +137,11 @@ subscription($roomId: ID!) {
 
 If you remove `null: false`, then you can return different data in the initial subscription and the subsequent updates. (See lifecycle methods below.)
 
-Instead of a generated type, you can provide an already-configured type with `payload_type`:
+Instead of a generated type, you can provide an already-configured type with `type` just like mutations and resolvers:
 
 ```ruby
 # Just return a message
-payload_type Types::MessageType
+type Types::MessageType
 ```
 
 (In that case, don't return a hash from `#subscribe` or `#update`, return a `message` object instead.)

--- a/lib/graphql/schema/subscription.rb
+++ b/lib/graphql/schema/subscription.rb
@@ -15,9 +15,6 @@ module GraphQL
       extend GraphQL::Schema::Resolver::HasPayloadType
       extend GraphQL::Schema::Member::HasFields
       NO_UPDATE = :no_update
-      # The generated payload type is required; If there's no payload,
-      # propagate null.
-      null false
 
       # @api private
       def initialize(object:, context:, field:)
@@ -69,7 +66,7 @@ module GraphQL
       def resolve_subscribe(**args)
         ret_val = !args.empty? ? subscribe(**args) : subscribe
         if ret_val == :no_response
-          context.skip
+          @null ? nil : context.skip
         else
           ret_val
         end

--- a/spec/graphql/schema/subscription_spec.rb
+++ b/spec/graphql/schema/subscription_spec.rb
@@ -417,7 +417,7 @@ describe GraphQL::Schema::Subscription do
     it "sends a minimal initial response if :no_response is returned when using type instead of payload_type, which is the default" do
       assert_equal 0, in_memory_subscription_count
 
-      res = exec_query <<-GRAPHQL, context: { legacy_schema: false }
+      res = exec_query <<-GRAPHQL
       subscription {
         userChanged(handle: "matz") {
           handle
@@ -480,7 +480,7 @@ describe GraphQL::Schema::Subscription do
     it "updates with the returned value but no initial subscription value" do
       res = exec_query <<-GRAPHQL
       subscription {
-        userChanged {
+        userChanged(handle: "matz") {
           handle
         }
       }


### PR DESCRIPTION
Addresses #5488 

The change is simple, if the payload type allows to be null then the initial subscription response returns nil instead of "nothing". This also changes the docs to have users use the `type` declaration instead of the `payload_type` to be more in alignment with mutations and resolvers. Backward compatibility can be achieved by adding the `null false` attribute back into their subscription base class and continuing to use the `payload_type`. Though I would think it would be smart to make that explicit in your codebase and have your declarations be the same as your mutations and resolvers.


#### Backward compatibility

```ruby
class BaseSubscription < GraphQL::Schema::Subscription
  null false # add this to use the same null default as before
end
```

