### PR TITLE
Fix Query variables storage after max errors

### DIFF
--- a/lib/graphql/query/variables.rb
+++ b/lib/graphql/query/variables.rb
@@ -19,7 +19,7 @@ module GraphQL
         @storage = ast_variables.each_with_object({}) do |ast_variable, memo|
           if schema.validate_max_errors && schema.validate_max_errors <= @errors.count
             add_max_errors_reached_message
-            break
+            break memo
           end
           # Find the right value for this variable:
           # - First, use the value provided at runtime

--- a/spec/graphql/query/variables_spec.rb
+++ b/spec/graphql/query/variables_spec.rb
@@ -57,6 +57,7 @@ describe "GraphQL::Query::Variables" do
         res = schema.execute(query_string, variables: variables)
         assert_equal 3, res["errors"].count
         assert_match(/Too many errors processing variables/, res["errors"].last["message"])
+        assert_equal 0, res.query.variables.length
       end
     end
 


### PR DESCRIPTION
Fix `GraphQL::Query::Variables` so `@storage` remains a hash when variable validation stops after reaching `validate_max_errors`.

This is a narrow edge case: normal execution already returns validation errors, but callers may still inspect `result.query.variables` for logging, instrumentation, or error handling. Previously, the `break` inside `each_with_object` could make the whole expression return `nil`, causing delegated methods like `length`, `to_h`, or `[]` to raise `NoMethodError`.