### PR TITLE
Try main branch of rails/bootsnap

### DIFF
--- a/gemfiles/rails_8.1.gemfile
+++ b/gemfiles/rails_8.1.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 # working around https://github.com/rails/bootsnap/issues/547
-gem "bootsnap", github: "rails/bootsnap", ref: "main"
+gem "bootsnap"
 gem "ruby-prof", platform: :ruby
 gem "pry"
 gem "pry-stack_explorer", platform: :ruby

--- a/gemfiles/rails_8.1.gemfile
+++ b/gemfiles/rails_8.1.gemfile
@@ -2,7 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "bootsnap"
+# working around https://github.com/rails/bootsnap/issues/547
+gem "bootsnap", github: "rails/bootsnap", ref: "main"
 gem "ruby-prof", platform: :ruby
 gem "pry"
 gem "pry-stack_explorer", platform: :ruby


### PR DESCRIPTION
This build started failing and I found a related issue on Bootsnap: https://github.com/rails/bootsnap/issues/547

One commenter said using `main` fixed it, so let's see.