### PR TITLE
Optimize validation rule hot paths

### DIFF
--- a/lib/graphql/static_validation/rules/argument_names_are_unique.rb
+++ b/lib/graphql/static_validation/rules/argument_names_are_unique.rb
@@ -16,12 +16,24 @@ module GraphQL
 
       def validate_arguments(node)
         argument_defns = node.arguments
-        if !argument_defns.empty?
-          args_by_name = Hash.new { |h, k| h[k] = [] }
-          argument_defns.each { |a| args_by_name[a.name] << a }
-          args_by_name.each do |name, defns|
-            if defns.size > 1
-              add_error(GraphQL::StaticValidation::ArgumentNamesAreUniqueError.new("There can be only one argument named \"#{name}\"", nodes: defns, name: name))
+        if argument_defns.size > 1
+          seen = {}
+          argument_defns.each do |a|
+            name = a.name
+            if seen.key?(name)
+              prev = seen[name]
+              if prev.is_a?(Array)
+                prev << a
+              else
+                seen[name] = [prev, a]
+              end
+            else
+              seen[name] = a
+            end
+          end
+          seen.each do |name, val|
+            if val.is_a?(Array)
+              add_error(GraphQL::StaticValidation::ArgumentNamesAreUniqueError.new("There can be only one argument named \"#{name}\"", nodes: val, name: name))
             end
           end
         end

--- a/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb
+++ b/lib/graphql/static_validation/rules/fields_have_appropriate_selections.rb
@@ -23,6 +23,17 @@ module GraphQL
 
 
       def validate_field_selections(ast_node, resolved_type)
+        # Fast paths for the two most common cases:
+        # 1. Leaf type with no selections (scalars, enums) — most fields
+        # 2. Non-leaf type with selections (objects, interfaces)
+        if resolved_type
+          if ast_node.selections.empty?
+            return true if resolved_type.kind.leaf?
+          else
+            return true unless resolved_type.kind.leaf?
+          end
+        end
+
         msg = if resolved_type.nil?
           nil
         elsif resolved_type.kind.leaf?

--- a/lib/graphql/static_validation/rules/required_arguments_are_present.rb
+++ b/lib/graphql/static_validation/rules/required_arguments_are_present.rb
@@ -2,6 +2,11 @@
 module GraphQL
   module StaticValidation
     module RequiredArgumentsArePresent
+      def initialize(*)
+        super
+        @required_args_cache = {}.compare_by_identity
+      end
+
       def on_field(node, _parent)
         assert_required_args(node, field_definition)
         super
@@ -16,13 +21,28 @@ module GraphQL
       private
 
       def assert_required_args(ast_node, defn)
-        args = @context.query.types.arguments(defn)
-        return if args.empty?
-        present_argument_names = ast_node.arguments.map(&:name)
-        required_argument_names = context.query.types.arguments(defn)
-          .select { |a| a.type.kind.non_null? && !a.default_value? && context.query.types.argument(defn, a.name) }
-          .map!(&:name)
+        return unless defn
 
+        # Cache required argument names per definition to avoid re-iterating
+        # arguments for the same definition across field instances
+        if @required_args_cache.key?(defn)
+          required_argument_names = @required_args_cache[defn]
+        else
+          args = @types.arguments(defn)
+          required_argument_names = nil
+          if !args.empty?
+            args.each do |a|
+              if a.type.kind.non_null? && !a.default_value? && @types.argument(defn, a.name)
+                (required_argument_names ||= []) << a.graphql_name
+              end
+            end
+          end
+          @required_args_cache[defn] = required_argument_names
+        end
+
+        return if required_argument_names.nil?
+
+        present_argument_names = ast_node.arguments.map(&:name)
         missing_names = required_argument_names - present_argument_names
         if !missing_names.empty?
           add_error(GraphQL::StaticValidation::RequiredArgumentsArePresentError.new(


### PR DESCRIPTION
Extracted from https://github.com/rmosolgo/graphql-ruby/pull/5578

These a few miscellaneous micro-optimizations to validation rules.

- `ArgumentNamesAreUnique`: avoid Hash.new block allocation on the common unique-args path; only build array on actual collision
- `FieldsHaveAppropriateSelections`: fast-path leaf+no-selections and non-leaf+selections cases, skipping the full validation method
- `RequiredArgumentsArePresent`: cache required arg names per definition to avoid re-iterating arguments for repeated field definitions
~- `FragmentSpreadsArePossible`: use Array#intersect? instead of none? { include? } for type overlap check~

Note: I'm keeping all the `FieldsWillMerge` optimizations for their own PR.