### PR TITLE
Don't crash analyzer when @skip/@include arg fails coercion

### DIFF
--- a/lib/graphql/execution/directive_checks.rb
+++ b/lib/graphql/execution/directive_checks.rb
@@ -18,11 +18,13 @@ module GraphQL
           case name
           when SKIP
             args = query.arguments_for(directive_ast_node, directive_defn)
+            next if args.is_a?(GraphQL::ExecutionError)
             if args[:if] == true
               return false
             end
           when INCLUDE
             args = query.arguments_for(directive_ast_node, directive_defn)
+            next if args.is_a?(GraphQL::ExecutionError)
             if args[:if] == false
               return false
             end

--- a/spec/graphql/directive_spec.rb
+++ b/spec/graphql/directive_spec.rb
@@ -50,6 +50,24 @@ describe "GraphQL::Directive" do
       end
     end
 
+    describe "when directive argument variable is explicitly null" do
+      let(:query_string) { <<-GRAPHQL
+        query($f: Boolean = false) {
+          cheese(id: 1) {
+            includeFlavor: flavor @include(if: $f)
+            skipFlavor: flavor @skip(if: $f)
+          }
+        }
+      GRAPHQL
+      }
+      let(:variables) { {"f" => nil} }
+
+      it "returns the coercion error without raising" do
+        expected = "`null` is not a valid input for `Boolean!`, please provide a value for this argument."
+        assert_equal [expected], result["errors"].map { |e| e["message"] }.uniq
+      end
+    end
+
     describe "when directive uses argument with default value" do
       describe "with false" do
         let(:query_string) { <<-GRAPHQL


### PR DESCRIPTION
When `null` is passed for an `@include(if: Boolean!)` / `@skip(if: Boolean!)` argument (e.g. a nullable variable with a default sent as null), `arguments_for` returns a `GraphQL::ExecutionError`.
`DirectiveChecks#include?` then called `args[:if]` on it and raised `NoMethodError`, crashing any schema that runs an analyzer (`max_depth`, `max_complexity`, etc).
Skip the directive in that case so execution surfaces the error normally.