### PR TITLE
Escape subscription serializer magic keys

### DIFF
--- a/lib/graphql/subscriptions/serialize.rb
+++ b/lib/graphql/subscriptions/serialize.rb
@@ -13,6 +13,8 @@ module GraphQL
       TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S.%N%z" # eg '2020-01-01 23:59:59.123456789+05:00'
       TIMESTAMP_CLASS_NAMES = ["Date", "DateTime", "Time"].freeze
       OPEN_STRUCT_KEY = "__ostruct__"
+      HASH_KEY = "__graphql_hash__"
+      RESERVED_KEYS = [GLOBALID_KEY, SYMBOL_KEY, SYMBOL_KEYS_KEY, TIMESTAMP_KEY, OPEN_STRUCT_KEY, HASH_KEY].freeze
 
       module_function
 
@@ -91,6 +93,10 @@ module GraphQL
               when OPEN_STRUCT_KEY
                 ostruct_values = load_value(value[OPEN_STRUCT_KEY])
                 OpenStruct.new(ostruct_values)
+              when HASH_KEY
+                value[HASH_KEY].each_with_object({}) do |(k, v), loaded_h|
+                  loaded_h[load_value(k)] = load_value(v)
+                end
               else
                 key = value.keys.first
                 { key => load_value(value[key]) }
@@ -120,6 +126,11 @@ module GraphQL
           if obj.is_a?(Array)
             obj.map{|item| dump_value(item)}
           elsif obj.is_a?(Hash)
+            if obj.any? { |k, _v| RESERVED_KEYS.include?(k.to_s) }
+              return {
+                HASH_KEY => obj.map { |k, v| [dump_value(k.is_a?(Symbol) ? k : k.to_s), dump_value(v)] },
+              }
+            end
             symbol_keys = nil
             dumped_h = {}
             obj.each do |k, v|

--- a/spec/graphql/subscriptions/serialize_spec.rb
+++ b/spec/graphql/subscriptions/serialize_spec.rb
@@ -155,4 +155,26 @@ describe GraphQL::Subscriptions::Serialize do
     reloaded = serialize_load(serialized)
     assert_equal os, reloaded
   end
+
+  it "round trips hashes with reserved serializer keys" do
+    reserved_values = {
+      "__gid__" => "gid://app/User/1",
+      "__sym__" => "user-value",
+      "__sym_keys__" => ["user-value"],
+      "__timestamp__" => ["UserClass", "user-value"],
+      "__ostruct__" => { "user-value" => true },
+      "__graphql_hash__" => [["user-value"]],
+    }
+
+    reserved_values.each do |key, value|
+      input = { "nested" => [{ key => value }] }
+      assert_equal input, serialize_load(serialize_dump(input)), key
+    end
+
+    input = { "__sym_keys__" => ["user-value"], "user-value" => true }
+    assert_equal input, serialize_load(serialize_dump(input))
+
+    input = { __gid__: "gid://app/User/1" }
+    assert_equal input, serialize_load(serialize_dump(input))
+  end
 end


### PR DESCRIPTION
`GraphQL::Subscriptions::Serialize` uses single-key Hashes with reserved keys to represent values such as Global IDs, symbols, timestamps, and OpenStructs.

Currently, user-provided Hashes containing those keys are serialized without escaping:

```ruby
value = { "__gid__" => "gid://app/User/1" }

GraphQL::Subscriptions::Serialize.load(
  GraphQL::Subscriptions::Serialize.dump(value)
)
# => result of GlobalID::Locator.locate(...)
```

Likewise, a Hash containing `__ostruct__` is loaded as an OpenStruct instead of being returned as the original Hash. Collisions with `__sym__`, `__sym_keys__`, and `__timestamp__` can also change or reject user data.

This can affect subscription arguments and scopes containing client-controlled JSON values.

This PR wraps Hashes whose keys collide with serializer metadata in a dedicated Hash representation using serialized key-value pairs. The wrapper key itself is also escaped recursively.

Hashes without reserved keys keep their existing serialized format, and existing GlobalID, Symbol, timestamp, and OpenStruct payloads continue to deserialize as before.