### PR TITLE
Optimize INVALID_NUMBER_FOLLOWED_BY_NAME_REGEXP

### DIFF
--- a/lib/graphql/language.rb
+++ b/lib/graphql/language.rb
@@ -79,22 +79,28 @@ module GraphQL
 
     LEADING_REGEX = Regexp.union(" ", *Lexer::Punctuation.constants.map { |const| Lexer::Punctuation.const_get(const) })
 
+    # Optimized pattern using:
+    # - Possessive quantifiers (*+, ++) to prevent backtracking in number patterns
+    # - Atomic group (?>...) for IGNORE to prevent backtracking
+    # - Single unified number pattern instead of three alternatives
+    EFFICIENT_NUMBER_REGEXP = /-?(?:0|[1-9][0-9]*+)(?:\.[0-9]++)?(?:[eE][+-]?[0-9]++)?/
+    EFFICIENT_IGNORE_REGEXP = /(?>[, \r\n\t]+|\#[^\n]*$)*/
+
+    MAYBE_INVALID_NUMBER = /\d[_a-zA-Z]/
+
     INVALID_NUMBER_FOLLOWED_BY_NAME_REGEXP = %r{
       (?<leading>#{LEADING_REGEX})
-      (
-        ((?<num>#{Lexer::INT_REGEXP}(#{Lexer::FLOAT_EXP_REGEXP})?)(?<name>#{Lexer::IDENTIFIER_REGEXP})#{Lexer::IGNORE_REGEXP}:)
-        |
-        ((?<num>#{Lexer::INT_REGEXP}#{Lexer::FLOAT_DECIMAL_REGEXP}#{Lexer::FLOAT_EXP_REGEXP})(?<name>#{Lexer::IDENTIFIER_REGEXP})#{Lexer::IGNORE_REGEXP}:)
-        |
-        ((?<num>#{Lexer::INT_REGEXP}#{Lexer::FLOAT_DECIMAL_REGEXP})(?<name>#{Lexer::IDENTIFIER_REGEXP})#{Lexer::IGNORE_REGEXP}:)
-      )}x
+      (?<num>#{EFFICIENT_NUMBER_REGEXP})
+      (?<name>#{Lexer::IDENTIFIER_REGEXP})
+      #{EFFICIENT_IGNORE_REGEXP}
+      :
+    }x
 
     def self.add_space_between_numbers_and_names(query_str)
-      if query_str.match?(INVALID_NUMBER_FOLLOWED_BY_NAME_REGEXP)
-        query_str.gsub(INVALID_NUMBER_FOLLOWED_BY_NAME_REGEXP, "\\k<leading>\\k<num> \\k<name>:")
-      else
-        query_str
-      end
+      # Fast check for digit followed by identifier char. If this doesn't match, skip the more expensive regexp entirely.
+      return query_str unless query_str.match?(MAYBE_INVALID_NUMBER)
+      return query_str unless query_str.match?(INVALID_NUMBER_FOLLOWED_BY_NAME_REGEXP)
+      query_str.gsub(INVALID_NUMBER_FOLLOWED_BY_NAME_REGEXP, "\\k<leading>\\k<num> \\k<name>:")
     end
   end
 end


### PR DESCRIPTION
Claude Code helped to optimize this potentially slow regexp depending on the document. Specifically, the backtracking in the original regexp was the main performance issue.

This does a few things:

1. adds a very simple and faster pre-check to gate if the main regexp should even run
2. prevents as much backtracking as possible

Benchmarks:

| Document Type                  | Before | After  | Speedup |
|--------------------------------|--------|--------|---------|
| Typical large (125KB)          | 0.72s  | 0.06s  | 12x     |
| Colon-heavy (35KB)             | 0.24s  | 0.007s | 34x     |
| Pathological worst-case (26KB) | 1.64s  | 0.25s  | 6.6x    |
| No digits (17KB)               | 0.10s  | 0.002s | 54x     |