### PR TITLE
Fix from_definition with extras

### DIFF
--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -519,35 +519,22 @@ module GraphQL
 
             # Don't do this for interfaces
             if default_resolve
-              define_field_resolve_method(owner, resolve_method_name, field_definition.name, field_definition.arguments.empty?)
+              define_field_resolve_method(owner, resolve_method_name, field_definition.name)
             end
           end
         end
 
-        def define_field_resolve_method(owner, method_name, field_name, empty_arguments)
-          if empty_arguments
-            owner.define_method(method_name) {
-              field_instance = context.types.field(owner, field_name)
-              context.schema.definition_default_resolve.call(self.class, field_instance, object, EmptyObjects::EMPTY_HASH, context)
-            }
-            owner.define_singleton_method(method_name) { |objects, context|
-              field_instance = context.types.field(owner, field_name)
-              objects.map do |object|
-                context.schema.definition_default_resolve.call(self, field_instance, object, EmptyObjects::EMPTY_HASH, context)
-              end
-            }
-          else
-            owner.define_method(method_name) { |**args|
-              field_instance = context.types.field(owner, field_name)
-              context.schema.definition_default_resolve.call(self.class, field_instance, object, args, context)
-            }
-            owner.define_singleton_method(method_name) { |objects, context, **args|
-              field_instance = context.types.field(owner, field_name)
-              objects.map do |object|
-                context.schema.definition_default_resolve.call(self, field_instance, object, args, context)
-              end
-            }
-          end
+        def define_field_resolve_method(owner, method_name, field_name)
+          owner.define_method(method_name) { |**args|
+            field_instance = context.types.field(owner, field_name)
+            context.schema.definition_default_resolve.call(self.class, field_instance, object, args, context)
+          }
+          owner.define_singleton_method(method_name) { |objects, context, **args|
+            field_instance = context.types.field(owner, field_name)
+            objects.map do |object|
+              context.schema.definition_default_resolve.call(self, field_instance, object, args, context)
+            end
+          }
         end
 
         def build_resolve_type(lookup_hash, directives, missing_type_handler)

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -1937,4 +1937,33 @@ type ReachableType implements Node {
 
     assert GraphQL::Schema.from_definition(sdl).to_definition
   end
+
+  it "lets you add extras after definition" do
+    schema_definition = <<~GRAPHQL
+      type Query {
+        testField: String!
+      }
+    GRAPHQL
+
+    lookahead = nil
+    resolver_implementation = {
+      "Query" => {
+        "testField" => lambda do |object, args, context|
+          lookahead = args[:lookahead]
+          "test value"
+        end
+      }
+    }
+
+    schema = GraphQL::Schema.from_definition(
+      schema_definition,
+      default_resolve: resolver_implementation
+    )
+
+    schema.query.fields["testField"].extras([:lookahead])
+
+    result = schema.execute("{ testField }")
+    assert_equal "test value", result["data"]["testField"]
+    assert_instance_of GraphQL::Execution::Lookahead, lookahead
+  end
 end


### PR DESCRIPTION
Oops, I "optimized" this in https://github.com/rmosolgo/graphql-ruby/pull/5509/changes#diff-1ff8d09dd48483a2bba959cc7627c912707deca2e3fd7e8896aaf1b9807fe7ad but it broke when `extras` were added to the field after definition. 

This adds a spec based on #5555 and reverts the change.

Fixes #5555 