### PR TITLE
Fix Schema union memberships lookup

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -665,8 +665,8 @@ module GraphQL
           inherited_um = find_inherited_value(:union_memberships, EMPTY_HASH).fetch(type.graphql_name, EMPTY_ARRAY)
           own_um + inherited_um
         else
-          joined_um = own_union_memberships.dup
-          find_inherited_value(:union_memberhips, EMPTY_HASH).each do |k, v|
+          joined_um = own_union_memberships.transform_values(&:dup)
+          find_inherited_value(:union_memberships, EMPTY_HASH).each do |k, v|
             um = joined_um[k] ||= []
             um.concat(v)
           end

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -87,6 +87,12 @@ describe GraphQL::Schema do
       assert_equal GraphQL::Query, schema.query_class
     end
 
+    it "inherits union memberships when no type is given" do
+      schema = Class.new(Dummy::Schema)
+
+      assert_equal Dummy::Schema.union_memberships, schema.union_memberships
+    end
+
     it "can override configuration from its superclass" do
       custom_query_class = Class.new(GraphQL::Query)
       extra_type_2 = Class.new(GraphQL::Schema::Enum)


### PR DESCRIPTION
Fix a typo in `Schema.union_memberships` when collecting inherited union memberships without a specific type.