### PR TITLE
AsyncDataloader: Rework task waiting

### DIFF
--- a/lib/graphql/dataloader.rb
+++ b/lib/graphql/dataloader.rb
@@ -59,7 +59,6 @@ module GraphQL
 
     def initialize(nonblocking: self.class.default_nonblocking, fiber_limit: self.class.default_fiber_limit)
       @source_cache = Hash.new { |h, k| h[k] = {} }.compare_by_identity
-      @pending_sources = []
       @pending_source_set = Set.new.compare_by_identity
       @pending_jobs = []
       if !nonblocking.nil?
@@ -152,9 +151,7 @@ module GraphQL
 
     # @api private
     def queue_pending_source(source)
-      return nil if !@pending_source_set.add?(source)
-
-      @pending_sources << source
+      @pending_source_set.add(source)
       nil
     end
 
@@ -311,8 +308,9 @@ module GraphQL
       end
       join_queues(job_fibers, next_job_fibers)
 
-      while (!source_fibers.empty? || !@pending_sources.empty?)
-        while (f = source_fibers.shift || (((job_fibers.size + source_fibers.size + next_source_fibers.size + next_job_fibers.size) < total_fiber_limit) && spawn_source_fiber(trace)))
+      while (!source_fibers.empty? || !@pending_source_set.empty?)
+        pending_sources = drain_pending_sources
+        while (f = source_fibers.shift || (((job_fibers.size + source_fibers.size + next_source_fibers.size + next_job_fibers.size) < total_fiber_limit) && (pending_sources&.any?) && spawn_source_fiber(trace, pending_sources)))
           if f.alive?
             finished = run_fiber(f)
             if !finished
@@ -363,35 +361,22 @@ module GraphQL
     end
 
     def drain_pending_sources
-      pending_sources = @pending_sources
-      @pending_sources = []
+      @pending_source_set.delete_if { |source| !source.pending }
+      pending_sources = @pending_source_set.to_a
       @pending_source_set.clear
-
-      pending_sources.select!(&:pending?)
       pending_sources.empty? ? nil : pending_sources
     end
 
-    def dequeue_pending_source
-      while (source = @pending_sources.shift)
-        @pending_source_set.delete(source)
-        return source if source.pending?
-      end
-    end
-
-    def spawn_source_fiber(trace)
-      pending_sources = @pending_sources.dup
-
-      if !pending_sources.empty?
-        spawn_fiber do
-          trace&.dataloader_spawn_source_fiber(pending_sources)
-          while (source = dequeue_pending_source)
-            Fiber[:__graphql_current_dataloader_source] = source
-            trace&.begin_dataloader_source(source)
-            source.run_pending_keys
-            trace&.end_dataloader_source(source)
-          end
-          trace&.dataloader_fiber_exit
+    def spawn_source_fiber(trace, pending_sources)
+      spawn_fiber do
+        trace&.dataloader_spawn_source_fiber(pending_sources)
+        while (source = pending_sources.shift)
+          Fiber[:__graphql_current_dataloader_source] = source
+          trace&.begin_dataloader_source(source)
+          source.run_pending_keys
+          trace&.end_dataloader_source(source)
         end
+        trace&.dataloader_fiber_exit
       end
     end
   end

--- a/lib/graphql/dataloader.rb
+++ b/lib/graphql/dataloader.rb
@@ -60,6 +60,7 @@ module GraphQL
     def initialize(nonblocking: self.class.default_nonblocking, fiber_limit: self.class.default_fiber_limit)
       @source_cache = Hash.new { |h, k| h[k] = {} }.compare_by_identity
       @pending_source_set = Set.new.compare_by_identity
+      @pending_sources = []
       @pending_jobs = []
       if !nonblocking.nil?
         @nonblocking = nonblocking
@@ -151,7 +152,9 @@ module GraphQL
 
     # @api private
     def queue_pending_source(source)
-      @pending_source_set.add(source)
+      if @pending_source_set.add?(source)
+        @pending_sources << source
+      end
       nil
     end
 
@@ -308,9 +311,8 @@ module GraphQL
       end
       join_queues(job_fibers, next_job_fibers)
 
-      while (!source_fibers.empty? || !@pending_source_set.empty?)
-        pending_sources = drain_pending_sources
-        while (f = source_fibers.shift || (((job_fibers.size + source_fibers.size + next_source_fibers.size + next_job_fibers.size) < total_fiber_limit) && (pending_sources&.any?) && spawn_source_fiber(trace, pending_sources)))
+      while (!source_fibers.empty? || !@pending_sources.empty?)
+        while (f = source_fibers.shift || (((job_fibers.size + source_fibers.size + next_source_fibers.size + next_job_fibers.size) < total_fiber_limit) && spawn_source_fiber(trace)))
           if f.alive?
             finished = run_fiber(f)
             if !finished
@@ -361,22 +363,35 @@ module GraphQL
     end
 
     def drain_pending_sources
-      @pending_source_set.delete_if { |source| !source.pending }
-      pending_sources = @pending_source_set.to_a
+      pending_sources = @pending_sources
+      @pending_sources = []
       @pending_source_set.clear
+
+      pending_sources.select!(&:pending?)
       pending_sources.empty? ? nil : pending_sources
     end
 
-    def spawn_source_fiber(trace, pending_sources)
-      spawn_fiber do
-        trace&.dataloader_spawn_source_fiber(pending_sources)
-        while (source = pending_sources.shift)
-          Fiber[:__graphql_current_dataloader_source] = source
-          trace&.begin_dataloader_source(source)
-          source.run_pending_keys
-          trace&.end_dataloader_source(source)
+    def dequeue_pending_source
+      while (source = @pending_sources.shift)
+        @pending_source_set.delete(source)
+        return source if source.pending?
+      end
+    end
+
+    def spawn_source_fiber(trace)
+      if !@pending_sources.empty?
+        spawn_fiber do
+          trace&.dataloader_spawn_source_fiber(@pending_sources)
+          # This will find sources which were enqueued during `#fetch`:
+          while (source = dequeue_pending_source)
+            next if !source.pending?
+            Fiber[:__graphql_current_dataloader_source] = source
+            trace&.begin_dataloader_source(source)
+            source.run_pending_keys
+            trace&.end_dataloader_source(source)
+          end
+          trace&.dataloader_fiber_exit
         end
-        trace&.dataloader_fiber_exit
       end
     end
   end

--- a/lib/graphql/dataloader.rb
+++ b/lib/graphql/dataloader.rb
@@ -223,10 +223,10 @@ module GraphQL
 
           if !@lazies_at_depth.empty?
             with_trace_query_lazy(trace_query_lazy) do
-              run_next_pending_lazies(@lazies_at_depth) do
+              if enqueue_next_pending_lazies(@lazies_at_depth)
                 job_fibers.unshift(spawn_job_fiber(trace))
+                run_pending_steps(trace, job_fibers, next_job_fibers, jobs_fiber_limit, source_fibers, next_source_fibers, total_fiber_limit)
               end
-              run_pending_steps(trace, job_fibers, next_job_fibers, jobs_fiber_limit, source_fibers, next_source_fibers, total_fiber_limit)
             end
           end
         end
@@ -287,17 +287,19 @@ module GraphQL
 
     private
 
-    def run_next_pending_lazies(lazies_at_depth)
+    # Returns true if anything was actually enqueued
+    def enqueue_next_pending_lazies(lazies_at_depth)
       smallest_depth = lazies_at_depth.each_key.min
-      return if smallest_depth.nil?
+      return false if smallest_depth.nil?
 
       lazies = lazies_at_depth.delete(smallest_depth)
-      return if lazies.empty?
+      return false if lazies.empty?
 
       lazies.each do |lazy|
         append_job { lazy.value }
       end
-      yield
+
+      true
     end
 
     def run_pending_steps(trace, job_fibers, next_job_fibers, jobs_fiber_limit, source_fibers, next_source_fibers, total_fiber_limit)

--- a/lib/graphql/dataloader/async_dataloader.rb
+++ b/lib/graphql/dataloader/async_dataloader.rb
@@ -83,6 +83,12 @@ module GraphQL
           @started_count_task.cancel
         end
 
+        def mark_finished(t_or_err)
+          if !@finished_tasks.closed? # This can be closed if a previous error caused the parent task to cancel
+            @finished_tasks.push(t_or_err)
+          end
+        end
+
         def running_count
           @snoozed_jobs_condition.instance_variable_get(:@ready).num_waiting +
             @snoozed_sources_condition.instance_variable_get(:@ready).num_waiting +
@@ -110,10 +116,14 @@ module GraphQL
 
           @started_count_task = @root_task.async do |task|
             @finished_first_pass.wait
-            while task = @started_tasks.wait
-              @started_count += 1
-              if task.status == :initialized # could also be resumed after waiting
-                task.run
+            while t_or_err = @started_tasks.wait
+              if t_or_err.is_a?(StandardError)
+                @finished_all_tasks.reject(t_or_err)
+              else
+                @started_count += 1
+                if t_or_err.status == :initialized # could also be resumed after waiting
+                  t_or_err.run
+                end
               end
             end
           end
@@ -263,9 +273,12 @@ module GraphQL
             while job = pending_jobs.shift
               job.call
             end
+          rescue StandardError => err
+            run.mark_finished(err)
+          else
+            run.mark_finished(task)
           ensure
             cleanup_fiber
-            run.finished_tasks.push($! || task)
             run.trace&.dataloader_fiber_exit
           end
           run.started_tasks.push(new_task)
@@ -302,6 +315,7 @@ module GraphQL
         if num_tasks == Float::INFINITY
           num_tasks = pending_sources.size
         end
+
         fiber_vars = get_fiber_variables
         trace = run.trace
         num_tasks.times do
@@ -316,8 +330,11 @@ module GraphQL
               trace&.end_dataloader_source(source)
             end
             nil
+          rescue StandardError => err
+            run.mark_finished(err)
+          else
+            run.mark_finished(task)
           ensure
-            run.finished_tasks.push($! || task)
             cleanup_fiber
             trace&.dataloader_fiber_exit
           end

--- a/lib/graphql/dataloader/async_dataloader.rb
+++ b/lib/graphql/dataloader/async_dataloader.rb
@@ -62,7 +62,7 @@ module GraphQL
 
         attr_accessor :trace, :root_task
 
-        attr_reader :jobs, :lazies_at_depth,  :snoozed_jobs_condition, :snoozed_sources_condition, :tasks_channel
+        attr_reader :jobs, :lazies_at_depth, :jobs_fiber_limit,  :snoozed_jobs_condition, :snoozed_sources_condition, :tasks_channel
 
         def jobs_bandwidth?
           running_count < @jobs_fiber_limit
@@ -248,62 +248,18 @@ module GraphQL
           condition.signal
         end
 
-        while (loop_pending_work = (mode == :jobs) ? (!run.jobs.empty? && run.jobs_bandwidth? ? run.jobs : nil) : (drain_pending_sources)) || unsnoozed
+        while (pending_work = (mode == :jobs) ? (!run.jobs.empty? && run.jobs_bandwidth? ? run.jobs : nil) : (drain_pending_sources)) || unsnoozed
           unsnoozed = false
-          if loop_pending_work
+          if pending_work
             if should_wait_for_all_tasks == false
               should_wait_for_all_tasks = true
               run.new_queues(mode)
             end
-
-            num_tasks = if mode == :sources
-              n = run.current_sources_fiber_limit
-              if n == Float::INFINITY
-                loop_pending_work.size
-              else
-                n
-              end
-            else
-              1
+            num_tasks = mode == :sources ? run.current_sources_fiber_limit : 1
+            if num_tasks > pending_work.size
+              num_tasks = pending_work.size
             end
-
-            fiber_vars = get_fiber_variables
-            trace = run.trace
-
-            num_tasks.times do
-              new_task = Async::Task.new(run.root_task) do |task|
-                pending_work = loop_pending_work # avoid overrides from assignment in `while`
-                task.graphql_async_dataloader_run = run
-                task.graphql_async_dataloader_condition = condition
-                set_fiber_variables(fiber_vars)
-                case mode
-                when :jobs
-                  trace&.dataloader_spawn_execution_fiber(pending_work)
-                  while job = pending_work.shift
-                    job.call
-                  end
-                when :sources
-                  trace&.dataloader_spawn_source_fiber(pending_work)
-                  while (source = pending_work.shift)
-                    Fiber[:__graphql_current_dataloader_source] = source
-                    trace&.begin_dataloader_source(source)
-                    source.run_pending_keys
-                    trace&.end_dataloader_source(source)
-                  end
-                else
-                  raise ArgumentError, "Unknown mode: #{mode.inspect}"
-                end
-                nil
-              rescue StandardError => err
-                run.tasks_channel.push([:task_error, err])
-              else
-                run.tasks_channel.push([:finished_task, task])
-              ensure
-                cleanup_fiber
-                trace&.dataloader_fiber_exit
-              end
-              run.tasks_channel.push([:started_task, new_task])
-            end
+            spawn_tasks(run, mode, condition, pending_work, num_tasks)
           end
 
           run.wait_for_no_running_tasks
@@ -315,6 +271,46 @@ module GraphQL
       ensure
         if should_wait_for_all_tasks
           run.close_queues
+        end
+      end
+
+      # Use a separate method for this so that the outer loop's reassignment of `pending_work`
+      # doesn't affect already-running tasks which (would) close over that variable
+      def spawn_tasks(run, mode, condition, pending_work, num_tasks)
+        fiber_vars = get_fiber_variables
+        trace = run.trace
+        num_tasks.times do
+          new_task = Async::Task.new(run.root_task) do |task|
+            task.graphql_async_dataloader_run = run
+            task.graphql_async_dataloader_condition = condition
+            set_fiber_variables(fiber_vars)
+            case mode
+            when :jobs
+              trace&.dataloader_spawn_execution_fiber(pending_work)
+              while job = pending_work.shift
+                job.call
+              end
+            when :sources
+              trace&.dataloader_spawn_source_fiber(pending_work)
+              while (source = pending_work.shift)
+                Fiber[:__graphql_current_dataloader_source] = source
+                trace&.begin_dataloader_source(source)
+                source.run_pending_keys
+                trace&.end_dataloader_source(source)
+              end
+            else
+              raise ArgumentError, "Unknown mode: #{mode.inspect}"
+            end
+            nil
+          rescue StandardError => err
+            run.tasks_channel.push([:task_error, err])
+          else
+            run.tasks_channel.push([:finished_task, task])
+          ensure
+            cleanup_fiber
+            trace&.dataloader_fiber_exit
+          end
+          run.tasks_channel.push([:started_task, new_task])
         end
       end
     end

--- a/lib/graphql/dataloader/async_dataloader.rb
+++ b/lib/graphql/dataloader/async_dataloader.rb
@@ -20,7 +20,7 @@ module GraphQL
       end
 
       # @api private
-      attr_reader :pending_source_set
+      attr_reader :pending_sources
       # @api private
       public :drain_pending_sources
 
@@ -53,6 +53,7 @@ module GraphQL
           @jobs_fiber_limit = jobs_fiber_limit
           @lazies_at_depth = Hash.new { |h, k| h[k] = [] }
 
+          @running_tasks = nil
           @tasks_channel = nil
           @tasks_channel_task = nil
           @finished_all_tasks = nil
@@ -69,7 +70,11 @@ module GraphQL
           running_count < jobs_fiber_limit
         end
 
-        def allowed_sources_tasks
+        def sources_bandwidth?
+          running_count < sources_fiber_limit
+        end
+
+        def sources_fiber_limit
           within_limit = total_fiber_limit - running_count
           if within_limit < 1
             1
@@ -138,7 +143,6 @@ module GraphQL
         end
 
         def new_queues(mode)
-          pending_work = mode == :jobs ? @jobs : @dataloader.pending_source_set
           @tasks_channel = Async::Queue.new(parent: @root_task)
           @no_running_tasks = Async::Promise.new
           @finished_all_tasks = Async::Promise.new
@@ -153,10 +157,10 @@ module GraphQL
                 @running_tasks.push(data)
               when :finished_task, :paused_task
                 @running_tasks.delete(data)
+                has_pending_work = mode == :jobs ? @jobs.any? : @dataloader.pending_sources.any?(&:pending?)
                 if @running_tasks.empty?
                   @no_running_tasks.resolve(true)
-                  has_pending_work = pending_work.any? # rubocop:disable Development/NoneWithoutBlockCop
-                  has_bandwidth = mode == :jobs ? jobs_bandwidth? : true
+                  has_bandwidth = mode == :jobs ? jobs_bandwidth? : sources_bandwidth?
                   if (!has_pending_work) || (!has_bandwidth)
                     @finished_all_tasks.resolve(true)
                   end
@@ -279,15 +283,64 @@ module GraphQL
           condition.signal
         end
 
-        while unsnoozed || (pending_work = run.get_pending_work_for(mode))
+        while (loop_pending_work = run.get_pending_work_for(mode)) || unsnoozed
           unsnoozed = false
-          if pending_work
+          if loop_pending_work
             if should_wait_for_all_tasks == false
               should_wait_for_all_tasks = true
               run.new_queues(mode)
             end
-            spawn_tasks(run, mode, condition, pending_work)
+
+            num_tasks = if mode == :sources
+              n = run.sources_fiber_limit
+              if n == Float::INFINITY
+                loop_pending_work.size
+              else
+                n
+              end
+            else
+              1
+            end
+
+            fiber_vars = get_fiber_variables
+            trace = run.trace
+
+            num_tasks.times do
+              new_task = Async::Task.new(run.root_task) do |task|
+                pending_work = loop_pending_work # avoid overrides from assignment in `while`
+                task.graphql_async_dataloader_run = run
+                task.graphql_async_dataloader_condition = condition
+                set_fiber_variables(fiber_vars)
+                case mode
+                when :jobs
+                  trace&.dataloader_spawn_execution_fiber(pending_work)
+                  while job = pending_work.shift
+                    job.call
+                  end
+                when :sources
+                  trace&.dataloader_spawn_source_fiber(pending_work)
+                  while (source = pending_work.shift)
+                    Fiber[:__graphql_current_dataloader_source] = source
+                    trace&.begin_dataloader_source(source)
+                    source.run_pending_keys
+                    trace&.end_dataloader_source(source)
+                  end
+                else
+                  raise ArgumentError, "Unknown mode: #{mode.inspect}"
+                end
+                nil
+              rescue StandardError => err
+                run.task_error(err)
+              else
+                run.finish_task(task)
+              ensure
+                cleanup_fiber
+                trace&.dataloader_fiber_exit
+              end
+              run.start_task(new_task)
+            end
           end
+
           run.wait_for_no_running_tasks
         end
 
@@ -298,56 +351,6 @@ module GraphQL
         if should_wait_for_all_tasks
           run.close_queues
         end
-      end
-
-      def spawn_tasks(run, mode, condition, pending_work)
-        num_tasks = if mode == :sources
-          n = run.allowed_sources_tasks
-          if n == Float::INFINITY
-            pending_work.size
-          else
-            n
-          end
-        else
-          1
-        end
-
-        fiber_vars = get_fiber_variables
-        trace = run.trace
-
-        num_tasks.times do
-          new_task = Async::Task.new(run.root_task) do |task|
-            task.graphql_async_dataloader_run = run
-            task.graphql_async_dataloader_condition = condition
-            set_fiber_variables(fiber_vars)
-            case mode
-            when :jobs
-              trace&.dataloader_spawn_execution_fiber(pending_work)
-              while job = pending_work.shift
-                job.call
-              end
-            when :sources
-              trace&.dataloader_spawn_source_fiber(pending_work)
-              while (source = pending_work.shift)
-                trace&.begin_dataloader_source(source)
-                source.run_pending_keys
-                trace&.end_dataloader_source(source)
-              end
-            else
-              raise ArgumentError, "Unknown mode: #{mode.inspect}"
-            end
-            nil
-          rescue StandardError => err
-            run.task_error(err)
-          else
-            run.finish_task(task)
-          ensure
-            cleanup_fiber
-            trace&.dataloader_fiber_exit
-          end
-          run.start_task(new_task)
-        end
-        nil
       end
     end
   end

--- a/lib/graphql/dataloader/async_dataloader.rb
+++ b/lib/graphql/dataloader/async_dataloader.rb
@@ -19,9 +19,14 @@ module GraphQL
         create_pending_run
       end
 
+      # @api private
+      attr_reader :pending_source_set
+      # @api private
+      public :drain_pending_sources
+
       def create_pending_run
         jobs_fiber_limit, total_fiber_limit = calculate_fiber_limit
-        @pending_run = Run.new(@pending_source_set, total_fiber_limit, jobs_fiber_limit)
+        @pending_run = Run.new(self, total_fiber_limit, jobs_fiber_limit)
       end
 
       def yield(source = Fiber[:__graphql_current_dataloader_source])
@@ -38,8 +43,8 @@ module GraphQL
       end
 
       class Run
-        def initialize(pending_source_set, total_fiber_limit, jobs_fiber_limit)
-          @pending_source_set = pending_source_set
+        def initialize(dataloader, total_fiber_limit, jobs_fiber_limit)
+          @dataloader = dataloader
           @root_task = nil
           @trace = nil
           @jobs = []
@@ -116,8 +121,24 @@ module GraphQL
 
         attr_reader :tasks_channel, :no_running_tasks
 
+
+        def get_pending_work_for(mode)
+          case mode
+          when :jobs
+            if jobs_bandwidth? && !@jobs.empty?
+              @jobs
+            else
+              nil
+            end
+          when :sources
+            @dataloader.drain_pending_sources
+          else
+            raise ArgumentError, "Unknown mode: #{mode.inspect}"
+          end
+        end
+
         def new_queues(mode)
-          pending_work = mode == :jobs ? @jobs : @pending_source_set
+          pending_work = mode == :jobs ? @jobs : @dataloader.pending_source_set
           @tasks_channel = Async::Queue.new(parent: @root_task)
           @no_running_tasks = Async::Promise.new
           @finished_all_tasks = Async::Promise.new
@@ -220,13 +241,13 @@ module GraphQL
 
             while first_pass || run.running? || !jobs.empty?
               first_pass = false
-              run_pending_steps(run)
-              run_sources(run)
+              run_queue(run, run.snoozed_jobs_condition, :jobs)
+              run_queue(run, run.snoozed_sources_condition, :sources)
 
               if !run.lazies_at_depth.empty?
                 with_trace_query_lazy(trace_query_lazy) do
-                  run_next_pending_lazies(run.lazies_at_depth) { run_pending_steps(run) }
-                  run_pending_steps(run)
+                  run_next_pending_lazies(run.lazies_at_depth) { run_queue(run, run.snoozed_jobs_condition, :jobs) }
+                  run_queue(run, run.snoozed_jobs_condition, :jobs)
                 end
               end
             end
@@ -249,21 +270,23 @@ module GraphQL
 
       private
 
-      def run_pending_steps(run)
-        pending_jobs = run.jobs
-        run.new_queues(:jobs)
+      def run_queue(run, condition, mode)
         should_wait_for_all_tasks = false
 
-        if (unsnoozed = run.snoozed_jobs_condition.waiting?)
+        if (unsnoozed = condition.waiting?)
           should_wait_for_all_tasks = true
-          run.snoozed_jobs_condition.signal
+          run.new_queues(mode)
+          condition.signal
         end
 
-        while (!pending_jobs.empty? && (has_limit = run.jobs_bandwidth?)) || (unsnoozed)
+        while unsnoozed || (pending_work = run.get_pending_work_for(mode))
           unsnoozed = false
-          if has_limit
-            should_wait_for_all_tasks = true
-            spawn_job_task(run)
+          if pending_work
+            if should_wait_for_all_tasks == false
+              should_wait_for_all_tasks = true
+              run.new_queues(mode)
+            end
+            spawn_tasks(run, mode, condition, pending_work)
           end
           run.wait_for_no_running_tasks
         end
@@ -272,75 +295,46 @@ module GraphQL
           run.wait_for_queues
         end
       ensure
-        run.close_queues
+        if should_wait_for_all_tasks
+          run.close_queues
+        end
       end
 
-      def spawn_job_task(run)
-        pending_jobs = run.jobs
-        fiber_vars = get_fiber_variables
-        new_task = Async::Task.new(run.root_task) do |task|
-          run.trace&.dataloader_spawn_execution_fiber(pending_jobs)
-          task.graphql_async_dataloader_run = run
-          task.graphql_async_dataloader_condition = run.snoozed_jobs_condition
-          set_fiber_variables(fiber_vars)
-          while job = pending_jobs.shift
-            job.call
+      def spawn_tasks(run, mode, condition, pending_work)
+        num_tasks = if mode == :sources
+          n = run.allowed_sources_tasks
+          if n == Float::INFINITY
+            pending_work.size
+          else
+            n
           end
-        rescue StandardError => err
-          run.task_error(err)
         else
-          run.finish_task(task)
-        ensure
-          cleanup_fiber
-          run.trace&.dataloader_fiber_exit
-        end
-        run.start_task(new_task)
-        new_task
-      end
-
-      def run_sources(run)
-        run.new_queues(:sources)
-        should_wait_for_sources = false
-
-        if (unsnoozed = run.snoozed_sources_condition.waiting?)
-          should_wait_for_sources = true
-          run.snoozed_sources_condition.signal
-        end
-
-        allowed_tasks = run.allowed_sources_tasks
-        while (pending_sources = drain_pending_sources) || unsnoozed
-          unsnoozed = false
-          if pending_sources
-            should_wait_for_sources = pending_sources
-            spawn_source_tasks(run, allowed_tasks, pending_sources)
-          end
-          run.wait_for_no_running_tasks
-        end
-
-        if should_wait_for_sources
-          run.wait_for_queues
-        end
-      ensure
-        run.close_queues
-      end
-
-      def spawn_source_tasks(run, num_tasks, pending_sources)
-        if num_tasks == Float::INFINITY
-          num_tasks = pending_sources.size
+          1
         end
 
         fiber_vars = get_fiber_variables
         trace = run.trace
+
         num_tasks.times do
           new_task = Async::Task.new(run.root_task) do |task|
             task.graphql_async_dataloader_run = run
-            task.graphql_async_dataloader_condition = run.snoozed_sources_condition
-            trace&.dataloader_spawn_source_fiber(pending_sources)
+            task.graphql_async_dataloader_condition = condition
             set_fiber_variables(fiber_vars)
-            while (source = pending_sources.shift)
-              trace&.begin_dataloader_source(source)
-              source.run_pending_keys
-              trace&.end_dataloader_source(source)
+            case mode
+            when :jobs
+              trace&.dataloader_spawn_execution_fiber(pending_work)
+              while job = pending_work.shift
+                job.call
+              end
+            when :sources
+              trace&.dataloader_spawn_source_fiber(pending_work)
+              while (source = pending_work.shift)
+                trace&.begin_dataloader_source(source)
+                source.run_pending_keys
+                trace&.end_dataloader_source(source)
+              end
+            else
+              raise ArgumentError, "Unknown mode: #{mode.inspect}"
             end
             nil
           rescue StandardError => err
@@ -352,8 +346,8 @@ module GraphQL
             trace&.dataloader_fiber_exit
           end
           run.start_task(new_task)
-          new_task
         end
+        nil
       end
     end
   end

--- a/lib/graphql/dataloader/async_dataloader.rb
+++ b/lib/graphql/dataloader/async_dataloader.rb
@@ -21,7 +21,7 @@ module GraphQL
 
       def create_pending_run
         jobs_fiber_limit, total_fiber_limit = calculate_fiber_limit
-        @pending_run = Run.new(total_fiber_limit, jobs_fiber_limit)
+        @pending_run = Run.new(@pending_source_set, total_fiber_limit, jobs_fiber_limit)
       end
 
       def yield(source = Fiber[:__graphql_current_dataloader_source])
@@ -29,16 +29,17 @@ module GraphQL
         run = task.graphql_async_dataloader_run
         trace = run.trace
         trace&.dataloader_fiber_yield(source)
-        run.finished_tasks.push(task)
+        run.pause_task(task)
         condition = task.graphql_async_dataloader_condition
         condition.wait
-        run.started_tasks.push(task)
+        run.resume_task(task)
         trace&.dataloader_fiber_resume(source)
         nil
       end
 
       class Run
-        def initialize(total_fiber_limit, jobs_fiber_limit)
+        def initialize(pending_source_set, total_fiber_limit, jobs_fiber_limit)
+          @pending_source_set = pending_source_set
           @root_task = nil
           @trace = nil
           @jobs = []
@@ -47,12 +48,9 @@ module GraphQL
           @jobs_fiber_limit = jobs_fiber_limit
           @lazies_at_depth = Hash.new { |h, k| h[k] = [] }
 
-          @finished_tasks = nil
-          @started_tasks = nil
-          @started_count_task = nil
-          @finished_count_task = nil
+          @tasks_channel = nil
+          @tasks_channel_task = nil
           @finished_all_tasks = nil
-          @finished_first_pass = nil
 
           @snoozed_jobs_condition = Async::Condition.new
           @snoozed_sources_condition = Async::Condition.new
@@ -76,67 +74,75 @@ module GraphQL
         end
 
         def close_queues
-          @finished_tasks.close
-          @finished_count_task.cancel
-
-          @started_tasks.close
-          @started_count_task.cancel
+          @tasks_channel.close
+          @tasks_channel_task.cancel
         end
 
-        def mark_finished(t_or_err)
-          if !@finished_tasks.closed? # This can be closed if a previous error caused the parent task to cancel
-            @finished_tasks.push(t_or_err)
-          end
+        def finish_task(t)
+          @tasks_channel.push([:finished_task, t])
+        end
+
+        def task_error(err)
+          @tasks_channel.push([:task_error, err])
+        end
+
+        def start_task(t)
+          @tasks_channel.push([:new_task, t])
+        end
+
+        def pause_task(t)
+          @tasks_channel.push([:paused_task, t])
+        end
+
+        def resume_task(t)
+          @tasks_channel.push([:resumed_task, t])
         end
 
         def running_count
           @snoozed_jobs_condition.instance_variable_get(:@ready).num_waiting +
             @snoozed_sources_condition.instance_variable_get(:@ready).num_waiting +
-            @started_count +
-            @started_tasks.size -
-            @finished_count
+            (@running_tasks&.size || 0)
         end
 
         def wait_for_queues
-          if !@finished_first_pass.resolved?
-            @finished_first_pass.resolve(true)
-          end
-
           @finished_all_tasks.wait
           @finished_all_tasks = Async::Promise.new
         end
 
-        def new_queues
-          @finished_tasks = Async::Queue.new
-          @finished_count = 0
-          @started_tasks = Async::Queue.new
-          @started_count = 0
-          @finished_first_pass = Async::Promise.new
+        def wait_for_no_running_tasks
+          @no_running_tasks.wait
+          @no_running_tasks = Async::Promise.new
+        end
+
+        attr_reader :tasks_channel, :no_running_tasks
+
+        def new_queues(mode)
+          pending_work = mode == :jobs ? @jobs : @pending_source_set
+          @tasks_channel = Async::Queue.new(parent: @root_task)
+          @no_running_tasks = Async::Promise.new
           @finished_all_tasks = Async::Promise.new
-
-          @started_count_task = @root_task.async do |task|
-            @finished_first_pass.wait
-            while t_or_err = @started_tasks.wait
-              if t_or_err.is_a?(StandardError)
-                @finished_all_tasks.reject(t_or_err)
-              else
-                @started_count += 1
-                if t_or_err.status == :initialized # could also be resumed after waiting
-                  t_or_err.run
+          @running_tasks = []
+          @tasks_channel_task = @root_task.async do |_t|
+            while ((msg, data) = @tasks_channel.wait)
+              case msg
+              when :new_task
+                @running_tasks.push(data)
+                data.run
+              when :resumed_task
+                @running_tasks.push(data)
+              when :finished_task, :paused_task
+                @running_tasks.delete(data)
+                if @running_tasks.empty?
+                  @no_running_tasks.resolve(true)
+                  has_pending_work = pending_work.any? # rubocop:disable Development/NoneWithoutBlockCop
+                  has_bandwidth = mode == :jobs ? jobs_bandwidth? : true
+                  if (!has_pending_work) || (!has_bandwidth)
+                    @finished_all_tasks.resolve(true)
+                  end
                 end
-              end
-            end
-          end
-
-          @finished_count_task = @root_task.async do |task|
-            while t_or_err = @finished_tasks.wait
-              if t_or_err.is_a?(StandardError)
-                @finished_all_tasks.reject(t_or_err)
-              else
-                @finished_count += 1
-                if @finished_count == @started_count
-                  @finished_all_tasks.resolve(true)
-                end
+              when :task_error
+                @no_running_tasks.resolve(true)
+                @finished_all_tasks.reject(data)
               end
             end
           end
@@ -219,7 +225,7 @@ module GraphQL
 
               if !run.lazies_at_depth.empty?
                 with_trace_query_lazy(trace_query_lazy) do
-                  run_next_pending_lazies(run.lazies_at_depth) { run_lazy_jobs(run) }
+                  run_next_pending_lazies(run.lazies_at_depth) { run_pending_steps(run) }
                   run_pending_steps(run)
                 end
               end
@@ -244,17 +250,25 @@ module GraphQL
       private
 
       def run_pending_steps(run)
-        run.new_queues
+        pending_jobs = run.jobs
+        run.new_queues(:jobs)
+        should_wait_for_all_tasks = false
 
         if (unsnoozed = run.snoozed_jobs_condition.waiting?)
+          should_wait_for_all_tasks = true
           run.snoozed_jobs_condition.signal
         end
-        pending_jobs = run.jobs
+
         while (!pending_jobs.empty? && (has_limit = run.jobs_bandwidth?)) || (unsnoozed)
           unsnoozed = false
           if has_limit
+            should_wait_for_all_tasks = true
             spawn_job_task(run)
           end
+          run.wait_for_no_running_tasks
+        end
+
+        if should_wait_for_all_tasks
           run.wait_for_queues
         end
       ensure
@@ -263,55 +277,54 @@ module GraphQL
 
       def spawn_job_task(run)
         pending_jobs = run.jobs
-        if !pending_jobs.empty?
-          fiber_vars = get_fiber_variables
-          new_task = Async::Task.new(run.root_task) do |task|
-            run.trace&.dataloader_spawn_execution_fiber(pending_jobs)
-            task.graphql_async_dataloader_run = run
-            task.graphql_async_dataloader_condition = run.snoozed_jobs_condition
-            set_fiber_variables(fiber_vars)
-            while job = pending_jobs.shift
-              job.call
-            end
-          rescue StandardError => err
-            run.mark_finished(err)
-          else
-            run.mark_finished(task)
-          ensure
-            cleanup_fiber
-            run.trace&.dataloader_fiber_exit
+        fiber_vars = get_fiber_variables
+        new_task = Async::Task.new(run.root_task) do |task|
+          run.trace&.dataloader_spawn_execution_fiber(pending_jobs)
+          task.graphql_async_dataloader_run = run
+          task.graphql_async_dataloader_condition = run.snoozed_jobs_condition
+          set_fiber_variables(fiber_vars)
+          while job = pending_jobs.shift
+            job.call
           end
-          run.started_tasks.push(new_task)
-          new_task
+        rescue StandardError => err
+          run.task_error(err)
+        else
+          run.finish_task(task)
+        ensure
+          cleanup_fiber
+          run.trace&.dataloader_fiber_exit
         end
+        run.start_task(new_task)
+        new_task
       end
 
       def run_sources(run)
-        run.new_queues
+        run.new_queues(:sources)
+        should_wait_for_sources = false
 
         if (unsnoozed = run.snoozed_sources_condition.waiting?)
+          should_wait_for_sources = true
           run.snoozed_sources_condition.signal
         end
 
         allowed_tasks = run.allowed_sources_tasks
         while (pending_sources = drain_pending_sources) || unsnoozed
           unsnoozed = false
-          spawn_source_task(run, allowed_tasks, pending_sources) if pending_sources
+          if pending_sources
+            should_wait_for_sources = pending_sources
+            spawn_source_tasks(run, allowed_tasks, pending_sources)
+          end
+          run.wait_for_no_running_tasks
+        end
+
+        if should_wait_for_sources
           run.wait_for_queues
         end
       ensure
         run.close_queues
       end
 
-      def run_lazy_jobs(run)
-        run.new_queues
-        spawn_job_task(run)
-        run.wait_for_queues
-      ensure
-        run.close_queues
-      end
-
-      def spawn_source_task(run, num_tasks, pending_sources)
+      def spawn_source_tasks(run, num_tasks, pending_sources)
         if num_tasks == Float::INFINITY
           num_tasks = pending_sources.size
         end
@@ -331,14 +344,14 @@ module GraphQL
             end
             nil
           rescue StandardError => err
-            run.mark_finished(err)
+            run.task_error(err)
           else
-            run.mark_finished(task)
+            run.finish_task(task)
           ensure
             cleanup_fiber
             trace&.dataloader_fiber_exit
           end
-          run.started_tasks.push(new_task)
+          run.start_task(new_task)
           new_task
         end
       end

--- a/lib/graphql/dataloader/async_dataloader.rb
+++ b/lib/graphql/dataloader/async_dataloader.rb
@@ -34,10 +34,10 @@ module GraphQL
         run = task.graphql_async_dataloader_run
         trace = run.trace
         trace&.dataloader_fiber_yield(source)
-        run.pause_task(task)
+        run.tasks_channel.push([:paused_task, task])
         condition = task.graphql_async_dataloader_condition
         condition.wait
-        run.resume_task(task)
+        run.tasks_channel.push([:resumed_task, task])
         trace&.dataloader_fiber_resume(source)
         nil
       end
@@ -64,54 +64,19 @@ module GraphQL
 
         attr_accessor :trace, :root_task
 
-        attr_reader :jobs, :lazies_at_depth, :jobs_fiber_limit, :total_fiber_limit, :finished_tasks, :started_tasks, :snoozed_jobs_condition, :snoozed_sources_condition
+        attr_reader :jobs, :lazies_at_depth,  :snoozed_jobs_condition, :snoozed_sources_condition, :tasks_channel
 
         def jobs_bandwidth?
-          running_count < jobs_fiber_limit
+          running_count < @jobs_fiber_limit
         end
 
         def sources_bandwidth?
-          running_count < sources_fiber_limit
-        end
-
-        def sources_fiber_limit
-          within_limit = total_fiber_limit - running_count
-          if within_limit < 1
-            1
-          else
-            within_limit
-          end
+          running_count < current_sources_fiber_limit
         end
 
         def close_queues
           @tasks_channel.close
           @tasks_channel_task.cancel
-        end
-
-        def finish_task(t)
-          @tasks_channel.push([:finished_task, t])
-        end
-
-        def task_error(err)
-          @tasks_channel.push([:task_error, err])
-        end
-
-        def start_task(t)
-          @tasks_channel.push([:new_task, t])
-        end
-
-        def pause_task(t)
-          @tasks_channel.push([:paused_task, t])
-        end
-
-        def resume_task(t)
-          @tasks_channel.push([:resumed_task, t])
-        end
-
-        def running_count
-          @snoozed_jobs_condition.instance_variable_get(:@ready).num_waiting +
-            @snoozed_sources_condition.instance_variable_get(:@ready).num_waiting +
-            (@running_tasks&.size || 0)
         end
 
         def wait_for_queues
@@ -124,24 +89,6 @@ module GraphQL
           @no_running_tasks = Async::Promise.new
         end
 
-        attr_reader :tasks_channel, :no_running_tasks
-
-
-        def get_pending_work_for(mode)
-          case mode
-          when :jobs
-            if jobs_bandwidth? && !@jobs.empty?
-              @jobs
-            else
-              nil
-            end
-          when :sources
-            @dataloader.drain_pending_sources
-          else
-            raise ArgumentError, "Unknown mode: #{mode.inspect}"
-          end
-        end
-
         def new_queues(mode)
           @tasks_channel = Async::Queue.new(parent: @root_task)
           @no_running_tasks = Async::Promise.new
@@ -150,7 +97,7 @@ module GraphQL
           @tasks_channel_task = @root_task.async do |_t|
             while ((msg, data) = @tasks_channel.wait)
               case msg
-              when :new_task
+              when :started_task
                 @running_tasks.push(data)
                 data.run
               when :resumed_task
@@ -168,6 +115,8 @@ module GraphQL
               when :task_error
                 @no_running_tasks.resolve(true)
                 @finished_all_tasks.reject(data)
+              else
+                raise ArgumentError, "Unknown tasks_channel action: #{msg.inspect}"
               end
             end
           end
@@ -175,6 +124,23 @@ module GraphQL
 
         def running?
           @snoozed_jobs_condition.waiting? || @snoozed_sources_condition.waiting?
+        end
+
+        def current_sources_fiber_limit
+          within_limit = @total_fiber_limit - running_count
+          if within_limit < 1
+            1
+          else
+            within_limit
+          end
+        end
+
+        private
+
+        def running_count
+          @snoozed_jobs_condition.instance_variable_get(:@ready).num_waiting +
+            @snoozed_sources_condition.instance_variable_get(:@ready).num_waiting +
+            (@running_tasks&.size || 0)
         end
       end
 
@@ -283,7 +249,7 @@ module GraphQL
           condition.signal
         end
 
-        while (loop_pending_work = run.get_pending_work_for(mode)) || unsnoozed
+        while (loop_pending_work = (mode == :jobs) ? (!run.jobs.empty? && run.jobs_bandwidth? ? run.jobs : nil) : (drain_pending_sources)) || unsnoozed
           unsnoozed = false
           if loop_pending_work
             if should_wait_for_all_tasks == false
@@ -292,7 +258,7 @@ module GraphQL
             end
 
             num_tasks = if mode == :sources
-              n = run.sources_fiber_limit
+              n = run.current_sources_fiber_limit
               if n == Float::INFINITY
                 loop_pending_work.size
               else
@@ -330,14 +296,14 @@ module GraphQL
                 end
                 nil
               rescue StandardError => err
-                run.task_error(err)
+                run.tasks_channel.push([:task_error, err])
               else
-                run.finish_task(task)
+                run.tasks_channel.push([:finished_task, task])
               ensure
                 cleanup_fiber
                 trace&.dataloader_fiber_exit
               end
-              run.start_task(new_task)
+              run.tasks_channel.push([:started_task, new_task])
             end
           end
 

--- a/lib/graphql/dataloader/async_dataloader.rb
+++ b/lib/graphql/dataloader/async_dataloader.rb
@@ -214,8 +214,9 @@ module GraphQL
 
               if !run.lazies_at_depth.empty?
                 with_trace_query_lazy(trace_query_lazy) do
-                  run_next_pending_lazies(run.lazies_at_depth) { run_queue(run, run.snoozed_jobs_condition, :jobs) }
-                  run_queue(run, run.snoozed_jobs_condition, :jobs)
+                  if enqueue_next_pending_lazies(run.lazies_at_depth)
+                    run_queue(run, run.snoozed_jobs_condition, :jobs)
+                  end
                 end
               end
             end

--- a/lib/graphql/dataloader/async_dataloader.rb
+++ b/lib/graphql/dataloader/async_dataloader.rb
@@ -157,7 +157,7 @@ module GraphQL
                 @running_tasks.push(data)
               when :finished_task, :paused_task
                 @running_tasks.delete(data)
-                has_pending_work = mode == :jobs ? @jobs.any? : @dataloader.pending_sources.any?(&:pending?)
+                has_pending_work = mode == :jobs ? @jobs.any? : @dataloader.pending_sources.any?(&:pending?) # rubocop:disable Development/NoneWithoutBlockCop
                 if @running_tasks.empty?
                   @no_running_tasks.resolve(true)
                   has_bandwidth = mode == :jobs ? jobs_bandwidth? : sources_bandwidth?

--- a/lib/graphql/dataloader/async_dataloader.rb
+++ b/lib/graphql/dataloader/async_dataloader.rb
@@ -21,8 +21,6 @@ module GraphQL
 
       # @api private
       attr_reader :pending_sources
-      # @api private
-      public :drain_pending_sources
 
       def create_pending_run
         jobs_fiber_limit, total_fiber_limit = calculate_fiber_limit

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -1273,16 +1273,16 @@ describe GraphQL::Dataloader do
             assert_equal (is_async ? 13 : 11), FiberCounting.last_spawn_count
             assert_last_max_count(9, "No limit works as expected")
 
-            extra_shortlived_jobs_fibers = is_async ? 1 : 0
+            extra_shortlived_jobs_fibers = is_async ? if_exec_next(8, 9) : 0
             res = schema.execute(query_str, context: { dataloader: fiber_counting_dataloader_class.new(fiber_limit: 4) })
             assert_equal 4, res.context.dataloader.fiber_limit
             assert_equal if_exec_next(11, 12) + extra_shortlived_jobs_fibers, FiberCounting.last_spawn_count
             assert_last_max_count(4, "Limit of 4 works as expected")
 
-            extra_shortlived_jobs_fibers = is_async ? 5 : 0
+            extra_shortlived_jobs_fibers = is_async ? 3 : 0
             res = schema.execute(query_str, context: { dataloader: fiber_counting_dataloader_class.new(fiber_limit: 6) })
             assert_equal 6, res.context.dataloader.fiber_limit
-            assert_equal 9 + extra_shortlived_jobs_fibers, FiberCounting.last_spawn_count
+            assert_equal if_exec_next(9, 8) + extra_shortlived_jobs_fibers, FiberCounting.last_spawn_count
             assert_last_max_count(6, "Limit of 6 works as expected")
           end
 

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -1236,7 +1236,7 @@ describe GraphQL::Dataloader do
             case diff
             when 1
               # TODO why does this happen sometimes?
-              warn "AsyncDataloader had +#{diff} last_max_count"
+              warn "AsyncDataloader had +#{diff} last_max_count (expected: #{expected_last_max_count}, actual: #{FiberCounting.last_max_count}) at #{caller(1, 1).first}"
               assert_equal (expected_last_max_count + diff), FiberCounting.last_max_count, message
             else
               assert_equal expected_last_max_count, FiberCounting.last_max_count, message
@@ -1273,13 +1273,13 @@ describe GraphQL::Dataloader do
             assert_equal (is_async ? 12 : 10), FiberCounting.last_spawn_count
             assert_last_max_count(9, "No limit works as expected")
 
-            extra_shortlived_jobs_fibers = is_async ? (if_exec_next(0, 1)) : 0
+            extra_shortlived_jobs_fibers = is_async ? (if_exec_next(-1, -1)) : 0
             res = schema.execute(query_str, context: { dataloader: fiber_counting_dataloader_class.new(fiber_limit: 4) })
             assert_equal 4, res.context.dataloader.fiber_limit
             assert_equal if_exec_next(11, 12) + extra_shortlived_jobs_fibers, FiberCounting.last_spawn_count
-            assert_last_max_count(4, "Limit of 4 works as expected")
+            assert_last_max_count(4 + (is_async ? 1 : 0), "Limit of 4 works as expected")
 
-            extra_shortlived_jobs_fibers = is_async ? if_exec_next(5, 4) : 0
+            extra_shortlived_jobs_fibers = is_async ? 3 : 0
             res = schema.execute(query_str, context: { dataloader: fiber_counting_dataloader_class.new(fiber_limit: 6) })
             assert_equal 6, res.context.dataloader.fiber_limit
             assert_equal 8 + extra_shortlived_jobs_fibers, FiberCounting.last_spawn_count

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -1270,19 +1270,19 @@ describe GraphQL::Dataloader do
 
             res = exec_query(query_str, context: { dataloader: fiber_counting_dataloader_class.new })
             assert_nil res.context.dataloader.fiber_limit
-            assert_equal (is_async ? 13 : 11), FiberCounting.last_spawn_count
+            assert_equal (is_async ? 12 : 10), FiberCounting.last_spawn_count
             assert_last_max_count(9, "No limit works as expected")
 
-            extra_shortlived_jobs_fibers = is_async ? if_exec_next(8, 9) : 0
+            extra_shortlived_jobs_fibers = is_async ? (if_exec_next(0, 1)) : 0
             res = schema.execute(query_str, context: { dataloader: fiber_counting_dataloader_class.new(fiber_limit: 4) })
             assert_equal 4, res.context.dataloader.fiber_limit
             assert_equal if_exec_next(11, 12) + extra_shortlived_jobs_fibers, FiberCounting.last_spawn_count
             assert_last_max_count(4, "Limit of 4 works as expected")
 
-            extra_shortlived_jobs_fibers = is_async ? 3 : 0
+            extra_shortlived_jobs_fibers = is_async ? if_exec_next(5, 4) : 0
             res = schema.execute(query_str, context: { dataloader: fiber_counting_dataloader_class.new(fiber_limit: 6) })
             assert_equal 6, res.context.dataloader.fiber_limit
-            assert_equal if_exec_next(9, 8) + extra_shortlived_jobs_fibers, FiberCounting.last_spawn_count
+            assert_equal 8 + extra_shortlived_jobs_fibers, FiberCounting.last_spawn_count
             assert_last_max_count(6, "Limit of 6 works as expected")
           end
 

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -1116,6 +1116,13 @@ describe GraphQL::Dataloader do
           assert_equal "Wheat", result["data"]["recursiveIngredientName"]
         end
 
+        it "works empty" do
+          dl = schema.dataloader_class.new
+          dl.run
+          assert "it finished"
+        end
+
+
         it "uses .batch_key_for in source classes" do
           query_str = <<-GRAPHQL
           {
@@ -1263,7 +1270,7 @@ describe GraphQL::Dataloader do
 
             res = exec_query(query_str, context: { dataloader: fiber_counting_dataloader_class.new })
             assert_nil res.context.dataloader.fiber_limit
-            assert_equal (is_async ? 12 : 10), FiberCounting.last_spawn_count
+            assert_equal (is_async ? 13 : 11), FiberCounting.last_spawn_count
             assert_last_max_count(9, "No limit works as expected")
 
             extra_shortlived_jobs_fibers = is_async ? 1 : 0
@@ -1272,10 +1279,10 @@ describe GraphQL::Dataloader do
             assert_equal if_exec_next(11, 12) + extra_shortlived_jobs_fibers, FiberCounting.last_spawn_count
             assert_last_max_count(4, "Limit of 4 works as expected")
 
-            extra_shortlived_jobs_fibers = is_async ? if_exec_next(6, 5) : 0
+            extra_shortlived_jobs_fibers = is_async ? 5 : 0
             res = schema.execute(query_str, context: { dataloader: fiber_counting_dataloader_class.new(fiber_limit: 6) })
             assert_equal 6, res.context.dataloader.fiber_limit
-            assert_equal 8 + extra_shortlived_jobs_fibers, FiberCounting.last_spawn_count
+            assert_equal 9 + extra_shortlived_jobs_fibers, FiberCounting.last_spawn_count
             assert_last_max_count(6, "Limit of 6 works as expected")
           end
 


### PR DESCRIPTION
Trying to fix #5671 

The previous control flow around paused tasks was very clunky. This PR streamlines it by replacing the `started_` and `finished_` queues with a single queue that receives status updates from running tasks. 

As a result, it's very easy to keep a set of currently-running tasks, and then to know when they're done. 

This change also makes the `Run` itself aware of whether its parent Dataloader still has unscheduled work. This allows me to properly distinguish between two different conditions: 

1) Previously-started tasks have all either completed or paused, so try starting more tasks if there's bandwidth 
2) All tasks have paused, and either the work is finished _or_ there's no more bandwidth, so move on to the next phase 

Those checks were mixed together previously, leading to ... bugs ..? 