### PR TITLE
Exec-next: improve null propagation errors

### DIFF
--- a/lib/graphql/execution/field_resolve_step.rb
+++ b/lib/graphql/execution/field_resolve_step.rb
@@ -105,15 +105,23 @@ module GraphQL
         set_current_field(nil)
       end
 
-      def add_graphql_error(result, key, err)
+      def add_graphql_error(result, key, err, return_type: @field_definition.type)
         err.path = path
         if err.ast_node.nil?
           err.ast_nodes = ast_nodes
         end
-        errs = @runner.error_results[result] ||= {}
-        errs[key] = err
+        errs = @runner.error_results[@selections_step.query][result] ||= {}.compare_by_identity
+        if (existing_error = errs[key])
+          if existing_error.is_a?(Array)
+            existing_error << err
+          else
+            errs[key] = [existing_error, err]
+          end
+        else
+          errs[key] = err
+        end
         if !err.is_a?(GraphQL::Execution::Skip)
-          field_type = @field_definition.type
+          field_type = return_type
           should_propagate_null = field_type.non_null?
           while (should_propagate_null == false && field_type.kind.wraps?)
             field_type = field_type.of_type
@@ -520,7 +528,7 @@ module GraphQL
           end
         elsif field_result.is_a?(Finalizer)
           if field_result.is_a?(GraphQL::RuntimeError)
-            add_graphql_error(result_h, result_key, field_result)
+            add_graphql_error(result_h, result_key, field_result, return_type: return_type)
           else
             field_result.path = path
             @runner.add_finalizer(ctx.query, result_h, key, field_result)

--- a/lib/graphql/execution/field_resolve_step.rb
+++ b/lib/graphql/execution/field_resolve_step.rb
@@ -161,13 +161,12 @@ module GraphQL
       def build_errors_result(errors, single_error)
         first_error = errors.nil? ? single_error : errors.pop
         @field_results = [first_error]
+        @results = [@selections_step.results.first]
         if errors
-          raise "TODO this is broken"
           errors.each do |e|
-            add_graphql_error(e)
+            add_graphql_error(@results.first, key, e)
           end
         end
-        @results = [@selections_step.results.first]
         build_results
       end
 

--- a/lib/graphql/execution/field_resolve_step.rb
+++ b/lib/graphql/execution/field_resolve_step.rb
@@ -110,16 +110,7 @@ module GraphQL
         if err.ast_node.nil?
           err.ast_nodes = ast_nodes
         end
-        errs = @runner.error_results[@selections_step.query][result] ||= {}.compare_by_identity
-        if (existing_error = errs[key])
-          if existing_error.is_a?(Array)
-            existing_error << err
-          else
-            errs[key] = [existing_error, err]
-          end
-        else
-          errs[key] = err
-        end
+        @runner.add_finalizer(@selections_step.query, result, key, err)
         if !err.is_a?(GraphQL::Execution::Skip)
           field_type = return_type
           should_propagate_null = field_type.non_null?

--- a/lib/graphql/execution/field_resolve_step.rb
+++ b/lib/graphql/execution/field_resolve_step.rb
@@ -49,6 +49,7 @@ module GraphQL
       end
 
       def value
+        return nil if @selections_step.killed
         query = @selections_step.query
         set_current_field
         query.current_trace.begin_execute_field(@field_definition, @arguments, @field_results, query)
@@ -79,7 +80,9 @@ module GraphQL
       end
 
       def call
+        return nil if @selections_step.killed
         set_current_field if @field_definition
+
         if @enqueued_authorization
           enqueue_next_steps
         elsif @finish_extension_idx
@@ -102,24 +105,69 @@ module GraphQL
         set_current_field(nil)
       end
 
-      def add_graphql_error(err)
+      def add_graphql_error(result, key, err)
         err.path = path
         if err.ast_node.nil?
           err.ast_nodes = ast_nodes
         end
-        @selections_step.query.context.add_error(err)
+        errs = @runner.error_results[result] ||= {}
+        errs[key] = err
+        if !err.is_a?(GraphQL::Execution::Skip)
+          field_type = @field_definition.type
+          should_propagate_null = field_type.non_null?
+          while (should_propagate_null == false && field_type.kind.wraps?)
+            field_type = field_type.of_type
+            should_propagate_null = field_type.non_null?
+          end
+          if should_propagate_null
+            propagate_nulls
+          end
+        end
         err
+      end
+
+      def propagate_nulls
+        propagating_null = true
+        highest_nulled_depth = path.size
+        highest_list_depth = nil
+        current_field_step = self
+        while current_field_step
+          return_type = current_field_step.field_definition.type
+          if propagating_null && return_type.non_null?
+            highest_nulled_depth = current_field_step.path.size
+          else
+            propagating_null = false
+          end
+
+          if return_type.list?
+            highest_list_depth = current_field_step.path.size
+          end
+
+          current_field_step = current_field_step.selections_step.field_resolve_step
+        end
+
+        if highest_nulled_depth == 0
+          # Actually everything should be killed here
+          raise "TODO depth of zero"
+        elsif highest_list_depth.nil? || highest_nulled_depth <= highest_list_depth
+          kill_field_step = self
+          while kill_field_step && highest_nulled_depth <= kill_field_step.path.size
+            kill_field_step.selections_step.killed = true
+            kill_field_step = kill_field_step.selections_step.field_resolve_step
+          end
+        end
       end
 
       def build_errors_result(errors, single_error)
         first_error = errors.nil? ? single_error : errors.pop
-        @field_results = error_instance_array(@selections_step.objects.size, first_error)
+        @field_results = [first_error]
         if errors
+          raise "TODO this is broken"
           errors.each do |e|
             add_graphql_error(e)
           end
         end
-        @results ||= @selections_step.results
+        @results = [@selections_step.results.first]
         build_results
       end
 
@@ -226,7 +274,7 @@ module GraphQL
                   authorized_results << @results[i]
                 end
               rescue GraphQL::ExecutionError => exec_err
-                add_graphql_error(exec_err)
+                add_graphql_error(@results[i], key, exec_err)
               end
             end
             i += 1
@@ -331,12 +379,12 @@ module GraphQL
           end
         end
       rescue GraphQL::ExecutionError => err
-        add_graphql_error(err)
+        build_errors_result(nil, err)
       rescue StandardError => stderr
         begin
           @selections_step.query.handle_or_reraise(stderr, field: @field_definition, arguments: @arguments, object: nil)
         rescue GraphQL::ExecutionError => err
-          add_graphql_error(err)
+          add_graphql_error(@results[0], key, err)
         end
       end
 
@@ -458,13 +506,13 @@ module GraphQL
       end
 
       def finish_leaf_result(result_h, key, field_result, return_type, ctx)
-        final_field_result = build_leaf_result(field_result, return_type, ctx, false)
+        final_field_result = build_leaf_result(result_h, key, field_result, return_type, ctx, false)
 
         @directive_finalizers&.each { |f| @runner.add_finalizer(ctx.query, result_h, key, f) }
         result_h[@key] = final_field_result
       end
 
-      def build_leaf_result(field_result, return_type, ctx, is_from_array)
+      def build_leaf_result(result_h, result_key, field_result, return_type, ctx, is_from_array)
         if field_result.nil?
           if return_type.non_null?
             add_non_null_error(is_from_array)
@@ -473,7 +521,7 @@ module GraphQL
           end
         elsif field_result.is_a?(Finalizer)
           if field_result.is_a?(GraphQL::RuntimeError)
-            add_graphql_error(field_result)
+            add_graphql_error(result_h, result_key, field_result)
           else
             field_result.path = path
             @runner.add_finalizer(ctx.query, result_h, key, field_result)
@@ -484,7 +532,11 @@ module GraphQL
           end
 
           inner_type = return_type.of_type
-          field_result.map { |item| build_leaf_result(item, inner_type, ctx, true) }
+          result_a = Array.new(field_result.size)
+          field_result.each_with_index do |item, idx|
+            result_a[idx] = build_leaf_result(result_a, idx, item, inner_type, ctx, true)
+          end
+          result_a
         else
           return_type.coerce_result(field_result, ctx)
         end
@@ -526,6 +578,7 @@ module GraphQL
               query.current_trace.objects(obj_type, next_objects, ctx)
               @runner.add_step(SelectionsStep.new(
                 path: path,
+                field_resolve_step: self,
                 parent_type: obj_type,
                 selections: @next_selections,
                 objects: next_objects,
@@ -538,6 +591,7 @@ module GraphQL
             query.current_trace.objects(@static_type, @all_next_objects, ctx)
             @runner.add_step(SelectionsStep.new(
               path: path,
+              field_resolve_step: self,
               parent_type: @static_type,
               selections: @next_selections,
               objects: @all_next_objects,
@@ -558,7 +612,11 @@ module GraphQL
 
       def add_non_null_error(is_from_array)
         err = @parent_type::InvalidNullError.new(@parent_type, @field_definition, ast_nodes, is_from_array: is_from_array, path: path)
-        @runner.schema.type_error(err, @selections_step.query.context)
+        nn_result = @runner.schema.type_error(err, @selections_step.query.context)
+        if nn_result.nil?
+          propagate_nulls
+        end
+        nn_result
       end
 
       def set_current_field(new_value = @field_definition)
@@ -576,7 +634,7 @@ module GraphQL
           end
         elsif field_result.is_a?(Finalizer)
           graphql_result[key] = if field_result.is_a?(GraphQL::RuntimeError)
-            add_graphql_error(field_result)
+            add_graphql_error(graphql_result, key, field_result)
           else
             field_result.path = path
             @runner.add_finalizer(@selections_step.query, graphql_result, key, field_result)

--- a/lib/graphql/execution/field_resolve_step.rb
+++ b/lib/graphql/execution/field_resolve_step.rb
@@ -145,10 +145,7 @@ module GraphQL
           current_field_step = current_field_step.selections_step.field_resolve_step
         end
 
-        if highest_nulled_depth == 0
-          # Actually everything should be killed here
-          raise "TODO depth of zero"
-        elsif highest_list_depth.nil? || highest_nulled_depth <= highest_list_depth
+        if highest_list_depth.nil? || highest_nulled_depth <= highest_list_depth
           kill_field_step = self
           while kill_field_step && highest_nulled_depth <= kill_field_step.path.size
             kill_field_step.selections_step.killed = true

--- a/lib/graphql/execution/finalize.rb
+++ b/lib/graphql/execution/finalize.rb
@@ -24,7 +24,21 @@ module GraphQL
 
         if !(error_results = runner.error_results[query]).empty?
           error_results.each do |result, error_h|
-            @finalizers[result] = error_h
+            if (prev_f = @finalizers[result])
+              error_h.each do |k, v|
+                if (prev_k_f = prev_f[k])
+                  if prev_k_f.is_a?(Array)
+                    prev_k_f << v
+                  else
+                    prev_f[k] = [prev_k_f, v]
+                  end
+                else
+                  prev_f[k] = v
+                end
+              end
+            else
+              @finalizers[result] = error_h
+            end
             @finalizers_count += error_h.size
           end
         end

--- a/lib/graphql/execution/finalize.rb
+++ b/lib/graphql/execution/finalize.rb
@@ -22,27 +22,6 @@ module GraphQL
           end
         end
 
-        if !(error_results = runner.error_results[query]).empty?
-          error_results.each do |result, error_h|
-            if (prev_f = @finalizers[result])
-              error_h.each do |k, v|
-                if (prev_k_f = prev_f[k])
-                  if prev_k_f.is_a?(Array)
-                    prev_k_f << v
-                  else
-                    prev_f[k] = [prev_k_f, v]
-                  end
-                else
-                  prev_f[k] = v
-                end
-              end
-            else
-              @finalizers[result] = error_h
-            end
-            @finalizers_count += error_h.size
-          end
-        end
-
         query.context.errors.each do |err|
           err_path = err.path - @current_exec_path
           key = err_path.pop

--- a/lib/graphql/execution/finalize.rb
+++ b/lib/graphql/execution/finalize.rb
@@ -22,6 +22,11 @@ module GraphQL
           end
         end
 
+        runner.error_results.each do |result, error_h|
+          @finalizers[result] = error_h
+          @finalizers_count += error_h.size
+        end
+
         query.context.errors.each do |err|
           err_path = err.path - @current_exec_path
           key = err_path.pop
@@ -33,14 +38,15 @@ module GraphQL
 
           targets.each_with_index do |target, idx|
             if target.is_a?(Hash)
-              if target[key].equal?(err)
+              value_at_key = target[key]
+              if value_at_key.equal?(err)
                 tf = @finalizers[target] ||= {}.compare_by_identity
                 tf[key] = err
                 @finalizers_count += 1
-              elsif (arr = target[key]).is_a?(Array)
-                arr.each_with_index do |el, idx|
+              elsif value_at_key.is_a?(Array)
+                value_at_key.each_with_index do |el, idx|
                   if el.equal?(err)
-                    tf = @finalizers[arr] ||= {}.compare_by_identity
+                    tf = @finalizers[value_at_key] ||= {}.compare_by_identity
                     tf[idx] = err
                     @finalizers_count += 1
                   end
@@ -170,9 +176,7 @@ module GraphQL
       end
 
       def check_list_result(result_arr, inner_type, ast_selections)
-        inner_type_non_null = false
-        if inner_type.non_null?
-          inner_type_non_null = true
+        if (inner_type_non_null = inner_type.non_null?)
           inner_type = inner_type.of_type
         end
 

--- a/lib/graphql/execution/finalize.rb
+++ b/lib/graphql/execution/finalize.rb
@@ -22,9 +22,11 @@ module GraphQL
           end
         end
 
-        runner.error_results.each do |result, error_h|
-          @finalizers[result] = error_h
-          @finalizers_count += error_h.size
+        if !(error_results = runner.error_results[query]).empty?
+          error_results.each do |result, error_h|
+            @finalizers[result] = error_h
+            @finalizers_count += error_h.size
+          end
         end
 
         query.context.errors.each do |err|

--- a/lib/graphql/execution/prepare_object_step.rb
+++ b/lib/graphql/execution/prepare_object_step.rb
@@ -73,6 +73,10 @@ module GraphQL
         @field_resolve_step.set_current_field(nil)
       end
 
+      def add_field_error(err)
+        @field_resolve_step.add_graphql_error(@graphql_result, @key, err)
+      end
+
       def authorize
         if @field_resolve_step.was_scoped && !@resolved_type.reauthorize_scoped_objects
           @authorized_value = @object
@@ -96,13 +100,13 @@ module GraphQL
           create_result
         end
       rescue GraphQL::RuntimeError => err
-        @graphql_result[@key] = @field_resolve_step.add_graphql_error(err)
+        @graphql_result[@key] = add_field_error(err)
       rescue StandardError => err
         query ||= @field_resolve_step.selections_step.query
         begin
           query.handle_or_reraise(err, field: @field_resolve_step.field_definition, arguments: @field_resolve_step.arguments, object: @object) # rubocop:disable Development/ContextIsPassedCop
         rescue GraphQL::RuntimeError => err
-          @graphql_result[@key] = @field_resolve_step.add_graphql_error(err)
+          @graphql_result[@key] = add_field_error(err)
         end
       end
 
@@ -120,13 +124,13 @@ module GraphQL
             elsif @is_non_null
               @graphql_result[@key] = @field_resolve_step.add_non_null_error(@is_from_array)
             else
-              @graphql_result[@key] = @field_resolve_step.add_graphql_error(@authorization_error)
+              @graphql_result[@key] = add_field_error(@authorization_error)
             end
           rescue GraphQL::RuntimeError => err
             if @is_non_null
               @graphql_result[@key] = @field_resolve_step.add_non_null_error(@is_from_array)
             else
-              @graphql_result[@key] = @field_resolve_step.add_graphql_error(err)
+              @graphql_result[@key] = add_field_error(err)
             end
           end
         end

--- a/lib/graphql/execution/runner.rb
+++ b/lib/graphql/execution/runner.rb
@@ -35,10 +35,6 @@ module GraphQL
         @authorizes_cache = Hash.new do |h, query_context|
           h[query_context] = {}.compare_by_identity
         end.compare_by_identity
-
-        @error_results = Hash.new do |h, query|
-          h[query] = {}.compare_by_identity
-        end.compare_by_identity
       end
 
       attr_reader :runtime_directives, :uses_runtime_directives, :finalizer_keys
@@ -57,7 +53,7 @@ module GraphQL
         @dataloader.append_job(step)
       end
 
-      attr_reader :steps_queue, :schema, :variables, :dataloader, :resolves_lazies, :authorizes, :static_type_at, :runtime_type_at, :finalizers, :input_values, :error_results
+      attr_reader :steps_queue, :schema, :variables, :dataloader, :resolves_lazies, :authorizes, :static_type_at, :runtime_type_at, :finalizers, :input_values
 
       # @return [void]
       def add_finalizer(query, result_value, key, finalizer)
@@ -132,7 +128,7 @@ module GraphQL
           queries.each_with_index.map do |query, idx|
             result = results[idx]
 
-            fin_result = if (!@finalizers&.key?(query) && query.context.errors.empty? && @error_results[query].empty?) || !query.valid?
+            fin_result = if (!@finalizers&.key?(query) && query.context.errors.empty?) || !query.valid?
               result
             else
               if result

--- a/lib/graphql/execution/runner.rb
+++ b/lib/graphql/execution/runner.rb
@@ -35,6 +35,8 @@ module GraphQL
         @authorizes_cache = Hash.new do |h, query_context|
           h[query_context] = {}.compare_by_identity
         end.compare_by_identity
+
+        @error_results = {}.compare_by_identity
       end
 
       attr_reader :runtime_directives, :uses_runtime_directives, :finalizer_keys
@@ -53,7 +55,7 @@ module GraphQL
         @dataloader.append_job(step)
       end
 
-      attr_reader :steps_queue, :schema, :variables, :dataloader, :resolves_lazies, :authorizes, :static_type_at, :runtime_type_at, :finalizers, :input_values
+      attr_reader :steps_queue, :schema, :variables, :dataloader, :resolves_lazies, :authorizes, :static_type_at, :runtime_type_at, :finalizers, :input_values, :error_results
 
       # @return [void]
       def add_finalizer(query, result_value, key, finalizer)
@@ -128,7 +130,7 @@ module GraphQL
           queries.each_with_index.map do |query, idx|
             result = results[idx]
 
-            fin_result = if (!@finalizers&.key?(query) && query.context.errors.empty?) || !query.valid?
+            fin_result = if (!@finalizers&.key?(query) && query.context.errors.empty? && @error_results.empty?) || !query.valid?
               result
             else
               if result
@@ -298,6 +300,7 @@ module GraphQL
           if query.query?
             isolated_steps[0] << SelectionsStep.new(
               parent_type: root_type,
+              field_resolve_step: nil,
               selections: selected_operation.selections,
               objects: objects,
               results: [data],
@@ -317,6 +320,7 @@ module GraphQL
               isolated_steps << [SelectionsStep.new(
                 clobber: false, # `data` is being shared among several selections steps
                 parent_type: root_type,
+                field_resolve_step: field_resolve_step,
                 selections: field_resolve_step.ast_nodes || Array(field_resolve_step.ast_node),
                 objects: objects,
                 results: [data],
@@ -332,6 +336,7 @@ module GraphQL
             end
             isolated_steps[0] << SelectionsStep.new(
               parent_type: root_type,
+              field_resolve_step: nil,
               selections: selected_operation.selections,
               objects: objects,
               results: [data],
@@ -355,6 +360,7 @@ module GraphQL
           results << { "data" => data }
           isolated_steps[0] << SelectionsStep.new(
             parent_type: resolved_type,
+            field_resolve_step: nil,
             selections: selected_operation.selections,
             objects: objects,
             results: [data],
@@ -372,6 +378,7 @@ module GraphQL
             results << { "data" => list_result }
             isolated_steps[0] << SelectionsStep.new(
               parent_type: inner_type,
+              field_resolve_step: nil,
               selections: selected_operation.selections,
               objects: root_value,
               results: list_result,
@@ -420,6 +427,7 @@ module GraphQL
         selections = partial.ast_nodes
         dummy_ss = SelectionsStep.new(
           parent_type: nil,
+          field_resolve_step: nil,
           selections: selections,
           objects: nil,
           results: nil,

--- a/lib/graphql/execution/runner.rb
+++ b/lib/graphql/execution/runner.rb
@@ -36,7 +36,9 @@ module GraphQL
           h[query_context] = {}.compare_by_identity
         end.compare_by_identity
 
-        @error_results = {}.compare_by_identity
+        @error_results = Hash.new do |h, query|
+          h[query] = {}.compare_by_identity
+        end.compare_by_identity
       end
 
       attr_reader :runtime_directives, :uses_runtime_directives, :finalizer_keys
@@ -130,7 +132,7 @@ module GraphQL
           queries.each_with_index.map do |query, idx|
             result = results[idx]
 
-            fin_result = if (!@finalizers&.key?(query) && query.context.errors.empty? && @error_results.empty?) || !query.valid?
+            fin_result = if (!@finalizers&.key?(query) && query.context.errors.empty? && @error_results[query].empty?) || !query.valid?
               result
             else
               if result

--- a/lib/graphql/execution/selections_step.rb
+++ b/lib/graphql/execution/selections_step.rb
@@ -2,8 +2,9 @@
 module GraphQL
   module Execution
     class SelectionsStep
-      def initialize(parent_type:, selections:, objects:, results:, runner:, query:, path:, clobber: true)
+      def initialize(parent_type:, field_resolve_step:, selections:, objects:, results:, runner:, query:, path:, clobber: true)
         @path = path
+        @field_resolve_step = field_resolve_step
         @parent_type = parent_type
         @selections = selections
         @runner = runner
@@ -12,10 +13,13 @@ module GraphQL
         @query = query
         @graphql_objects = nil
         @all_selections = nil
+        @killed = false
         @clobber = clobber
       end
 
-      attr_reader :path, :query, :objects, :results
+      attr_reader :path, :query, :objects, :results, :field_resolve_step
+
+      attr_accessor :killed
 
       def graphql_objects
         @graphql_objects ||= @objects.map do |obj|

--- a/lib/graphql/execution_error.rb
+++ b/lib/graphql/execution_error.rb
@@ -26,6 +26,10 @@ module GraphQL
     end
 
     def finalize_graphql_result(query, result_data, key)
+      add_this_error = !query.context.errors.any? { |e| e.eql?(self) }
+      if add_this_error
+        query.context.add_error(self)
+      end
       if ast_node.is_a?(GraphQL::Language::Nodes::Directive)
         # This is for backwards compatibility ... what does the spec say?
         result_data.delete(key)

--- a/spec/graphql/authorization_spec.rb
+++ b/spec/graphql/authorization_spec.rb
@@ -620,11 +620,7 @@ describe "GraphQL::Authorization" do
     it "halts on unauthorized mutations" do
       query = "mutation { doUnauthorizedStuff(input: {}) { __typename } }"
       res = auth_execute(query, context: { unauthorized_mutation: true })
-      if TESTING_EXEC_NEXT
-        assert_equal({}, res["data"])
-      else
-        assert_nil res["data"].fetch("doUnauthorizedStuff")
-      end
+      assert_nil res["data"].fetch("doUnauthorizedStuff")
       assert_raises GraphQL::RequiredImplementationMissingError do
         auth_execute(query)
       end

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -792,12 +792,14 @@ describe GraphQL::Execution::Interpreter do
 
     it "works on different branches" do
       res = ConnectionErrorTest::Schema.execute("{ things { nodes { title } } otherThings { nodes { title } }  }")
+      assert_equal({ "things" => nil, "otherThings" => nil }, res["data"])
       assert_equal [["things", "nodes", 0, "title"], ["otherThings", "nodes", 0, "title"]], res["errors"].map { |e| e["path"] }
       assert_equal 2, res.context[:authorized_calls]
     end
 
     it "Does non-null propagation across branches" do
       res = ConnectionErrorTest::Schema.execute("{ nonNullThings { nodes { title } } nonNullOtherThings { nodes { title } }  }")
+      assert_nil res.fetch("data")
       expected_error_paths = if_exec_next([
         ["nonNullThings", "nodes", 0, "title"]
       ], [

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -786,7 +786,6 @@ describe GraphQL::Execution::Interpreter do
       assert_equal 2, res.context[:authorized_calls]
     end
 
-    focus
     it "returns only 1 error and stops resolving fields after that" do
       res = ConnectionErrorTest::Schema.execute("{ things { nodes { title } } }")
       assert_equal [["things", "nodes", 0, "title"]], res["errors"].map { |e| e["path"] }

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -747,12 +747,17 @@ describe GraphQL::Execution::Interpreter do
 
       class Query < GraphQL::Schema::Object
         field :things, Thing.connection_type, null: false, resolve_static: true
+        field :other_things, Thing.connection_type, null: false, resolve_static: :things
 
         def self.things(context)
           [{title: "a"}, {title: "b"}, {title: "c"}]
         end
 
         def things
+          self.class.things(context)
+        end
+
+        def other_things
           self.class.things(context)
         end
 
@@ -775,18 +780,24 @@ describe GraphQL::Execution::Interpreter do
       end
     end
 
+    it "works on different branches" do
+      res = ConnectionErrorTest::Schema.execute("{ things { nodes { title } } otherThings { nodes { title } }  }")
+      assert_equal [["things", "nodes", 0, "title"], ["otherThings", "nodes", 0, "title"]], res["errors"].map { |e| e["path"] }
+      assert_equal 2, res.context[:authorized_calls]
+    end
+
+    focus
     it "returns only 1 error and stops resolving fields after that" do
       res = ConnectionErrorTest::Schema.execute("{ things { nodes { title } } }")
-      assert_equal 1, res["errors"].size
+      assert_equal [["things", "nodes", 0, "title"]], res["errors"].map { |e| e["path"] }
       assert_equal 1, res.context[:authorized_calls]
 
       res = ConnectionErrorTest::Schema.execute("{ things { edges { node { title } } } }")
-      assert_equal 1, res["errors"].size
+      assert_equal [["things", "edges", 0, "node", "title"]], res["errors"].map { |e| e["path"] }
       assert_equal 1, res.context[:authorized_calls]
 
       res = ConnectionErrorTest::Schema.execute("{ thing { title body } }")
-      exec_next_TODO "should abort other branches in this case"
-      assert_equal 1, res["errors"].size
+      assert_equal [["thing", "title"]], res["errors"].map { |e| e["path"] }
       assert_equal 1, res.context[:authorized_calls]
     end
   end

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -746,8 +746,10 @@ describe GraphQL::Execution::Interpreter do
       end
 
       class Query < GraphQL::Schema::Object
-        field :things, Thing.connection_type, null: false, resolve_static: true
-        field :other_things, Thing.connection_type, null: false, resolve_static: :things
+        field :things, Thing.connection_type, resolve_static: true
+        field :other_things, Thing.connection_type, resolve_static: :things
+        field :non_null_things, Thing.connection_type, null: false, resolve_static: :things
+        field :non_null_other_things, Thing.connection_type, null: false, resolve_static: :things
 
         def self.things(context)
           [{title: "a"}, {title: "b"}, {title: "c"}]
@@ -758,6 +760,14 @@ describe GraphQL::Execution::Interpreter do
         end
 
         def other_things
+          self.class.things(context)
+        end
+
+        def non_null_other_things
+          self.class.things(context)
+        end
+
+        def non_null_things
           self.class.things(context)
         end
 
@@ -784,6 +794,18 @@ describe GraphQL::Execution::Interpreter do
       res = ConnectionErrorTest::Schema.execute("{ things { nodes { title } } otherThings { nodes { title } }  }")
       assert_equal [["things", "nodes", 0, "title"], ["otherThings", "nodes", 0, "title"]], res["errors"].map { |e| e["path"] }
       assert_equal 2, res.context[:authorized_calls]
+    end
+
+    it "Does non-null propagation across branches" do
+      res = ConnectionErrorTest::Schema.execute("{ nonNullThings { nodes { title } } nonNullOtherThings { nodes { title } }  }")
+      expected_error_paths = if_exec_next([
+        ["nonNullThings", "nodes", 0, "title"]
+      ], [
+        ["nonNullThings", "nodes", 0, "title"],
+        ["nonNullOtherThings", "nodes", 0, "title"]
+      ])
+      assert_equal expected_error_paths, res["errors"].map { |e| e["path"] }
+      assert_equal if_exec_next(1, 2), res.context[:authorized_calls]
     end
 
     it "returns only 1 error and stops resolving fields after that" do

--- a/spec/graphql/schema/validator_spec.rb
+++ b/spec/graphql/schema/validator_spec.rb
@@ -141,11 +141,13 @@ describe GraphQL::Schema::Validator do
           { "validated" => nil },
         ]
       },
-      "errors" => [
+      "errors" => if_exec_next([
+        {"message"=>"value must be greater than 5", "locations"=>[{"line"=>1, "column"=>10}], "path"=>["list", 0, "validated"]},
+      ],[
         {"message"=>"value must be greater than 5", "locations"=>[{"line"=>1, "column"=>10}], "path"=>["list", 0, "validated"]},
         {"message"=>"value must be greater than 5", "locations"=>[{"line"=>1, "column"=>10}], "path"=>["list", 1, "validated"]},
         {"message"=>"value must be greater than 5", "locations"=>[{"line"=>1, "column"=>10}], "path"=>["list", 2, "validated"]},
-      ]
+      ])
     }
     assert_equal expected_response, res
   end


### PR DESCRIPTION
Null propagation _basically_ works, but the errors produced aren't quite right yet. 

Fixes #5622 



TODO: 

- [x] ~~Implement top-level eager killing~~ I removed it -- the existing support worked well enough.
- [x] Further unify finalizers and error results? These are almost the exact same structure. 
- [x] Look at where finalizers and error results are merged. I think they clobber each other in some cases. 