### PR TITLE
Forward Relay subscription errors

### DIFF
--- a/javascript_client/src/subscriptions/__tests__/createRelaySubscriptionHandlerTest.ts
+++ b/javascript_client/src/subscriptions/__tests__/createRelaySubscriptionHandlerTest.ts
@@ -62,6 +62,37 @@ describe("createRelaySubscriptionHandler", () => {
     ]
     expect(performLog).toEqual(expectedLog)
   })
+
+  it("forwards transport errors to the Relay observer", () => {
+    var channel: any
+    var dummyActionCableConsumer = {
+      subscriptions: {
+        create: (_params: any, handlers: any) => {
+          channel = handlers
+          return { unsubscribe: () => true }
+        }
+      }
+    }
+
+    var handler = createRelaySubscriptionHandler({
+      cable: (dummyActionCableConsumer as unknown) as Consumer
+    })
+    var observable = handler(
+      { id: "abc", text: null, name: "def", operationKind: "subscription", metadata: {} },
+      {}
+    )
+    var receivedError: Error | undefined
+    observable.subscribe({
+      error: (error: Error) => {
+        receivedError = error
+      }
+    })
+
+    var error = new Error("Subscription failed")
+    channel.received({ result: { errors: error }, more: true })
+
+    expect(receivedError).toBe(error)
+  })
 })
 
 describe("createLegacyRelaySubscriptionHandler", () => {

--- a/javascript_client/src/subscriptions/createRelaySubscriptionHandler.ts
+++ b/javascript_client/src/subscriptions/createRelaySubscriptionHandler.ts
@@ -52,8 +52,8 @@ function createRelaySubscriptionHandler(options: ActionCableHandlerOptions | Pus
           variables,
           {},
           {
-            onError: (_error: Error) => {
-              observer.error;
+            onError: (error: Error) => {
+              observer.error(error);
             },
             onNext: (res: any) => {
               if (!res || !res.data) {


### PR DESCRIPTION
Fix Relay subscription errors being silently discarded.

The shared Relay subscription handler referenced `observer.error` without calling it. This prevented errors from reaching Relay consumers using ActionCable, Pusher, or Ably. This change calls `observer.error(error)` and adds regression coverage verifying that transport errors are forwarded unchanged to the Relay observer.