### PR TITLE
Restore current multiplex after nested execution

### DIFF
--- a/lib/graphql/execution/interpreter.rb
+++ b/lib/graphql/execution/interpreter.rb
@@ -22,6 +22,7 @@ module GraphQL
         # @param max_complexity [Integer, nil]
         # @return [Array<GraphQL::Query::Result>] One result per query
         def run_all(schema, query_options, context: {}, max_complexity: schema.max_complexity)
+          previous_multiplex = Fiber[:__graphql_current_multiplex]
           queries = query_options.map do |opts|
             query = case opts
             when Hash
@@ -131,7 +132,6 @@ module GraphQL
               queries.map { |q| q.result_values ||= {} }
               raise
             ensure
-              Fiber[:__graphql_current_multiplex] = nil
               queries.map { |query|
                 runtime = query.context.namespace(:interpreter_runtime)[:runtime]
                 if runtime
@@ -140,6 +140,8 @@ module GraphQL
               }
             end
           end
+        ensure
+          Fiber[:__graphql_current_multiplex] = previous_multiplex
         end
       end
 

--- a/lib/graphql/execution/runner.rb
+++ b/lib/graphql/execution/runner.rb
@@ -72,6 +72,7 @@ module GraphQL
       end
 
       def execute
+        previous_multiplex = Fiber[:__graphql_current_multiplex]
         Fiber[:__graphql_current_multiplex] = @multiplex
         isolated_steps = [[]]
         trace = @multiplex.current_trace
@@ -162,7 +163,7 @@ module GraphQL
           query.result
         end
       ensure
-        Fiber[:__graphql_current_multiplex] = nil
+        Fiber[:__graphql_current_multiplex] = previous_multiplex
       end
 
       def gather_selections(type_defn, ast_selections, selections_step, query, all_selections, prototype_result, into:)

--- a/spec/graphql/current_spec.rb
+++ b/spec/graphql/current_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "spec_helper"
+require "async" if RUBY_VERSION >= "3.2.0"
 
 describe GraphQL::Current do
   describe "when no query is running" do
@@ -37,6 +38,7 @@ describe GraphQL::Current do
       end
       class Query < GraphQL::Schema::Object
         field :thing, Thing, resolve_static: true
+        field :operation_name_after_nested_query, String, resolve_static: true
 
         def self.thing(context)
           context[:current_field] << GraphQL::Current.field.path
@@ -46,11 +48,25 @@ describe GraphQL::Current do
         def thing
           self.class.thing(context)
         end
+
+        def self.operation_name_after_nested_query(context)
+          context.schema.public_send(context[:execute_method], "{ __typename }")
+          GraphQL::Current.operation_name
+        end
+
+        def operation_name_after_nested_query
+          self.class.operation_name_after_nested_query(context)
+        end
       end
 
       query(Query)
       use GraphQL::Dataloader
+      use GraphQL::Execution::Next
     end
+
+    class AsyncCurrentSchema < CurrentSchema
+      use GraphQL::Dataloader::AsyncDataloader
+    end if RUBY_VERSION >= "3.2.0"
 
     it "returns execution information" do
       ctx = {
@@ -65,6 +81,21 @@ describe GraphQL::Current do
       assert_equal ["GetThingName"], ctx[:current_operation_name]
       assert_equal [CurrentSchema::ThingSource], ctx[:current_source]
       assert_equal ["Query.thing", "Thing.name"], ctx[:current_field]
+    end
+
+    it "restores execution information after a nested query" do
+      schemas = [CurrentSchema]
+      schemas << AsyncCurrentSchema if RUBY_VERSION >= "3.2.0"
+
+      schemas.product([:execute_legacy, :execute_next]).each do |schema, execute_method|
+        result = schema.public_send(
+          execute_method,
+          "query OuterOperation { operationNameAfterNestedQuery }",
+          context: { execute_method: execute_method },
+        )
+
+        assert_equal "OuterOperation", result["data"]["operationNameAfterNestedQuery"]
+      end
     end
   end
 end


### PR DESCRIPTION
Nested GraphQL execution currently clears the outer execution's fiber-local multiplex.

This can happen when a resolver executes another schema, for example while triggering subscriptions or composing an internal GraphQL API:

```ruby
before = GraphQL::Current.operation_name
InnerSchema.execute("{ value }")
after = GraphQL::Current.operation_name

before # => "OuterOperation"
after  # => nil
```

Both `GraphQL::Execution::Interpreter` and `GraphQL::Execution::Runner` replace `Fiber[:__graphql_current_multiplex]` when execution starts, then unconditionally set it to nil in ensure. As a result, the outer multiplex is lost after the nested query finishes.

Besides breaking `GraphQL::Current.operation_name`, this can cause later dataloader runs to lose their current trace because they read it from the same fiber-local multiplex.

This PR saves the previous multiplex before starting execution and restores it in ensure. Top-level execution continues to restore nil, while nested execution returns to the outer multiplex.