### PR TITLE
Fix a few minor issues in the Pagination Cursors guide

### DIFF
--- a/guides/pagination/cursors.md
+++ b/guides/pagination/cursors.md
@@ -39,4 +39,4 @@ end
 
 Now, all connections will use URL-safe base-64 encoding.
 
-From a connection instance, the `cursor_encoders` methods are available via {{ "GraphQL::Pagination::Connection#encode" | api_doc }} and {{ "GraphQL::Pagination::Connection#decode" | api_doc }}
+From a connection instance, the `cursor_encoder` methods are available via [GraphQL::Pagination::Connection](https://github.com/rmosolgo/graphql-ruby/blob/master/lib/graphql/pagination/connection.rb) `#encode` and `#decode`


### PR DESCRIPTION
### Detail

Replace the API documentation link with the source code link in Pagination Cursors guide.