### PR TITLE
Fix C parser compiler warnings

### DIFF
--- a/graphql-c_parser/ext/graphql_c_parser_ext/graphql_c_parser_ext.c
+++ b/graphql-c_parser/ext/graphql_c_parser_ext/graphql_c_parser_ext.c
@@ -9,7 +9,7 @@ VALUE GraphQL_CParser_Parser_c_parse(VALUE self) {
   return Qnil;
 }
 
-void Init_graphql_c_parser_ext() {
+void Init_graphql_c_parser_ext(void) {
   VALUE GraphQL = rb_define_module("GraphQL");
   VALUE CParser = rb_define_module_under(GraphQL, "CParser");
   VALUE Lexer = rb_define_module_under(CParser, "Lexer");

--- a/graphql-c_parser/ext/graphql_c_parser_ext/graphql_c_parser_ext.h
+++ b/graphql-c_parser/ext/graphql_c_parser_ext/graphql_c_parser_ext.h
@@ -4,5 +4,5 @@
 #include <ruby/encoding.h>
 #include "lexer.h"
 #include "parser.h"
-void Init_graphql_c_parser_ext();
+void Init_graphql_c_parser_ext(void);
 #endif

--- a/graphql-c_parser/ext/graphql_c_parser_ext/lexer.c
+++ b/graphql-c_parser/ext/graphql_c_parser_ext/lexer.c
@@ -1989,7 +1989,7 @@ var_name = rb_utf8_str_new_cstr(str_content); \
 rb_global_variable(&var_name); \
 rb_str_freeze(var_name); \
 
-void setup_static_token_variables() {
+void setup_static_token_variables(void) {
 	SETUP_STATIC_TOKEN_VARIABLE(ON, "on")
 	SETUP_STATIC_TOKEN_VARIABLE(FRAGMENT, "fragment")
 	SETUP_STATIC_TOKEN_VARIABLE(QUERY, "query")

--- a/graphql-c_parser/ext/graphql_c_parser_ext/lexer.h
+++ b/graphql-c_parser/ext/graphql_c_parser_ext/lexer.h
@@ -2,5 +2,5 @@
 #define Graphql_lexer_h
 #include <ruby.h>
 VALUE tokenize(VALUE query_rbstr, int fstring_identifiers, int reject_numbers_followed_by_names, int max_tokens);
-void setup_static_token_variables();
+void setup_static_token_variables(void);
 #endif

--- a/graphql-c_parser/ext/graphql_c_parser_ext/lexer.rl
+++ b/graphql-c_parser/ext/graphql_c_parser_ext/lexer.rl
@@ -421,7 +421,7 @@ VALUE tokenize(VALUE query_rbstr, int fstring_identifiers, int reject_numbers_fo
   rb_global_variable(&var_name); \
   rb_str_freeze(var_name); \
 
-void setup_static_token_variables() {
+void setup_static_token_variables(void) {
   SETUP_STATIC_TOKEN_VARIABLE(ON, "on")
   SETUP_STATIC_TOKEN_VARIABLE(FRAGMENT, "fragment")
   SETUP_STATIC_TOKEN_VARIABLE(QUERY, "query")

--- a/graphql-c_parser/ext/graphql_c_parser_ext/parser.c
+++ b/graphql-c_parser/ext/graphql_c_parser_ext/parser.c
@@ -75,7 +75,7 @@
 #define YYSTACK_USE_ALLOCA 1
 
 int yylex(YYSTYPE *, VALUE, VALUE);
-void yyerror(VALUE, VALUE, const char*);
+NORETURN(void yyerror(VALUE, VALUE, const char*));
 
 static VALUE GraphQL_Language_Nodes_NONE;
 static VALUE r_string_query;
@@ -3318,7 +3318,7 @@ void yyerror(VALUE parser, VALUE filename, const char *msg) {
     rb_global_variable(&GraphQL_Language_Nodes_##node_class_name); \
     GraphQL_Language_Nodes_##node_class_name = rb_const_get_at(mGraphQLLanguageNodes, rb_intern(#node_class_name));
 
-void initialize_node_class_variables() {
+void initialize_node_class_variables(void) {
   VALUE mGraphQL = rb_const_get_at(rb_cObject, rb_intern("GraphQL"));
   VALUE mGraphQLLanguage = rb_const_get_at(mGraphQL, rb_intern("Language"));
   VALUE mGraphQLLanguageNodes = rb_const_get_at(mGraphQLLanguage, rb_intern("Nodes"));

--- a/graphql-c_parser/ext/graphql_c_parser_ext/parser.h
+++ b/graphql-c_parser/ext/graphql_c_parser_ext/parser.h
@@ -1,5 +1,5 @@
 #ifndef Graphql_parser_h
 #define Graphql_parser_h
 int yyparse(VALUE parser, VALUE filename);
-void initialize_node_class_variables();
+void initialize_node_class_variables(void);
 #endif

--- a/graphql-c_parser/ext/graphql_c_parser_ext/parser.y
+++ b/graphql-c_parser/ext/graphql_c_parser_ext/parser.y
@@ -9,7 +9,7 @@
 #define YYSTACK_USE_ALLOCA 1
 
 int yylex(YYSTYPE *, VALUE, VALUE);
-void yyerror(VALUE, VALUE, const char*);
+NORETURN(void yyerror(VALUE, VALUE, const char*));
 
 static VALUE GraphQL_Language_Nodes_NONE;
 static VALUE r_string_query;
@@ -928,7 +928,7 @@ void yyerror(VALUE parser, VALUE filename, const char *msg) {
     rb_global_variable(&GraphQL_Language_Nodes_##node_class_name); \
     GraphQL_Language_Nodes_##node_class_name = rb_const_get_at(mGraphQLLanguageNodes, rb_intern(#node_class_name));
 
-void initialize_node_class_variables() {
+void initialize_node_class_variables(void) {
   VALUE mGraphQL = rb_const_get_at(rb_cObject, rb_intern("GraphQL"));
   VALUE mGraphQLLanguage = rb_const_get_at(mGraphQL, rb_intern("Language"));
   VALUE mGraphQLLanguageNodes = rb_const_get_at(mGraphQLLanguage, rb_intern("Nodes"));


### PR DESCRIPTION
The C parser currently declares and defines several no-argument functions using empty parameter lists:

```c
void Init_graphql_c_parser_ext() {
```

In C, `()` leaves the parameters unspecified and GCC reports these definitions with -Wold-style-definition:

```
warning: old-style function definition [-Wold-style-definition]
```

The parser's `yyerror` function always raises through `rb_exc_raise`, but it is not declared as non-returning, which produces an additional compiler warning.

This PR updates the no-argument declarations and definitions to use `(void)` and marks `yyerror` with Ruby's portable `NORETURN` macro. The Ragel and Bison source files and their generated C files are updated together.

There is no runtime behavior change.