### PR TITLE
Allow instances of subclasses of wrapper class to be pattern matched via #deconstruct_keys

### DIFF
--- a/lib/graphql/schema/wrapper.rb
+++ b/lib/graphql/schema/wrapper.rb
@@ -25,6 +25,10 @@ module GraphQL
       def ==(other)
         self.class == other.class && of_type == other.of_type
       end
+
+      def deconstruct_keys(_keys)
+        { of_type: of_type }
+      end
     end
   end
 end

--- a/spec/graphql/schema/list_spec.rb
+++ b/spec/graphql/schema/list_spec.rb
@@ -215,4 +215,33 @@ describe GraphQL::Schema::List do
       assert_equal 3, res["errors"][0]["extensions"]["problems"].count
     end
   end
+
+  describe "pattern matching" do
+    it "matches the of_type" do
+      assert case list_type
+      in { of_type: of_type }
+        true
+      else
+        false
+      end
+    end
+
+    it "matches nested list" do
+      nested = GraphQL::Schema::List.new(GraphQL::Schema::List.new(Jazz::Musician))
+      inner_type = case nested
+      in { of_type: { of_type: t } }
+        t
+      end
+      assert_equal Jazz::Musician, inner_type
+    end
+
+    it "does not match missing keys" do
+      assert case list_type
+      in { z: }
+        false
+      else
+        true
+      end
+    end
+  end
 end

--- a/spec/graphql/schema/non_null_spec.rb
+++ b/spec/graphql/schema/non_null_spec.rb
@@ -86,4 +86,33 @@ describe GraphQL::Schema::NonNull do
       assert_equal [nil], res["data"]["__type"]["fields"].map { |f| f["description"] }
     end
   end
+
+  describe "pattern matching" do
+    it "matches the of_type" do
+      assert case non_null_type
+      in { of_type: of_type }
+        true
+      else
+        false
+      end
+    end
+
+    it "matches nested list" do
+      nested = GraphQL::Schema::NonNull.new(GraphQL::Schema::NonNull.new(Jazz::Musician))
+      inner_type = case nested
+      in { of_type: { of_type: t } }
+        t
+      end
+      assert_equal Jazz::Musician, inner_type
+    end
+
+    it "does not match missing keys" do
+      assert case non_null_type
+      in { z: }
+        false
+      else
+        true
+      end
+    end
+  end
 end


### PR DESCRIPTION
Added `#deconstruct_keys` to the `GraphQL::Schema::Wrapper` class. This allows pattern matching against `List` and `NonNull`, which are subclasses of the `Wrapper` class.

This allows using pattern matching for concise access to internal elements when dealing with nested structures.

Example: 
```rb
obj = GraphQL::Schema::List.new(GraphQL::Schema::NonNull.new("Matched!"))
case obj
in GraphQL::Schema::List(of_type: GraphQL::Schema::NonNull(of_type: message))
  p message # => "Matched!"
else
  p "No match"
end
```

I also referred to the PR that adds #deconstruct_keys to the InputObject.
https://github.com/rmosolgo/graphql-ruby/pull/5170