### PR TITLE
Handle SystemStackError during query execution

### DIFF
--- a/lib/generators/graphql/templates/schema.erb
+++ b/lib/generators/graphql/templates/schema.erb
@@ -26,7 +26,8 @@ class <%= schema_name %> < GraphQL::Schema
     raise(GraphQL::RequiredImplementationMissingError)
   end
 
-  # Limit the size of incoming queries:
+  # Limit the depth and size of incoming queries:
+  max_depth(15)
   max_query_string_tokens(5000)
 
   # Stop validating when it encounters this many errors:

--- a/lib/graphql/execution/interpreter.rb
+++ b/lib/graphql/execution/interpreter.rb
@@ -119,6 +119,12 @@ module GraphQL
               end
 
               results
+            rescue SystemStackError => err
+              queries.map do |query|
+                schema.query_stack_error(query, err)
+                query.result_values ||= { "errors" => query.context.errors.map(&:to_h) }
+                query.result
+              end
             rescue Exception
               # TODO rescue at a higher level so it will catch errors in analysis, too
               # Assign values here so that the query's `@executed` becomes true

--- a/spec/graphql/execution/interpreter_spec.rb
+++ b/spec/graphql/execution/interpreter_spec.rb
@@ -1065,6 +1065,37 @@ describe GraphQL::Execution::Interpreter do
     end
   end
 
+  describe "when execution raises SystemStackError" do
+    class StackErrorSchema < GraphQL::Schema
+      class Query < GraphQL::Schema::Object
+        field :crash, String
+
+        def crash
+          raise SystemStackError, "stack level too deep"
+        end
+      end
+
+      query(Query)
+
+      def self.query_stack_error(query, err)
+        query.context[:stack_error] = err
+        super
+      end
+    end
+
+    it "returns a query error" do
+      result = GraphQL::Execution::Interpreter.run_all(
+        StackErrorSchema,
+        [{ query: "{ crash }" }]
+      ).first
+
+      assert_instance_of SystemStackError, result.context[:stack_error]
+      assert_equal \
+        [{ "message" => "This query is too large to execute." }],
+        result["errors"]
+    end
+  end
+
   describe "list items with dataloader and current_path usage" do
     class ListBugExampleSchema < GraphQL::Schema
       class PathTest < GraphQL::Schema::Directive

--- a/spec/integration/rails/generators/graphql/install_generator_spec.rb
+++ b/spec/integration/rails/generators/graphql/install_generator_spec.rb
@@ -75,7 +75,8 @@ class DummySchema < GraphQL::Schema
     raise(GraphQL::RequiredImplementationMissingError)
   end
 
-  # Limit the size of incoming queries:
+  # Limit the depth and size of incoming queries:
+  max_depth(15)
   max_query_string_tokens(5000)
 
   # Stop validating when it encounters this many errors:
@@ -415,7 +416,8 @@ class DummySchema < GraphQL::Schema
     raise(GraphQL::RequiredImplementationMissingError)
   end
 
-  # Limit the size of incoming queries:
+  # Limit the depth and size of incoming queries:
+  max_depth(15)
   max_query_string_tokens(5000)
 
   # Stop validating when it encounters this many errors:


### PR DESCRIPTION
A sufficiently deep but relatively small query can pass `max_query_string_tokens` and raise an uncaught `SystemStackError` during interpreter execution.

For example, a 4,518-byte query with a selection depth of 450 passes the generated schema's 5,000-token limit but can exhaust the Ruby stack. Generated schemas currently don't configure `max_depth`, so this may propagate as an unhandled exception.

Validation already delegates `SystemStackError` to `Schema#query_stack_error`, but the execution phase did not.