### PR TITLE
Fix the link to The Query, Mutation, and Subscription types documentation in the Getting Started guide

### DIFF
--- a/guides/getting_started.md
+++ b/guides/getting_started.md
@@ -72,7 +72,7 @@ end
 
 ### Build a Schema
 
-Before building a schema, you have to define an [entry point to your system, the "query root"](https://graphql.org/learn/schema/#the-query-and-mutation-types):
+Before building a schema, you have to define an [entry point to your system, the "query root"](https://graphql.org/learn/schema/#the-query-mutation-and-subscription-types):
 
 ```ruby
 class QueryType < GraphQL::Schema::Object


### PR DESCRIPTION
### Detail
- Fix the link to root operation types documentation in the Getting Started guide