### PR TITLE
conditionally require graphql/dashboard

### DIFF
--- a/lib/graphql.rb
+++ b/lib/graphql.rb
@@ -129,7 +129,7 @@ This is probably a bug in GraphQL-Ruby, please report this error on GitHub: http
     # This needs to be defined before Rails runs `add_routing_paths`,
     # otherwise GraphQL::Dashboard's routes won't have been gathered for loading
     # when that initializer runs.
-    require 'graphql/dashboard'
+    ActiveSupport.on_load(:action_controller) { require 'graphql/dashboard' }
   end
 end
 


### PR DESCRIPTION
More context here: https://github.com/rmosolgo/graphql-ruby/pull/5505/files#r2725942442

Using this script, this require has triggered a lot of autoloaded constants related to ActionController
<img width="1725" height="514" alt="image" src="https://github.com/user-attachments/assets/3e287796-e7c6-4375-bea7-d2cdcdd4ba22" />
