### PR TITLE
Remove obsolete NoMethodError compatibility

### DIFF
--- a/lib/graphql/execution/interpreter/runtime.rb
+++ b/lib/graphql/execution/interpreter/runtime.rb
@@ -765,8 +765,7 @@ module GraphQL
 
                 response_list
               rescue NoMethodError => err
-                # Ruby 2.2 doesn't have NoMethodError#receiver, can't check that one in this case. (It's been EOL since 2017.)
-                if err.name == :each && (err.respond_to?(:receiver) ? err.receiver == value : true)
+                if err.name == :each && err.receiver == value
                   # This happens when the GraphQL schema doesn't match the implementation. Help the dev debug.
                   raise ListResultFailedError.new(value: value, field: field, path: current_path)
                 else


### PR DESCRIPTION
My understanding is that this gem supports Ruby 2.7 and later, so support for version 2.2 is likely no longer necessary.
https://github.com/rmosolgo/graphql-ruby/blob/c30cc15b68fbb998aaf8591d5d17f8f3071fd114/graphql.gemspec#L16

I have tried removing the code that appears to be obsolete. What do you think?
