### PR TITLE
Prevent duplicate relation count queries

### DIFF
--- a/lib/graphql/pagination/relation_connection.rb
+++ b/lib/graphql/pagination/relation_connection.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "graphql/pagination/connection"
+require "monitor"
 
 module GraphQL
   module Pagination
@@ -178,6 +179,17 @@ module GraphQL
       # Apply `first` and `last` to `sliced_nodes`,
       # returning a new relation
       def limited_nodes
+        return @limited_nodes if @limited_nodes
+        if async_dataloader?
+          (@load_monitor ||= Monitor.new).synchronize do
+            build_limited_nodes
+          end
+        else
+          build_limited_nodes
+        end
+      end
+
+      def build_limited_nodes
         @limited_nodes ||= begin
           calculate_sliced_nodes_parameters
           if @sliced_nodes_null_relation
@@ -217,15 +229,19 @@ module GraphQL
         end
       end
 
+      def async_dataloader?
+        @context&.[](:dataloader).is_a?(GraphQL::Dataloader::AsyncDataloader)
+      end
+
       # Load nodes after applying first/last/before/after,
       # returns an array of nodes
       def load_nodes
         # Return an array so we can consistently use `.index(node)` on it
         return @nodes if @nodes
-        if (@context&.[](:dataloader).is_a?(GraphQL::Dataloader::AsyncDataloader))
+        if async_dataloader?
           # `AsyncDataloader` may resolve sibling fields (eg, `edges` and `pageInfo`)
           # in separate Fibers, so several callers can get here before `@nodes` is set.
-          (@load_lock ||= Mutex.new).synchronize do
+          (@load_monitor ||= Monitor.new).synchronize do
             @nodes ||= limited_nodes.to_a
           end
         else

--- a/spec/graphql/pagination/active_record_relation_connection_spec.rb
+++ b/spec/graphql/pagination/active_record_relation_connection_spec.rb
@@ -258,6 +258,18 @@ if testing_rails?
       require "async"
 
       describe "when Fibers share a connection" do
+        class SlowCountingRelationConnection < GraphQL::Pagination::ActiveRecordRelationConnection
+          attr_reader :count_calls
+
+          private
+
+          def relation_count(relation)
+            @count_calls = (@count_calls || 0) + 1
+            sleep(0.05)
+            super
+          end
+        end
+
         it "loads the page only once when several Fibers resolve it" do
           connection = GraphQL::Pagination::ActiveRecordRelationConnection.new(Food.all, first: 2, max_page_size: 10, context: { dataloader: GraphQL::Dataloader::AsyncDataloader.new })
           results = []
@@ -270,6 +282,23 @@ if testing_rails?
 
           assert_equal 1, log.split("\n").size, "It runs one query"
           assert_equal [2, 2, 2], results.map(&:size)
+        end
+
+        it "counts the relation only once when page fields resolve in separate Fibers" do
+          connection = SlowCountingRelationConnection.new(Food.all, last: 2, max_page_size: 10, context: { dataloader: GraphQL::Dataloader::AsyncDataloader.new })
+          nodes = nil
+          has_previous_page = nil
+
+          Sync do
+            [
+              Async { nodes = connection.nodes },
+              Async { has_previous_page = connection.has_previous_page },
+            ].each(&:wait)
+          end
+
+          assert_equal 1, connection.count_calls
+          assert_equal 2, nodes.size
+          assert_equal true, has_previous_page
         end
       end
     end


### PR DESCRIPTION
 This follows up on #5708, which prevents concurrent Fibers from loading the same relation page more than once.

`RelationConnection#limited_nodes` remains independently memoized outside that lock. With `last:` pagination and no existing relation limit, it calls `relation_count(sliced_nodes)`. If that query yields, another Fiber can enter the same `@limited_nodes ||= ...` block before the first one finishes.

Under `AsyncDataloader`, this can happen when connection fields resolve separately:

- `edges` or `nodes` calls `load_nodes`
- `pageInfo.hasPreviousPage` calls `limited_nodes` directly

Both Fibers can therefore issue the same `COUNT` query.

```ruby
connection = Connection.new(
  relation,
  last: 2,
  context: { dataloader: GraphQL::Dataloader::AsyncDataloader.new },
)

Sync do
  [
    Async { connection.nodes },
    Async { connection.has_previous_page },
  ].each(&:wait)
end
```

Before this change, the relation is counted twice. After this change, it is counted once.

This PR protects both limited_nodes construction and the final node load with the same Monitor. Monitor is reentrant, so load_nodes can safely call limited_nodes while holding it without risking ThreadError: deadlock; recursive locking.

The synchronization is only used with AsyncDataloader; other dataloaders retain the existing unsynchronized path and its current overhead.