### PR TITLE
Add test for lazy batching of .resolve_type

### DIFF
--- a/lib/graphql/execution/prepare_object_step.rb
+++ b/lib/graphql/execution/prepare_object_step.rb
@@ -28,7 +28,10 @@ module GraphQL
           ctx = @field_resolve_step.selections_step.query.context
           st = @field_resolve_step.static_type
           ctx.query.current_trace.begin_resolve_type(st, @object, ctx)
-          @resolved_type, _ignored_value = @field_resolve_step.sync(@resolved_type)
+          @resolved_type, new_value = @field_resolve_step.sync(@resolved_type)
+          if new_value
+            @object = new_value
+          end
           ctx.query.current_trace.end_resolve_type(st, @object, ctx, @resolved_type)
         end
         @runner.add_step(self)
@@ -41,7 +44,10 @@ module GraphQL
           if static_type.kind.abstract?
             ctx = @field_resolve_step.selections_step.query.context
             ctx.query.current_trace.begin_resolve_type(static_type, @object, ctx)
-            @resolved_type, _ignored_value = @runner.schema.resolve_type(static_type, @object, ctx)
+            @resolved_type, new_value = @runner.schema.resolve_type(static_type, @object, ctx)
+            if new_value
+              @object = new_value
+            end
             ctx.query.current_trace.end_resolve_type(static_type, @object, ctx, @resolved_type)
           else
             @resolved_type = static_type

--- a/spec/graphql/execution/lazy_spec.rb
+++ b/spec/graphql/execution/lazy_spec.rb
@@ -245,4 +245,109 @@ describe GraphQL::Execution::Lazy do
       assert_equal(:value, map.get(s))
     end
   end
+
+  describe "Interface.resolve_type" do
+    class LazyResolveTypeSchema < GraphQL::Schema
+      class Loader
+        LOG = []
+        DATA = {
+          1 => { versionable: 3 },
+          2 => { versionable: 4 },
+          3 => { foo: "foo" },
+          4 => { bar: "bar" },
+        }
+
+        def initialize(loading_key)
+          @loading_key = loading_key
+          @loading_ids = Set.new
+          @loaded = {}
+        end
+
+        def self.for(context, loading_key)
+          l_cache = context[:loader_cache] ||= Hash.new { |h, k| h[k] = Loader.new(k) }
+          l_cache[loading_key]
+        end
+
+        def load(id)
+          @loading_ids.add(id)
+          -> {
+            resolve
+            result = @loaded.fetch(id)
+            if block_given?
+              yield(result)
+            else
+              result
+            end
+          }
+        end
+
+        def resolve
+          if @loading_ids.any?
+            Loader::LOG << [@loading_key, @loading_ids.to_a]
+            @loading_ids.to_a.each do |id|
+              @loaded[id] = DATA[id]
+            end
+            @loading_ids.clear
+          end
+        end
+      end
+
+      module Version
+        include GraphQL::Schema::Interface
+
+        def self.resolve_type(obj, ctx)
+          Loader.for(ctx, :versionable).load(obj[:versionable]) do |versionable|
+            versionable[:foo] ? FooVersionable : BarVersionable
+          end
+        end
+      end
+
+      class FooVersionable < GraphQL::Schema::Object
+        implements Version
+        field :foo, String
+      end
+
+      class BarVersionable < GraphQL::Schema::Object
+        implements Version
+        field :bar, String
+      end
+
+      class VersionReference < GraphQL::Schema::Object
+        field :version, Version
+
+        def version
+          Loader.for(context, :version).load(object[:version])
+        end
+      end
+      class Query < GraphQL::Schema::Object
+        field :version_references, [VersionReference]
+
+        def version_references
+          [{ version: 1 }, { version: 2 }]
+        end
+      end
+
+      lazy_resolve(Proc, :call)
+      query(Query)
+      orphan_types FooVersionable, BarVersionable
+    end
+
+    it "resolves lazies efficiently" do
+      LazyResolveTypeSchema::Loader::LOG.clear
+      query_str = " {
+        versionReferences {
+          version {
+            ... on FooVersionable { foo }
+            ... on BarVersionable { bar }
+          }
+        }
+      }"
+      res = LazyResolveTypeSchema.execute(query_str)
+      pp res.to_h
+      expected_log = [
+
+      ]
+      assert_equal expected_log, LazyResolveTypeSchema::Loader::LOG
+    end
+  end
 end

--- a/spec/graphql/execution/lazy_spec.rb
+++ b/spec/graphql/execution/lazy_spec.rb
@@ -297,32 +297,32 @@ describe GraphQL::Execution::Lazy do
 
         def self.resolve_type(obj, ctx)
           Loader.for(ctx, :versionable).load(obj[:versionable]) do |versionable|
-            versionable[:foo] ? FooVersionable : BarVersionable
+            [(versionable[:foo] ? FooVersionable : BarVersionable), versionable]
           end
         end
       end
 
       class FooVersionable < GraphQL::Schema::Object
         implements Version
-        field :foo, String
+        field :foo, String, hash_key: :foo
       end
 
       class BarVersionable < GraphQL::Schema::Object
         implements Version
-        field :bar, String
+        field :bar, String, hash_key: :bar
       end
 
       class VersionReference < GraphQL::Schema::Object
-        field :version, Version
+        field :version, Version, resolve_each: true
 
-        def version
+        def self.version(object, context)
           Loader.for(context, :version).load(object[:version])
         end
       end
       class Query < GraphQL::Schema::Object
-        field :version_references, [VersionReference]
+        field :version_references, [VersionReference], resolve_static: true
 
-        def version_references
+        def self.version_references(context)
           [{ version: 1 }, { version: 2 }]
         end
       end
@@ -330,6 +330,7 @@ describe GraphQL::Execution::Lazy do
       lazy_resolve(Proc, :call)
       query(Query)
       orphan_types FooVersionable, BarVersionable
+      use GraphQL::Execution::Next
     end
 
     it "resolves lazies efficiently" do
@@ -342,10 +343,19 @@ describe GraphQL::Execution::Lazy do
           }
         }
       }"
-      res = LazyResolveTypeSchema.execute(query_str)
-      pp res.to_h
-      expected_log = [
 
+      res = LazyResolveTypeSchema.execute_next(query_str)
+      expected_data = {
+        "versionReferences" => [
+          {"version" => {"foo" => "foo"}},
+          {"version" => {"bar" => "bar"}}
+        ]
+      }
+
+      assert_equal expected_data, res["data"]
+      expected_log = [
+        [:version, [1, 2]],
+        [:versionable, [3, 4]]
       ]
       assert_equal expected_log, LazyResolveTypeSchema::Loader::LOG
     end

--- a/spec/graphql/execution/lazy_spec.rb
+++ b/spec/graphql/execution/lazy_spec.rb
@@ -282,7 +282,7 @@ describe GraphQL::Execution::Lazy do
         end
 
         def resolve
-          if @loading_ids.any?
+          if !@loading_ids.empty?
             Loader::LOG << [@loading_key, @loading_ids.to_a]
             @loading_ids.to_a.each do |id|
               @loaded[id] = DATA[id]


### PR DESCRIPTION
This test demonstrates that an old bug is fixed on `Execution::Next`. Also, make `Execution::Next` properly retain the new object from `.resolve_type`. 

Fixes #4835 
Fixes #4892