### PR TITLE
Support JSON 3

### DIFF
--- a/lib/graphql/language.rb
+++ b/lib/graphql/language.rb
@@ -31,7 +31,7 @@ module GraphQL
 
         "[#{serialized_array}]"
       else
-        JSON.generate(value, quirks_mode: true)
+        JSON.generate(value)
       end
     rescue JSON::GeneratorError
       if Float::INFINITY == value

--- a/lib/graphql/schema/input_object.rb
+++ b/lib/graphql/schema/input_object.rb
@@ -172,12 +172,12 @@ module GraphQL
           types = ctx.types
 
           if input.is_a?(Array)
-            return GraphQL::Query::InputValidationResult.from_problem(INVALID_OBJECT_MESSAGE % { object: JSON.generate(input, quirks_mode: true) })
+            return GraphQL::Query::InputValidationResult.from_problem(INVALID_OBJECT_MESSAGE % { object: JSON.generate(input) })
           end
 
           if !(input.respond_to?(:to_h) || input.respond_to?(:to_unsafe_h))
             # We're not sure it'll act like a hash, so reject it:
-            return GraphQL::Query::InputValidationResult.from_problem(INVALID_OBJECT_MESSAGE % { object: JSON.generate(input, quirks_mode: true) })
+            return GraphQL::Query::InputValidationResult.from_problem(INVALID_OBJECT_MESSAGE % { object: JSON.generate(input) })
           end
 
 

--- a/lib/graphql/subscriptions/serialize.rb
+++ b/lib/graphql/subscriptions/serialize.rb
@@ -26,7 +26,7 @@ module GraphQL
       # @param obj [Object] Some subscription-related data to dump
       # @return [String] The stringified object
       def dump(obj)
-        JSON.generate(dump_value(obj), quirks_mode: true)
+        JSON.generate(dump_value(obj))
       end
 
       # This is for turning objects into subscription scopes.


### PR DESCRIPTION
`quirks_mode` hasn't been a valid parsing option since `json 2.0.0` released circa 2011.

On `json 3.x` invalid arguments are rejected, causing an `ArgumentError`.

It's likely safe to assume no-one runs with `json 1.x`.