### PR TITLE
exec-next: Add method: to dataload shorthands

### DIFF
--- a/guides/execution/next.md
+++ b/guides/execution/next.md
@@ -170,6 +170,8 @@ end
 
 `Execution::Next` supports field configuration shorthands for common dataloader usage. Under the hood, these make sure data fetching is batched and cached.
 
+`method:` can be added to any hash-style `dataload:` config to call a public method on the loaded value.
+
 #### Sources
 
 Use a custom dataloader source from your application:
@@ -184,6 +186,11 @@ class Types::CommentType
   #
   # Equivalent to `dataload(Sources::ReadingDuration, :comment, object.body)
   field :reading_duration, Integer, dataload: { with: Sources::ReadingDuration, using: :body, by: [:comment] }
+
+  # `method:`: A method to call on the loaded value
+  #
+  # Equivalent to `dataload(Sources::CommentRating, object).to_s`
+  field :rating_string, String, dataload: { with: Sources::CommentRating, method: :to_s }
 ```
 
 #### Rails Associations
@@ -196,6 +203,8 @@ class Types::CommentType < Types::BaseObject
   field :post, Types::Post, dataload: { association: true }
   # Equivalent to `dataload_association(:user)
   field :author, Types::Post, dataload: { association: :user }
+  # Equivalent to `dataload_association(:author)&.name`
+  field :author_name, String, null: true, dataload: { association: :author, method: :name }
 end
 ```
 
@@ -209,6 +218,8 @@ class Types::SearchResult < Types::BaseObject
   field :post, Types::Post, dataload: { model: Post, using: :post_id }
   # Equivalent to `dataload_record(User, object.created_by_handle, find_by: :handle)`
   field :author, Types::User, dataload: { model: User, using: :created_by_handle, find_by: :handle }
+  # Equivalent to `dataload_record(Post, object.post_id)&.title`
+  field :post_title, String, null: true, dataload: { model: Post, using: :post_id, method: :title }
 end
 ```
 

--- a/lib/graphql/execution/field_resolve_step.rb
+++ b/lib/graphql/execution/field_resolve_step.rb
@@ -744,7 +744,8 @@ module GraphQL
         when :dig
           objects.map { |o| o.dig(*@field_definition.execution_mode_key) }
         when :dataload
-          if (k = @field_definition.execution_mode_key).is_a?(Class)
+          k = @field_definition.execution_mode_key
+          results = if k.is_a?(Class)
             context.dataload_all(k, objects)
           elsif (source_class = k[:with])
             if (batch_args = k[:by])
@@ -763,6 +764,12 @@ module GraphQL
             context.dataload_all_associations(objects, assoc, scope: k[:scope])
           else
             raise ArgumentError, "Unexpected `dataload: ...` configuration: #{k.inspect}"
+          end
+          method = k.is_a?(Hash) ? k[:method] : nil
+          if method
+            results.map { |r| r&.public_send(method) }
+          else
+            results
           end
         when :resolver_class
           results = Array.new(objects.size, nil)

--- a/spec/graphql/dataloader/active_record_association_source_spec.rb
+++ b/spec/graphql/dataloader/active_record_association_source_spec.rb
@@ -48,6 +48,21 @@ describe GraphQL::Dataloader::ActiveRecordAssociationSource do
       assert_equal ["Vulfpeck", "Vulfpeck"], result["data"]["band"]["allAlbums"].map { |a| a["band"]["name"] }
     end
 
+    it "loads a method result through an association dataload" do
+      exec_next_only("Only exec-next uses these configs")
+      result = exec_query <<-GRAPHQL
+        {
+          band(name: "Vulfpeck") {
+            allAlbums {
+              bandName
+            }
+          }
+        }
+      GRAPHQL
+
+      assert_equal ["Vulfpeck", "Vulfpeck"], result["data"]["band"]["allAlbums"].map { |a| a["bandName"] }
+    end
+
     it_dataloads "queries for associated records when the association isn't already loaded" do |d|
       my_first_car = ::Album.find(2)
       homey = ::Album.find(4)

--- a/spec/graphql/dataloader/active_record_source_spec.rb
+++ b/spec/graphql/dataloader/active_record_source_spec.rb
@@ -11,6 +11,13 @@ describe GraphQL::Dataloader::ActiveRecordSource do
       assert_equal "Chon", exec_query(query_str, root_value: OpenStruct.new(band_name: "Chon"))["data"]["rootBand"]["name"]
     end
 
+    it "works with method on model and with dataload shorthands" do
+      exec_next_only("Only exec-next uses these configs")
+      result = exec_query "{ rootBandName bandsCountString }", root_value: OpenStruct.new(band_name: "Wilco")
+      assert_equal "Wilco", result["data"]["rootBandName"]
+      assert_equal "4", result["data"]["bandsCountString"]
+    end
+
     describe "finding by ID" do
       it_dataloads "loads once, then returns from a cache when available" do |d|
         log = with_active_record_log(colorize: false) do

--- a/spec/support/active_record_setup.rb
+++ b/spec/support/active_record_setup.rb
@@ -182,6 +182,7 @@ if testing_rails?
 
       class Album < GraphQL::Schema::Object
         field :name, String
+        field :band_name, String, dataload: { association: :band, method: :name }
         field :band, "VulfpeckSchemaHelpers::VulfpeckSchema::Band", dataload: { association: true }
       end
       class Band < GraphQL::Schema::Object
@@ -223,7 +224,9 @@ if testing_rails?
         end
 
         field :root_band, Band, dataload: { model: ::Band, using: :band_name, find_by: :name }
+        field :root_band_name, String, dataload: { model: ::Band, using: :band_name, find_by: :name, method: :name }
         field :bands_count, Integer, dataload: { with: ModelCountSource, by: [::Band]}
+        field :bands_count_string, String, dataload: { with: ModelCountSource, by: [::Band], method: :to_s }
         field :albums_count, Integer, dataload: { with: ModelCountSource, by: [::Album]}
       end
 


### PR DESCRIPTION
## Motivation

A very common pattern in our schema is resolving a scalar by first batch-loading an association, then calling a method on the loaded associated object.

Without this PR, every such field requires a custom `def self.<field>` batch resolver. For example, in our `UserType` we end up with a lot of boilerplate like this:

```ruby
# app/graphql/types/user_type.rb
field :age, String, null: true, resolve_batch: true

def self.age(objects, context)
  dataload_all_associations(context, objects, :verified_info).map { it&.age }
end

field :country, String, null: true, resolve_batch: true

def self.country(objects, context)
  dataload_all_associations(context, objects, :latest_device).map { it&.country }
end

def self.dataload_all_associations(context, records, association_name, scope: nil)
  source = if scope
             context.dataloader.with(GraphQL::Dataloader::ActiveRecordAssociationSource, association_name, scope)
           else
             context.dataloader.with(GraphQL::Dataloader::ActiveRecordAssociationSource, association_name)
           end
  source.load_all(records)
end
```

This becomes repetitive quickly and makes the type file mostly boilerplate.

With the `method:` option on `dataload:` shorthands, the same fields can be written declaratively:

```ruby
field :age, String, null: true,
      dataload: { association: :verified_info, method: :age }

field :country, String, null: true,
      dataload: { association: :latest_device, method: :country }
```

It keeps the dataloader batching, removes the need for one resolver per field, and makes the schema definition a lot more readable. Because `method:` works for `with:`, `association:`, and `model:` shorthands, it covers most of our real-world cases.

## Summary

- Adds a `method:` option to hash-style `dataload:` field configs under `Execution::Next`. When present, the loaded value's public method is called before returning it, e.g. `dataload: { association: :author, method: :name }` is equivalent to `dataload_association(:author)&.name`.
- Works with all three hash-style shorthands (`with:`, `association:`, `model:`).
- Updated `guides/execution/next.md` with examples for each shorthand.

## Tests

Added specs covering `method:` for the source shorthand, the Rails association shorthand, and the Rails model shorthand.
