### PR TITLE
Fix lexer positions for multibyte input

### DIFF
--- a/lib/graphql/language/lexer.rb
+++ b/lib/graphql/language/lexer.rb
@@ -175,11 +175,13 @@ module GraphQL
       end
 
       def line_number
-        @scanner.string[0..@pos].count("\n") + 1
+        @scanner.string.byteslice(0, @pos).b.count("\n".b) + 1
       end
 
       def column_number
-        @scanner.string[0..@pos].split("\n").last.length
+        line_prefix = @scanner.string.byteslice(0, @pos)
+        line_prefix = line_prefix.b unless line_prefix.valid_encoding?
+        line_prefix.split("\n").last.to_s.length + 1
       end
 
       def raise_parse_error(message, line = line_number, col = column_number)

--- a/spec/graphql/language/lexer_spec.rb
+++ b/spec/graphql/language/lexer_spec.rb
@@ -11,4 +11,13 @@ describe GraphQL::Language::Lexer do
     end
     assert_equal expected_err_message, err.message
   end
+
+  it "reports positions correctly after multibyte input" do
+    err = assert_raises(GraphQL::ParseError) do
+      subject.tokenize("{\n  # 日本語\n  field(arg: -foo)\n}")
+    end
+
+    assert_equal 3, err.line
+    assert_equal 14, err.col
+  end
 end


### PR DESCRIPTION
This PR fixes incorrect lexer error positions when GraphQL input contains multibyte characters.

`GraphQL::Language::Lexer` stores scanner positions as byte offsets, but line and column calculation used character-based string indexing. As a result, Japanese comments or string literals before a syntax error could cause the reported location to point to the wrong line and column.

The lexer now uses byte slices for position calculations while preserving character-based column counts. Invalid UTF-8 prefixes are also handled safely.