### PR TITLE
Load mounted routes before integration tests

### DIFF
--- a/spec/dummy/test/test_helper.rb
+++ b/spec/dummy/test/test_helper.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 require File.expand_path('../../config/environment', __FILE__)
+# Load mounted route helpers before ActionDispatch::IntegrationTest includes them.
+Rails.application.reload_routes_unless_loaded
 require 'rails/test_help'


### PR DESCRIPTION
  Load the dummy application's routes before `rails/test_help` includes the mounted route helpers.

### Background

The Rails master build fails the dashboard integration tests with:

```text
NameError: undefined local variable or method 'graphql_dashboard'
```

This also reproduces on the current graphql-ruby master branch, independently of #5683.

With Rails master, the application routes may not be loaded yet when ActionDispatch::IntegrationTest includes Rails.application.routes.mounted_helpers. As a result, the graphql_dashboard mounted helper is unavailable in the integration tests.