### PR TITLE
Use a specific message for end-of-file parse errors

### DIFF
--- a/lib/graphql/language/lexer.rb
+++ b/lib/graphql/language/lexer.rb
@@ -130,7 +130,7 @@ module GraphQL
         elsif token_name == :STRING
           string_value
         elsif @scanner.matched_size.nil?
-          @scanner.peek(1)
+          @string.byteslice(@scanner.pos - 1, 1)
         else
           token_value
         end

--- a/lib/graphql/language/parser.rb
+++ b/lib/graphql/language/parser.rb
@@ -806,7 +806,7 @@ module GraphQL
 
       def expect_token(expected_token_name)
         unless @token_name == expected_token_name
-          raise_parse_error("Expected #{expected_token_name}, actual: #{token_name || "(none)"} (#{debug_token_value.inspect})")
+          raise_parse_error("Expected #{expected_token_name}, #{@token_name == false ? "not end of file" : "actual: #{@token_name} (#{debug_token_value.inspect})"}")
         end
         advance_token
       end

--- a/spec/graphql/language/parser_spec.rb
+++ b/spec/graphql/language/parser_spec.rb
@@ -235,6 +235,19 @@ createRecord(data: {
     assert_equal expected_msg, err.message
   end
 
+  it "shows the right character in error messages" do
+    err = assert_raises(GraphQL::ParseError) {
+      GraphQL.parse("query # comment\n ~ { a b }")
+    }
+    expected_msg = if USING_C_PARSER
+      "syntax error, unexpected invalid token (\"~\"), expecting LCURLY at [2, 2]"
+    else
+      "Expected NAME, actual: UNKNOWN_CHAR (\"~\") at [2, 2]"
+    end
+
+    assert_equal expected_msg, err.message
+  end
+
   it "can reject name start at the end of numbers" do
     prev_reject_numers_followed_by_names = GraphQL.reject_numbers_followed_by_names
     GraphQL.reject_numbers_followed_by_names = false

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -680,7 +680,7 @@ describe GraphQL::Query do
       if USING_C_PARSER
         expected_err = "syntax error, unexpected end of file at [1, 2]"
       else
-        expected_err = "Expected NAME, actual: (none) (\" \") at [1, 2]"
+        expected_err = "Expected NAME, not end of file at [1, 2]"
       end
       expected_locations = [{"line" => 1, "column" => 2}]
       assert_equal expected_err, res["errors"][0]["message"]
@@ -691,7 +691,7 @@ describe GraphQL::Query do
       if USING_C_PARSER
         expected_err = "syntax error, unexpected end of file at [1, 1]"
       else
-        expected_err = "Expected NAME, actual: (none) (\"\") at [1, 1]"
+        expected_err = "Expected NAME, not end of file at [1, 1]"
       end
       expected_locations = [{"line" => 1, "column" => 1}]
       assert_equal expected_err, res["errors"][0]["message"]


### PR DESCRIPTION
Oops, this case of parser error message started giving the wrong debug info after 88d6c1ca51927556b3c9cd4377db2fa1089f3905. 

It was because `@scanner.matched_size.nil?` was now true/false in slightly different circumstances, depending on whether the query had comments or ignored characters in it. 

I tried to preserve compatibility as-is, but it didn't seem like the right move. Instead, I'm adding a specific end-of-file debug message in this case, like GraphQL-CParser already has.