### PR TITLE
Fix Dataloader#with for JRuby

### DIFF
--- a/lib/graphql/dataloader.rb
+++ b/lib/graphql/dataloader.rb
@@ -108,7 +108,7 @@ module GraphQL
     # @param batch_parameters [Array<Object>]
     # @return [GraphQL::Dataloader::Source] An instance of {source_class}, initialized with `self, *batch_parameters`,
     #   and cached for the lifetime of this {Multiplex}.
-    if RUBY_VERSION < "3" || RUBY_ENGINE != "ruby" # truffle-ruby wasn't doing well with the implementation below
+    if (RUBY_ENGINE == "ruby" && RUBY_ENGINE < "3") || RUBY_ENGINE == "truffleruby" # truffle-ruby wasn't doing well with the implementation below
       def with(source_class, *batch_args)
         batch_key = source_class.batch_key_for(*batch_args)
         @source_cache[source_class][batch_key] ||= begin


### PR DESCRIPTION
Fixes #5541 

Apparently JRuby 10+ handles this fine, so I reworked these conditionals to allow it to use the `else` branch instead. I ran the script from #5541 and it passed with this change: 

```
RUBY_ENGINE: jruby
RUBY_VERSION: 3.4.5
graphql gem version: 2.6.1

Attempting: dataloader.with(KeywordSource, name: 'test', value: 42).load('key1')
SUCCESS: "test:42:key1"
```

I don't have any JRuby or TruffleRuby CI set up, though 🙈 

I got the RUBY_ENGINE value for TruffleRuby (`"truffleruby"`) here: https://www.graalvm.org/22.0/reference-manual/ruby/Compatibility/