### PR TITLE
Fix lexer columns after newlines

### DIFF
--- a/lib/graphql/language/lexer.rb
+++ b/lib/graphql/language/lexer.rb
@@ -181,7 +181,8 @@ module GraphQL
       def column_number
         line_prefix = @scanner.string.byteslice(0, @pos)
         line_prefix = line_prefix.b unless line_prefix.valid_encoding?
-        line_prefix.split("\n").last.to_s.length + 1
+        newline_index = line_prefix.rindex("\n")
+        newline_index ? line_prefix.length - newline_index : line_prefix.length + 1
       end
 
       def raise_parse_error(message, line = line_number, col = column_number)

--- a/spec/graphql/language/lexer_spec.rb
+++ b/spec/graphql/language/lexer_spec.rb
@@ -20,4 +20,11 @@ describe GraphQL::Language::Lexer do
     assert_equal 3, err.line
     assert_equal 14, err.col
   end
+
+  it "reports column one after a newline" do
+    tokens = subject.tokenize("{ field }\n# 日本語\nfragment F on Type { field }")
+    fragment_token = tokens.find { |token| token.first == :FRAGMENT }
+
+    assert_equal [:FRAGMENT, 3, 1, "fragment"], fragment_token
+  end
 end


### PR DESCRIPTION
Sorry. This PR fixes a follow-up edge case from #5692.

#5692 changed lexer position calculations to use byte slices so multibyte input is handled correctly. However, `column_number` still used `String#split`. When a token starts immediately after a newline, `split("\n")` discards the trailing empty string and calculates the column from the previous line instead.

`column_number` now finds the final newline with `rindex` and calculates the character length after it. This preserves the multibyte and invalid-encoding handling added in #5692 while also avoiding the array allocation from `split`.

A regression test verifies that a token following a multibyte comment is reported at column 1.