### PR TITLE
Share lazy job scheduling across dataloaders

### DIFF
--- a/lib/graphql/dataloader.rb
+++ b/lib/graphql/dataloader.rb
@@ -212,7 +212,9 @@ module GraphQL
 
           if !@lazies_at_depth.empty?
             with_trace_query_lazy(trace_query_lazy) do
-              run_next_pending_lazies(job_fibers, trace)
+              run_next_pending_lazies(@lazies_at_depth) do
+                job_fibers.unshift(spawn_job_fiber(trace))
+              end
               run_pending_steps(trace, job_fibers, next_job_fibers, jobs_fiber_limit, source_fibers, next_source_fibers, total_fiber_limit)
             end
           end
@@ -274,24 +276,17 @@ module GraphQL
 
     private
 
-    def run_next_pending_lazies(job_fibers, trace)
-      smallest_depth = nil
-      @lazies_at_depth.each_key do |depth_key|
-        smallest_depth ||= depth_key
-        if depth_key < smallest_depth
-          smallest_depth = depth_key
-        end
-      end
+    def run_next_pending_lazies(lazies_at_depth)
+      smallest_depth = lazies_at_depth.each_key.min
+      return if smallest_depth.nil?
 
-      if smallest_depth
-        lazies = @lazies_at_depth.delete(smallest_depth)
-        if !lazies.empty?
-          lazies.each_with_index do |l, idx|
-            append_job { l.value }
-          end
-          job_fibers.unshift(spawn_job_fiber(trace))
-        end
+      lazies = lazies_at_depth.delete(smallest_depth)
+      return if lazies.empty?
+
+      lazies.each do |lazy|
+        append_job { lazy.value }
       end
+      yield
     end
 
     def run_pending_steps(trace, job_fibers, next_job_fibers, jobs_fiber_limit, source_fibers, next_source_fibers, total_fiber_limit)

--- a/lib/graphql/dataloader/async_dataloader.rb
+++ b/lib/graphql/dataloader/async_dataloader.rb
@@ -208,7 +208,7 @@ module GraphQL
 
               if !run.lazies_at_depth.empty?
                 with_trace_query_lazy(trace_query_lazy) do
-                  run_next_pending_lazies(run)
+                  run_next_pending_lazies(run.lazies_at_depth) { run_lazy_jobs(run) }
                   run_pending_steps(run)
                 end
               end
@@ -291,31 +291,12 @@ module GraphQL
         run.close_queues
       end
 
-      #### TODO DRY  Had to duplicate to remove spawn_job_fiber
-      def run_next_pending_lazies(run)
-        smallest_depth = nil
-        run.lazies_at_depth.each_key do |depth_key|
-          smallest_depth ||= depth_key
-          if depth_key < smallest_depth
-            smallest_depth = depth_key
-          end
-        end
-
-        if smallest_depth
-          lazies = run.lazies_at_depth.delete(smallest_depth)
-          if !lazies.empty?
-            begin
-              run.new_queues
-              lazies.each_with_index do |l, idx|
-                append_job { l.value }
-              end
-              spawn_job_task(run) # Todo what was the last `true` condition?
-              run.wait_for_queues
-            ensure
-              run.close_queues
-            end
-          end
-        end
+      def run_lazy_jobs(run)
+        run.new_queues
+        spawn_job_task(run)
+        run.wait_for_queues
+      ensure
+        run.close_queues
       end
 
       def spawn_source_task(run, num_tasks)


### PR DESCRIPTION
This refactors lazy job scheduling shared by `Dataloader` and `AsyncDataloader`.

- Move selection and enqueueing of the next lazy depth into the base `Dataloader`
- Use a block for implementation-specific Fiber/Task execution
- Keep Async queue lifecycle management isolated in `run_lazy_jobs`
- Remove duplicated code and stale TODOs 

No behavior change is intended.