### PR TITLE
Apply query token limit in Schema.validate

### DIFF
--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -860,7 +860,7 @@ module GraphQL
       # @return [Array<GraphQL::StaticValidation::Error >]
       def validate(string_or_document, rules: nil, context: nil)
         doc = if string_or_document.is_a?(String)
-          GraphQL.parse(string_or_document)
+          GraphQL.parse(string_or_document, max_tokens: max_query_string_tokens)
         else
           string_or_document
         end

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -435,6 +435,18 @@ To add other types to your schema, you might want `extra_types`: https://graphql
 
         assert_equal(1, errors.size)
       end
+
+      it "applies max_query_string_tokens to query strings" do
+        limited_schema = Class.new(schema) do
+          max_query_string_tokens 3
+        end
+
+        error = assert_raises(GraphQL::ParseError) do
+          limited_schema.validate("{ root root }")
+        end
+
+        assert_equal "This query is too large to execute.", error.message
+      end
     end
   end
 


### PR DESCRIPTION
`Schema.validate(string)` parsed query strings without passing the schema's `max_query_string_tokens` setting. This allowed validation-only callers to bypass the configured token limit.

```ruby
LimitedSchema.validate("{ value value }")
# Before => validation proceeds despite exceeding the token limit
# After => raises GraphQL::ParseError
```

This passes `max_query_string_tokens` to `GraphQL.parse` and adds regression coverage.