### PR TITLE
Fix documentation typos

### DIFF
--- a/guides/dataloader/adopting.md
+++ b/guides/dataloader/adopting.md
@@ -61,7 +61,7 @@ In this example, one object is loaded, then another object is loaded _based on_ 
 
 Sometimes, you need multiple _independent_ records to perform a calculation. Each record is loaded, then they're combined in some bit of work.
 
-- With __GraphQL-Batch__, `Promise.all(...)` is used to to wait for several pending loads:
+- With __GraphQL-Batch__, `Promise.all(...)` is used to wait for several pending loads:
 
   ```ruby
   promise_1 = Loaders::Record.load(1)

--- a/guides/schema/definition.md
+++ b/guides/schema/definition.md
@@ -83,7 +83,7 @@ To use these features, you must provide some methods for generating UUIDs and fe
 
 {{ "Schema.id_from_object" | api_doc }} is used to implement `Node.id`. It should return a unique ID for the given object. This ID will later be sent to `object_from_id` to refetch the object.
 
-Additionally, {{ "Schema.resolve_type" | api_doc }} is called by GraphQL-Ruby to get the runtime Object type for fields that return return {% internal_link "interface", "/type_definitions/interfaces" %} or {% internal_link "union", "/type_definitions/unions" %} types.
+Additionally, {{ "Schema.resolve_type" | api_doc }} is called by GraphQL-Ruby to get the runtime Object type for fields that return {% internal_link "interface", "/type_definitions/interfaces" %} or {% internal_link "union", "/type_definitions/unions" %} types.
 
 ## Error Handling
 


### PR DESCRIPTION
Two small documentation typos noticed while reading the guides:

- `guides/dataloader/adopting.md`: "is used to to wait for several pending loads" -> "is used to wait for several pending loads"
- `guides/schema/definition.md`: "fields that return return {% internal_link ... %}" -> "fields that return {% internal_link ... %}"

Documentation only; no code changes.
