### PR TITLE
AsyncDataloader: avoid ClosedError race condition with straggler fibers

### DIFF
--- a/lib/graphql/dataloader/async_dataloader.rb
+++ b/lib/graphql/dataloader/async_dataloader.rb
@@ -36,10 +36,14 @@ module GraphQL
         run = task.graphql_async_dataloader_run
         trace = run.trace
         trace&.dataloader_fiber_yield(source)
-        run.tasks_channel.push([:paused_task, task])
+        if !run.push_task_message(:paused_task, task)
+          task.stop
+        end
         condition = task.graphql_async_dataloader_condition
         condition.wait
-        run.tasks_channel.push([:resumed_task, task])
+        if !run.push_task_message(:resumed_task, task)
+          task.stop
+        end
         trace&.dataloader_fiber_resume(source)
         nil
       end
@@ -69,7 +73,7 @@ module GraphQL
 
         attr_accessor :trace, :root_task
 
-        attr_reader :jobs, :lazies_at_depth, :jobs_fiber_limit,  :snoozed_jobs_condition, :snoozed_sources_condition, :tasks_channel
+        attr_reader :jobs, :lazies_at_depth, :jobs_fiber_limit,  :snoozed_jobs_condition, :snoozed_sources_condition
 
         def jobs_bandwidth?
           running_count < @jobs_fiber_limit
@@ -82,6 +86,20 @@ module GraphQL
         def close_queues
           @tasks_channel.close
           @tasks_channel_task.cancel
+        end
+
+        # Push to the tasks_channel, tolerating a closed channel: on the error path, `run_queue`
+        # closes the channel while sibling tasks can still run one more slice before
+        # `root_task.cancel` reaches them. Record `:task_error` payloads so they aren't lost, and
+        # return false so the caller can stop the task instead of raising `ClosedError` into user code.
+        def push_task_message(msg, data)
+          @tasks_channel.push([msg, data])
+          true
+        rescue Async::Queue::ClosedError
+          if msg == :task_error
+            @task_error ||= data
+          end
+          false
         end
 
         def wait_for_activity
@@ -336,14 +354,14 @@ module GraphQL
             end
             nil
           rescue StandardError => err
-            run.tasks_channel.push([:task_error, err])
+            run.push_task_message(:task_error, err)
           else
-            run.tasks_channel.push([:finished_task, task])
+            run.push_task_message(:finished_task, task)
           ensure
             cleanup_fiber
             trace&.dataloader_fiber_exit
           end
-          run.tasks_channel.push([:started_task, new_task])
+          run.push_task_message(:started_task, new_task)
         end
       end
     end

--- a/spec/graphql/dataloader/async_dataloader_spec.rb
+++ b/spec/graphql/dataloader/async_dataloader_spec.rb
@@ -2,6 +2,7 @@
 require "spec_helper"
 if RUBY_VERSION >= "3.2.0"
   require "async"
+  require "timeout"
   describe GraphQL::Dataloader::AsyncDataloader do
     class AsyncSchema < GraphQL::Schema
       class SleepSource < GraphQL::Dataloader::Source
@@ -547,6 +548,49 @@ if RUBY_VERSION >= "3.2.0"
         iter_finished = true
         assert "completed #{MAX_ITERATIONS} iterations cleanly"
         assert watchdog.join
+      end
+    end
+
+    describe "when a job errors while sibling tasks are parked in non-dataloader IO" do
+      # When a job errors, `run_queue` closes the tasks_channel while sibling tasks are still
+      # parked in non-Dataloader IO; a straggler's next push used to leak
+      # `Async::Queue::ClosedError` into resolver code and lose its own error report.
+      it "doesn't leak Async::Queue::ClosedError into straggler fibers or lose the original error" do
+        rng = Random.new(20260814)
+        leaked_error = nil
+
+        250.times do |i|
+          break if leaked_error
+
+          dataloader = GraphQL::Dataloader::AsyncDataloader.new
+
+          3.times do |j|
+            io_delay = rng.rand(0.003)
+            fetch_delay = rng.rand(0.002)
+            dataloader.append_job do
+              sleep(io_delay)
+              begin
+                dataloader.with(SlowSource, fetch_delay).load([i, j])
+              rescue Async::Queue::ClosedError => err
+                leaked_error = err
+                raise
+              end
+            end
+          end
+
+          err_delay = rng.rand(0.003)
+          dataloader.append_job do
+            sleep(err_delay)
+            raise "boom-#{i}"
+          end
+
+          err = assert_raises(RuntimeError) do
+            Timeout.timeout(15) { dataloader.run }
+          end
+          assert_equal "boom-#{i}", err.message
+        end
+
+        assert_nil leaked_error, "Async::Queue::ClosedError leaked into straggler fibers"
       end
     end
   end


### PR DESCRIPTION
## Problem

`AsyncDataloader` can leak `Async::Queue::ClosedError` into resolver code, and lose the task's own error report when:

1. A job fiber raises a `StandardError`, so `run_queue`'s `check_error!` re-raises and its `ensure` runs `run.close_queues`, and
2. At that moment, sibling tasks are still mid-flight, parked in **non-Dataloader** waits (e.g. sleep, socket waits).

Introduced with the queue-based rewrite in #5479 (2.6.4+). Related prior reports: #5654 (#5656) and #5671 (#5672, #5679). All of those fixes are in 2.6.8, but this race survives them, which matches the #5671 reporter's observation that the warnings went away while a hang remained.

### Production stacktrace

Seen intermittently in production (Puma, Ruby 3.4, `graphql` 2.6.8, `async` 2.36.0, `config.active_support.isolation_level = :fiber`, `fiber_limit: 16`, sources doing Redis + Postgres I/O):

```
Async::Queue::ClosedError: Cannot enqueue items to a closed queue!
  async-2.36.0/lib/async/queue.rb:65:in 'Async::Queue#push'
  graphql-2.6.8/lib/graphql/dataloader/async_dataloader.rb:39:in 'AsyncDataloader#yield'
  graphql-2.6.8/lib/graphql/dataloader/source.rb:105:in 'Source#sync'
  graphql-2.6.8/lib/graphql/dataloader/source.rb:84:in 'Source#load_all'
  ... resolver frames ...
=> rescued at async_dataloader.rb:339, where push([:task_error, err]) raises
  ClosedError again => task dies as an unhandled exception, error report lost
```

### Minimal repro

Single-threaded, no GraphQL execution needed.  A job error while siblings sit in plain `sleep`s is the whole trigger:

```ruby
dataloader = GraphQL::Dataloader::AsyncDataloader.new

3.times do |j|
  dataloader.append_job do
    sleep(rand(0.003))                              # non-Dataloader IO
    dataloader.with(SlowSource, rand(0.002)).load(j) # -> yield -> ClosedError
  end
end

dataloader.append_job do
  sleep(rand(0.003))
  raise "boom"
end

dataloader.run # should raise "boom"; instead stragglers intermittently
               # hit ClosedError and their task_error reports are lost
```

With randomized delays this reproduces within a few dozen iterations on `master`, against both async 2.36.0 and async 2.44.1. A single straggler job (SlowSource) reproduces the issue ~1% of runs, while three stragglers increases repro rate to ~5%.

## Root cause

Closing the channel and stopping the fibers that report to it are meant to be one atomic act, but the scheduler can interleave another fiber between them.

The stragglers are accounted for and sit in `@running_tasks`, so bookkeeping is accurate. On the error path the round is deliberately abandoned with straggler fibers still parked: `check_error!` raises, the `ensure` closes the tasks_channel, and `root_task.cancel` is about to stop everyone. But teardown itself yields control: cancelling a non-current task transfers into it (`IO::Event::Selector#raise` pushes the calling fiber onto the ready list, then `fiber.raise`s into the target), and each transfer gives the reactor a chance to resume whatever else became ready.

So a parked straggler's wakeup (sleep timer, IO completion, etc) has three possible timings:

- **Before the error is processed** => it wakes while the channel is open, yields, parks on the condition; later cancelled cleanly. Fine.
- **After cancellation reaches it** => `Stop` is raised at its suspension point; it unwinds without pushing. Fine.
- **Inside the teardown window** => after `close_queues`, before its own cancel. The reactor resumes it and it runs one normal slice: its `dataloader.yield` pushes `[:paused_task, ...]` into the closed channel and `ClosedError` leaks into resolver code (`async_dataloader.rb:39`); its rescue then pushes `[:task_error, ClosedError]` into the same closed channel (`:339`) → a second `ClosedError`, an unhandled task exception, and a lost error report.

The window is microseconds wide, which is why the failure is intermittent and timing-dependent, and why every additional mid-flight fiber is another independent chance to land in it.

## Fix

Route all four task-message pushes through a new `Run#push_task_message`, which tolerates a closed channel:

- `:task_error` payloads are recorded directly on the `Run` (`@task_error ||= err`) so an error report is never lost to a closed channel.
- `yield`'s two push sites do `push_task_message(...) || task.stop`: a straggler that finds the channel closed stops itself, exactly what `root_task.cancel` was about to do a moment later, instead of leaking `ClosedError` into resolver code.
- `:finished_task` on a closed channel is discarded: the round's accounting is already finished, and the task completes cleanly.

## Tests

New regression test in `spec/graphql/dataloader/async_dataloader_spec.rb` ("doesn't leak Async::Queue::ClosedError into straggler fibers or lose the original error"): seeded randomized straggler/error timing over up to 500 dataloader runs, asserting that no `ClosedError` reaches job code and that `dataloader.run` always re-raises the injected job error. It fails on `master` within ~10 iterations and passes with this change (~2s). Existing dataloader specs (including the #5671 stress test) still pass.