### PR TITLE
Support Ruby 4.1 fiber interrupts

### DIFF
--- a/spec/support/dummy_scheduler.rb
+++ b/spec/support/dummy_scheduler.rb
@@ -212,6 +212,16 @@ class DummyScheduler
     io.write_nonblock('.')
   end
 
+  FiberInterrupt = Struct.new(:fiber, :exception) do
+    def resume
+      fiber.raise(exception) if fiber.alive?
+    end
+  end
+
+  def fiber_interrupt(fiber, exception)
+    unblock(nil, FiberInterrupt.new(fiber, exception))
+  end
+
   def fiber(&block)
     fiber = Fiber.new(blocking: false, &block)
 


### PR DESCRIPTION
Ruby 4.0 introduced `Fiber::Scheduler#fiber_interrupt` with a compatibility warning. Ruby 4.1 now requires the hook and rejects schedulers that do not implement it ([ruby/ruby#18513](https://github.com/ruby/ruby/pull/18513)).

GraphQL-Ruby's `DummyScheduler` predates that addition, so the Ruby head test job fails during setup:

```text
ArgumentError: Scheduler must implement #fiber_interrupt
```

Because `Fiber.set_scheduler` fails, all tests using the nonblocking dataloader report the same error before their test logic runs.

This PR adds `fiber_interrupt` to `DummyScheduler`. Interrupts are placed on its existing thread-safe ready queue and delivered by the scheduler thread, avoiding an unsafe cross-thread `Fiber#raise`.