### PR TITLE
Exec-next: Implement GraphQL::Current.field

### DIFF
--- a/lib/graphql/current.rb
+++ b/lib/graphql/current.rb
@@ -41,7 +41,13 @@ module GraphQL
     # @see GraphQL::Field#path for a string identifying this field
     # @return [GraphQL::Field, nil] The currently-running field, if there is one.
     def self.field
-      Fiber[:__graphql_runtime_info]&.values&.first&.current_field
+      if (interpreter_info = Fiber[:__graphql_runtime_info])
+        interpreter_info.values&.first&.current_field
+      elsif (field = Fiber[:__graphql_current_field])
+        field
+      else
+        nil
+      end
     end
 
     # @return [Class, nil] The currently-running {Dataloader::Source} class, if there is one.

--- a/lib/graphql/execution/field_resolve_step.rb
+++ b/lib/graphql/execution/field_resolve_step.rb
@@ -56,6 +56,8 @@ module GraphQL
         query.current_trace.end_execute_field(@field_definition, @arguments, @field_results, query, @field_results)
         @runner.add_step(self)
         true
+      ensure
+        set_current_field(nil)
       end
 
       def sync(lazy)
@@ -96,6 +98,8 @@ module GraphQL
         else
           raise
         end
+      ensure
+        set_current_field(nil)
       end
 
       def add_graphql_error(err)
@@ -134,6 +138,8 @@ module GraphQL
             @field_results.nil? # Make sure the arguments flow didn't already call through
           execute_field
         end
+      ensure
+        set_current_field(nil)
       end
 
       # Used for compatibility in Schema::Subscription
@@ -555,8 +561,8 @@ module GraphQL
         @runner.schema.type_error(err, @selections_step.query.context)
       end
 
-      def set_current_field
-        Fiber[:__graphql_current_field] = @field_definition
+      def set_current_field(new_value = @field_definition)
+        Fiber[:__graphql_current_field] = new_value
       end
 
       private

--- a/lib/graphql/execution/field_resolve_step.rb
+++ b/lib/graphql/execution/field_resolve_step.rb
@@ -50,6 +50,7 @@ module GraphQL
 
       def value
         query = @selections_step.query
+        set_current_field
         query.current_trace.begin_execute_field(@field_definition, @arguments, @field_results, query)
         sync(@field_results)
         query.current_trace.end_execute_field(@field_definition, @arguments, @field_results, query, @field_results)
@@ -76,6 +77,7 @@ module GraphQL
       end
 
       def call
+        set_current_field if @field_definition
         if @enqueued_authorization
           enqueue_next_steps
         elsif @finish_extension_idx
@@ -121,6 +123,7 @@ module GraphQL
         query = @selections_step.query
         field_name = @ast_node.name
         @field_definition = query.types.field(@parent_type, field_name) || raise(GraphQL::Error, "No field definition found for #{@parent_type.to_type_signature}.#{ast_node.name} (at #{@ast_node.position})")
+        set_current_field
         @arguments, errors = @runner.input_values[query].argument_values(@field_definition, @ast_node.arguments, self) # rubocop:disable Development/ContextIsPassedCop
         if errors
           build_errors_result(errors, nil)
@@ -550,6 +553,10 @@ module GraphQL
       def add_non_null_error(is_from_array)
         err = @parent_type::InvalidNullError.new(@parent_type, @field_definition, ast_nodes, is_from_array: is_from_array, path: path)
         @runner.schema.type_error(err, @selections_step.query.context)
+      end
+
+      def set_current_field
+        Fiber[:__graphql_current_field] = @field_definition
       end
 
       private

--- a/lib/graphql/execution/load_argument_step.rb
+++ b/lib/graphql/execution/load_argument_step.rb
@@ -35,6 +35,8 @@ module GraphQL
           @loaded_value = ex_err
         end
         assign_value
+      ensure
+        @field_resolve_step.set_current_field(nil)
       end
 
       def call
@@ -66,6 +68,8 @@ module GraphQL
           ex_err
         end
         assign_value
+      ensure
+        @field_resolve_step.set_current_field(nil)
       end
 
       private

--- a/lib/graphql/execution/load_argument_step.rb
+++ b/lib/graphql/execution/load_argument_step.rb
@@ -14,6 +14,7 @@ module GraphQL
       end
 
       def value
+        @field_resolve_step.set_current_field
         schema = @field_resolve_step.runner.schema
         @loaded_value = schema.sync_lazy(@loaded_value)
         assign_value
@@ -37,6 +38,7 @@ module GraphQL
       end
 
       def call
+        @field_resolve_step.set_current_field
         context = @field_resolve_step.selections_step.query.context
         @loaded_value = begin
           @load_receiver.load_and_authorize_application_object(@argument_definition, @argument_value, context)

--- a/lib/graphql/execution/prepare_object_step.rb
+++ b/lib/graphql/execution/prepare_object_step.rb
@@ -19,6 +19,7 @@ module GraphQL
       end
 
       def value
+        @field_resolve_step.set_current_field
         if @authorized_value
           query = @field_resolve_step.selections_step.query
           query.current_trace.begin_authorized(@resolved_type, @object, query.context)
@@ -39,6 +40,7 @@ module GraphQL
       end
 
       def call
+        @field_resolve_step.set_current_field
         case @next_step
         when :resolve_type
           static_type = @field_resolve_step.static_type

--- a/lib/graphql/execution/prepare_object_step.rb
+++ b/lib/graphql/execution/prepare_object_step.rb
@@ -37,6 +37,8 @@ module GraphQL
           ctx.query.current_trace.end_resolve_type(st, @object, ctx, @resolved_type)
         end
         @runner.add_step(self)
+      ensure
+        @field_resolve_step.set_current_field(nil)
       end
 
       def call
@@ -67,6 +69,8 @@ module GraphQL
         else
           raise ArgumentError, "This is a bug, unknown step: #{@next_step.inspect}"
         end
+      ensure
+        @field_resolve_step.set_current_field(nil)
       end
 
       def authorize

--- a/spec/graphql/current_spec.rb
+++ b/spec/graphql/current_spec.rb
@@ -24,11 +24,15 @@ describe GraphQL::Current do
         end
       end
       class Thing < GraphQL::Schema::Object
-        field :name, String
+        field :name, String, resolve_static: :get_name
 
-        def name
+        def self.get_name(context)
           context[:current_field] << GraphQL::Current.field.path
           context.dataload(ThingSource, context, "thing")
+        end
+
+        def name
+          self.class.get_name(context)
         end
       end
       class Query < GraphQL::Schema::Object
@@ -49,7 +53,6 @@ describe GraphQL::Current do
     end
 
     it "returns execution information" do
-      exec_next_TODO("not implemented yet")
       ctx = {
         current_field: [],
         current_source: [],

--- a/spec/graphql/query/partial_spec.rb
+++ b/spec/graphql/query/partial_spec.rb
@@ -269,7 +269,7 @@ describe GraphQL::Query::Partial do
 
   it "works with GraphQL::Current" do
     res = run_partials("query CheckCurrentValues { query { currentValues } }", [path: ["query"], object: nil])
-    assert_equal ["CheckCurrentValues", if_exec_next(nil, "Query.currentValues"), "nil"], res[0]["data"]["currentValues"]
+    assert_equal ["CheckCurrentValues", "Query.currentValues", "nil"], res[0]["data"]["currentValues"]
   end
 
 

--- a/spec/integration/rails/query_logs_spec.rb
+++ b/spec/integration/rails/query_logs_spec.rb
@@ -103,7 +103,6 @@ describe "Integration with ActiveRecord::QueryLogs" do
     assert_equal "Fork", res["data"]["someThing"]["otherThing"]["name"]
     # These can appear in different orders in the SQL comment:
     assert_includes log, "current_graphql_operation:OtherThingName"
-    exec_next_TODO "Exec-next doesn't broadcast this info yet but it should"
     assert_includes log, "current_graphql_field:Query.someThing"
     assert_includes log, "current_graphql_field:Thing.otherThing"
   end


### PR DESCRIPTION
Now `Execution::Next` populates `GraphQL::Current.field`.

One cool thing is that I expect this overhead to be a lot less than the implementation for `Execution::Interpreter`. Since lists are handled together, this is assigned once for a _whole batch_ of objects.