### PR TITLE
Cache `unwrap` and `to_type_signature` on type wrappers

### DIFF
--- a/lib/graphql/schema/list.rb
+++ b/lib/graphql/schema/list.rb
@@ -19,7 +19,7 @@ module GraphQL
       end
 
       def to_type_signature
-        "[#{@of_type.to_type_signature}]"
+        @type_signature ||= -"[#{@of_type.to_type_signature}]"
       end
 
       # This is for introspection, where it's expected the name will be `null`

--- a/lib/graphql/schema/non_null.rb
+++ b/lib/graphql/schema/non_null.rb
@@ -24,7 +24,7 @@ module GraphQL
       end
 
       def to_type_signature
-        "#{@of_type.to_type_signature}!"
+        @type_signature ||= -"#{@of_type.to_type_signature}!"
       end
 
       def inspect

--- a/lib/graphql/schema/wrapper.rb
+++ b/lib/graphql/schema/wrapper.rb
@@ -13,7 +13,13 @@ module GraphQL
       end
 
       def unwrap
-        @of_type.unwrap
+        @unwrapped ||= @of_type.unwrap
+      end
+
+      def freeze
+        unwrap
+        to_type_signature
+        super
       end
 
       def ==(other)


### PR DESCRIPTION
Type wrappers (NonNull, List) are schema-level immutable objects whose `unwrap` and `to_type_signature` results never change. Memoize both to eliminate repeated recursive unwrap calls and string allocations during validation and introspection.

I can't find any reason why these wouldn't be safe to memoize.

Extracted from https://github.com/rmosolgo/graphql-ruby/pull/5578