### PR TITLE
AsyncDataloader: don't reuse another dataloader's run when nested

### DIFF
--- a/lib/graphql/dataloader/async_dataloader.rb
+++ b/lib/graphql/dataloader/async_dataloader.rb
@@ -69,7 +69,7 @@ module GraphQL
 
         attr_accessor :trace, :root_task
 
-        attr_reader :jobs, :lazies_at_depth, :jobs_fiber_limit,  :snoozed_jobs_condition, :snoozed_sources_condition, :tasks_channel
+        attr_reader :dataloader, :jobs, :lazies_at_depth, :jobs_fiber_limit,  :snoozed_jobs_condition, :snoozed_sources_condition, :tasks_channel
 
         def jobs_bandwidth?
           running_count < @jobs_fiber_limit
@@ -175,11 +175,19 @@ module GraphQL
       end
 
       def active_run
-        @pending_run || Async::Task.current?&.graphql_async_dataloader_run || raise(GraphQL::Error, "No available Run to append to, GraphQL-Ruby bug")
+        @pending_run || current_task_run || raise(GraphQL::Error, "No available Run to append to, GraphQL-Ruby bug")
+      end
+
+      # The current task's run, but only if it belongs to this dataloader. A different
+      # dataloader may be running inside one of our tasks (or vice versa), e.g. a query
+      # executed from a resolver or a subscription trigger; its run must not be reused.
+      def current_task_run
+        run = Async::Task.current?&.graphql_async_dataloader_run
+        run if run&.dataloader.equal?(self)
       end
 
       def run_isolated
-        previous_run = Async::Task.current?&.graphql_async_dataloader_run
+        previous_run = current_task_run
         prev_pending_keys = {}
         # Clear pending loads but keep already-cached records
         # in case they are useful to the given block.
@@ -215,7 +223,7 @@ module GraphQL
 
       def run(trace_query_lazy: nil)
         trace = Fiber[:__graphql_current_multiplex]&.current_trace
-        run = @pending_run || Async::Task.current?&.graphql_async_dataloader_run || raise(GraphQL::Error, "No available Run, GraphQL-Ruby internal bug")
+        run = @pending_run || current_task_run || raise(GraphQL::Error, "No available Run, GraphQL-Ruby internal bug")
         @pending_run = nil
         run.trace = trace
         first_pass = true

--- a/spec/graphql/dataloader/async_dataloader_spec.rb
+++ b/spec/graphql/dataloader/async_dataloader_spec.rb
@@ -2,6 +2,7 @@
 require "spec_helper"
 if RUBY_VERSION >= "3.2.0"
   require "async"
+  require "timeout"
   describe GraphQL::Dataloader::AsyncDataloader do
     class AsyncSchema < GraphQL::Schema
       class SleepSource < GraphQL::Dataloader::Source
@@ -462,6 +463,32 @@ if RUBY_VERSION >= "3.2.0"
 
           assert_equal Array.new(10, ["William Shakespeare", "Hamlet"]), results
         end
+      end
+    end
+
+    describe "when another dataloader runs inside a job" do
+      class EchoSource < GraphQL::Dataloader::Source
+        def fetch(keys)
+          keys.map { |k| "v#{k}" }
+        end
+      end
+
+      # A query executed from inside a resolver (or a subscription trigger) gets its own
+      # dataloader, but shares the outer dataloader's task tree. `run_isolated` used to
+      # mistake the outer task's run for its own and clear `@pending_run`, so the inner
+      # `run` took over the outer run's queues and the outer run never finished.
+      it "doesn't take over the outer dataloader's run" do
+        outer = GraphQL::Dataloader::AsyncDataloader.new
+        inner_result = nil
+        outer.append_job do
+          inner = GraphQL::Dataloader::AsyncDataloader.new
+          inner.run_isolated { inner.with(EchoSource).load(1) }
+          inner.append_job { inner_result = inner.with(EchoSource).load(2) }
+          inner.run
+        end
+
+        Timeout.timeout(5) { outer.run }
+        assert_equal "v2", inner_result
       end
     end
 


### PR DESCRIPTION
## Problem

An `AsyncDataloader` run hangs forever when a second dataloader is used inside one of its jobs and that second dataloader calls `run_isolated` before its first `run`.

In our case, a mutation triggered a subscription from an `after_commit` hook, and the subscription document is executed inline (`Schema.execute` => its own dataloader) from within the mutation's job fiber. 

Introduced with the queue-based rewrite in #5479 (2.6.4+). Not fixed by #5672/#5679, and independent of #5702 (that race is collateral of the same nesting in our case: on `master` this repro also logs `Async::Queue::ClosedError` from `async_dataloader.rb:341`, because the inner run closes the outer run's channel).

### Minimal repro

```ruby
class EchoSource < GraphQL::Dataloader::Source
  def fetch(keys) = keys.map { |k| "v#{k}" }
end

outer = GraphQL::Dataloader::AsyncDataloader.new
outer.append_job do
  inner = GraphQL::Dataloader::AsyncDataloader.new
  inner.run_isolated { inner.with(EchoSource).load(1) }   # e.g. argument coercion
  inner.append_job { inner.with(EchoSource).load(2) }
  inner.run
end
outer.run  # never returns
```

Production symptom (Puma, `graphql` 2.6.8, `async` 2.36.0): every mutation that triggered an inline subscription sat idle after ~0.2s of work until `Rack::Timeout` (10s) fired, with the root task parked in `Run#wait_for_activity`, and no job tasks alive.

## Root cause

`run_isolated` decides whether it is nested by looking at the *current task's* run:

```ruby
previous_run = Async::Task.current?&.graphql_async_dataloader_run
...
ensure
  if previous_run
    Async::Task.current.graphql_async_dataloader_run = previous_run
    @pending_run = nil   # "clear the one created in #run"
  end
```

Inside the outer dataloader's job fiber, that run belongs to the outer dataloader, but `run_isolated` treats it as its own nesting case and clears the inner dataloader's `@pending_run`. The inner dataloader's next `run` (and `active_run`/`append_job`) then falls back the same way, `@pending_run || Async::Task.current?&.graphql_async_dataloader_run`, and picks up the outer run. It calls `new_queues`/`run_queue` on it, replacing the outer run's `tasks_channel`/`@activity`, and closes them when it finishes. The outer root task is still blocked on the old `@activity` condition, which nothing signals anymore, so the reactor sits in `select` with no timers or IO. Meanwhile the outer job's `:finished_task` push lands on a closed channel (`ClosedError`).

## Fix

Only treat the current task's run as ours if it belongs to this dataloader:

```ruby
def current_task_run
  run = Async::Task.current?&.graphql_async_dataloader_run
  run if run&.dataloader.equal?(self)
end
```

Used by `active_run`, `run_isolated` (`previous_run`) and `run`. `Run` already holds `@dataloader`, but this exposes it. Same-dataloader nesting (`run_isolated` from a resolver of the same query) is unchanged; a foreign run is now simply not a candidate, so the inner dataloader keeps its own `@pending_run` and runs its own queues.

## Tests

`spec/graphql/dataloader/async_dataloader_spec.rb`: "when another dataloader runs inside a job, it doesn't take over the outer dataloader's run".