### PR TITLE
Execution::Next: fix NoMethodError when fragment non-null propagation nullifies the parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bug fixes
 
+- `Execution::Next`: don't crash when non-null propagation nullifies an object inside a fragment that has sibling selections
+
 # 2.6.2
 
 ### New features

--- a/lib/graphql/execution/finalize.rb
+++ b/lib/graphql/execution/finalize.rb
@@ -154,12 +154,14 @@ module GraphQL
                 @runner.type_condition_applies?(@query.context, static_type_at_result, t.name)
               )
               result_h = check_object_result(result_h, parent_type, ast_selection.selections)
+              return nil if result_h.nil?
             end
           when Language::Nodes::FragmentSpread
             fragment_defn = @query.document.definitions.find { |defn| defn.is_a?(Language::Nodes::FragmentDefinition) && defn.name == ast_selection.name }
             static_type_at_result = @static_type_at[result_h]
             if static_type_at_result && @runner.type_condition_applies?(@query.context, static_type_at_result, fragment_defn.type.name)
               result_h = check_object_result(result_h, parent_type, fragment_defn.selections)
+              return nil if result_h.nil?
             end
           end
         end

--- a/lib/graphql/execution/finalize.rb
+++ b/lib/graphql/execution/finalize.rb
@@ -117,7 +117,7 @@ module GraphQL
               @current_exec_path << key
               @current_result_path << key
 
-              field_defn = @query.context.types.field(parent_type, ast_selection.name) || raise("Invariant: No field found for #{static_type.to_type_signature}.#{ast_selection.name}")
+              field_defn = @query.context.types.field(parent_type, ast_selection.name) || raise("Invariant: No field found for #{parent_type.to_type_signature}.#{ast_selection.name}")
               result_type = field_defn.type
               if (result_type_non_null = result_type.non_null?)
                 result_type = result_type.of_type

--- a/spec/graphql/execution/finalize_spec.rb
+++ b/spec/graphql/execution/finalize_spec.rb
@@ -358,6 +358,52 @@ class ExecutionFinalizeTest < Minitest::Test
     assert_equal expected, exec_test(schema, "{ test { req opt } }", source)
   end
 
+  def test_bubbles_null_through_fragment_spread_with_sibling_field
+    schema = "type Test { req: String! opt: String } type Query { test: Test }"
+    query = "{ test { ...F opt } } fragment F on Test { req }"
+    source = {
+      "test" => {
+        "req" => nil,
+        "opt" => "yes"
+      },
+    }
+    expected = {
+      "data" => {
+        "test" => nil,
+      },
+      "errors" => [{
+        "message" => "Cannot return null for non-nullable field Test.req",
+        "path" => ["test", "req"],
+        "locations" => [{ "line" => 1, "column" => 44 }],
+      }],
+    }
+
+    assert_equal expected, exec_test(schema, query, source)
+  end
+
+  def test_bubbles_null_through_inline_fragment_with_sibling_field
+    schema = "type Test { req: String! opt: String } type Query { test: Test }"
+    query = "{ test { ... on Test { req } opt } }"
+    source = {
+      "test" => {
+        "req" => nil,
+        "opt" => "yes"
+      },
+    }
+    expected = {
+      "data" => {
+        "test" => nil,
+      },
+      "errors" => [{
+        "message" => "Cannot return null for non-nullable field Test.req",
+        "path" => ["test", "req"],
+        "locations" => [{ "line" => 1, "column" => 24 }],
+      }],
+    }
+
+    assert_equal expected, exec_test(schema, query, source)
+  end
+
   def test_inline_errors_in_null_positions_report
     schema = "type Test { req: String! opt: String } type Query { test: [Test] }"
     source = {

--- a/spec/graphql/execution/finalize_spec.rb
+++ b/spec/graphql/execution/finalize_spec.rb
@@ -316,6 +316,7 @@ class ExecutionFinalizeTest < Minitest::Test
 
   def test_bubble_through_inline_fragment
     schema = "type Test { req: String! opt: String } type Query { test: Test }"
+    query = "{ test { ... on Test { req opt } } }"
     source = {
       "test" => {
         "req" => nil,
@@ -329,15 +330,16 @@ class ExecutionFinalizeTest < Minitest::Test
       "errors" => [{
         "message" => "Cannot return null for non-nullable field Test.req",
         "path" => ["test", "req"],
-        "locations" => [{ "line" => 1, "column" => 10 }],
+        "locations" => [{ "line" => 1, "column" => 24 }],
       }],
     }
 
-    assert_equal expected, exec_test(schema, "{ test { req opt } }", source)
+    assert_equal expected, exec_test(schema, query, source)
   end
 
   def test_bubble_through_fragment_spreads
     schema = "type Test { req: String! opt: String } type Query { test: Test }"
+    query = "{ test { ...F } } fragment F on Test { req opt }"
     source = {
       "test" => {
         "req" => nil,
@@ -351,11 +353,11 @@ class ExecutionFinalizeTest < Minitest::Test
       "errors" => [{
         "message" => "Cannot return null for non-nullable field Test.req",
         "path" => ["test", "req"],
-        "locations" => [{ "line" => 1, "column" => 10 }],
+        "locations" => [{ "line" => 1, "column" => 40 }],
       }],
     }
 
-    assert_equal expected, exec_test(schema, "{ test { req opt } }", source)
+    assert_equal expected, exec_test(schema, query, source)
   end
 
   def test_bubbles_null_through_fragment_spread_with_sibling_field


### PR DESCRIPTION
## Problem

Under `GraphQL::Execution::Next`, `GraphQL::Execution::Finalize#check_object_result` crashes with `NoMethodError: undefined method 'key?' for nil` when:

1. A non-null field returns `nil` *inside* a fragment spread or inline fragment, and
2. The same parent has at least one sibling selection appearing *after* that fragment.

### Minimal repro

**Schema:**
- `Query.test: Test` — `test` is nullable (no `!`)
- `Test.req: String!` — `req` is required
- `Test.opt: String` — `opt` is nullable

**Query:**

```graphql
{ test { ...F opt } }
fragment F on Test { req }
```

**Resolved data going into the finalize pass:**

```ruby
{ "test" => { "req" => nil, "opt" => "yes" } }
```

The non-null error is already in `context.errors`; finalize's job is to propagate the null upward. Instead, it crashes.

**Expected final response:**

```ruby
{ "data" => { "test" => nil }, "errors" => [<req null error>] }
```

### Production stacktrace

```
NoMethodError: undefined method 'key?' for nil
  lib/graphql/execution/finalize.rb:115:in 'block in GraphQL::Execution::Finalize#check_object_result'
  lib/graphql/execution/finalize.rb:131:in 'block in GraphQL::Execution::Finalize#check_object_result'
  lib/graphql/execution/finalize.rb:106:in 'check_object_result'
```

## Root cause

The `InlineFragment` and `FragmentSpread` branches of `check_object_result` reassign the local `result_h`:

```ruby
result_h = check_object_result(result_h, parent_type, ast_selection.selections)
```

`check_object_result` legitimately returns `nil` via non-null propagation:

```ruby
if new_result_value.nil? && result_type_non_null
  return nil
end
```

When that happens through a fragment branch, the outer `result_h` is now `nil`, but `ast_selections.each` keeps iterating. The next `Language::Nodes::Field` selection hits `result_h.key?(key)` on `nil`.

The bug is order-dependent: if the fragment is the *last* selection on its parent, the loop ends naturally and the method returns `nil` cleanly. The crash only occurs when at least one selection follows the offending fragment — which is structurally unavoidable in payloads built from heavily-nested fragment graphs.

## Fix

After each fragment-branch recursion, `return nil` if the recursion nullified `result_h`. Mirrors the existing `return nil` in the Field branch at line 137-138. The outer caller already handles `nil` correctly via the same non-null propagation logic.

## Tests

Two new regression tests in `spec/graphql/execution/finalize_spec.rb` (`test_bubbles_null_through_fragment_spread_with_sibling_field`, `test_bubbles_null_through_inline_fragment_with_sibling_field`) cover both fragment forms with a trailing sibling field. Both fail on `master` with the exact production `NoMethodError` and pass with this change.

Second commit fixes pre-existing tests `test_bubble_through_inline_fragment` and `test_bubble_through_fragment_spreads`: their queries (`{ test { req opt } }`) didn't actually use fragments, making them duplicates of `test_bubbles_null_for_single_object_scopes`. Rewritten to use the constructs their names imply (no sibling field after the fragment, so they don't overlap with the new tests).

Verified the broader `Execution::Next` test surface stays green: `finalize_spec.rb`, `next_spec.rb`, `breadth_runtime_spec.rb`, `input_values_spec.rb`, and `lookahead_spec.rb` all pass with zero failures.