### PR TITLE
Avoid duplicate selection step enqueueing

### DIFF
--- a/lib/graphql/execution/selections_step.rb
+++ b/lib/graphql/execution/selections_step.rb
@@ -30,10 +30,10 @@ module GraphQL
       def call
         @all_selections = [{}, (prototype_result = {})]
         @runner.gather_selections(@parent_type, @selections, self, self.query, @all_selections, @all_selections[1], into: @all_selections[0])
+        continue_selections = []
         i = 0
         l = @all_selections.length
         while i < l
-          continue_selections = []
           grouped_selections = @all_selections[i]
           selections_prototype_result = @all_selections[i + 1]
           if (directives_owner = grouped_selections.delete(:__node))
@@ -83,11 +83,11 @@ module GraphQL
             end
           end
 
-          continue_selections.each do |frs|
-            @runner.add_step(frs)
-          end
-
           i += 2
+        end
+
+        continue_selections.each do |frs|
+          @runner.add_step(frs)
         end
       end
     end

--- a/lib/graphql/execution/selections_step.rb
+++ b/lib/graphql/execution/selections_step.rb
@@ -30,10 +30,10 @@ module GraphQL
       def call
         @all_selections = [{}, (prototype_result = {})]
         @runner.gather_selections(@parent_type, @selections, self, self.query, @all_selections, @all_selections[1], into: @all_selections[0])
-        continue_selections = []
         i = 0
         l = @all_selections.length
         while i < l
+          continue_selections = []
           grouped_selections = @all_selections[i]
           selections_prototype_result = @all_selections[i + 1]
           if (directives_owner = grouped_selections.delete(:__node))

--- a/spec/graphql/execution/selections_step_spec.rb
+++ b/spec/graphql/execution/selections_step_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe GraphQL::Execution::SelectionsStep do
+  class SelectionsStepRunner
+    attr_reader :steps
+
+    def initialize(groups)
+      @groups = groups
+      @steps = []
+    end
+
+    def gather_selections(_parent_type, _selections, _step, _query, all_selections, _prototype_result, into:)
+      all_selections.replace(@groups)
+    end
+
+    def runtime_directives
+      GraphQL::EmptyObjects::EMPTY_HASH
+    end
+
+    def add_step(step)
+      @steps << step
+    end
+  end
+
+  it "enqueues each field step once across selection groups" do
+    first_step = Object.new
+    second_step = Object.new
+    inline_fragment = GraphQL.parse("{ ... @include(if: true) { __typename } }").definitions.first.selections.first
+    runner = SelectionsStepRunner.new([
+      { "first" => first_step },
+      { "first" => nil },
+      { __node: inline_fragment, "second" => second_step },
+      { "second" => nil },
+    ])
+    step = GraphQL::Execution::SelectionsStep.new(
+      parent_type: nil,
+      field_resolve_step: nil,
+      selections: [],
+      objects: [],
+      results: [{}],
+      runner: runner,
+      query: Object.new,
+      path: [],
+      clobber: false,
+    )
+
+    step.call
+
+    assert_equal [first_step, second_step], runner.steps
+  end
+end


### PR DESCRIPTION
 Prevent `SelectionsStep` from enqueueing field steps from previous selection groups more than once. `continue_selections` was initialized outside the group loop, so each group retained and re-enqueued every step collected from earlier groups.

For example, two groups containing `first` and `second` were enqueued as `[first, first, second]`. This change scopes `continue_selections` to each group, producing `[first,
  second]`.