### PR TITLE
Fix `required: :nullable` crash when combined with `as:`

### DIFF
--- a/lib/graphql/schema/argument.rb
+++ b/lib/graphql/schema/argument.rb
@@ -94,7 +94,7 @@ module GraphQL
         end
 
         if required == :nullable
-          self.owner.validates(required: { argument: arg_name })
+          self.owner.validates(required: { argument: @keyword })
         end
 
         if definition_block

--- a/spec/graphql/schema/argument_spec.rb
+++ b/spec/graphql/schema/argument_spec.rb
@@ -620,6 +620,35 @@ describe GraphQL::Schema::Argument do
       res = RequiredNullableSchema.execute('{ echo }')
       assert_equal ["echo must include the following argument: str."], res["errors"].map { |e| e["message"] }
     end
+
+    describe "combined with `as:`" do
+      class RequiredNullableAsSchema < GraphQL::Schema
+        class Query < GraphQL::Schema::Object
+          field :echo, String, resolve_static: true do
+            argument :str, String, required: :nullable, as: :renamed_str
+          end
+
+          def self.echo(context, renamed_str:)
+            renamed_str.inspect
+          end
+
+          def echo(renamed_str:)
+            renamed_str.inspect
+          end
+        end
+
+        query(Query)
+      end
+
+      it "validates against the aliased keyword" do
+        res = RequiredNullableAsSchema.execute('{ echo(str: "ok") }')
+        assert_equal "\"ok\"", res["data"]["echo"]
+        res = RequiredNullableAsSchema.execute('{ echo(str: null) }')
+        assert_equal "nil", res["data"]["echo"]
+        res = RequiredNullableAsSchema.execute('{ echo }')
+        assert_equal ["echo must include the following argument: str."], res["errors"].map { |e| e["message"] }
+      end
+    end
   end
 
   describe "replace_null_with_default: true" do


### PR DESCRIPTION
I ran across this issue when trying to use `as:` on an argument which used `required: :nullable`. In my version it crashes with NoMethodError but it looks like in newer versions the validation just always fails.

This fix uses `@keyword` instead of `arg_name`, which I think should be correct. Tests pass.