### PR TITLE
Avoid freezing execution results during finalization

### DIFF
--- a/lib/graphql/execution/finalize.rb
+++ b/lib/graphql/execution/finalize.rb
@@ -28,7 +28,7 @@ module GraphQL
           targets = [data]
           while (part = err_path.shift)
             targets.map! { |t| t[part] }
-            targets.flatten!
+            targets = targets.flatten
           end
 
           targets.each_with_index do |target, idx|


### PR DESCRIPTION
 Ruby head currently freezes the nested array in `Array#flatten!`'s single-array fast path:

```ruby
result = []
[result].flatten!
result.frozen? # => true
```

`GraphQL::Execution::Finalize` used flatten! while locating errors in nested list results. This unintentionally froze the execution result array, then null propagation attempted to update it and raised `FrozenError`.

This change uses non-destructive flatten instead. It preserves the existing recursive traversal without freezing result arrays.

The existing `[Test], [Test!],` and `[Test!]!` null-propagation cases fail before this change and pass afterward on Ruby 4.1.0dev. They also pass on Ruby 4.0.