### PR TITLE
Don't generate fields for filtered parameters

### DIFF
--- a/lib/generators/graphql/field_extractor.rb
+++ b/lib/generators/graphql/field_extractor.rb
@@ -13,7 +13,7 @@ module Graphql
             elsif ActiveSupport.respond_to?(:filter_parameters)
               ActiveSupport.filter_parameters
             else
-              EmptyObjects::EMPTY_ARRAY
+              []
             end
             ActiveSupport::ParameterFilter.new(fp, mask: nil)
           else

--- a/lib/generators/graphql/field_extractor.rb
+++ b/lib/generators/graphql/field_extractor.rb
@@ -19,12 +19,8 @@ module Graphql
           else
             nil
           end
-          warn [filter, fp].inspect
           columns += model_columns
-            .select { |c|
-              warn [c.name, filter.filter_param(c.name, c.name)].inspect
-              filter ? filter.filter_param(c.name, c.name) : true
-            }
+            .select { |c| filter ? filter.filter_param(c.name, c.name) : true }
             .map { |c| generate_column_string(c) }
         end
         columns + custom_fields

--- a/lib/generators/graphql/field_extractor.rb
+++ b/lib/generators/graphql/field_extractor.rb
@@ -6,7 +6,27 @@ module Graphql
     module FieldExtractor
       def fields
         columns = []
-        columns += (klass&.columns&.map { |c| generate_column_string(c) }  || [])
+        if (model_columns = klass&.columns)
+          filter = if defined?(ActiveSupport::ParameterFilter)
+            fp = if defined?(Rails) && Rails.application && (app_config = Rails.application.config.filter_parameters).present? && !app_config.empty?
+              app_config
+            elsif ActiveSupport.respond_to?(:filter_parameters)
+              ActiveSupport.filter_parameters
+            else
+              EmptyObjects::EMPTY_ARRAY
+            end
+            ActiveSupport::ParameterFilter.new(fp, mask: nil)
+          else
+            nil
+          end
+          warn [filter, fp].inspect
+          columns += model_columns
+            .select { |c|
+              warn [c.name, filter.filter_param(c.name, c.name)].inspect
+              filter ? filter.filter_param(c.name, c.name) : true
+            }
+            .map { |c| generate_column_string(c) }
+        end
         columns + custom_fields
       end
 

--- a/spec/integration/rails/generators/base_generator_test.rb
+++ b/spec/integration/rails/generators/base_generator_test.rb
@@ -1,5 +1,18 @@
 # frozen_string_literal: true
+
 class BaseGeneratorTest < Rails::Generators::TestCase
   destination File.expand_path("../../tmp", File.dirname(__FILE__))
   setup :prepare_destination
+
+  setup do
+    Rails.application = OpenStruct.new(
+      # Defaults from https://github.com/rails/rails/blob/main/railties/lib/rails/generators/rails/app/templates/config/initializers/filter_parameter_logging.rb.tt
+      config: OpenStruct.new(
+        filter_parameters: [
+          :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
+        ]
+      )
+    )
+  end
+
 end

--- a/spec/integration/rails/generators/base_generator_test.rb
+++ b/spec/integration/rails/generators/base_generator_test.rb
@@ -3,16 +3,4 @@
 class BaseGeneratorTest < Rails::Generators::TestCase
   destination File.expand_path("../../tmp", File.dirname(__FILE__))
   setup :prepare_destination
-
-  setup do
-    Rails.application = OpenStruct.new(
-      # Defaults from https://github.com/rails/rails/blob/main/railties/lib/rails/generators/rails/app/templates/config/initializers/filter_parameter_logging.rb.tt
-      config: OpenStruct.new(
-        filter_parameters: [
-          :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
-        ]
-      )
-    )
-  end
-
 end

--- a/spec/integration/rails/generators/graphql/object_generator_spec.rb
+++ b/spec/integration/rails/generators/graphql/object_generator_spec.rb
@@ -5,6 +5,22 @@ require "generators/graphql/object_generator"
 class GraphQLGeneratorsObjectGeneratorTest < BaseGeneratorTest
   tests Graphql::Generators::ObjectGenerator
 
+  setup do
+    @prev_rails_application = Rails.application
+    Rails.application = OpenStruct.new(
+      # Defaults from https://github.com/rails/rails/blob/main/railties/lib/rails/generators/rails/app/templates/config/initializers/filter_parameter_logging.rb.tt
+      config: OpenStruct.new(
+        filter_parameters: [
+          :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
+        ]
+      )
+    )
+  end
+
+  teardown do
+    Rails.application = @prev_rails_application
+  end
+
   # rubocop:disable Style/ClassAndModuleChildren
   class ::TestUser < ActiveRecord::Base
   end

--- a/spec/support/active_record_setup.rb
+++ b/spec/support/active_record_setup.rb
@@ -106,6 +106,9 @@ if testing_rails?
       t.date :birthday
       t.integer :points, null: false
       t.decimal :rating, null: false
+      t.string :password_digest
+      t.string :secret_message
+      t.string :ssn
     end
 
     create_table :graphql_detailed_traces, force: true do |t|


### PR DESCRIPTION
In a greenfield project a while ago, I used the generators heavily and didn't find `field :password_digest` to be helpful 😆 