### PR TITLE
Ensure dataloader fibers are cleaned up

### DIFF
--- a/lib/graphql/dataloader.rb
+++ b/lib/graphql/dataloader.rb
@@ -262,11 +262,12 @@ module GraphQL
 
     def spawn_fiber
       fiber_vars = get_fiber_variables
-      Fiber.new(blocking: !@nonblocking) {
+      Fiber.new(blocking: !@nonblocking) do
         set_fiber_variables(fiber_vars)
         yield
+      ensure
         cleanup_fiber
-      }
+      end
     end
 
     # Pre-warm the Dataloader cache with ActiveRecord objects which were loaded elsewhere.
@@ -359,6 +360,7 @@ module GraphQL
           while job = @pending_jobs.shift
             job.call
           end
+        ensure
           trace&.dataloader_fiber_exit
         end
       end
@@ -392,6 +394,7 @@ module GraphQL
             source.run_pending_keys
             trace&.end_dataloader_source(source)
           end
+        ensure
           trace&.dataloader_fiber_exit
         end
       end

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -1333,6 +1333,30 @@ describe GraphQL::Dataloader do
 
   include DataloaderAssertions
 
+  it "cleans up fibers that raise errors" do
+    events = []
+    dataloader_class = Class.new(GraphQL::Dataloader) do
+      define_method(:cleanup_fiber) { events << :cleanup }
+    end
+    trace_class = Class.new(GraphQL::Tracing::Trace) do
+      define_method(:dataloader_fiber_exit) { events << :trace_exit }
+    end
+    source_class = Class.new(GraphQL::Dataloader::Source) do
+      def run_pending_keys
+        raise "Source failed"
+      end
+    end
+
+    dataloader = dataloader_class.new
+    trace = trace_class.new
+    dataloader.append_job { raise "Job failed" }
+    assert_raises(RuntimeError) { dataloader.send(:spawn_job_fiber, trace).resume }
+    dataloader.with(source_class).request(:key)
+    assert_raises(RuntimeError) { dataloader.send(:spawn_source_fiber, trace).resume }
+
+    assert_equal [:trace_exit, :cleanup, :trace_exit, :cleanup], events
+  end
+
   if RUBY_VERSION >= "3.1.1"
     require "async"
     describe "AsyncDataloader" do


### PR DESCRIPTION
`GraphQL::Dataloader#spawn_fiber` currently calls `cleanup_fiber` only after the Fiber's work completes successfully:

```ruby
yield
cleanup_fiber
```

If a job or source Fiber raises, cleanup is skipped. The corresponding `dataloader_fiber_exit` trace hook in spawn_job_fiber and `spawn_source_fiber` is also skipped.

This can leave resources managed by `cleanup_fiber`, such as database connections, unreleased and prevent tracing integrations from closing their Fiber spans.

This PR moves both lifecycle callbacks into ensure blocks. Exceptions continue to propagate as before, while cleanup and trace exit hooks are always invoked. This also matches the existing behavior of `AsyncDataloader#spawn_tasks`.