### PR TITLE
Keep multiplex results aligned after setup errors

### DIFF
--- a/lib/graphql/execution/runner.rb
+++ b/lib/graphql/execution/runner.rb
@@ -87,10 +87,10 @@ module GraphQL
           @schema.analysis_engine.analyze_multiplex(@multiplex, multiplex_analyzers)
           trace.end_analyze_multiplex(@multiplex, multiplex_analyzers)
 
-          results = []
+          results = {}.compare_by_identity
           queries.each do |query|
             if query.validate && !query.valid?
-              results << {
+              results[query] = {
                 "errors" => query.static_errors.map(&:to_h)
               }
               next
@@ -125,8 +125,8 @@ module GraphQL
             end
           end
 
-          queries.each_with_index.map do |query, idx|
-            result = results[idx]
+          queries.map do |query|
+            result = results[query]
 
             fin_result = if (!@finalizers&.key?(query) && query.context.errors.empty?) || !query.valid?
               result
@@ -262,12 +262,12 @@ module GraphQL
             end
 
             if !auth_check
-              results << {}
+              results[query] = {}
               return
             end
           end
 
-          results << { "data" => data }
+          results[query] = { "data" => data }
           objects = [root_value]
           query.current_trace.objects(root_type, objects, query.context)
 
@@ -361,7 +361,7 @@ module GraphQL
           objects = [root_value]
           query.current_trace.objects(resolved_type, objects, query.context)
           runtime_type_at[data] = resolved_type
-          results << { "data" => data }
+          results[query] = { "data" => data }
           isolated_steps[0] << SelectionsStep.new(
             parent_type: resolved_type,
             field_resolve_step: nil,
@@ -376,10 +376,10 @@ module GraphQL
           inner_type = root_type.unwrap
           case inner_type.kind.name
           when "SCALAR", "ENUM"
-            results << run_isolated_scalar(root_type, query)
+            results[query] = run_isolated_scalar(root_type, query)
           else
             list_result = Array.new(root_value.size) { Hash.new.compare_by_identity }
-            results << { "data" => list_result }
+            results[query] = { "data" => list_result }
             isolated_steps[0] << SelectionsStep.new(
               parent_type: inner_type,
               field_resolve_step: nil,
@@ -392,7 +392,7 @@ module GraphQL
             )
           end
         when "SCALAR", "ENUM"
-          results << run_isolated_scalar(root_type, query)
+          results[query] = run_isolated_scalar(root_type, query)
         else
           raise "Unhandled root type kind: #{root_type.kind.name.inspect}"
         end

--- a/spec/graphql/query/partial_spec.rb
+++ b/spec/graphql/query/partial_spec.rb
@@ -191,6 +191,8 @@ describe GraphQL::Query::Partial do
     end
 
     def self.resolve_type(abs_type, object, ctx)
+      raise GraphQL::ExecutionError, "Root type resolution failed" if object[:resolve_type_error]
+
       object[:is_market] ? Market : Farm
     end
 
@@ -442,6 +444,25 @@ describe GraphQL::Query::Partial do
 
     assert_equal({ "name" => "Whisper Hill" }, results[0]["data"])
     assert_equal({ "name" => "Crozet Farmers Market", "isYearRound" => false }, results[1]["data"])
+  end
+
+  it "keeps results aligned when a partial fails before producing a result" do
+    exec_next_only("Execution::Next runner result bookkeeping")
+
+    str = "{
+      thing {
+        ...on Farm { name }
+      }
+    }"
+
+    results = run_partials(str, [
+      { path: ["thing"], object: OpenStruct.new({ resolve_type_error: true }) },
+      { path: ["thing"], object: OpenStruct.new({ name: "Whisper Hill" }) },
+    ])
+
+    assert_nil results[0]["data"]
+    assert_equal ["Root type resolution failed"], results[0]["errors"].map { |err| err["message"] }
+    assert_equal({ "data" => { "name" => "Whisper Hill" } }, results[1].to_h)
   end
 
   it "runs on interface selections" do


### PR DESCRIPTION
`GraphQL::Execution::Runner` currently stores temporary multiplex results in an Array and later associates them with queries by position.

If a query raises `GraphQL::RuntimeError` during setup before appending a result, the error is added to that query's context, but no entry is added to the results Array. Results from subsequent queries then shift to the wrong query.

This is reproducible with `Query#run_partials` when abstract root type resolution raises `GraphQL::ExecutionError`: the following partial's data is assigned to the failed partial, while the following partial receives no data.

This PR stores temporary results by query identity instead of insertion order. Setup errors can therefore leave a query without a temporary result without affecting any other query in the multiplex.