### PR TITLE
Reraise unexpected lexer argument errors

### DIFF
--- a/lib/graphql/language/lexer.rb
+++ b/lib/graphql/language/lexer.rb
@@ -9,6 +9,9 @@ module GraphQL
         end
         @string = graphql_str
         @filename = filename
+        if !@string.valid_encoding?
+          raise_parse_error("Parse error on bad Unicode escape sequence", nil, nil)
+        end
         @scanner = StringScanner.new(graphql_str)
         @pos = nil
         @max_tokens = max_tokens || Float::INFINITY
@@ -109,10 +112,6 @@ module GraphQL
         else
           @scanner.pos += 1
           :UNKNOWN_CHAR
-        end
-      rescue ArgumentError => err
-        if err.message == "invalid byte sequence in UTF-8"
-          raise_parse_error("Parse error on bad Unicode escape sequence", nil, nil)
         end
       end
 

--- a/spec/graphql/language/lexer_spec.rb
+++ b/spec/graphql/language/lexer_spec.rb
@@ -27,4 +27,14 @@ describe GraphQL::Language::Lexer do
 
     assert_equal [:FRAGMENT, 3, 1, "fragment"], fragment_token
   end
+
+  it "reraises unexpected argument errors" do
+    lexer = subject.new("{")
+    scanner = lexer.instance_variable_get(:@scanner)
+
+    scanner.stub(:skip, ->(*) { raise ArgumentError, "unexpected failure" }) do
+      err = assert_raises(ArgumentError) { lexer.advance }
+      assert_equal "unexpected failure", err.message
+    end
+  end
 end


### PR DESCRIPTION
`GraphQL::Language::Lexer#advance` currently rescues every `ArgumentError`, but only handles errors whose message exactly matches `"invalid byte sequence in UTF-8"`. Any other `ArgumentError` is silently swallowed and `advance` returns `nil`.

The exact message is produced while scanning an invalidly encoded string, so matching it also depends on Ruby's exception wording.

This PR validates the query string's encoding when the lexer is initialized and removes the broad rescue from `advance`. Invalid UTF-8 continues to raise the existing `GraphQL::ParseError`, while unrelated `ArgumentError`s are propagated normally.