### PR TITLE
Fix Ruby warnings in the GraphQL::Schema::InputObject class tests

### DIFF
--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -892,7 +892,7 @@ describe GraphQL::Schema::InputObject do
 
     it "does not match missing keys" do
       assert case input_object
-      in { z: }
+      in { z: 5 }
         false
       else
         true

--- a/spec/graphql/schema/input_object_spec.rb
+++ b/spec/graphql/schema/input_object_spec.rb
@@ -892,8 +892,8 @@ describe GraphQL::Schema::InputObject do
 
     it "does not match missing keys" do
       assert case input_object
-      in { z: 5 }
-        false
+      in { z: }
+        raise "Unexpectedly matched a non-present key, z: #{z.inspect} (in: #{input_object.inspect})"
       else
         true
       end


### PR DESCRIPTION
I ran tests for the `GraphQL::Schema::InputObject` class with Ruby warnings enabled:

```
RUBYOPT="-W2" bundle exec rake test TEST=spec/graphql/schema/input_object_spec.rb

/home/andrey/projects/graphql-ruby/spec/graphql/schema/input_object_spec.rb:848: warning: assigned but unused variable - z
```
Tests passed though :green_circle: .