### PR TITLE
Handle out-of-range Unicode escapes as parse errors

### DIFF
--- a/lib/graphql/language/lexer.rb
+++ b/lib/graphql/language/lexer.rb
@@ -163,7 +163,11 @@ module GraphQL
           if !str.valid_encoding? || !str.match?(VALID_STRING)
             raise_parse_error("Bad unicode escape in #{str.inspect}")
           else
-            Lexer.replace_escaped_characters_in_place(str)
+            begin
+              Lexer.replace_escaped_characters_in_place(str)
+            rescue RangeError
+              raise_parse_error("Bad unicode escape in #{str.inspect}")
+            end
 
             if !str.valid_encoding?
               raise_parse_error("Bad unicode escape in #{str.inspect}")

--- a/spec/graphql/language/lexer_spec.rb
+++ b/spec/graphql/language/lexer_spec.rb
@@ -12,6 +12,10 @@ describe GraphQL::Language::Lexer do
     assert_equal expected_err_message, err.message
   end
 
+  it "rejects unicode escapes outside the valid range" do
+    assert_bad_unicode('"\\u{FFFFFFFFFF}"', 'Bad unicode escape in "\\\\u{FFFFFFFFFF}"')
+  end
+
   it "reports positions correctly after multibyte input" do
     err = assert_raises(GraphQL::ParseError) do
       subject.tokenize("{\n  # 日本語\n  field(arg: -foo)\n}")


### PR DESCRIPTION
An out-of-range Unicode escape currently causes `GraphQL::Language::Lexer` to raise a raw `RangeError`:

```ruby
MySchema.execute('{ echo(input: "\\u{FFFFFFFFFF}") }')
# RangeError: pack(U): value out of range
```

This happens when replace_escaped_characters_in_place passes the decoded codepoint to Array#pack("U"). Since the exception bypasses GraphQL's parse error handling, applications may return an HTTP 500 for an invalid query.

This PR catches that RangeError and reports it through the lexer's existing raise_parse_error path. The same query is now returned as a normal GraphQL parse error.

A regression test covers Unicode escapes above the valid codepoint range.