### PR TITLE
Restrict dashboard schema selection

### DIFF
--- a/lib/graphql/dashboard.rb
+++ b/lib/graphql/dashboard.rb
@@ -10,6 +10,9 @@ module Graphql
   # @example Mounting the Dashboard in your app
   #   mount GraphQL::Dashboard, at: "graphql_dashboard", schema: "MySchema"
   #
+  # Pass an array to allow selecting from multiple schemas with the `schema` query parameter.
+  #   mount GraphQL::Dashboard, at: "graphql_dashboard", schema: ["MySchema", "OtherSchema"]
+  #
   # @example Authenticating the Dashboard with HTTP Basic Auth
   #   # config/initializers/graphql_dashboard.rb
   #   GraphQL::Dashboard.middleware.use(Rack::Auth::Basic) do |username, password|

--- a/lib/graphql/dashboard/application_controller.rb
+++ b/lib/graphql/dashboard/application_controller.rb
@@ -22,7 +22,11 @@ module Graphql
 
       def schema_class
         @schema_class ||= begin
-          schema_param = request.query_parameters["schema"] || params[:schema]
+          configured_schemas = Array(request.path_parameters[:schema] || request.path_parameters["schema"])
+          schema_param = request.query_parameters["schema"]
+          schema_param = configured_schemas.find { |schema| schema.to_s == schema_param } if schema_param
+          schema_param ||= configured_schemas.first
+
           case schema_param
           when Class
             schema_param

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 Rails.application.routes.draw do
   root to: "pages#show"
-  mount GraphQL::Dashboard, at: "/dash", schema: "DummySchema"
+  mount GraphQL::Dashboard, at: "/dash", schema: ["DummySchema", "NotInstalledSchema", "GraphQL::Schema"]
 end

--- a/spec/dummy/test/controllers/dashboard/landings_controller_test.rb
+++ b/spec/dummy/test/controllers/dashboard/landings_controller_test.rb
@@ -19,5 +19,7 @@ class DashboardLandingsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "<code>DummySchema</code>"
     get graphql_dashboard.root_path, params: { schema: "NotInstalledSchema" }
     assert_includes response.body, "<code>NotInstalledSchema</code>"
+    get graphql_dashboard.root_path, params: { schema: "Kernel" }
+    assert_includes response.body, "<code>DummySchema</code>"
   end
 end


### PR DESCRIPTION
`GraphQL::Dashboard` currently resolves the `schema` query parameter before the schema configured at mount time and calls `constantize` on any string value. A request such as `? schema=Kernel` can therefore trigger arbitrary constant resolution, causing repeated `NameError` exceptions and potentially exposing information about constants in the application.

This also means that `mount GraphQL::Dashboard, schema: "MySchema"` does not reliably enforce the configured schema because the query parameter can override it.

The mount-time schema configuration is now treated as trusted configuration. Query parameters are only accepted when they match one of the configured schemas, and unknown values fall back to the configured default schema.
This prevents arbitrary constantization while preserving the intended mount configuration. Tests cover both allowed schema selection and rejected arbitrary values.