### PR TITLE
Skip `did_you_mean` suggestions when feature is disabled

### DIFF
--- a/lib/graphql/static_validation/rules/arguments_are_defined.rb
+++ b/lib/graphql/static_validation/rules/arguments_are_defined.rb
@@ -10,9 +10,12 @@ module GraphQL
         elsif parent_defn
           kind_of_node = node_type(parent)
           error_arg_name = parent_name(parent, parent_defn)
-          arg_names = context.types.arguments(parent_defn).map(&:graphql_name)
+          suggestion = if @schema.did_you_mean
+            arg_names = context.types.arguments(parent_defn).map(&:graphql_name)
+            context.did_you_mean_suggestion(node.name, arg_names)
+          end
           add_error(GraphQL::StaticValidation::ArgumentsAreDefinedError.new(
-            "#{kind_of_node} '#{error_arg_name}' doesn't accept argument '#{node.name}'#{context.did_you_mean_suggestion(node.name, arg_names)}",
+            "#{kind_of_node} '#{error_arg_name}' doesn't accept argument '#{node.name}'#{suggestion}",
             nodes: node,
             name: error_arg_name,
             type: kind_of_node,

--- a/lib/graphql/static_validation/rules/directives_are_defined.rb
+++ b/lib/graphql/static_validation/rules/directives_are_defined.rb
@@ -10,9 +10,12 @@ module GraphQL
         if !@types.directive_exists?(node.name)
           @directives_are_defined_errors_by_name ||= {}
           error = @directives_are_defined_errors_by_name[node.name] ||= begin
-            @directive_names ||= @types.directives.map(&:graphql_name)
+            suggestion = if @schema.did_you_mean
+              @directive_names ||= @types.directives.map(&:graphql_name)
+              context.did_you_mean_suggestion(node.name, @directive_names)
+            end
             err = GraphQL::StaticValidation::DirectivesAreDefinedError.new(
-              "Directive @#{node.name} is not defined#{context.did_you_mean_suggestion(node.name, @directive_names)}",
+              "Directive @#{node.name} is not defined#{suggestion}",
               nodes: [],
               directive: node.name
             )

--- a/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb
+++ b/lib/graphql/static_validation/rules/fields_are_defined_on_type.rb
@@ -14,8 +14,9 @@ module GraphQL
               node_name: parent_type.graphql_name
             ))
           else
-            possible_fields = possible_fields(context, parent_type)
-            suggestion = context.did_you_mean_suggestion(node.name, possible_fields)
+            suggestion = if @schema.did_you_mean
+              context.did_you_mean_suggestion(node.name, possible_fields(context, parent_type))
+            end
             message = "Field '#{node.name}' doesn't exist on type '#{parent_type.graphql_name}'#{suggestion}"
             add_error(GraphQL::StaticValidation::FieldsAreDefinedOnTypeError.new(
               message,

--- a/lib/graphql/static_validation/rules/fragment_types_exist.rb
+++ b/lib/graphql/static_validation/rules/fragment_types_exist.rb
@@ -23,18 +23,21 @@ module GraphQL
           type_name = fragment_node.type.name
           type = @types.type(type_name)
           if type.nil?
-            @all_possible_fragment_type_names ||= begin
-              names = []
-              context.types.all_types.each do |type|
-                if type.kind.fields?
-                  names << type.graphql_name
+            suggestion = if @schema.did_you_mean
+              @all_possible_fragment_type_names ||= begin
+                names = []
+                context.types.all_types.each do |type|
+                  if type.kind.fields?
+                    names << type.graphql_name
+                  end
                 end
+                names
               end
-              names
+              context.did_you_mean_suggestion(type_name, @all_possible_fragment_type_names)
             end
 
             add_error(GraphQL::StaticValidation::FragmentTypesExistError.new(
-              "No such type #{type_name}, so it can't be a fragment condition#{context.did_you_mean_suggestion(type_name, @all_possible_fragment_type_names)}",
+              "No such type #{type_name}, so it can't be a fragment condition#{suggestion}",
               nodes: fragment_node,
               type: type_name
             ))

--- a/lib/graphql/static_validation/rules/variables_are_input_types.rb
+++ b/lib/graphql/static_validation/rules/variables_are_input_types.rb
@@ -7,17 +7,20 @@ module GraphQL
         type = context.query.types.type(type_name)
 
         if type.nil?
-          @all_possible_input_type_names ||= begin
-            names = []
-            context.types.all_types.each { |(t)|
-              if t.kind.input?
-                names << t.graphql_name
-              end
-            }
-            names
+          suggestion = if @schema.did_you_mean
+            @all_possible_input_type_names ||= begin
+              names = []
+              context.types.all_types.each { |(t)|
+                if t.kind.input?
+                  names << t.graphql_name
+                end
+              }
+              names
+            end
+            context.did_you_mean_suggestion(type_name, @all_possible_input_type_names)
           end
           add_error(GraphQL::StaticValidation::VariablesAreInputTypesError.new(
-            "#{type_name} isn't a defined input type (on $#{node.name})#{context.did_you_mean_suggestion(type_name, @all_possible_input_type_names)}",
+            "#{type_name} isn't a defined input type (on $#{node.name})#{suggestion}",
             nodes: node,
             name: node.name,
             type: type_name


### PR DESCRIPTION
When `did_you_mean` is disabled (common in production), skip the expensive all_types loading and dictionary computation entirely. Previously these allocations happened unconditionally on every validation error path.

Extracted from https://github.com/rmosolgo/graphql-ruby/pull/5578