### PR TITLE
Fix O(n^2) transitive interface check in Schema.from_definition

### DIFF
--- a/lib/graphql/schema/build_from_definition.rb
+++ b/lib/graphql/schema/build_from_definition.rb
@@ -82,6 +82,7 @@ module GraphQL
           replace_late_bound_types_with_built_in(types)
 
           schema_extensions = nil
+          definitions_by_name = nil
           document.definitions.each do |definition|
             case definition
             when GraphQL::Language::Nodes::SchemaDefinition, GraphQL::Language::Nodes::DirectiveDefinition
@@ -101,9 +102,16 @@ module GraphQL
               if prev_type.nil? || prev_type.is_a?(Schema::LateBoundType)
                 if definition.is_a?(GraphQL::Language::Nodes::ObjectTypeDefinition) || definition.is_a?(Language::Nodes::InterfaceTypeDefinition)
                   interface_names = definition.interfaces.map(&:name)
-                  transitive_names = interface_names.map { |n| document.definitions.find { |d| d.respond_to?(:name) && d.name == n }&.interfaces&.map(&:name) }
-                  transitive_names.flatten!
-                  transitive_names.compact!
+                  if !interface_names.empty?
+                    definitions_by_name ||= document.definitions.each_with_object({}) do |d, by_name|
+                      by_name[d.name] ||= d if d.respond_to?(:name)
+                    end
+                    transitive_names = interface_names.map { |n| definitions_by_name[n]&.interfaces&.map(&:name) }
+                    transitive_names.flatten!
+                    transitive_names.compact!
+                  else
+                    transitive_names = interface_names
+                  end
                   if !(missing_transitive_interfaces = transitive_names - interface_names).empty?
                     raise GraphQL::Schema::InvalidDocumentError, "type #{definition.name} is missing one or more transitive interface names: #{missing_transitive_interfaces.join(", ")}. Add them to the type's `implements` list and try again."
                   end


### PR DESCRIPTION
238f1932 validates each object/interface type by calling `document.definitions.find { ... }` for every interface name of every type — a linear scan inside the definitions loop, so `Schema.from_definition` became O(n²) in the number of definitions. On a large real-world SDL (9MB, ~10,700 types), build time roughly doubled between v2.5.11 and v2.6.6; `git bisect` points at 238f1932 as the sole cause.

### Fix

Build a `name => definition` hash once (lazily, only if some type declares interfaces) and look up in O(1). Two details preserve the exact previous behavior:

- `by_name[d.name] ||= d`: first occurrence wins, matching `Array#find` when a name appears as both a definition and a type-extension node (the `Type extensions` specs fail with last-wins).
- Types with no interfaces skip the check entirely.

Same validation, same error message; all `build_from_definition` specs pass, including the ones added in 238f1932.

### Benchmark

N types implementing an interface that appears *after* them in the document (e.g. any alphabetically-ordered schema — if the interface comes first, `find` returns early and hides the cost):

```ruby
s = +"type Query { f: Int }\n"
n.times { |i| s << "type T#{i} implements Node { id: ID! f1: String f2: Int }\n" }
s << "interface Node { id: ID! }\n"
GraphQL::Schema.from_definition(s)
```

| types | master | this PR |
|---|---|---|
| 2,000 | 582ms | 363ms |
| 4,000 | 1,316ms | 477ms |
| 8,000 | 4,693ms | 1,409ms |

The 9MB real-world schema: 1,598ms → 758ms. With this PR the check measures within noise of removing it entirely (700ms vs 708ms).
