### PR TITLE
🐛 `RelationConnection` loads the same relation twice under `AsyncDataloader` (2.6.7)

### DIFF
--- a/lib/graphql/pagination/relation_connection.rb
+++ b/lib/graphql/pagination/relation_connection.rb
@@ -220,8 +220,19 @@ module GraphQL
       # Load nodes after applying first/last/before/after,
       # returns an array of nodes
       def load_nodes
-        # Return an array so we can consistently use `.index(node)` on it
-        @nodes ||= limited_nodes.to_a
+        return @nodes if @nodes
+
+        if @loading_nodes
+          context.dataloader.yield until @nodes
+          return @nodes
+        end
+
+        @loading_nodes = true
+        begin
+          @nodes = limited_nodes.to_a
+        ensure
+          @loading_nodes = false
+        end
       end
     end
   end


### PR DESCRIPTION
Given a query like:

```
{ posts(first: 20) { edges { node { id } } pageInfo { endCursor } } }
```
Both fields call load_nodes. 2.6.7 runs them concurrently, earlier releases didn't.

```
@nodes ||= limited_nodes.to_a   # relation_connection.rb:224
```

Fiber one waits on the DB before setting @nodes. Fiber two sees empty and loads the same relation again. Whichever finishes first clears ActiveRecord's load state from under the other.

This results in:

`NoMethodError: undefined method 'instantiate' for nil`, plus a duplicate query on every paginated connection.