### PR TITLE
Add GitHub Actions linting CI

### DIFF
--- a/.github/workflows/actions-lint.yaml
+++ b/.github/workflows/actions-lint.yaml
@@ -1,0 +1,42 @@
+name: Lint GitHub Actions
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions: {}
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Run actionlint
+        uses: docker://rhysd/actionlint:1.7.12
+        with:
+          args: -color
+
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
+        with:
+          advanced-security: false
+          annotations: true
+          min-severity: high
+          version: 1.28.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,8 +6,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - uses: ruby/setup-ruby@v1
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
       with:
         ruby-version: 3.4
         bundler-cache: true
@@ -16,12 +16,12 @@ jobs:
   system_tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: shogo82148/actions-setup-redis@v1
+    - uses: shogo82148/actions-setup-redis@59cda539fd5cc9be4c42bb07e4b28156951f37d6 # v1.55.0
       with:
         redis-version: "7.x"
     - run: redis-cli ping
-    - uses: actions/checkout@v7
-    - uses: ruby/setup-ruby@v1
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
       with:
         ruby-version: 3.4
         bundler-cache: true
@@ -64,19 +64,19 @@ jobs:
             redis: 1
     runs-on: ubuntu-latest
     steps:
-    - run: echo BUNDLE_GEMFILE=${{ matrix.gemfile }} > $GITHUB_ENV
-    - run: echo GRAPHQL_FUTURE=1 > $GITHUB_ENV
+    - run: echo BUNDLE_GEMFILE=${{ matrix.gemfile }} > "$GITHUB_ENV"
+    - run: echo GRAPHQL_FUTURE=1 > "$GITHUB_ENV"
       if: ${{ !!matrix.graphql_future }}
-    - run: echo ISOLATION_LEVEL_FIBER=1 > $GITHUB_ENV
+    - run: echo ISOLATION_LEVEL_FIBER=1 > "$GITHUB_ENV"
       if: ${{ !!matrix.isolation_level_fiber }}
-    - uses: shogo82148/actions-setup-redis@v1
+    - uses: shogo82148/actions-setup-redis@59cda539fd5cc9be4c42bb07e4b28156951f37d6 # v1.55.0
       with:
         redis-version: "7.x"
       if: ${{ !!matrix.redis }}
     - run: redis-cli ping
       if: ${{ !!matrix.redis }}
-    - uses: actions/checkout@v7
-    - uses: ruby/setup-ruby@v1
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
@@ -85,8 +85,8 @@ jobs:
   javascript_test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-node@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: latest
     - run: npm ci
@@ -105,7 +105,7 @@ jobs:
           ruby: 3.3
     services:
       postgres:
-        image: postgres:latest
+        image: postgres:18.4@sha256:3a82e1f56c8f0f5616a11103ac3d47e632c3938698946a7ad26da0df1334744a
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -119,14 +119,14 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-    - run: echo BUNDLE_GEMFILE='' > $GITHUB_ENV
-    - run: echo DATABASE='POSTGRESQL' > $GITHUB_ENV
-    - run: echo PGPASSWORD='postgres' > $GITHUB_ENV
-    - run: echo GRAPHQL_CPARSER=1 > $GITHUB_ENV
-    - run: echo ISOLATION_LEVEL_FIBER=1 > $GITHUB_ENV
+    - run: echo BUNDLE_GEMFILE='' > "$GITHUB_ENV"
+    - run: echo DATABASE='POSTGRESQL' > "$GITHUB_ENV"
+    - run: echo PGPASSWORD='postgres' > "$GITHUB_ENV"
+    - run: echo GRAPHQL_CPARSER=1 > "$GITHUB_ENV"
+    - run: echo ISOLATION_LEVEL_FIBER=1 > "$GITHUB_ENV"
       if: ${{ !!matrix.isolation_level_fiber }}
-    - uses: actions/checkout@v7
-    - uses: ruby/setup-ruby@v1
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
       with:
         ruby-version: "3.3"
         bundler-cache: true
@@ -141,13 +141,13 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mongodb:
-        image: mongo
+        image: mongo:8.2.12@sha256:e0ce8c35124d4a9f9785532d1f268f39e9728ffa1cb38f46fa482436424c4bd3
         ports:
         - 27017:27017
     steps:
-    - run: echo BUNDLE_GEMFILE=${{ matrix.gemfile }} > $GITHUB_ENV
-    - uses: actions/checkout@v7
-    - uses: ruby/setup-ruby@v1
+    - run: echo BUNDLE_GEMFILE=${{ matrix.gemfile }} > "$GITHUB_ENV"
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
       with:
         ruby-version: 3.4
         bundler-cache: true

--- a/.github/workflows/pronto.yaml
+++ b/.github/workflows/pronto.yaml
@@ -1,22 +1,31 @@
 name: Pronto
-on:
+on: # zizmor: ignore[dangerous-triggers] Runs trusted base-branch code to report on pull requests.
   - pull_request_target
+
+permissions: {}
 
 jobs:
   pronto:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
-      - run: echo BUNDLE_GEMFILE=gemfiles/pronto.gemfile > $GITHUB_ENV
+      - run: echo BUNDLE_GEMFILE=gemfiles/pronto.gemfile > "$GITHUB_ENV"
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha }}
       - run: git fetch --no-tags --prune --unshallow origin +refs/heads/*:refs/remotes/origin/*
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: 3.4
           bundler-cache: true
       - name: Run Pronto
-        run: bundle exec pronto run -f github_pr -c origin/${{ github.base_ref }}
+        run: bundle exec pronto run -f github_pr -c "origin/${BASE_REF}"
         env:
+          BASE_REF: ${{ github.base_ref }}
           PRONTO_PULL_REQUEST_ID: ${{ github.event.pull_request.number }}
           PRONTO_GITHUB_ACCESS_TOKEN: "${{ github.token }}"

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -29,16 +29,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout master
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Checkout GitHub pages branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: gh-pages
           ref: gh-pages
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: '3.1'
-          bundler-cache: true
+      - run: bundle install
       - name: Build HTML, reindex
         env:
           ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
@@ -50,7 +50,7 @@ jobs:
           git config --global user.email "$(git log --format="%aE" -n 1)"
           bundle exec rake site:commit_changes
       - name: Deploy to GitHub pages via gh-pages branch
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./gh-pages
@@ -63,21 +63,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.GITHUB_REF }}
       - name: Checkout GitHub pages branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: gh-pages
           ref: gh-pages
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: '3.2'
-          bundler-cache: true
+      - run: bundle install
       - name: Build API docs
+        env:
+          PUBLISH_VERSION: ${{ inputs.publish_version || env.GITHUB_REF }}
         run: |
-          bundle exec rake site:fetch_latest apidocs:gen_version["${{ inputs.publish_version || env.GITHUB_REF }}"]
+          bundle exec rake site:fetch_latest "apidocs:gen_version[${PUBLISH_VERSION}]"
       - name: Commit changes as rmosolgo
         run: |
           git config --global user.name rmosolgo
@@ -86,7 +88,7 @@ jobs:
           bundle exec rake site:commit_changes
           git status
       - name: Deploy to GitHub pages via gh-pages branch
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./gh-pages


### PR DESCRIPTION
This PR adds a dedicated GitHub Actions linting workflow that runs on pull requests and pushes to `master`.

Refs:
- zizmor (https://github.com/zizmorcore/zizmor)
- actionlint (https://github.com/rhysd/actionlint)