### PR TITLE
Reduce allocations in BlockString#trim_whitespace

### DIFF
--- a/lib/graphql/language/block_string.rb
+++ b/lib/graphql/language/block_string.rb
@@ -21,17 +21,12 @@ module GraphQL
             next
           end
           line_length = line.size
-          line_indent = if line.match?(/\A  [^ ]/)
-            2
-          elsif line.match?(/\A    [^ ]/)
-            4
-          elsif line.match?(/\A[^ ]/)
-            0
-          else
-            line[/\A */].size
+          leading = 0
+          while leading < line_length && line.getbyte(leading) == 32
+            leading += 1
           end
-          if line_indent < line_length && (common_indent.nil? || line_indent < common_indent)
-            common_indent = line_indent
+          if leading < line_length && (common_indent.nil? || leading < common_indent)
+            common_indent = leading
           end
         end
 
@@ -41,7 +36,7 @@ module GraphQL
             if idx == 0
               next
             else
-              line.slice!(0, common_indent)
+              line[0, common_indent] = ""
             end
           end
         end


### PR DESCRIPTION
`line[//]` allocates a string (which is used to get a length), and `line.slice!` allocates a string to return what was removed (but isn't used).

This commit replaces both with allocationless alternatives. Iterating with getbyte is actually faster than match? ing a bunch of times.

```ruby
# frozen_string_literal: true
require "benchmark/ips"
require_relative "lib/graphql/language/block_string"

module Original
  def self.trim_whitespace(str)
    if str == ""
      return "".dup
    elsif !(has_newline = str.include?("\n")) && !(str.start_with?(" "))
      return str
    end
    lines = has_newline ? str.split("\n") : [str]
    common_indent = nil
    lines.each_with_index do |line, idx|
      if idx == 0
        next
      end
      line_length = line.size
      line_indent = if line.match?(/\A  [^ ]/)
        2
      elsif line.match?(/\A    [^ ]/)
        4
      elsif line.match?(/\A[^ ]/)
        0
      else
        line[/\A */].size
      end
      if line_indent < line_length && (common_indent.nil? || line_indent < common_indent)
        common_indent = line_indent
      end
    end
    if common_indent && common_indent > 0
      lines.each_with_index do |line, idx|
        if idx == 0
          next
        else
          line.slice!(0, common_indent)
        end
      end
    end
    while lines.size > 0 && contains_only_whitespace?(lines.first)
      lines.shift
    end
    while lines.size > 0 && contains_only_whitespace?(lines.last)
      lines.pop
    end
    lines.size > 1 ? lines.join("\n") : (lines.first || "".dup)
  end
  def self.contains_only_whitespace?(line)
    line.match?(/^\s*$/)
  end
end

BS = GraphQL::Language::BlockString
TWO   = "\n  Hello,\n    World!\n\n  Yours,\n    GraphQL.\n  "
EIGHT = "\n        Hello,\n          World!\n\n        Yours,\n          GraphQL.\n        "

Benchmark.ips do |x|
  x.report("original 2sp") { Original.trim_whitespace(TWO) }
  x.report("final 2sp")    { BS.trim_whitespace(TWO) }
  x.compare!
end

Benchmark.ips do |x|
  x.report("original 8sp") { Original.trim_whitespace(EIGHT) }
  x.report("final 8sp")    { BS.trim_whitespace(EIGHT) }
  x.compare!
end
```