### PR TITLE
Require action_controller before using it

### DIFF
--- a/lib/graphql/dashboard.rb
+++ b/lib/graphql/dashboard.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'rails/engine'
+require 'action_controller'
 module Graphql
   # `GraphQL::Dashboard` is a `Rails::Engine`-based dashboard for viewing metadata about your GraphQL schema.
   #


### PR DESCRIPTION
This fixes this problem:

```
❯ irb
>> require "rails"
=> true
>> require "graphql"
/Users/rafaelfranca/.gem/ruby/4.0.0/gems/graphql-2.5.17/lib/graphql/dashboard.rb:83:in '<class:Dashboard>': uninitialized constant ActionController::Base (NameError)

    class ApplicationController < ActionController::Base
                                                  ^^^^^^
Did you mean?  Base64
        from /Users/rafaelfranca/.gem/ruby/4.0.0/gems/graphql-2.5.17/lib/graphql/dashboard.rb:34:in '<module:Graphql>'
        from /Users/rafaelfranca/.gem/ruby/4.0.0/gems/graphql-2.5.17/lib/graphql/dashboard.rb:3:in '<top (required)>'
        from /Users/rafaelfranca/.gem/ruby/4.0.0/gems/graphql-2.5.17/lib/graphql.rb:132:in 'Kernel#require'
        from /Users/rafaelfranca/.gem/ruby/4.0.0/gems/graphql-2.5.17/lib/graphql.rb:132:in '<module:GraphQL>'
        from /Users/rafaelfranca/.gem/ruby/4.0.0/gems/graphql-2.5.17/lib/graphql.rb:10:in '<top (required)>'
        from (irb):2:in 'Kernel#require'
        from (irb):2:in '<main>'
        from /opt/rubies/4.0.0/lib/ruby/gems/4.0.0/gems/irb-1.16.0/exe/irb:9:in '<top (required)>'
        from /opt/rubies/4.0.0/lib/ruby/4.0.0/rubygems.rb:303:in 'Kernel#load'
        from /opt/rubies/4.0.0/lib/ruby/4.0.0/rubygems.rb:303:in 'Gem.activate_and_load_bin_path'
        from /Users/rafaelfranca/.gem/ruby/4.0.0/bin/irb:25:in '<main>'
(irb):2:in 'Kernel#require': cannot load such file -- graphql (LoadError)
        from (irb):2:in '<main>'
        from /opt/rubies/4.0.0/lib/ruby/gems/4.0.0/gems/irb-1.16.0/lib/irb/workspace.rb:110:in 'Kernel#eval'
        from /opt/rubies/4.0.0/lib/ruby/gems/4.0.0/gems/irb-1.16.0/lib/irb/workspace.rb:110:in 'IRB::WorkSpace#evaluate'
        from /opt/rubies/4.0.0/lib/ruby/gems/4.0.0/gems/irb-1.16.0/lib/irb/context.rb:591:in 'IRB::Context#evaluate_expression'
        from /opt/rubies/4.0.0/lib/ruby/gems/4.0.0/gems/irb-1.16.0/lib/irb/context.rb:557:in 'IRB::Context#evaluate'
        from /opt/rubies/4.0.0/lib/ruby/gems/4.0.0/gems/irb-1.16.0/lib/irb.rb:202:in 'block (2 levels) in IRB::Irb#eval_input'
        from /opt/rubies/4.0.0/lib/ruby/gems/4.0.0/gems/irb-1.16.0/lib/irb.rb:521:in 'IRB::Irb#signal_status'
        from /opt/rubies/4.0.0/lib/ruby/gems/4.0.0/gems/irb-1.16.0/lib/irb.rb:194:in 'block in IRB::Irb#eval_input'
        from /opt/rubies/4.0.0/lib/ruby/gems/4.0.0/gems/irb-1.16.0/lib/irb.rb:281:in 'block in IRB::Irb#each_top_level_statement'
        from /opt/rubies/4.0.0/lib/ruby/gems/4.0.0/gems/irb-1.16.0/lib/irb.rb:278:in 'Kernel#loop'
        from /opt/rubies/4.0.0/lib/ruby/gems/4.0.0/gems/irb-1.16.0/lib/irb.rb:278:in 'IRB::Irb#each_top_level_statement'
        from /opt/rubies/4.0.0/lib/ruby/gems/4.0.0/gems/irb-1.16.0/lib/irb.rb:193:in 'IRB::Irb#eval_input'
        from /opt/rubies/4.0.0/lib/ruby/gems/4.0.0/gems/irb-1.16.0/lib/irb.rb:174:in 'block in IRB::Irb#run'
        from /opt/rubies/4.0.0/lib/ruby/gems/4.0.0/gems/irb-1.16.0/lib/irb.rb:173:in 'Kernel#catch'
        from /opt/rubies/4.0.0/lib/ruby/gems/4.0.0/gems/irb-1.16.0/lib/irb.rb:173:in 'IRB::Irb#run'
        from /opt/rubies/4.0.0/lib/ruby/gems/4.0.0/gems/irb-1.16.0/lib/irb.rb:54:in 'IRB.start'
        ... 4 levels...
```

The reason for it is that this gem is using a Rails framework without requiring it first