### PR TITLE
Fix docs link in the Object Cache's Runtime Considerations guide

### DIFF
--- a/guides/object_cache/runtime_considerations.md
+++ b/guides/object_cache/runtime_considerations.md
@@ -64,4 +64,4 @@ pp result.context[:object_cache]
 
 If you need to manually clear the cache for a query, pass `context: { refresh_object_cache: true, ... }`. This will cause the `ObjectCache` to remove the already-cached result (if there was one), reassess the query for cache validity, and return a freshly-executed result.
 
-Usually, this shouldn't be necessary; making sure objects update their {% internal_link "cache fingerprints", "/object_cache/schema_setup.html#object-fingerprint" %} will cause entries to expire when they should be re-executed. See also {% internal_link "Schema fingerprint", "/object_cache/schema_setup.html#schema-fingerprint %} for expiring _all_ results in the cache.
+Usually, this shouldn't be necessary; making sure objects update their {% internal_link "cache fingerprints", "/object_cache/schema_setup.html#object-fingerprint" %} will cause entries to expire when they should be re-executed. See also {% internal_link "Schema fingerprint", "/object_cache/schema_setup.html#schema-fingerprint" %} for expiring _all_ results in the cache.


### PR DESCRIPTION
### Detail

Add missing double quote to the link address.

The link is currently incorrect. See below:

<img width="2320" height="399" alt="Screenshot from 2026-01-23 13-40-56" src="https://github.com/user-attachments/assets/83a8171d-908e-46e9-9cfd-3ce375765421" />

