### PR TITLE
Allow RelationConnection without context

### DIFF
--- a/lib/graphql/pagination/relation_connection.rb
+++ b/lib/graphql/pagination/relation_connection.rb
@@ -222,7 +222,7 @@ module GraphQL
       def load_nodes
         # Return an array so we can consistently use `.index(node)` on it
         return @nodes if @nodes
-        if (@context[:dataloader].is_a?(GraphQL::Dataloader::AsyncDataloader))
+        if (@context&.[](:dataloader).is_a?(GraphQL::Dataloader::AsyncDataloader))
           # `AsyncDataloader` may resolve sibling fields (eg, `edges` and `pageInfo`)
           # in separate Fibers, so several callers can get here before `@nodes` is set.
           (@load_lock ||= Mutex.new).synchronize do

--- a/spec/graphql/pagination/connection_spec.rb
+++ b/spec/graphql/pagination/connection_spec.rb
@@ -19,3 +19,17 @@ describe GraphQL::Pagination::Connection do
     end
   end
 end
+
+describe GraphQL::Pagination::RelationConnection do
+  it "loads nodes without context" do
+    connection_class = Class.new(GraphQL::Pagination::RelationConnection) do
+      private
+
+      def limited_nodes
+        items
+      end
+    end
+
+    assert_equal [1, 2, 3], connection_class.new([1, 2, 3]).nodes
+  end
+end


### PR DESCRIPTION
`GraphQL::Pagination::RelationConnection#load_nodes` currently dereferences `@context` while checking for `AsyncDataloader`:

```ruby
@context[:dataloader]
```

However, connection initialization allows context: nil, and custom relation connections previously loaded nodes without requiring a GraphQL query context. Since b9a1897, those connections raise:

```
NoMethodError: undefined method `[]' for nil
```

This PR uses a nil-safe context lookup. Contextless connections continue through the regular loading path, while connections using AsyncDataloader retain the mutex-protected path.