### PR TITLE
Preserve subscription serializer round trips

### DIFF
--- a/lib/graphql/subscriptions/serialize.rb
+++ b/lib/graphql/subscriptions/serialize.rb
@@ -57,7 +57,7 @@ module GraphQL
         # @return [Object] An object that load Global::Identification recursive
         def load_value(value)
           if value.is_a?(Array)
-            is_gids = (v1 = value[0]).is_a?(Hash) && v1.size == 1 && v1[GLOBALID_KEY]
+            is_gids = !value.empty? && value.all? { |v| v.is_a?(Hash) && v.size == 1 && v[GLOBALID_KEY] }
             if is_gids
               # Assume it's an array of global IDs
               ids = value.map { |v| v[GLOBALID_KEY] }
@@ -98,14 +98,20 @@ module GraphQL
             else
               loaded_h = {}
               sym_keys = value.fetch(SYMBOL_KEYS_KEY, [])
+              symbol_key_values = sym_keys.is_a?(Hash) ? sym_keys : nil
               value.each do |k, v|
                 if k == SYMBOL_KEYS_KEY
                   next
                 end
-                if sym_keys.include?(k)
+                if !symbol_key_values && sym_keys.include?(k)
                   k = k.to_sym
                 end
                 loaded_h[k] = load_value(v)
+              end
+              if symbol_key_values
+                symbol_key_values.each do |k, v|
+                  loaded_h[k.to_sym] = load_value(v)
+                end
               end
               loaded_h
             end
@@ -120,16 +126,26 @@ module GraphQL
           if obj.is_a?(Array)
             obj.map{|item| dump_value(item)}
           elsif obj.is_a?(Hash)
+            has_colliding_symbol_key = obj.any? { |k, _v| k.is_a?(Symbol) && obj.key?(k.to_s) }
             symbol_keys = nil
+            symbol_key_values = nil
             dumped_h = {}
             obj.each do |k, v|
-              dumped_h[k.to_s] = dump_value(v)
-              if k.is_a?(Symbol)
+              dumped_v = dump_value(v)
+              if has_colliding_symbol_key && k.is_a?(Symbol)
+                symbol_key_values ||= {}
+                symbol_key_values[k.to_s] = dumped_v
+              else
+                dumped_h[k.to_s] = dumped_v
+              end
+              if !has_colliding_symbol_key && k.is_a?(Symbol)
                 symbol_keys ||= Set.new
                 symbol_keys << k.to_s
               end
             end
-            if symbol_keys
+            if symbol_key_values
+              dumped_h[SYMBOL_KEYS_KEY] = symbol_key_values
+            elsif symbol_keys
               dumped_h[SYMBOL_KEYS_KEY] = symbol_keys.to_a
             end
             dumped_h

--- a/spec/graphql/subscriptions/serialize_spec.rb
+++ b/spec/graphql/subscriptions/serialize_spec.rb
@@ -58,6 +58,12 @@ describe GraphQL::Subscriptions::Serialize do
       assert_equal false, user_a.located_many?
       assert_equal [true, true], loaded["users"].map(&:located_many?)
     end
+
+    it "deserializes arrays containing global ids and other values" do
+      value = [GlobalIDUser.new("a"), 1, "two"]
+
+      assert_equal value, serialize_load(serialize_dump(value))
+    end
   end
 
   it "can deserialize symbols" do
@@ -68,6 +74,12 @@ describe GraphQL::Subscriptions::Serialize do
     assert_equal expected_dumped, dumped
     loaded = serialize_load(dumped)
     assert_equal value, loaded
+  end
+
+  it "preserves symbol and string keys with the same name" do
+    value = { a: 1, "a" => 2 }
+
+    assert_equal value, serialize_load(serialize_dump(value))
   end
 
   it "can deserialize date/times" do


### PR DESCRIPTION
This follows up on #5722 with two additional cases where `GraphQL::Subscriptions::Serialize.dump` and `.load` don't round-trip their input.

First, arrays are treated as GlobalID arrays based only on their first element:

```ruby
value = [GlobalIDUser.new("a"), 1, "two"]

GraphQL::Subscriptions::Serialize.load(
  GraphQL::Subscriptions::Serialize.dump(value)
)
# => TypeError: no implicit conversion of String into Integer
```

The loader attempts to read `__gid__` from every remaining element. Other mixed values may produce nil IDs and cause `GlobalID::Locator.locate_many` to return incorrect results or fail.

Second, Symbol and String keys with the same name are collapsed when keys are converted to strings:

```ruby
value = { a: 1, "a" => 2 }

dumped = GraphQL::Subscriptions::Serialize.dump(value)
# => {"a":2,"__sym_keys__":["a"]}

GraphQL::Subscriptions::Serialize.load(dumped)
# => { a: 2 }
```

This PR only uses the batched `GlobalID::Locator.locate_many` path when every array element is a GlobalID wrapper. Mixed arrays use the existing recursive loading path, while homogeneous GlobalID arrays retain batched lookup.

For Hash key collisions, Symbol-keyed values are stored separately in the existing `__sym_keys__` metadata. Hashes without collisions retain their existing serialized format.