### PR TITLE
Support data_collection configuration for Sentry

### DIFF
--- a/lib/graphql/tracing/sentry_trace.rb
+++ b/lib/graphql/tracing/sentry_trace.rb
@@ -37,12 +37,17 @@ module GraphQL
                     scope.set_transaction_name(transaction_name(query))
                   end
                 end
-                span.set_data('graphql.document', query.query_string)
+                if graphql_data_collection.nil? || graphql_data_collection.document
+                  span.set_data('graphql.document', query.query_string)
+                end
                 if query.selected_operation_name
                   span.set_data('graphql.operation.name', query.selected_operation_name)
                 end
                 if query.selected_operation
                   span.set_data('graphql.operation.type', query.selected_operation.operation_type)
+                end
+                if graphql_data_collection&.variables && !query.provided_variables.empty?
+                  span.set_data('graphql.variables', query.provided_variables)
                 end
               end
             end
@@ -54,6 +59,13 @@ module GraphQL
         include MonitorTrace::Monitor::GraphQLPrefixNames
 
         private
+
+        def graphql_data_collection
+          @graphql_data_collection ||= if Sentry.respond_to?(:configuration)
+            configuration = Sentry.configuration
+            configuration.data_collection.graphql if configuration.respond_to?(:data_collection)
+          end
+        end
 
         def operation_name(query)
           selected_op = query.selected_operation

--- a/spec/graphql/tracing/sentry_trace_spec.rb
+++ b/spec/graphql/tracing/sentry_trace_spec.rb
@@ -25,6 +25,11 @@ describe GraphQL::Tracing::SentryTrace do
 
       field :thing, Thing, resolve_legacy_instance_method: true
       def thing; :thing; end
+
+      field :echo, Integer, null: false, resolve_legacy_instance_method: true do
+        argument :value, Integer
+      end
+      def echo(value:); value; end
     end
 
     class SchemaWithoutTransactionName < GraphQL::Schema
@@ -50,8 +55,8 @@ describe GraphQL::Tracing::SentryTrace do
     Sentry.clear_all
   end
 
-  def exec_query(query_str, context: {}, schema: SentryTraceTest::SchemaWithoutTransactionName)
-    schema.execute(query_str, context: context)
+  def exec_query(query_str, context: {}, variables: {}, schema: SentryTraceTest::SchemaWithoutTransactionName)
+    schema.execute(query_str, context: context, variables: variables)
   end
 
   it "works with other trace modules" do
@@ -119,6 +124,26 @@ describe GraphQL::Tracing::SentryTrace do
     ].compact
 
     assert_equal expected_span_data.sort, Sentry::SPAN_DATA.sort
+  end
+
+  it "does not collect the document when configured not to" do
+    Sentry.configuration.data_collection.graphql.document = false
+    exec_query("query Ab { int }")
+
+    refute Sentry::SPAN_DATA.any? { |key, _value| key == "graphql.document" }
+  end
+
+  it "sets span data for query variables when configured to do so" do
+    exec_query("query($value: Int!) { echo(value: $value) }", variables: {"value" => 1})
+
+    assert_includes Sentry::SPAN_DATA, ["graphql.variables", {"value" => 1}]
+  end
+
+  it "does not collect query variables when configured not to" do
+    Sentry.configuration.data_collection.graphql.variables = false
+    exec_query("query($value: Int!) { echo(value: $value) }", variables: {"value" => 1})
+
+    refute Sentry::SPAN_DATA.any? { |key, _value| key == "graphql.variables" }
   end
 
   it "sets span descriptions for a named query" do

--- a/spec/support/sentry.rb
+++ b/spec/support/sentry.rb
@@ -11,12 +11,41 @@ module Sentry
   SPAN_DESCRIPTIONS = []
   TRANSACTION_NAMES = []
 
+  class DataCollection
+    class GraphQL
+      attr_accessor :document, :variables
+
+      def initialize
+        @document = true
+        @variables = true
+      end
+    end
+
+    attr_reader :graphql
+
+    def initialize
+      @graphql = GraphQL.new
+    end
+  end
+
+  class Configuration
+    attr_reader :data_collection
+
+    def initialize
+      @data_collection = DataCollection.new
+    end
+  end
+
   class << self
     attr_accessor :use_nil_span
   end
 
   def self.initialized?
     true
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
   end
 
   def self.utc_now
@@ -45,6 +74,8 @@ module Sentry
     SPAN_DESCRIPTIONS.clear
     SPAN_OPS.clear
     TRANSACTION_NAMES.clear
+    configuration.data_collection.graphql.document = true
+    configuration.data_collection.graphql.variables = true
   end
 
   module DummySpan


### PR DESCRIPTION
The new [Sentry 7.0.0 release](https://github.com/getsentry/sentry-ruby/releases/tag/7.0.0) has a new configuration parameter called `data_collection` that allows users to opt in/out from graphql `document` and `variables` collection.