### PR TITLE
Execution::Next: fix NoMethodError when a non-null root mutation fiel…

### DIFF
--- a/lib/graphql/execution/field_resolve_step.rb
+++ b/lib/graphql/execution/field_resolve_step.rb
@@ -130,7 +130,7 @@ module GraphQL
         highest_nulled_depth = path.size
         highest_list_depth = nil
         current_field_step = self
-        while current_field_step
+        while current_field_step && current_field_step.field_definition
           return_type = current_field_step.field_definition.type
           if propagating_null && return_type.non_null?
             highest_nulled_depth = current_field_step.path.size
@@ -147,7 +147,7 @@ module GraphQL
 
         if highest_list_depth.nil? || highest_nulled_depth <= highest_list_depth
           kill_field_step = self
-          while kill_field_step && highest_nulled_depth <= kill_field_step.path.size
+          while kill_field_step && kill_field_step.field_definition && highest_nulled_depth <= kill_field_step.path.size
             kill_field_step.selections_step.killed = true
             kill_field_step = kill_field_step.selections_step.field_resolve_step
           end

--- a/spec/graphql/execution/next_spec.rb
+++ b/spec/graphql/execution/next_spec.rb
@@ -210,6 +210,65 @@ describe "Next Execution" do
     assert_graphql_equal(expected_result, result)
   end
 
+  describe "non-null root mutation fields" do
+    class NonNullMutationSchema < GraphQL::Schema
+      class Query < GraphQL::Schema::Object
+        field :i, Integer, null: false, resolve_static: :resolve_i
+
+        def self.resolve_i(_ctx)
+          1
+        end
+      end
+
+      class Mutation < GraphQL::Schema::Object
+        RESOLVED_ARGUMENTS = []
+
+        field :do_something, Integer, null: false, resolve_static: :resolve_do_something do
+          argument :ok, Boolean
+        end
+
+        def self.resolve_do_something(_ctx, ok:)
+          RESOLVED_ARGUMENTS << ok
+          if ok
+            5
+          else
+            raise GraphQL::ExecutionError, "something went wrong"
+          end
+        end
+      end
+
+      query(Query)
+      mutation(Mutation)
+      use GraphQL::Execution::Next
+    end
+
+    it "returns errors when a non-null root mutation field errors" do
+      result = NonNullMutationSchema.execute_next("mutation { doSomething(ok: false) }")
+      expected_result = {
+        "errors" => [{ "message" => "something went wrong", "locations" => [{ "line" => 1, "column" => 12 }], "path" => ["doSomething"] }],
+        "data" => nil,
+      }
+      assert_graphql_equal(expected_result, result)
+    end
+
+    it "runs sibling root mutation fields when one errors" do
+      NonNullMutationSchema::Mutation::RESOLVED_ARGUMENTS.clear
+      result = NonNullMutationSchema.execute_next(<<~GRAPHQL)
+        mutation {
+          m1: doSomething(ok: true)
+          m2: doSomething(ok: false)
+          m3: doSomething(ok: true)
+        }
+      GRAPHQL
+      expected_result = {
+        "errors" => [{ "message" => "something went wrong", "locations" => [{ "line" => 3, "column" => 3 }], "path" => ["m2"] }],
+        "data" => nil,
+      }
+      assert_graphql_equal(expected_result, result)
+      assert_equal [true, false, true], NonNullMutationSchema::Mutation::RESOLVED_ARGUMENTS
+    end
+  end
+
   it "runs introspection" do
     result = run_next(GraphQL::Introspection::INTROSPECTION_QUERY)
     new_schema = GraphQL::Schema.from_introspection(result)


### PR DESCRIPTION
## Problem

Under `GraphQL::Execution::Next`, `GraphQL::Execution::FieldResolveStep#propagate_nulls` crashes with `NoMethodError: undefined method 'type' for nil` when:

1. The operation is a mutation,
2. The root mutation field's return type is non-null, and
3. That field adds a GraphQL error (raised `GraphQL::ExecutionError`, `UnauthorizedError` routed through `unauthorized_object`, etc.).

Introduced in #5644, first released in 2.6.5. Query and subscription roots are unaffected.

### Minimal repro

**Schema:**
- `Mutation.doSomething: Int!` — non-null root mutation field
- Its resolver raises `GraphQL::ExecutionError`

```ruby
class Mutation < GraphQL::Schema::Object
  field :do_something, Integer, null: false, resolve_static: :resolve_do_something

  def self.resolve_do_something(_ctx)
    raise GraphQL::ExecutionError, "something went wrong"
  end
end
```

**Query:**

```graphql
mutation { doSomething }
```

**Expected final response:**

```ruby
{ "errors" => [<something went wrong>], "data" => nil }
```

Instead, execution crashes while building the error result.

### Production stacktrace

```
NoMethodError: undefined method 'type' for nil
  lib/graphql/execution/field_resolve_step.rb:134:in 'propagate_nulls'
  lib/graphql/execution/field_resolve_step.rb:122:in 'add_graphql_error'
  lib/graphql/execution/field_resolve_step.rb:632:in 'build_graphql_result'
```

## Root cause

For serial mutation execution, `Runner#execute` gathers root selections with no parent step:

```ruby
gather_selections(root_type, selected_operation.selections, nil, query, ...)
```

This builds a prototype `FieldResolveStep` per root field with `selections_step: nil`. The prototype never executes — it only carries AST nodes into the isolated steps — so its `@field_definition` is never assigned. Each isolated mutation-root `SelectionsStep` then holds the prototype as its `field_resolve_step`.

When the real executing step adds an error on a non-null field, `propagate_nulls` walks the ancestor chain:

```ruby
current_field_step = current_field_step.selections_step.field_resolve_step
```

and calls `.field_definition.type` on the prototype — `nil.type`.

Query and subscription roots pass `field_resolve_step: nil`, which already terminates the walk cleanly; only the mutation path stores a non-nil, never-executed step there. And since `propagate_nulls` only runs for non-null return types, nullable mutation fields — including all of this repo's test schemas — never hit it. Schemas following the non-null payload convention hit it on every mutation error path.

## Fix

Stop both walks in `propagate_nulls` when a step has no `field_definition`, treating it as the top of the chain — mirroring how a nil `field_resolve_step` already terminates them. The added guard in the kill loop also protects `path`, which would raise on the prototype's nil `selections_step`.

Same bug family as #5637 (nil boundary during non-null propagation, in the `Finalize` walk); this is the eager propagation path.

## Tests

Two new regression tests in `spec/graphql/execution/next_spec.rb` ("returns errors when a non-null root mutation field errors", "runs sibling root mutation fields when one errors" — the second also asserts the resolver invocations `[true, false, true]`, proving serial siblings still execute past the killed step). Both fail on `master` with the exact production `NoMethodError` and pass with this change.