### PR TITLE
Restrict subscription timestamp deserialization

### DIFF
--- a/lib/graphql/subscriptions/serialize.rb
+++ b/lib/graphql/subscriptions/serialize.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "date"
 require "set"
 module GraphQL
   class Subscriptions
@@ -10,6 +11,7 @@ module GraphQL
       SYMBOL_KEYS_KEY = "__sym_keys__"
       TIMESTAMP_KEY = "__timestamp__"
       TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S.%N%z" # eg '2020-01-01 23:59:59.123456789+05:00'
+      TIMESTAMP_CLASS_NAMES = ["Date", "DateTime", "Time"].freeze
       OPEN_STRUCT_KEY = "__ostruct__"
 
       module_function
@@ -72,15 +74,19 @@ module GraphQL
                 value[SYMBOL_KEY].to_sym
               when TIMESTAMP_KEY
                 timestamp_class_name, *timestamp_args = value[TIMESTAMP_KEY]
-                timestamp_class = Object.const_get(timestamp_class_name)
-                if defined?(ActiveSupport::TimeWithZone) && timestamp_class <= ActiveSupport::TimeWithZone
+                timestamp_class = if TIMESTAMP_CLASS_NAMES.include?(timestamp_class_name)
+                  Object.const_get(timestamp_class_name, false)
+                end
+                if defined?(ActiveSupport::TimeWithZone) && timestamp_class_name == ActiveSupport::TimeWithZone.name
                   zone_name, timestamp_s = timestamp_args
                   zone = ActiveSupport::TimeZone[zone_name]
                   raise "Zone #{zone_name} not found, unable to deserialize" unless zone
                   zone.strptime(timestamp_s, TIMESTAMP_FORMAT)
-                else
+                elsif timestamp_class
                   timestamp_s = timestamp_args.first
                   timestamp_class.strptime(timestamp_s, TIMESTAMP_FORMAT)
+                else
+                  raise ArgumentError, "Unsupported timestamp class: #{timestamp_class_name.inspect}"
                 end
               when OPEN_STRUCT_KEY
                 ostruct_values = load_value(value[OPEN_STRUCT_KEY])

--- a/spec/graphql/subscriptions/serialize_spec.rb
+++ b/spec/graphql/subscriptions/serialize_spec.rb
@@ -1,6 +1,17 @@
 # frozen_string_literal: true
 require "spec_helper"
 
+class GraphQLSubscriptionsSerializeTimestampGadget
+  class << self
+    attr_accessor :called
+
+    def strptime(*_args)
+      self.called = true
+      :unexpected_result
+    end
+  end
+end
+
 describe GraphQL::Subscriptions::Serialize do
   def serialize_dump(v)
     GraphQL::Subscriptions::Serialize.dump(v)
@@ -68,6 +79,18 @@ describe GraphQL::Subscriptions::Serialize do
       reloaded = serialize_load(serialized)
       assert_equal timestamp, reloaded, "#{timestamp.inspect} is serialized to #{serialized.inspect} and reloaded"
     end
+  end
+
+  it "doesn't invoke methods on arbitrary timestamp classes" do
+    GraphQLSubscriptionsSerializeTimestampGadget.called = false
+    serialized = JSON.generate(GraphQL::Subscriptions::Serialize::TIMESTAMP_KEY => [
+      "GraphQLSubscriptionsSerializeTimestampGadget",
+      "2020-01-03 10:11:12.000000000+0000",
+    ])
+
+    error = assert_raises(ArgumentError) { serialize_load(serialized) }
+    assert_equal "Unsupported timestamp class: \"GraphQLSubscriptionsSerializeTimestampGadget\"", error.message
+    refute GraphQLSubscriptionsSerializeTimestampGadget.called
   end
 
   if defined?(ActiveSupport::TimeWithZone) && defined?(Rails) && Rails.version.split(".").first.to_i >= 7


### PR DESCRIPTION
This PR prevents arbitrary constant resolution during subscription payload deserialization.

Previously, timestamp payloads used `Object.const_get` to resolve the class name and then called `strptime` on it. If an untrusted payload reached this code path, it could invoke methods on an arbitrary top-level class.

Timestamp deserialization is now restricted to `Date`, `DateTime`, `Time`, and `ActiveSupport::TimeWithZone` when available. Unsupported classes raise `ArgumentError`.

A regression test verifies that `strptime` is not invoked on arbitrary classes.