### PR TITLE
Apply directive argument defaults

### DIFF
--- a/lib/graphql/schema/directive.rb
+++ b/lib/graphql/schema/directive.rb
@@ -170,7 +170,7 @@ module GraphQL
             end
           elsif arg_defn.default_value?
             value = arg_defn.default_value
-            graphql_value = value.nil? ? nil : arg_type.coerce_isolated_result(value)
+            graphql_value = arg_type.coerce_isolated_result(value) unless value.nil?
           else
             value = graphql_value = nil
           end

--- a/lib/graphql/schema/directive.rb
+++ b/lib/graphql/schema/directive.rb
@@ -168,6 +168,9 @@ module GraphQL
               # Let validation handle this
               value
             end
+          elsif arg_defn.default_value?
+            value = arg_defn.default_value
+            graphql_value = value.nil? ? nil : arg_type.coerce_isolated_result(value)
           else
             value = graphql_value = nil
           end

--- a/spec/graphql/schema/directive_spec.rb
+++ b/spec/graphql/schema/directive_spec.rb
@@ -88,7 +88,7 @@ Use `locations(OBJECT)` to update this directive's definition, or remove it from
     defaulted_directive = Class.new(GraphQL::Schema::Directive) do
       graphql_name "defaulted"
       locations GraphQL::Schema::Directive::OBJECT
-      argument :enabled, GraphQL::Types::Boolean, required: true, default_value: true
+      argument :enabled, GraphQL::Types::Boolean, default_value: true
     end
 
     thing = Class.new(GraphQL::Schema::Object) do

--- a/spec/graphql/schema/directive_spec.rb
+++ b/spec/graphql/schema/directive_spec.rb
@@ -84,6 +84,34 @@ Use `locations(OBJECT)` to update this directive's definition, or remove it from
     assert_equal "@secret.topSecret on Thing.something is invalid (nil): Expected value to not be null", err.message
   end
 
+  it "applies argument default values when omitted" do
+    defaulted_directive = Class.new(GraphQL::Schema::Directive) do
+      graphql_name "defaulted"
+      locations GraphQL::Schema::Directive::OBJECT
+      argument :enabled, GraphQL::Types::Boolean, required: true, default_value: true
+    end
+
+    thing = Class.new(GraphQL::Schema::Object) do
+      graphql_name "DefaultedThing"
+      field :id, GraphQL::Types::ID
+    end
+    thing.directive(defaulted_directive)
+
+    assert_equal true, thing.directives.first.arguments[:enabled]
+  end
+
+  it "applies argument default values when omitted in SDL" do
+    schema = GraphQL::Schema.from_definition <<~GRAPHQL
+      directive @flag(enabled: Boolean! = true) on OBJECT
+
+      type Query @flag {
+        id: ID
+      }
+    GRAPHQL
+
+    assert_equal true, schema.query.directives.first.arguments[:enabled]
+  end
+
   describe 'repeatable directives' do
     module RepeatDirectiveTest
       class Secret < GraphQL::Schema::Directive


### PR DESCRIPTION
### Problem

`Directive#initialize` validates every defined argument, but treats omitted ones as `nil` without consulting `default_value`. Any directive with a defaulted non-null argument raises when the argument is omitted at a usage site, even though the SDL is valid per spec:

```ruby
GraphQL::Schema.from_definition <<~GRAPHQL
  directive @flag(enabled: Boolean! = true) on OBJECT

  type Query @flag {
    id: ID
  }
GRAPHQL
# => GraphQL::Schema::Directive::InvalidArgumentError:
#    @flag.enabled on Query is invalid (nil): Expected value to not be null
```

Notably, this makes `from_definition` unable to load real Apollo Federation supergraph SDL — the join v0.3 spec's `@join__type` declares `extension: Boolean! = false, resolvable: Boolean! = true, ...`, so every plain `@join__type(graph: X)` usage raises.

### Fix

In the validation loop, fall back to the argument's declared default when the keyword is omitted — mirroring what `Argument#coerce_into_values` already does on the coercion path.

### Tests

Two regression tests: a Ruby-land directive attached without its defaulted argument, and the SDL repro above. Both fail without the fix and pass with it.
