### PR TITLE
Reject invalid ArrayConnection cursors

### DIFF
--- a/lib/graphql/pagination/array_connection.rb
+++ b/lib/graphql/pagination/array_connection.rb
@@ -27,7 +27,11 @@ module GraphQL
       private
 
       def index_from_cursor(cursor)
-        decode(cursor).to_i
+        index = Integer(decode(cursor), 10, exception: false)
+        if index.nil? || index <= 0
+          raise GraphQL::ExecutionError, "Invalid cursor: #{cursor.inspect}"
+        end
+        [index, items.length + 1].min
       end
 
       # Populate all the pagination info _once_,

--- a/spec/graphql/pagination/array_connection_spec.rb
+++ b/spec/graphql/pagination/array_connection_spec.rb
@@ -19,4 +19,19 @@ describe GraphQL::Pagination::ArrayConnection do
   }
 
   include ConnectionAssertions
+
+  it "rejects malformed cursors" do
+    query = <<~GRAPHQL
+      query($after: String!) {
+        items(first: 3, after: $after) { nodes { name } }
+      }
+    GRAPHQL
+
+    ["-1", "0", "abc", "1e10"].each do |cursor|
+      encoded_cursor = ConnectionAssertions::NonceEnabledEncoder.encode(cursor)
+      result = schema.execute(query, variables: { "after" => encoded_cursor })
+      assert_nil result.dig("data", "items", "nodes")
+      assert_includes result["errors"].first["message"], "Invalid cursor"
+    end
+  end
 end

--- a/spec/support/connection_assertions.rb
+++ b/spec/support/connection_assertions.rb
@@ -290,10 +290,15 @@ module ConnectionAssertions
         end
 
         it "handles out-of-bounds cursors" do
-          # It treats negative cursors like zero
+          # Negative cursors don't wrap around to the end
           bogus_negative_cursor = NonceEnabledEncoder.encode("-10")
           res = exec_query(query_str, first: 3, after: bogus_negative_cursor)
-          assert_names(["Avocado", "Beet", "Cucumber"], res)
+          if schema.connection_class <= GraphQL::Pagination::ArrayConnection
+            assert_nil res.dig("data", "items", "nodes")
+            assert_includes res["errors"].first["message"], "Invalid cursor"
+          else
+            assert_names(["Avocado", "Beet", "Cucumber"], res)
+          end
 
           # It returns nothing for cursors beyond the array
           bogus_huge_cursor = NonceEnabledEncoder.encode("100")


### PR DESCRIPTION
`GraphQL::Pagination::ArrayConnection` currently converts decoded cursors with `String#to_i` and uses the result directly as an Array index.

This allows negative cursor offsets to wrap around to the end of the Array:

```ruby
items = (1..10).map { |i| "item#{i}" }
after: "3"  # => ["item4", "item5", "item6"]
after: "-3" # => ["item8", "item9", "item10"]
after: "-1" # => ["item10"]
```

Malformed values are also partially or silently converted:

```ruby
"abc".to_i  # => 0
"1e10".to_i # => 1
```

As a result, invalid client-provided cursors can return unrelated pages and produce incorrect pageInfo values.

This PR parses decoded ArrayConnection cursors with Integer and raises GraphQL::ExecutionError for malformed, zero, or negative values. Positive offsets beyond the Array continue to return an empty page, preserving the existing out-of-bounds behavior. Very large positive integers are capped to a safe sentinel index so they cannot raise a Ruby RangeError.