### PR TITLE
Fall back to getRandomValues when crypto.randomUUID is unavailable (ActionCable)

### DIFF
--- a/javascript_client/src/subscriptions/ActionCableLink.ts
+++ b/javascript_client/src/subscriptions/ActionCableLink.ts
@@ -1,6 +1,7 @@
 import { ApolloLink, Observable, FetchResult, Operation, NextLink } from "@apollo/client/core"
 import type { Consumer } from "@rails/actioncable"
 import { print } from "graphql"
+import defaultChannelId from "./defaultChannelId"
 
 type RequestResult = FetchResult<{ [key: string]: any; }, Record<string, any>, Record<string, any>>
 type ConnectionParams = object | ((operation: Operation) => object)
@@ -33,7 +34,7 @@ class ActionCableLink extends ApolloLink {
     this.actionName = options.actionName || "execute"
     this.connectionParams = options.connectionParams || {}
     this.callbacks = options.callbacks || {}
-    this.createChannelId = options.createChannelId || crypto.randomUUID.bind(crypto)
+    this.createChannelId = options.createChannelId || defaultChannelId
   }
 
   // Interestingly, this link does _not_ call through to `next` because

--- a/javascript_client/src/subscriptions/ActionCableSubscriber.ts
+++ b/javascript_client/src/subscriptions/ActionCableSubscriber.ts
@@ -1,5 +1,6 @@
 import printer from "graphql/language/printer"
 import registry from "./registry"
+import defaultChannelId from "./defaultChannelId"
 import type { Consumer } from "@rails/actioncable"
 
 interface ApolloNetworkInterface {
@@ -20,7 +21,7 @@ class ActionCableSubscriber {
     this._cable = cable
     this._networkInterface = networkInterface
     this._channelName = channelName || "GraphqlChannel"
-    this._createChannelId = createChannelId || crypto.randomUUID.bind(crypto)
+    this._createChannelId = createChannelId || defaultChannelId
   }
 
   /**

--- a/javascript_client/src/subscriptions/__tests__/defaultChannelIdTest.ts
+++ b/javascript_client/src/subscriptions/__tests__/defaultChannelIdTest.ts
@@ -1,0 +1,43 @@
+import defaultChannelId from "../defaultChannelId"
+
+describe("defaultChannelId", () => {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(crypto, "randomUUID")
+
+  afterEach(() => {
+    if (originalDescriptor) {
+      Object.defineProperty(crypto, "randomUUID", originalDescriptor)
+    }
+  })
+
+  it("uses crypto.randomUUID when available", () => {
+    Object.defineProperty(crypto, "randomUUID", {
+      value: () => "11111111-2222-3333-4444-555555555555",
+      configurable: true,
+      writable: true,
+    })
+
+    expect(defaultChannelId()).toEqual("11111111-2222-3333-4444-555555555555")
+  })
+
+  it("falls back to crypto.getRandomValues on insecure contexts, where crypto.randomUUID is not exposed", () => {
+    Object.defineProperty(crypto, "randomUUID", {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    })
+
+    expect(defaultChannelId()).toMatch(/^[0-9a-f]{32}$/)
+  })
+
+  it("generates unique ids without crypto.randomUUID", () => {
+    Object.defineProperty(crypto, "randomUUID", {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    })
+
+    const ids = new Set(Array.from({ length: 1000 }, () => defaultChannelId()))
+
+    expect(ids.size).toEqual(1000)
+  })
+})

--- a/javascript_client/src/subscriptions/createActionCableHandler.ts
+++ b/javascript_client/src/subscriptions/createActionCableHandler.ts
@@ -1,4 +1,5 @@
 import type { Consumer } from "@rails/actioncable"
+import defaultChannelId from "./defaultChannelId"
 
 /**
  * Create a Relay Modern-compatible subscription handler.
@@ -16,7 +17,7 @@ interface ActionCableHandlerOptions {
 }
 
 function createActionCableHandler(options: ActionCableHandlerOptions) {
-  const createChannelId = options.createChannelId || crypto.randomUUID.bind(crypto)
+  const createChannelId = options.createChannelId || defaultChannelId
   return function (operation: { text: string, name: string, id?: string }, variables: object, _cacheConfig: object, observer: {onError: Function, onNext: Function, onCompleted: Function}) {
     var channelId = createChannelId()
     var cable = options.cable

--- a/javascript_client/src/subscriptions/defaultChannelId.ts
+++ b/javascript_client/src/subscriptions/defaultChannelId.ts
@@ -1,0 +1,16 @@
+// `crypto.randomUUID` is only exposed in secure contexts (HTTPS or localhost),
+// so fall back to `crypto.getRandomValues` — available in all contexts — to
+// keep subscriptions working on plain-HTTP origins with the same 128 bits of
+// entropy. (https://github.com/rmosolgo/graphql-ruby/issues/5648)
+function defaultChannelId(): string {
+  if (typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID()
+  }
+
+  return Array.from(
+    crypto.getRandomValues(new Uint8Array(16)),
+    (byte) => byte.toString(16).padStart(2, "0")
+  ).join("")
+}
+
+export default defaultChannelId


### PR DESCRIPTION
Fixes #5648

## Problem

Since `graphql-ruby-client` 1.15.0 (#5642 / #5643), the ActionCable integrations evaluate `crypto.randomUUID.bind(crypto)` at construction time. `crypto.randomUUID` is only exposed in [secure contexts](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID) (HTTPS or localhost), so on plain-HTTP origins (LAN IPs, internal/self-hosted deployments) this throws:

```
TypeError: Cannot read properties of undefined (reading 'bind')
```

## Solution

As discussed in #5648, add a shared `defaultChannelId` helper that prefers `crypto.randomUUID()` and falls back to a 128-bit hex id built with `crypto.getRandomValues`, which is available in all contexts. This keeps the entropy introduced for #5639 everywhere.

Applied to the three call sites: `ActionCableLink`, `ActionCableSubscriber`, `createActionCableHandler`.

## Tests

- New `defaultChannelIdTest` covering: native `randomUUID` preferred, fallback format on insecure contexts, uniqueness over 1000 ids
