### PR TITLE
Optimize repeated FieldsWillMerge comparisons

### DIFF
--- a/lib/graphql/static_validation/rules/fields_will_merge.rb
+++ b/lib/graphql/static_validation/rules/fields_will_merge.rb
@@ -15,6 +15,8 @@ module GraphQL
       # separately (which leads to exponential recursion through nested fragments),
       # we flatten all fragment spreads into a single field map and compare within it.
       NO_ARGS = GraphQL::EmptyObjects::EMPTY_HASH
+      EXCLUSIVE_COMPARISON = 1
+      NONEXCLUSIVE_COMPARISON = 2
 
       class Field
         attr_reader :node, :definition, :owner_type, :parents
@@ -33,6 +35,10 @@ module GraphQL
         def unwrapped_return_type
           @unwrapped_return_type ||= return_type&.unwrap
         end
+
+        def comparison_key
+          @comparison_key ||= [@node, @parents]
+        end
       end
 
       def initialize(*)
@@ -43,6 +49,9 @@ module GraphQL
         # Track which sub-selection node pairs have been compared to prevent
         # infinite recursion with cyclic fragments
         @compared_sub_selections = {}.compare_by_identity
+        @compared_field_groups = {}
+        @field_group_signatures = {}.compare_by_identity
+        @field_selection_signatures = {}.compare_by_identity
         # Cache mutually_exclusive? results for type pairs
         @mutually_exclusive_cache = {}.compare_by_identity
         # Cache collect_fields results for sub-selection comparison
@@ -215,21 +224,7 @@ module GraphQL
             end
 
             if all_same
-              # All fields share a signature, so they can only conflict on
-              # sub-selections. Deduplicate by AST node identity — fields from
-              # the same node always have identical sub-selections.
-              unique_nodes = fields.uniq { |f| f.node.object_id }
-              i = 0
-              while i < unique_nodes.size
-                j = i + 1
-                while j < unique_nodes.size
-                  if unique_nodes[i].node.selections.size > 0 || unique_nodes[j].node.selections.size > 0
-                    find_conflict(key, unique_nodes[i], unique_nodes[j])
-                  end
-                  j += 1
-                end
-                i += 1
-              end
+              find_conflicts_between_selection_groups(key, fields)
             else
               groups = fields.group_by { |f| field_signature(f) }
               unique_groups = groups.values
@@ -243,22 +238,10 @@ module GraphQL
                   gj += 1
                 end
 
-                # Within same group, deduplicate by AST node and compare all
-                # pairs for sub-selection conflicts
+                # Within the same group, fields can only conflict on sub-selections.
                 group = unique_groups[gi]
                 if group.size >= 2
-                  unique_in_group = group.uniq { |f| f.node.object_id }
-                  ui = 0
-                  while ui < unique_in_group.size
-                    uj = ui + 1
-                    while uj < unique_in_group.size
-                      if unique_in_group[ui].node.selections.size > 0 || unique_in_group[uj].node.selections.size > 0
-                        find_conflict(key, unique_in_group[ui], unique_in_group[uj])
-                      end
-                      uj += 1
-                    end
-                    ui += 1
-                  end
+                  find_conflicts_between_selection_groups(key, group)
                 end
 
                 gi += 1
@@ -277,6 +260,29 @@ module GraphQL
             end
           end
         end
+      end
+
+      def find_conflicts_between_selection_groups(response_key, fields)
+        fields_by_selection = {}
+        fields.each do |field|
+          fields_by_selection[field_selection_signature(field)] ||= field
+        end
+
+        representatives = fields_by_selection.values
+        i = 0
+        while i < representatives.size
+          j = i + 1
+          while j < representatives.size
+            find_conflict(response_key, representatives[i], representatives[j])
+            j += 1
+          end
+          i += 1
+        end
+      end
+
+      def field_selection_signature(field)
+        node = field.node
+        @field_selection_signatures[node] ||= node.selections.map(&:to_query_string)
       end
 
       def fields_same_signature?(f1, f2)
@@ -458,6 +464,7 @@ module GraphQL
         response_keys.each do |key, fields|
           fields2 = response_keys2[key]
           next unless fields2
+          next if field_groups_already_compared?(fields, fields2, mutually_exclusive)
 
           fields_arr = fields.is_a?(Field) ? [fields] : fields
           fields2_arr = fields2.is_a?(Field) ? [fields2] : fields2
@@ -472,6 +479,36 @@ module GraphQL
               )
             end
           end
+        end
+      end
+
+      def field_groups_already_compared?(fields, fields2, mutually_exclusive)
+        signature1 = field_group_signature(fields)
+        signature2 = field_group_signature(fields2)
+        previous_comparisons = @compared_field_groups[signature1]
+        comparison_state = previous_comparisons && previous_comparisons[signature2]
+
+        if mutually_exclusive
+          return true if comparison_state
+          new_state = EXCLUSIVE_COMPARISON
+        else
+          return true if comparison_state == NONEXCLUSIVE_COMPARISON
+          new_state = NONEXCLUSIVE_COMPARISON
+        end
+
+        previous_comparisons ||= (@compared_field_groups[signature1] = {})
+        previous_comparisons[signature2] = new_state
+
+        reverse_comparisons = @compared_field_groups[signature2] ||= {}
+        reverse_comparisons[signature1] = new_state
+        false
+      end
+
+      def field_group_signature(fields)
+        if fields.is_a?(Field)
+          fields.comparison_key
+        else
+          @field_group_signatures[fields] ||= fields.map(&:comparison_key)
         end
       end
 

--- a/spec/graphql/static_validation/rules/fields_will_merge_spec.rb
+++ b/spec/graphql/static_validation/rules/fields_will_merge_spec.rb
@@ -1491,6 +1491,37 @@ describe GraphQL::StaticValidation::FieldsWillMerge do
     end
   end
 
+  describe "many identical sub-selections from a shared fragment" do
+    let(:query_string) do
+      repeated_fields = "toys { ...ToyFields }\n" * 400
+      repeated_fragment_fields = "name\n" * 20
+
+      <<~GRAPHQL
+        {
+          dog {
+            #{repeated_fields}
+            toys { ...OtherToyFields }
+          }
+        }
+
+        fragment ToyFields on Toy {
+          #{repeated_fragment_fields}
+        }
+
+        fragment OtherToyFields on Toy {
+          name: image(maxWidth: 1)
+        }
+      GRAPHQL
+    end
+
+    it "finds a divergent conflict before the validation timeout" do
+      validation_errors = schema.validate(query_string)
+
+      refute validation_errors.any? { |error| error.is_a?(GraphQL::StaticValidation::ValidationTimeoutError) }
+      assert validation_errors.any? { |error| error.message.include?("Field 'name' has a field conflict") && error.message.include?("image") }
+    end
+  end
+
   describe "boundary at exactly 4 and 5 fields" do
     describe "4 fields uses O(n^2) path and catches conflict" do
       let(:query_string) {%|


### PR DESCRIPTION
Improve the performance of `FieldsWillMerge` validation for queries containing many repeated composite fields and shared fragment selections.

Previously, the validator could repeatedly compare the same expanded fragment fields for every pair of parent fields. This caused nested Cartesian comparisons and severe superlinear runtime growth before query execution or authentication.

This change:

- groups fields with identical sub-selections and compares only one representative from each group
- memoizes comparisons between equivalent expanded field groups
- keeps mutually exclusive and non-exclusive comparisons separate
- adds a regression test that verifies a divergent conflict is still detected without reaching the default validation timeout

### Benchmark

Measured using a query with repeated composite fields and a shared fragment containing repeated fields.

| Fields | Query size | Before | After | Speedup |
| ---: | ---: | ---: | ---: | ---: |
| 100 | 2,320 bytes | 193.6 ms | 3.14 ms | 61.7x |
| 200 | 4,552 bytes | 1,438.4 ms | 3.72 ms | 386.7x |
| 400 | 9,000 bytes | 11,732.5 ms | 8.68 ms | 1,351.7x |
| 800 | 17,864 bytes | did not finish within 30 seconds | 20.08 ms | — |

The 400-field case is reduced by approximately 99.93%.