### PR TITLE
Require transitive interface names when loading a schema from SDL

### DIFF
--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -99,6 +99,16 @@ module GraphQL
               # It's possible that this was already loaded by the directives
               prev_type = types[definition.name]
               if prev_type.nil? || prev_type.is_a?(Schema::LateBoundType)
+                if definition.is_a?(GraphQL::Language::Nodes::ObjectTypeDefinition) || definition.is_a?(Language::Nodes::InterfaceTypeDefinition)
+                  interface_names = definition.interfaces.map(&:name)
+                  transitive_names = interface_names.map { |n| document.definitions.find { |d| d.respond_to?(:name) && d.name == n }&.interfaces&.map(&:name) }
+                  transitive_names.flatten!
+                  transitive_names.compact!
+                  if (missing_transitive_interfaces = transitive_names - interface_names).any?
+                    raise GraphQL::Schema::InvalidDocumentError, "type #{definition.name} is missing one or more transitive interface names: #{missing_transitive_interfaces.join(", ")}. Add them to the type's `implements` list and try again."
+                  end
+                end
+
                 types[definition.name] = build_definition_from_node(definition, type_resolver, default_resolve, base_types)
               end
             end

--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -104,7 +104,7 @@ module GraphQL
                   transitive_names = interface_names.map { |n| document.definitions.find { |d| d.respond_to?(:name) && d.name == n }&.interfaces&.map(&:name) }
                   transitive_names.flatten!
                   transitive_names.compact!
-                  if (missing_transitive_interfaces = transitive_names - interface_names).any?
+                  if !(missing_transitive_interfaces = transitive_names - interface_names).empty?
                     raise GraphQL::Schema::InvalidDocumentError, "type #{definition.name} is missing one or more transitive interface names: #{missing_transitive_interfaces.join(", ")}. Add them to the type's `implements` list and try again."
                   end
                 end

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -539,6 +539,29 @@ interface WorldInterface {
       assert_schema_and_compare_output(schema)
     end
 
+    it "requires transitive dependencies to be named" do
+      schema_str = <<~GRAPHQL
+      interface A implements B {
+        s: String
+      }
+
+      interface B {
+        s: String
+      }
+
+      type Query implements A & B {
+        s: String
+      }
+      GRAPHQL
+
+      assert_schema_and_compare_output(schema_str)
+
+      invalid_schema_str = schema_str.sub("A & B", "A")
+      assert_raises GraphQL::Schema::InvalidDocumentError do
+        GraphQL::Schema.from_definition(invalid_schema_str)
+      end
+    end
+
     it "supports interfaces that implement interfaces" do
       schema = <<-SCHEMA
 interface Named implements Node {
@@ -1542,13 +1565,13 @@ type ReachableType implements Node {
         person: Person
       }
 
-      type Person implements NamedEntity {
+      type Person implements NamedEntity & Entity {
         id: ID!
         name: String
         nationality: String
       }
 
-      type Product implements NamedEntity {
+      type Product implements NamedEntity & Entity {
         id: ID!
         name: String
         amount: Int


### PR DESCRIPTION
Fixes #5580 

This is a "breaking fix", as some previously-accepted (but broken) SDL strings will now raise errors. I'm going to wait for 2.6.0 to merge this.